### PR TITLE
feat: add embed mapping for discord messages

### DIFF
--- a/bot/src/discord/embeds.js
+++ b/bot/src/discord/embeds.js
@@ -1,0 +1,89 @@
+const APOLLO_BOT_ID = process.env.DISCORD_APOLLO_BOT_ID;
+
+// Emojis commonly used by Apollo for RSVP
+const RSVP_EMOJIS = ['✅', '❌', '❓', '❔', '🤷'];
+
+function isApolloEmbed(message) {
+  if (!message) return false;
+  if (APOLLO_BOT_ID && message.author?.id !== APOLLO_BOT_ID) return false;
+  const embed = message.embeds && message.embeds[0];
+  if (!embed) return false;
+  const footer = embed.footer?.text?.toLowerCase() || '';
+  if (footer.includes('apollo')) return true;
+  // Fallback: look for RSVP emojis in footer or reactions
+  if (RSVP_EMOJIS.some(e => footer.includes(e))) return true;
+  if (message.reactions && message.reactions.cache) {
+    for (const r of message.reactions.cache.values()) {
+      if (RSVP_EMOJIS.includes(r.emoji.name)) return true;
+    }
+  }
+  return true; // assume true if bot id matches
+}
+
+function extractButtons(message, embed) {
+  const buttons = [];
+  if (message.components?.length) {
+    for (const row of message.components) {
+      for (const comp of row.components) {
+        if (comp.type === 2) {
+          buttons.push({
+            label: comp.label,
+            url: comp.url,
+            customId: comp.customId
+          });
+        }
+      }
+    }
+  }
+
+  if (buttons.length === 0) {
+    // attempt to create RSVP buttons from reactions or footer text
+    const counts = {};
+    if (message.reactions?.cache?.size) {
+      for (const [key, r] of message.reactions.cache) {
+        if (RSVP_EMOJIS.includes(r.emoji.name)) {
+          counts[r.emoji.name] = r.count;
+        }
+      }
+    }
+    const footerText = embed.footer?.text || '';
+    for (const emoji of RSVP_EMOJIS) {
+      if (counts[emoji] === undefined) {
+        const regex = new RegExp(`${emoji}\\s*(\\d+)`);
+        const match = footerText.match(regex);
+        if (match) counts[emoji] = parseInt(match[1], 10);
+      }
+    }
+    for (const emoji of Object.keys(counts)) {
+      buttons.push({ label: `${emoji} ${counts[emoji]}`, customId: emoji });
+    }
+  }
+
+  return buttons.length ? buttons : undefined;
+}
+
+function mapEmbed(embed, message) {
+  if (!embed || !message) return null;
+  const dto = {
+    id: message.id,
+    channelId: message.channelId,
+    timestamp: embed.timestamp ? new Date(embed.timestamp).toISOString() : undefined,
+    color: embed.color ?? undefined,
+    authorName: embed.author?.name,
+    authorIconUrl: embed.author?.iconURL || embed.author?.icon_url,
+    title: embed.title,
+    description: embed.description,
+    fields: embed.fields?.length ? embed.fields.map(f => ({ name: f.name, value: f.value })) : undefined,
+    thumbnailUrl: embed.thumbnail?.url,
+    imageUrl: embed.image?.url,
+    buttons: extractButtons(message, embed),
+    mentions: message.mentions?.users?.size > 0 ? Array.from(message.mentions.users.values()).map(u => u.username) : undefined
+  };
+  return dto;
+}
+
+module.exports = {
+  mapEmbed,
+  isApolloEmbed,
+};
+

--- a/bot/src/discord/index.js
+++ b/bot/src/discord/index.js
@@ -2,6 +2,7 @@ const { Client, GatewayIntentBits, Events, REST, Routes } = require('discord.js'
 const crypto = require('crypto');
 const WebSocket = require('ws');
 const enqueue = require('../rateLimiter');
+const { mapEmbed } = require('./embeds');
 
 let wss;
 let rest;
@@ -47,35 +48,6 @@ function trackEventChannel(id) {
 
 function trackChatChannel(id) {
   if (!chatChannels.includes(id)) chatChannels.push(id);
-}
-
-function mapEmbed(embed, message) {
-  const buttons = [];
-  if (message.components?.length) {
-    for (const row of message.components) {
-      for (const comp of row.components) {
-        if (comp.type === 2) {
-          buttons.push({
-            label: comp.label,
-            url: comp.url,
-            customId: comp.customId
-          });
-        }
-      }
-    }
-  }
-
-  return {
-    id: message.id,
-    channelId: message.channelId,
-    title: embed.title,
-    description: embed.description,
-    fields: embed.fields.map(f => ({ name: f.name, value: f.value })),
-    thumbnailUrl: embed.thumbnail?.url,
-    imageUrl: embed.image?.url,
-    buttons: buttons.length ? buttons : undefined,
-    mentions: message.mentions.users.size > 0 ? Array.from(message.mentions.users.keys()) : undefined
-  };
 }
 
 function mapMessage(message) {


### PR DESCRIPTION
## Summary
- map discord messages to EmbedDto objects with color, fields, mentions and buttons
- detect Apollo embeds and create RSVP buttons from reactions or footers
- use shared embed mapper in discord index

## Testing
- `npm test --prefix bot` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6895530085f083289537dad2a1e633dc