### PR TITLE
feat(discord): add client and event handlers

### DIFF
--- a/bot/src/discord/client.js
+++ b/bot/src/discord/client.js
@@ -1,0 +1,13 @@
+const { Client, GatewayIntentBits, Partials } = require('discord.js');
+
+const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.GuildMessageReactions,
+    GatewayIntentBits.MessageContent
+  ],
+  partials: [Partials.Message, Partials.Channel, Partials.Reaction]
+});
+
+module.exports = client;

--- a/bot/src/discord/events.js
+++ b/bot/src/discord/events.js
@@ -1,0 +1,77 @@
+const client = require('./client');
+
+const DISCORD_APOLLO_BOT_ID = process.env.DISCORD_APOLLO_BOT_ID;
+const RING_BUFFER_SIZE = 10;
+
+// Map of channelId -> array of latest embeds
+const channelEmbeds = new Map();
+
+function getBuffer(channelId) {
+  let buf = channelEmbeds.get(channelId);
+  if (!buf) {
+    buf = [];
+    channelEmbeds.set(channelId, buf);
+  }
+  return buf;
+}
+
+function isApollo(message) {
+  if (!DISCORD_APOLLO_BOT_ID) return true;
+  return message.author && message.author.id === DISCORD_APOLLO_BOT_ID;
+}
+
+function mapEmbed(message) {
+  const embed = message.embeds[0];
+  return {
+    id: message.id,
+    channelId: message.channelId,
+    ...embed.toJSON()
+  };
+}
+
+function upsert(message) {
+  if (!message || !message.embeds || message.embeds.length === 0) return;
+  if (!isApollo(message)) return;
+
+  const buf = getBuffer(message.channelId);
+  const mapped = mapEmbed(message);
+  const idx = buf.findIndex(e => e.id === message.id);
+  if (idx !== -1) {
+    buf[idx] = mapped;
+  } else {
+    buf.push(mapped);
+    if (buf.length > RING_BUFFER_SIZE) buf.shift();
+  }
+}
+
+client.on('messageCreate', message => {
+  upsert(message);
+});
+
+client.on('messageUpdate', (oldMessage, newMessage) => {
+  const handle = msg => upsert(msg);
+  if (newMessage.partial) {
+    newMessage.fetch().then(handle).catch(() => {});
+  } else {
+    handle(newMessage);
+  }
+});
+
+async function handleReaction(reaction) {
+  try {
+    const msg = await reaction.message.fetch();
+    upsert(msg);
+  } catch (err) {
+    // ignore fetch errors
+  }
+}
+
+client.on('messageReactionAdd', handleReaction);
+client.on('messageReactionRemove', handleReaction);
+
+module.exports = {
+  channelEmbeds,
+  getEmbeds(channelId) {
+    return channelEmbeds.get(channelId) || [];
+  }
+};


### PR DESCRIPTION
## Summary
- add Discord client configured with guild, message, reaction, and content intents
- track Apollo embeds per-channel via event listeners updating ring buffers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68954ddf10e883288a6742575a050294