### PR TITLE
feat: websocket hubs for messages and embeds

### DIFF
--- a/bot/src/http/routes/events.js
+++ b/bot/src/http/routes/events.js
@@ -23,7 +23,7 @@ module.exports = ({ db, discord, logger }) => {
       const files = imageBase64 ? [{ attachment: Buffer.from(imageBase64, 'base64'), name: 'image.png' }] : [];
       const message = await enqueue(() => channel.send({ embeds: [embed], files }));
       const mapped = discord.mapEmbed(message.embeds[0], message);
-      discord.broadcast(mapped);
+      discord.broadcastEmbed(mapped);
       await db.addEventChannel(channelId);
       discord.trackEventChannel(channelId);
       await db.saveEvent({

--- a/bot/src/http/server.js
+++ b/bot/src/http/server.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const http = require('http');
-const WebSocket = require('ws');
 
 function start(config, db, discord, logger) {
   const app = express();
@@ -71,17 +70,15 @@ function start(config, db, discord, logger) {
   app.use('/api/admin/setup', adminSetup({ db, discord }));
 
   const server = http.createServer(app);
-  const wss = new WebSocket.Server({ server });
 
-  wss.on('connection', ws => {
-    discord.embedCache.forEach(e => ws.send(JSON.stringify(e)));
-  });
+  const ws = require('./ws');
+  ws.start(server, discord, logger);
 
   server.listen(config.port, () => {
     logger.info(`Plugin endpoint listening on port ${config.port}`);
   });
 
-  return { app, server, wss };
+  return { app, server };
 }
 
 module.exports = { start };

--- a/bot/src/http/ws.js
+++ b/bot/src/http/ws.js
@@ -1,0 +1,75 @@
+const WebSocket = require('ws');
+
+let messageHub;
+let embedHub;
+
+function heartbeat(wss) {
+  wss.on('connection', ws => {
+    ws.isAlive = true;
+    ws.on('pong', () => {
+      ws.isAlive = true;
+    });
+  });
+
+  const interval = setInterval(() => {
+    wss.clients.forEach(ws => {
+      if (!ws.isAlive) return ws.terminate();
+      ws.isAlive = false;
+      ws.ping();
+    });
+  }, 30000);
+
+  wss.on('close', () => clearInterval(interval));
+}
+
+function broadcastMessage(msg) {
+  if (!messageHub) return;
+  const data = JSON.stringify(msg);
+  messageHub.clients.forEach(ws => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(data);
+    }
+  });
+}
+
+function broadcastEmbed(embed) {
+  if (!embedHub) return;
+  const data = JSON.stringify(embed);
+  embedHub.clients.forEach(ws => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(data);
+    }
+  });
+}
+
+function start(server, discord, logger) {
+  messageHub = new WebSocket.Server({ noServer: true });
+  embedHub = new WebSocket.Server({ noServer: true });
+
+  heartbeat(messageHub);
+  heartbeat(embedHub);
+
+  server.on('upgrade', (req, socket, head) => {
+    if (req.url === '/ws/messages') {
+      messageHub.handleUpgrade(req, socket, head, ws => {
+        messageHub.emit('connection', ws, req);
+        for (const arr of discord.messageCache.values()) {
+          for (const msg of arr) {
+            ws.send(JSON.stringify(msg));
+          }
+        }
+      });
+    } else if (req.url === '/ws/embeds') {
+      embedHub.handleUpgrade(req, socket, head, ws => {
+        embedHub.emit('connection', ws, req);
+        discord.embedCache.forEach(e => ws.send(JSON.stringify(e)));
+      });
+    } else {
+      socket.destroy();
+    }
+  });
+
+  if (logger) logger.info('WebSocket hubs configured');
+}
+
+module.exports = { start, broadcastMessage, broadcastEmbed };

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -7,8 +7,7 @@ const httpServer = require('./http');
 async function start() {
   await db.init(config.db);
   await discord.init(config, db, logger);
-  const { wss } = httpServer.start(config, db, discord, logger);
-  discord.setWss(wss);
+  httpServer.start(config, db, discord, logger);
 }
 
 start().catch(err => {


### PR DESCRIPTION
## Summary
- add WebSocket server with `/ws/messages` and `/ws/embeds` hubs
- stream MessageDto and EmbedDto updates with heartbeat and dead-socket cleanup
- wire Discord handlers and HTTP endpoints to broadcast through the new hubs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689558d7edbc8328925fe83213244545