### PR TITLE
Cache bot embeds and track RSVP reactions

### DIFF
--- a/discord-helper/DiscordBotHostedService.cs
+++ b/discord-helper/DiscordBotHostedService.cs
@@ -1,0 +1,100 @@
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using System.Linq;
+
+namespace DiscordHelper;
+
+public class DiscordBotHostedService : IHostedService
+{
+    private readonly DiscordSocketClient _client;
+    private readonly BotConfig _config;
+    private readonly EmbedCache _cache;
+
+    public DiscordBotHostedService(DiscordSocketClient client, IOptions<BotConfig> config, EmbedCache cache)
+    {
+        _client = client;
+        _config = config.Value;
+        _cache = cache;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _client.MessageReceived += OnMessageReceived;
+        _client.ReactionAdded += OnReactionUpdated;
+        _client.ReactionRemoved += OnReactionUpdated;
+
+        await _client.LoginAsync(TokenType.Bot, _config.BotToken);
+        await _client.StartAsync();
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _client.MessageReceived -= OnMessageReceived;
+        _client.ReactionAdded -= OnReactionUpdated;
+        _client.ReactionRemoved -= OnReactionUpdated;
+
+        await _client.StopAsync();
+        await _client.LogoutAsync();
+    }
+
+    private Task OnMessageReceived(SocketMessage msg)
+    {
+        if (msg is not IUserMessage message)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (message.Author.Id != _config.BotId || message.Embeds.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        foreach (var embed in message.Embeds)
+        {
+            var dto = MapEmbed(embed, message);
+            _cache.Add(dto);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task OnReactionUpdated(Cacheable<IUserMessage, ulong> messageCache,
+        Cacheable<IMessageChannel, ulong> channelCache, SocketReaction reaction)
+    {
+        var message = await messageCache.GetOrDownloadAsync();
+        if (message.Author.Id != _config.BotId || message.Embeds.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var embed in message.Embeds)
+        {
+            var dto = MapEmbed(embed, message);
+            _cache.Update(dto);
+        }
+    }
+
+    private static EmbedDto MapEmbed(IEmbed embed, IUserMessage message)
+    {
+        return new EmbedDto
+        {
+            Id = message.Id.ToString(),
+            Timestamp = embed.Timestamp,
+            Color = embed.Color?.RawValue,
+            AuthorName = embed.Author?.Name,
+            AuthorIconUrl = embed.Author?.IconUrl,
+            Title = embed.Title,
+            Description = embed.Description,
+            Fields = embed.Fields.Select(f => new EmbedFieldDto
+            {
+                Name = f.Name,
+                Value = f.Value
+            }).ToList(),
+            ThumbnailUrl = embed.Thumbnail?.Url,
+            ImageUrl = embed.Image?.Url,
+            Mentions = message.MentionedUserIds.Count > 0 ? message.MentionedUserIds.ToList() : null
+        };
+    }
+}

--- a/discord-helper/Program.cs
+++ b/discord-helper/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddSingleton(_ =>
 });
 
 // Register hosted service and controllers
+builder.Services.AddSingleton<EmbedCache>();
 builder.Services.AddHostedService<DiscordBotHostedService>();
 builder.Services.AddControllers();
 
@@ -64,30 +65,5 @@ public class BotConfig
     public ulong[] ChannelIds { get; set; } = Array.Empty<ulong>();
     public ulong BotId { get; set; }
     public int Port { get; set; } = 5000;
-}
-
-// Hosted service for the Discord bot
-public class DiscordBotHostedService : IHostedService
-{
-    private readonly DiscordSocketClient _client;
-    private readonly BotConfig _config;
-
-    public DiscordBotHostedService(DiscordSocketClient client, IOptions<BotConfig> config)
-    {
-        _client = client;
-        _config = config.Value;
-    }
-
-    public async Task StartAsync(CancellationToken cancellationToken)
-    {
-        await _client.LoginAsync(TokenType.Bot, _config.BotToken);
-        await _client.StartAsync();
-    }
-
-    public async Task StopAsync(CancellationToken cancellationToken)
-    {
-        await _client.StopAsync();
-        await _client.LogoutAsync();
-    }
 }
 


### PR DESCRIPTION
## Summary
- register EmbedCache and hosted service
- cache embeds sent by the bot and refresh them on reactions

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6892a86a0e308328bdc1696e9e114597