### PR TITLE
Update DemiCat plugin metadata

### DIFF
--- a/dalamud-plugin/Plugin.cs
+++ b/dalamud-plugin/Plugin.cs
@@ -11,7 +11,7 @@ namespace DalamudPlugin;
 
 public class Plugin : IDalamudPlugin
 {
-    public string Name => "SamplePlugin";
+    public string Name => "DemiCat";
 
     private readonly UiRenderer _ui;
     private readonly SettingsWindow _settings;

--- a/dalamud-plugin/dalamud-plugin.csproj
+++ b/dalamud-plugin/dalamud-plugin.csproj
@@ -4,6 +4,11 @@
     <RootNamespace>DalamudPlugin</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AssemblyName>DemiCat</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <Description>DemiCat Dalamud plugin.</Description>
+    <Authors>DemiCat</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dalamud-plugin/manifest.json
+++ b/dalamud-plugin/manifest.json
@@ -1,8 +1,8 @@
 {
-  "Author": "YourName",
-  "Name": "SamplePlugin",
-  "InternalName": "SamplePlugin",
+  "Author": "DemiCat",
+  "Name": "DemiCat",
+  "InternalName": "DemiCat",
   "AssemblyVersion": "1.0.0.0",
-  "Description": "Sample Dalamud plugin.",
+  "Description": "DemiCat Dalamud plugin.",
   "ApplicableVersion": "any"
 }


### PR DESCRIPTION
## Summary
- personalize plugin manifest and assembly metadata for DemiCat
- align plugin name constant with manifest

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68934d4fa67083288f8d05c352ae546c