### PR TITLE
Add event creation window and server endpoint

### DIFF
--- a/bot/src/db.js
+++ b/bot/src/db.js
@@ -19,15 +19,23 @@ function write(file, data) {
 
 function setKey(userId, key) {
   const data = read(userFile);
-  data[userId] = key;
+  const existing = data[userId] || {};
+  data[userId] = { ...existing, key };
   write(userFile, data);
 }
 
-function getUserIdByKey(key) {
+function setCharacter(userId, character) {
   const data = read(userFile);
-  for (const [id, storedKey] of Object.entries(data)) {
-    if (storedKey === key) {
-      return id;
+  const existing = data[userId] || {};
+  data[userId] = { ...existing, character };
+  write(userFile, data);
+}
+
+function getUserByKey(key) {
+  const data = read(userFile);
+  for (const [id, info] of Object.entries(data)) {
+    if (info.key === key) {
+      return { userId: id, character: info.character };
     }
   }
   return null;
@@ -47,4 +55,4 @@ function addEventChannel(channelId) {
   }
 }
 
-module.exports = { setKey, getUserIdByKey, getEventChannels, addEventChannel };
+module.exports = { setKey, setCharacter, getUserByKey, getEventChannels, addEventChannel };

--- a/dalamud-plugin/EventCreateWindow.cs
+++ b/dalamud-plugin/EventCreateWindow.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using ImGuiNET;
+
+namespace DalamudPlugin;
+
+public class EventCreateWindow : IDisposable
+{
+    private readonly Config _config;
+    private readonly HttpClient _httpClient = new();
+
+    private string _title = string.Empty;
+    private string _description = string.Empty;
+    private string _time = DateTime.UtcNow.ToString("o");
+    private string _channelId = string.Empty;
+    private string _imagePath = string.Empty;
+    private string? _lastResult;
+
+    public bool IsOpen { get; set; }
+
+    public EventCreateWindow(Config config)
+    {
+        _config = config;
+    }
+
+    public void Draw()
+    {
+        if (!IsOpen)
+        {
+            return;
+        }
+
+        if (!ImGui.Begin("Create Event", ref Unsafe.AsRef(ref IsOpen)))
+        {
+            ImGui.End();
+            return;
+        }
+
+        ImGui.InputText("Title", ref _title, 256);
+        ImGui.InputText("Channel Id", ref _channelId, 32);
+        ImGui.InputText("Time", ref _time, 64);
+        ImGui.InputTextMultiline("Description", ref _description, 4096, new Vector2(400, 100));
+        ImGui.InputText("Image Path", ref _imagePath, 260);
+        if (ImGui.Button("Create"))
+        {
+            CreateEvent();
+        }
+
+        if (!string.IsNullOrEmpty(_lastResult))
+        {
+            ImGui.TextUnformatted(_lastResult);
+        }
+
+        ImGui.End();
+    }
+
+    private async void CreateEvent()
+    {
+        try
+        {
+            string? imageBase64 = null;
+            if (!string.IsNullOrEmpty(_imagePath) && File.Exists(_imagePath))
+            {
+                var bytes = await File.ReadAllBytesAsync(_imagePath);
+                imageBase64 = Convert.ToBase64String(bytes);
+            }
+
+            var body = new
+            {
+                channelId = _channelId,
+                title = _title,
+                time = _time,
+                description = _description,
+                imageBase64
+            };
+
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/events");
+            request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AuthToken);
+            }
+
+            var response = await _httpClient.SendAsync(request);
+            _lastResult = response.IsSuccessStatusCode ? "Event posted" : $"Error: {response.StatusCode}";
+        }
+        catch (Exception ex)
+        {
+            _lastResult = $"Failed: {ex.Message}";
+        }
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+}

--- a/dalamud-plugin/Plugin.cs
+++ b/dalamud-plugin/Plugin.cs
@@ -20,6 +20,7 @@ public class Plugin : IDalamudPlugin
 
     private readonly UiRenderer _ui;
     private readonly SettingsWindow _settings;
+    private readonly EventCreateWindow _createWindow;
     private Config _config;
     private readonly System.Timers.Timer _timer;
     private readonly HttpClient _httpClient = new();
@@ -30,6 +31,7 @@ public class Plugin : IDalamudPlugin
 
         _ui = new UiRenderer(_config);
         _settings = new SettingsWindow(_config) { IsOpen = true };
+        _createWindow = new EventCreateWindow(_config) { IsOpen = true };
 
         _timer = new System.Timers.Timer(_config.PollIntervalSeconds * 1000);
         _timer.Elapsed += OnPollTimer;
@@ -42,6 +44,7 @@ public class Plugin : IDalamudPlugin
 
         Service.Interface.UiBuilder.Draw += _ui.DrawWindow;
         Service.Interface.UiBuilder.Draw += _settings.Draw;
+        Service.Interface.UiBuilder.Draw += _createWindow.Draw;
     }
 
     private Config LoadConfig()
@@ -97,11 +100,13 @@ public class Plugin : IDalamudPlugin
     {
         Service.Interface.UiBuilder.Draw -= _ui.DrawWindow;
         Service.Interface.UiBuilder.Draw -= _settings.Draw;
+        Service.Interface.UiBuilder.Draw -= _createWindow.Draw;
         _timer.Stop();
         _timer.Dispose();
         _httpClient.Dispose();
         _ui.Dispose();
         _settings.Dispose();
+        _createWindow.Dispose();
     }
 }
 

--- a/dalamud-plugin/Service.cs
+++ b/dalamud-plugin/Service.cs
@@ -12,6 +12,7 @@ public interface IDalamudTextureWrap : IDisposable
 public static class Service
 {
     public static PluginInterface Interface { get; } = new();
+    public static ClientState ClientState { get; } = new();
 
     public class PluginInterface
     {
@@ -28,6 +29,16 @@ public static class Service
         {
             return new DummyTextureWrap(width, height);
         }
+    }
+
+    public class ClientState
+    {
+        public LocalPlayer? LocalPlayer { get; } = new();
+    }
+
+    public class LocalPlayer
+    {
+        public string Name { get; } = "Test Character";
     }
 
     private class DummyTextureWrap : IDalamudTextureWrap

--- a/dalamud-plugin/SettingsWindow.cs
+++ b/dalamud-plugin/SettingsWindow.cs
@@ -48,7 +48,8 @@ public class SettingsWindow : IDisposable
         {
             var url = $"{_config.HelperBaseUrl.TrimEnd('/')}/validate";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
-            request.Content = new StringContent(JsonSerializer.Serialize(new { key = _key }), Encoding.UTF8, "application/json");
+            var character = Service.ClientState.LocalPlayer?.Name ?? string.Empty;
+            request.Content = new StringContent(JsonSerializer.Serialize(new { key = _key, characterName = character }), Encoding.UTF8, "application/json");
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
## Summary
- allow plugin to create new events with title, time, description, channel, and image upload
- send user key and character name on validation
- support event posting on bot server using key-character mapping for footer

## Testing
- `dotnet build dalamud-plugin` *(fails: command not found)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6892cb38c34883289dfe7d2e925df253