### PR TITLE
Render event embeds with textures

### DIFF
--- a/dalamud-plugin/EmbedDto.cs
+++ b/dalamud-plugin/EmbedDto.cs
@@ -1,7 +1,25 @@
+using System;
+using System.Collections.Generic;
+
 namespace DiscordHelper;
 
 public class EmbedDto
 {
+    public string Id { get; set; } = string.Empty;
+    public DateTimeOffset? Timestamp { get; set; }
+    public uint? Color { get; set; }
+    public string? AuthorName { get; set; }
+    public string? AuthorIconUrl { get; set; }
     public string? Title { get; set; }
     public string? Description { get; set; }
+    public List<EmbedFieldDto>? Fields { get; set; }
+    public string? ThumbnailUrl { get; set; }
+    public string? ImageUrl { get; set; }
+    public List<ulong>? Mentions { get; set; }
+}
+
+public class EmbedFieldDto
+{
+    public string Name { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
 }

--- a/dalamud-plugin/Plugin.cs
+++ b/dalamud-plugin/Plugin.cs
@@ -18,7 +18,7 @@ public class Plugin : IDalamudPlugin
 {
     public string Name => "SamplePlugin";
 
-    private readonly UiRenderer _ui = new();
+    private readonly UiRenderer _ui;
     private Config _config;
     private readonly System.Timers.Timer _timer;
     private readonly HttpClient _httpClient = new();
@@ -26,6 +26,8 @@ public class Plugin : IDalamudPlugin
     public Plugin()
     {
         _config = LoadConfig();
+
+        _ui = new UiRenderer(_config);
 
         _timer = new System.Timers.Timer(_config.PollIntervalSeconds * 1000);
         _timer.Elapsed += OnPollTimer;
@@ -80,10 +82,7 @@ public class Plugin : IDalamudPlugin
 
             var stream = await response.Content.ReadAsStreamAsync();
             var embeds = await JsonSerializer.DeserializeAsync<List<EmbedDto>>(stream) ?? new List<EmbedDto>();
-            foreach (var dto in embeds)
-            {
-                _ui.Draw(dto);
-            }
+            _ui.SetEmbeds(embeds);
         }
         catch
         {

--- a/dalamud-plugin/Service.cs
+++ b/dalamud-plugin/Service.cs
@@ -2,6 +2,13 @@ using System;
 
 namespace DalamudPlugin;
 
+public interface IDalamudTextureWrap : IDisposable
+{
+    nint ImGuiHandle { get; }
+    int Width { get; }
+    int Height { get; }
+}
+
 public static class Service
 {
     public static PluginInterface Interface { get; } = new();
@@ -16,6 +23,28 @@ public static class Service
         public event Action? Draw;
 
         public void TriggerDraw() => Draw?.Invoke();
+
+        public IDalamudTextureWrap LoadImageRaw(byte[] data, int width, int height, int bytesPerPixel)
+        {
+            return new DummyTextureWrap(width, height);
+        }
+    }
+
+    private class DummyTextureWrap : IDalamudTextureWrap
+    {
+        public nint ImGuiHandle { get; } = (nint)1;
+        public int Width { get; }
+        public int Height { get; }
+
+        public DummyTextureWrap(int width, int height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        public void Dispose()
+        {
+        }
     }
 }
 

--- a/dalamud-plugin/UiRenderer.cs
+++ b/dalamud-plugin/UiRenderer.cs
@@ -1,31 +1,241 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Numerics;
+using System.Text;
+using System.Text.Json;
 using DiscordHelper;
+using ImGuiNET;
+using StbImageSharp;
 
 namespace DalamudPlugin;
 
 public class UiRenderer : IDisposable
 {
-    private readonly List<EmbedDto> _embeds = new();
+    private readonly HttpClient _httpClient = new();
+    private readonly Config _config;
 
-    public void Draw(EmbedDto dto)
+    private readonly Dictionary<string, EmbedState> _embeds = new();
+
+    private class EmbedState
     {
-        _embeds.Add(dto);
-        // In a real plugin, rendering logic would load textures here.
+        public EmbedDto Dto { get; set; }
+        public IDalamudTextureWrap? AuthorIcon { get; set; }
+        public IDalamudTextureWrap? Thumbnail { get; set; }
+        public IDalamudTextureWrap? Image { get; set; }
+
+        public EmbedState(EmbedDto dto)
+        {
+            Dto = dto;
+        }
+    }
+
+    public UiRenderer(Config config)
+    {
+        _config = config;
+    }
+
+    public void SetEmbeds(IEnumerable<EmbedDto> embeds)
+    {
+        var ids = new HashSet<string>();
+        foreach (var dto in embeds)
+        {
+            ids.Add(dto.Id);
+            if (_embeds.TryGetValue(dto.Id, out var state))
+            {
+                // Update DTO and reload textures if URLs changed
+                if (state.Dto.AuthorIconUrl != dto.AuthorIconUrl)
+                {
+                    state.AuthorIcon?.Dispose();
+                    state.AuthorIcon = LoadTexture(dto.AuthorIconUrl);
+                }
+                if (state.Dto.ThumbnailUrl != dto.ThumbnailUrl)
+                {
+                    state.Thumbnail?.Dispose();
+                    state.Thumbnail = LoadTexture(dto.ThumbnailUrl);
+                }
+                if (state.Dto.ImageUrl != dto.ImageUrl)
+                {
+                    state.Image?.Dispose();
+                    state.Image = LoadTexture(dto.ImageUrl);
+                }
+                state.Dto = dto;
+            }
+            else
+            {
+                var stateNew = new EmbedState(dto)
+                {
+                    AuthorIcon = LoadTexture(dto.AuthorIconUrl),
+                    Thumbnail = LoadTexture(dto.ThumbnailUrl),
+                    Image = LoadTexture(dto.ImageUrl)
+                };
+                _embeds[dto.Id] = stateNew;
+            }
+        }
+
+        // Remove embeds no longer present
+        foreach (var key in _embeds.Keys.Where(k => !ids.Contains(k)).ToList())
+        {
+            DisposeState(_embeds[key]);
+            _embeds.Remove(key);
+        }
+    }
+
+    private IDalamudTextureWrap? LoadTexture(string? url)
+    {
+        if (string.IsNullOrEmpty(url))
+        {
+            return null;
+        }
+
+        try
+        {
+            var bytes = _httpClient.GetByteArrayAsync(url).GetAwaiter().GetResult();
+            using var stream = new System.IO.MemoryStream(bytes);
+            var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
+            return Service.Interface.UiBuilder.LoadImageRaw(image.Data, image.Width, image.Height, 4);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void DisposeState(EmbedState state)
+    {
+        state.AuthorIcon?.Dispose();
+        state.Thumbnail?.Dispose();
+        state.Image?.Dispose();
     }
 
     public void DrawWindow()
     {
-        foreach (var dto in _embeds)
+        if (!ImGui.Begin("Events"))
         {
-            // In a real plugin, rendering logic would go here.
+            ImGui.End();
+            return;
         }
 
-        _embeds.Clear();
+        ImGui.BeginChild("##eventScroll", new Vector2(0, 0), true);
+
+        foreach (var state in _embeds.Values)
+        {
+            var dto = state.Dto;
+
+            if (dto.Color.HasValue)
+            {
+                var color = dto.Color.Value | 0xFF000000;
+                var dl = ImGui.GetWindowDrawList();
+                var p = ImGui.GetCursorScreenPos();
+                var end = new Vector2(p.X + 4, p.Y + ImGui.GetTextLineHeightWithSpacing() * 3);
+                dl.AddRectFilled(p, end, color);
+                ImGui.Dummy(new Vector2(4, 0));
+                ImGui.SameLine();
+            }
+
+            if (state.AuthorIcon != null)
+            {
+                ImGui.Image(state.AuthorIcon.ImGuiHandle, new Vector2(32, 32));
+                ImGui.SameLine();
+            }
+
+            var header = dto.Title ?? string.Empty;
+            if (dto.Timestamp.HasValue)
+            {
+                header += $" - {dto.Timestamp.Value.LocalDateTime}";
+            }
+            ImGui.TextUnformatted(header);
+
+            if (!string.IsNullOrEmpty(dto.Description))
+            {
+                ImGui.TextWrapped(dto.Description);
+            }
+
+            if (dto.Fields != null && dto.Fields.Count > 0)
+            {
+                if (ImGui.BeginTable($"fields{dto.Id}", 2, ImGuiTableFlags.Borders))
+                {
+                    foreach (var field in dto.Fields)
+                    {
+                        ImGui.TableNextRow();
+                        ImGui.TableSetColumnIndex(0);
+                        ImGui.TextUnformatted(field.Name);
+                        ImGui.TableSetColumnIndex(1);
+                        ImGui.TextUnformatted(field.Value);
+                    }
+                    ImGui.EndTable();
+                }
+            }
+
+            if (state.Image != null)
+            {
+                var size = new Vector2(state.Image.Width, state.Image.Height);
+                ImGui.Image(state.Image.ImGuiHandle, size);
+            }
+
+            if (state.Thumbnail != null)
+            {
+                ImGui.Image(state.Thumbnail.ImGuiHandle, new Vector2(state.Thumbnail.Width, state.Thumbnail.Height));
+            }
+
+            if (dto.Mentions != null && dto.Mentions.Count > 0)
+            {
+                ImGui.Text($"Mentions: {string.Join(", ", dto.Mentions)}");
+            }
+
+            if (ImGui.Button($"✅##yes{dto.Id}"))
+            {
+                SendRsvp(dto.Id, "✅");
+            }
+            ImGui.SameLine();
+            if (ImGui.Button($"❌##no{dto.Id}"))
+            {
+                SendRsvp(dto.Id, "❌");
+            }
+            ImGui.SameLine();
+            if (ImGui.Button($"❓##maybe{dto.Id}"))
+            {
+                SendRsvp(dto.Id, "❓");
+            }
+
+            ImGui.Separator();
+        }
+
+        ImGui.EndChild();
+        ImGui.End();
+    }
+
+    private void SendRsvp(string id, string emoji)
+    {
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post,
+                $"{_config.HelperBaseUrl.TrimEnd('/')}/embeds/{id}/rsvp");
+            request.Content = new StringContent(JsonSerializer.Serialize(new { Emoji = emoji }), Encoding.UTF8,
+                "application/json");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AuthToken);
+            }
+
+            _httpClient.SendAsync(request);
+        }
+        catch
+        {
+            // ignored
+        }
     }
 
     public void Dispose()
     {
+        foreach (var state in _embeds.Values)
+        {
+            DisposeState(state);
+        }
         _embeds.Clear();
+        _httpClient.Dispose();
     }
 }
+

--- a/dalamud-plugin/dalamud-plugin.csproj
+++ b/dalamud-plugin/dalamud-plugin.csproj
@@ -5,4 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ImGui.NET" Version="1.89.4" />
+    <PackageReference Include="StbImageSharp" Version="2.27.8" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- expand EmbedDto with metadata for rendering
- implement UiRenderer with scrolling event window, image decoding, RSVP HTTP calls, and texture cleanup
- wire plugin to update embed list and dispose resources

## Testing
- `dotnet build dalamud-plugin/dalamud-plugin.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892b13780ec8328a7f834f7a4d28380