### PR TITLE
feat: add embed RSVP endpoints and websocket broadcast

### DIFF
--- a/discord-helper/EmbedSocketHandler.cs
+++ b/discord-helper/EmbedSocketHandler.cs
@@ -1,0 +1,55 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+
+namespace DiscordHelper;
+
+public class EmbedSocketHandler
+{
+    private readonly List<WebSocket> _sockets = new();
+    private readonly object _lock = new();
+
+    public async Task AddSocketAsync(WebSocket socket)
+    {
+        lock (_lock)
+        {
+            _sockets.Add(socket);
+        }
+
+        var buffer = new byte[4 * 1024];
+        while (socket.State == WebSocketState.Open)
+        {
+            var result = await socket.ReceiveAsync(buffer, CancellationToken.None);
+            if (result.CloseStatus.HasValue)
+            {
+                break;
+            }
+        }
+
+        lock (_lock)
+        {
+            _sockets.Remove(socket);
+        }
+
+        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+    }
+
+    public async Task BroadcastAsync(EmbedDto embed)
+    {
+        string json = JsonSerializer.Serialize(embed);
+        var data = Encoding.UTF8.GetBytes(json);
+        List<WebSocket> sockets;
+        lock (_lock)
+        {
+            sockets = _sockets.ToList();
+        }
+
+        foreach (var socket in sockets)
+        {
+            if (socket.State == WebSocketState.Open)
+            {
+                await socket.SendAsync(data, WebSocketMessageType.Text, true, CancellationToken.None);
+            }
+        }
+    }
+}

--- a/discord-helper/EmbedsController.cs
+++ b/discord-helper/EmbedsController.cs
@@ -1,15 +1,111 @@
+using Discord;
+using Discord.WebSocket;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using System.Linq;
 
 namespace DiscordHelper;
 
 [ApiController]
-[Route("[controller]")]
+[Route("api/[controller]")]
 public class EmbedsController : ControllerBase
 {
+    private readonly EmbedCache _cache;
+    private readonly DiscordSocketClient _client;
+    private readonly IOptions<BotConfig> _config;
+    private readonly EmbedSocketHandler _sockets;
+
+    public EmbedsController(EmbedCache cache, DiscordSocketClient client, IOptions<BotConfig> config, EmbedSocketHandler sockets)
+    {
+        _cache = cache;
+        _client = client;
+        _config = config;
+        _sockets = sockets;
+    }
+
+    [HttpGet]
+    public ActionResult<IEnumerable<EmbedDto>> Get()
+    {
+        return Ok(_cache.GetAll());
+    }
+
+    public class RsvpRequest
+    {
+        public string Emoji { get; set; } = string.Empty;
+    }
+
+    [HttpPost("{id}/rsvp")]
+    public async Task<IActionResult> Rsvp(string id, [FromBody] RsvpRequest request)
+    {
+        if (!ulong.TryParse(id, out var messageId))
+        {
+            return BadRequest();
+        }
+
+        var emoji = new Emoji(request.Emoji);
+        var message = await FindMessageAsync(messageId);
+        if (message == null)
+        {
+            return NotFound();
+        }
+
+        await message.AddReactionAsync(emoji);
+
+        foreach (var embed in message.Embeds)
+        {
+            var dto = MapEmbed(embed, message);
+            if (_cache.Update(dto))
+            {
+                await _sockets.BroadcastAsync(dto);
+            }
+        }
+
+        return NoContent();
+    }
+
     [HttpPost]
     public IActionResult Post(EmbedDto dto)
     {
-        // In a real bot, this would send the embed to Discord.
+        // Placeholder for future custom event creation.
         return Ok(dto);
+    }
+
+    private async Task<IUserMessage?> FindMessageAsync(ulong messageId)
+    {
+        foreach (var channelId in _config.Value.ChannelIds)
+        {
+            if (_client.GetChannel(channelId) is IMessageChannel channel)
+            {
+                var msg = await channel.GetMessageAsync(messageId) as IUserMessage;
+                if (msg != null)
+                {
+                    return msg;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static EmbedDto MapEmbed(IEmbed embed, IUserMessage message)
+    {
+        return new EmbedDto
+        {
+            Id = message.Id.ToString(),
+            Timestamp = embed.Timestamp,
+            Color = embed.Color?.RawValue,
+            AuthorName = embed.Author?.Name,
+            AuthorIconUrl = embed.Author?.IconUrl,
+            Title = embed.Title,
+            Description = embed.Description,
+            Fields = embed.Fields.Select(f => new EmbedFieldDto
+            {
+                Name = f.Name,
+                Value = f.Value
+            }).ToList(),
+            ThumbnailUrl = embed.Thumbnail?.Url,
+            ImageUrl = embed.Image?.Url,
+            Mentions = message.MentionedUserIds.Count > 0 ? message.MentionedUserIds.ToList() : null
+        };
     }
 }


### PR DESCRIPTION
## Summary
- replace EmbedsController with API to list and RSVP to embeds
- broadcast cache updates over new /ws/embeds websocket
- push new cache updates from Discord bot service

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6892aa9a8f6c83288d3135351f525b0a