### PR TITLE
Add chat relay between plugin and Discord

### DIFF
--- a/bot/src/db.js
+++ b/bot/src/db.js
@@ -55,4 +55,26 @@ function addEventChannel(channelId) {
   }
 }
 
-module.exports = { setKey, setCharacter, getUserByKey, getEventChannels, addEventChannel };
+function getChatChannels() {
+  const data = read(serverFile);
+  return Array.isArray(data.chatChannels) ? data.chatChannels : [];
+}
+
+function addChatChannel(channelId) {
+  const data = read(serverFile);
+  data.chatChannels = Array.isArray(data.chatChannels) ? data.chatChannels : [];
+  if (!data.chatChannels.includes(channelId)) {
+    data.chatChannels.push(channelId);
+    write(serverFile, data);
+  }
+}
+
+module.exports = {
+  setKey,
+  setCharacter,
+  getUserByKey,
+  getEventChannels,
+  addEventChannel,
+  getChatChannels,
+  addChatChannel
+};

--- a/dalamud-plugin/ChatWindow.cs
+++ b/dalamud-plugin/ChatWindow.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Numerics;
+using ImGuiNET;
+
+namespace DalamudPlugin;
+
+public class ChatWindow : IDisposable
+{
+    private readonly Config _config;
+    private readonly HttpClient _httpClient = new();
+    private readonly List<ChatMessageDto> _messages = new();
+    private string _channelId = string.Empty;
+    private string _input = string.Empty;
+    private bool _useCharacterName = false;
+    private DateTime _lastFetch = DateTime.MinValue;
+
+    public bool IsOpen;
+
+    public ChatWindow(Config config)
+    {
+        _config = config;
+    }
+
+    public void Draw()
+    {
+        if (!IsOpen)
+        {
+            return;
+        }
+
+        if (!ImGui.Begin("Chat", ref IsOpen))
+        {
+            ImGui.End();
+            return;
+        }
+
+        ImGui.InputText("Channel Id", ref _channelId, 32);
+        ImGui.Checkbox("Use Character Name", ref _useCharacterName);
+
+        if (DateTime.UtcNow - _lastFetch > TimeSpan.FromSeconds(_config.PollIntervalSeconds))
+        {
+            RefreshMessages();
+        }
+
+        ImGui.BeginChild("##chatScroll", new Vector2(0, -30), true);
+        foreach (var msg in _messages)
+        {
+            ImGui.TextWrapped($"{msg.AuthorName}: {FormatContent(msg)}");
+        }
+        ImGui.EndChild();
+
+        var send = ImGui.InputText("##chatInput", ref _input, 512, ImGuiInputTextFlags.EnterReturnsTrue);
+        ImGui.SameLine();
+        if (ImGui.Button("Send") || send)
+        {
+            SendMessage();
+        }
+
+        ImGui.End();
+    }
+
+    private string FormatContent(ChatMessageDto msg)
+    {
+        var text = msg.Content;
+        if (msg.Mentions != null)
+        {
+            foreach (var m in msg.Mentions)
+            {
+                text = text.Replace($"<@{m.Id}>", $"@{m.Name}");
+            }
+        }
+        text = Regex.Replace(text, "<a?:([a-zA-Z0-9_]+):\\d+>", ":$1:");
+        return text;
+    }
+
+    private async void SendMessage()
+    {
+        if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
+        {
+            return;
+        }
+
+        try
+        {
+            var body = new { channelId = _channelId, content = _input, useCharacterName = _useCharacterName };
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/messages");
+            request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AuthToken);
+            }
+            var response = await _httpClient.SendAsync(request);
+            if (response.IsSuccessStatusCode)
+            {
+                _input = string.Empty;
+                RefreshMessages();
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    public async void RefreshMessages()
+    {
+        if (string.IsNullOrEmpty(_channelId))
+        {
+            return;
+        }
+
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.HelperBaseUrl.TrimEnd('/')}/messages/{_channelId}");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AuthToken);
+            }
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                return;
+            }
+            var stream = await response.Content.ReadAsStreamAsync();
+            var msgs = await JsonSerializer.DeserializeAsync<List<ChatMessageDto>>(stream) ?? new List<ChatMessageDto>();
+            _messages.Clear();
+            _messages.AddRange(msgs);
+            _lastFetch = DateTime.UtcNow;
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+
+    private class ChatMessageDto
+    {
+        public string Id { get; set; } = string.Empty;
+        public string ChannelId { get; set; } = string.Empty;
+        public string AuthorName { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public List<MentionDto>? Mentions { get; set; }
+    }
+
+    private class MentionDto
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/dalamud-plugin/EventCreateWindow.cs
+++ b/dalamud-plugin/EventCreateWindow.cs
@@ -5,7 +5,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using ImGuiNET;
 
 namespace DalamudPlugin;
@@ -22,7 +21,7 @@ public class EventCreateWindow : IDisposable
     private string _imagePath = string.Empty;
     private string? _lastResult;
 
-    public bool IsOpen { get; set; }
+    public bool IsOpen;
 
     public EventCreateWindow(Config config)
     {
@@ -36,7 +35,7 @@ public class EventCreateWindow : IDisposable
             return;
         }
 
-        if (!ImGui.Begin("Create Event", ref Unsafe.AsRef(ref IsOpen)))
+        if (!ImGui.Begin("Create Event", ref IsOpen))
         {
             ImGui.End();
             return;

--- a/dalamud-plugin/Plugin.cs
+++ b/dalamud-plugin/Plugin.cs
@@ -21,6 +21,7 @@ public class Plugin : IDalamudPlugin
     private readonly UiRenderer _ui;
     private readonly SettingsWindow _settings;
     private readonly EventCreateWindow _createWindow;
+    private readonly ChatWindow _chatWindow;
     private Config _config;
     private readonly System.Timers.Timer _timer;
     private readonly HttpClient _httpClient = new();
@@ -32,6 +33,7 @@ public class Plugin : IDalamudPlugin
         _ui = new UiRenderer(_config);
         _settings = new SettingsWindow(_config) { IsOpen = true };
         _createWindow = new EventCreateWindow(_config) { IsOpen = true };
+        _chatWindow = new ChatWindow(_config) { IsOpen = true };
 
         _timer = new System.Timers.Timer(_config.PollIntervalSeconds * 1000);
         _timer.Elapsed += OnPollTimer;
@@ -45,6 +47,7 @@ public class Plugin : IDalamudPlugin
         Service.Interface.UiBuilder.Draw += _ui.DrawWindow;
         Service.Interface.UiBuilder.Draw += _settings.Draw;
         Service.Interface.UiBuilder.Draw += _createWindow.Draw;
+        Service.Interface.UiBuilder.Draw += _chatWindow.Draw;
     }
 
     private Config LoadConfig()
@@ -101,12 +104,14 @@ public class Plugin : IDalamudPlugin
         Service.Interface.UiBuilder.Draw -= _ui.DrawWindow;
         Service.Interface.UiBuilder.Draw -= _settings.Draw;
         Service.Interface.UiBuilder.Draw -= _createWindow.Draw;
+        Service.Interface.UiBuilder.Draw -= _chatWindow.Draw;
         _timer.Stop();
         _timer.Dispose();
         _httpClient.Dispose();
         _ui.Dispose();
         _settings.Dispose();
         _createWindow.Dispose();
+        _chatWindow.Dispose();
     }
 }
 

--- a/dalamud-plugin/Service.cs
+++ b/dalamud-plugin/Service.cs
@@ -12,7 +12,7 @@ public interface IDalamudTextureWrap : IDisposable
 public static class Service
 {
     public static PluginInterface Interface { get; } = new();
-    public static ClientState ClientState { get; } = new();
+    public static ClientStateService ClientState { get; } = new();
 
     public class PluginInterface
     {
@@ -31,7 +31,7 @@ public static class Service
         }
     }
 
-    public class ClientState
+    public class ClientStateService
     {
         public LocalPlayer? LocalPlayer { get; } = new();
     }

--- a/database/servers.json
+++ b/database/servers.json
@@ -1,3 +1,4 @@
 {
-  "eventChannels": []
+  "eventChannels": [],
+  "chatChannels": []
 }


### PR DESCRIPTION
## Summary
- Relay messages from configured Discord text channels and expose new message APIs
- Add plugin chat window with message rendering and send support
- Allow choosing character or Discord name for plugin-sent chat messages

## Testing
- `npm test` *(fails: Error: no test specified)*
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6892cd64ee64832899a82e7912e720a2