### PR TITLE
Add tabbed main window for events and chat

### DIFF
--- a/dalamud-plugin/ChatWindow.cs
+++ b/dalamud-plugin/ChatWindow.cs
@@ -20,8 +20,6 @@ public class ChatWindow : IDisposable
     private bool _useCharacterName = false;
     private DateTime _lastFetch = DateTime.MinValue;
 
-    public bool IsOpen;
-
     public ChatWindow(Config config)
     {
         _config = config;
@@ -29,17 +27,6 @@ public class ChatWindow : IDisposable
 
     public void Draw()
     {
-        if (!IsOpen)
-        {
-            return;
-        }
-
-        if (!ImGui.Begin("Chat", ref IsOpen))
-        {
-            ImGui.End();
-            return;
-        }
-
         ImGui.InputText("Channel Id", ref _channelId, 32);
         ImGui.Checkbox("Use Character Name", ref _useCharacterName);
 
@@ -62,7 +49,6 @@ public class ChatWindow : IDisposable
             SendMessage();
         }
 
-        ImGui.End();
     }
 
     private string FormatContent(ChatMessageDto msg)

--- a/dalamud-plugin/MainWindow.cs
+++ b/dalamud-plugin/MainWindow.cs
@@ -1,0 +1,83 @@
+using System.Numerics;
+using ImGuiNET;
+
+namespace DalamudPlugin;
+
+public class MainWindow
+{
+    private readonly Config _config;
+    private readonly UiRenderer _ui;
+    private readonly ChatWindow _chat;
+    private readonly SettingsWindow _settings;
+
+    public bool IsOpen;
+
+    public MainWindow(Config config, UiRenderer ui, ChatWindow chat, SettingsWindow settings)
+    {
+        _config = config;
+        _ui = ui;
+        _chat = chat;
+        _settings = settings;
+        IsOpen = true;
+    }
+
+    public void Draw()
+    {
+        if (!IsOpen)
+        {
+            return;
+        }
+
+        ImGui.SetNextWindowSize(new Vector2(800, 600), ImGuiCond.FirstUseEver);
+        ImGui.PushStyleColor(ImGuiCol.WindowBg, new Vector4(0.11f, 0.11f, 0.12f, 1f));
+        ImGui.PushStyleColor(ImGuiCol.ChildBg, new Vector4(0.09f, 0.09f, 0.1f, 1f));
+        ImGui.PushStyleColor(ImGuiCol.Tab, new Vector4(0.15f, 0.15f, 0.16f, 1f));
+        ImGui.PushStyleColor(ImGuiCol.TabActive, new Vector4(0.2f, 0.2f, 0.21f, 1f));
+        ImGui.PushStyleColor(ImGuiCol.TabHovered, new Vector4(0.25f, 0.25f, 0.26f, 1f));
+
+        if (!ImGui.Begin("DemiCat", ref IsOpen, ImGuiWindowFlags.NoCollapse))
+        {
+            ImGui.End();
+            ImGui.PopStyleColor(5);
+            return;
+        }
+
+        var padding = ImGui.GetStyle().FramePadding;
+        var buttonSize = ImGui.GetFrameHeight();
+        var cursor = ImGui.GetCursorPos();
+        ImGui.SetCursorPos(new Vector2(ImGui.GetWindowContentRegionMax().X - buttonSize - padding.X, padding.Y));
+        if (ImGui.Button("\u2699"))
+        {
+            _settings.IsOpen = true;
+        }
+        ImGui.SetCursorPos(cursor);
+
+        ImGui.BeginChild("ChannelList", new Vector2(150, 0), true);
+        ImGui.TextUnformatted("Channels");
+        ImGui.EndChild();
+
+        ImGui.SameLine();
+
+        ImGui.BeginChild("MainContent", new Vector2(0, 0), false);
+        if (ImGui.BeginTabBar("MainTabs"))
+        {
+            if (ImGui.BeginTabItem("Events"))
+            {
+                _ui.Draw();
+                ImGui.EndTabItem();
+            }
+
+            if (ImGui.BeginTabItem("Chat"))
+            {
+                _chat.Draw();
+                ImGui.EndTabItem();
+            }
+
+            ImGui.EndTabBar();
+        }
+        ImGui.EndChild();
+
+        ImGui.End();
+        ImGui.PopStyleColor(5);
+    }
+}

--- a/dalamud-plugin/Plugin.cs
+++ b/dalamud-plugin/Plugin.cs
@@ -22,6 +22,7 @@ public class Plugin : IDalamudPlugin
     private readonly SettingsWindow _settings;
     private readonly EventCreateWindow _createWindow;
     private readonly ChatWindow _chatWindow;
+    private readonly MainWindow _mainWindow;
     private Config _config;
     private readonly System.Timers.Timer _timer;
     private readonly HttpClient _httpClient = new();
@@ -31,9 +32,10 @@ public class Plugin : IDalamudPlugin
         _config = LoadConfig();
 
         _ui = new UiRenderer(_config);
-        _settings = new SettingsWindow(_config) { IsOpen = true };
+        _settings = new SettingsWindow(_config);
         _createWindow = new EventCreateWindow(_config) { IsOpen = true };
-        _chatWindow = new ChatWindow(_config) { IsOpen = true };
+        _chatWindow = new ChatWindow(_config);
+        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _settings) { IsOpen = true };
 
         _timer = new System.Timers.Timer(_config.PollIntervalSeconds * 1000);
         _timer.Elapsed += OnPollTimer;
@@ -44,10 +46,9 @@ public class Plugin : IDalamudPlugin
             _timer.Start();
         }
 
-        Service.Interface.UiBuilder.Draw += _ui.DrawWindow;
+        Service.Interface.UiBuilder.Draw += _mainWindow.Draw;
         Service.Interface.UiBuilder.Draw += _settings.Draw;
         Service.Interface.UiBuilder.Draw += _createWindow.Draw;
-        Service.Interface.UiBuilder.Draw += _chatWindow.Draw;
     }
 
     private Config LoadConfig()
@@ -101,10 +102,9 @@ public class Plugin : IDalamudPlugin
 
     public void Dispose()
     {
-        Service.Interface.UiBuilder.Draw -= _ui.DrawWindow;
+        Service.Interface.UiBuilder.Draw -= _mainWindow.Draw;
         Service.Interface.UiBuilder.Draw -= _settings.Draw;
         Service.Interface.UiBuilder.Draw -= _createWindow.Draw;
-        Service.Interface.UiBuilder.Draw -= _chatWindow.Draw;
         _timer.Stop();
         _timer.Dispose();
         _httpClient.Dispose();

--- a/dalamud-plugin/UiRenderer.cs
+++ b/dalamud-plugin/UiRenderer.cs
@@ -68,14 +68,8 @@ public class UiRenderer : IDisposable
         }
     }
 
-    public void DrawWindow()
+    public void Draw()
     {
-        if (!ImGui.Begin("Events"))
-        {
-            ImGui.End();
-            return;
-        }
-
         ImGui.BeginChild("##eventScroll", new Vector2(0, 0), true);
 
         foreach (var view in _embeds.Values)
@@ -84,7 +78,6 @@ public class UiRenderer : IDisposable
         }
 
         ImGui.EndChild();
-        ImGui.End();
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- Add Discord-styled main window with channel list, Events/Chat tabs, and settings gear
- Refactor chat and event rendering to work inside the main window
- Hook plugin to draw the new window

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892cfaa7bb883289b4f10fd1c2b1feb