### PR TITLE
Add embed cache and expand embed DTO

### DIFF
--- a/discord-helper/EmbedCache.cs
+++ b/discord-helper/EmbedCache.cs
@@ -1,0 +1,70 @@
+using System.Collections.Concurrent;
+
+namespace DiscordHelper;
+
+public class EmbedCache
+{
+    private const int MaxItems = 50;
+    private readonly ConcurrentDictionary<string, EmbedDto> _embeds = new();
+    private readonly Queue<string> _order = new();
+    private readonly object _lock = new();
+
+    public void Add(EmbedDto embed)
+    {
+        if (embed.Id == null)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            if (_embeds.TryAdd(embed.Id, embed))
+            {
+                _order.Enqueue(embed.Id);
+                TrimExcess();
+            }
+        }
+    }
+
+    public EmbedDto? Get(string id)
+    {
+        _embeds.TryGetValue(id, out var embed);
+        return embed;
+    }
+
+    public bool Update(EmbedDto embed)
+    {
+        if (embed.Id == null)
+        {
+            return false;
+        }
+
+        lock (_lock)
+        {
+            if (!_embeds.ContainsKey(embed.Id))
+            {
+                return false;
+            }
+
+            _embeds[embed.Id] = embed;
+            return true;
+        }
+    }
+
+    public IReadOnlyCollection<EmbedDto> GetAll()
+    {
+        lock (_lock)
+        {
+            return _order.Select(id => _embeds[id]).ToList().AsReadOnly();
+        }
+    }
+
+    private void TrimExcess()
+    {
+        while (_order.Count > MaxItems)
+        {
+            var oldest = _order.Dequeue();
+            _embeds.TryRemove(oldest, out _);
+        }
+    }
+}

--- a/discord-helper/EmbedDto.cs
+++ b/discord-helper/EmbedDto.cs
@@ -2,6 +2,28 @@ namespace DiscordHelper;
 
 public class EmbedDto
 {
+    public string? Id { get; set; }
+    public DateTimeOffset? Timestamp { get; set; }
+    public uint? Color { get; set; }
+    public string? AuthorName { get; set; }
+    public string? AuthorIconUrl { get; set; }
     public string? Title { get; set; }
     public string? Description { get; set; }
+    public List<EmbedFieldDto>? Fields { get; set; }
+    public string? ThumbnailUrl { get; set; }
+    public string? ImageUrl { get; set; }
+    public List<EmbedButtonDto>? Buttons { get; set; }
+    public List<ulong>? Mentions { get; set; }
+}
+
+public class EmbedFieldDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+}
+
+public class EmbedButtonDto
+{
+    public string Label { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
- add rich fields to `EmbedDto` for complete embed metadata
- implement thread-safe `EmbedCache` with capacity 50

## Testing
- `dotnet build discord-helper/bot.csproj`
- `dotnet build dalamud-plugin/dalamud-plugin.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6892a76a6a488328a3091ed16c4c2846