### PR TITLE
feat: add channel listing endpoint and dropdowns

### DIFF
--- a/bot/src/main.js
+++ b/bot/src/main.js
@@ -250,6 +250,19 @@ app.get('/embeds', (req, res) => {
   res.json(embedCache);
 });
 
+app.get('/channels', async (req, res) => {
+  try {
+    const [event, chat] = await Promise.all([
+      db.getEventChannels(),
+      db.getChatChannels()
+    ]);
+    res.json({ event, chat });
+  } catch (err) {
+    console.error('Failed to fetch channels', err);
+    res.status(500).json({ error: 'Failed to fetch channels' });
+  }
+});
+
 app.post('/interactions', async (req, res) => {
   const { messageId, channelId, customId } = req.body;
   try {


### PR DESCRIPTION
## Summary
- expose a `/channels` REST endpoint to list event and chat channel IDs
- update ChatWindow and EventCreateWindow to fetch channel IDs and choose from dropdowns instead of typing IDs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `dotnet build dalamud-plugin/dalamud-plugin.csproj` *(fails: Unable to find package Dalamud)*

------
https://chatgpt.com/codex/tasks/task_e_68934d8a24148328a938f69c5aa939a4