### PR TITLE
chore: set default helper url

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm start
 On first run you will be prompted for the Discord bot credentials and MySQL connection details. They are stored in `bot/.env`.
 
 ### 2. Configure the Dalamud plugin
-Update `dalamud-plugin/manifest.json` with the usual plugin metadata. In-game, open the plugin configuration and set the **Helper Base URL** (e.g. `http://localhost:3000`).
+Update `dalamud-plugin/manifest.json` with the usual plugin metadata. In-game, open the plugin configuration and set the **Helper Base URL** if needed (defaults to `http://localhost:3000`).
 
 ## Building and Running
 

--- a/dalamud-plugin/Config.cs
+++ b/dalamud-plugin/Config.cs
@@ -4,7 +4,7 @@ public class Config
 {
     public bool Enabled { get; set; } = true;
 
-    public string HelperBaseUrl { get; set; } = "http://localhost:5000";
+    public string HelperBaseUrl { get; set; } = "http://localhost:3000";
 
     public int PollIntervalSeconds { get; set; } = 5;
 


### PR DESCRIPTION
## Summary
- default Dalamud HelperBaseUrl to http://localhost:3000
- note the default port in setup instructions

## Testing
- `dotnet build` *(fails: Unable to find package Dalamud / Dalamud.Plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68934d81624c8328a39ecd0840d12b4c