### PR TITLE
Implement event CRUD routes and Discord embed helper

### DIFF
--- a/bot/src/db.js
+++ b/bot/src/db.js
@@ -116,7 +116,7 @@ async function addChatChannel(channelId) {
 }
 
 async function saveEvent(event) {
-  await query(
+  const res = await query(
     'INSERT INTO events (user_id, channel_id, message_id, title, description, time, metadata) VALUES (?, ?, ?, ?, ?, ?, ?)',
     [
       event.userId,
@@ -128,10 +128,22 @@ async function saveEvent(event) {
       event.metadata
     ]
   );
+  return res.insertId;
 }
 
 async function getEvents(channelId) {
   return await query('SELECT * FROM events WHERE channel_id = ?', [channelId]);
+}
+
+async function getEvent(id) {
+  return await one('SELECT * FROM events WHERE id = ?', [id]);
+}
+
+async function updateEvent(event) {
+  await query(
+    'UPDATE events SET title = ?, description = ?, time = ?, metadata = ? WHERE id = ?',
+    [event.title, event.description, event.time, event.metadata, event.id]
+  );
 }
 
 async function getApiKey(key) {
@@ -158,6 +170,8 @@ module.exports = {
   addChatChannel,
   saveEvent,
   getEvents,
+  getEvent,
+  updateEvent,
   getApiKey
 };
 

--- a/bot/src/discord/send.js
+++ b/bot/src/discord/send.js
@@ -1,0 +1,33 @@
+const enqueue = require('../rateLimiter');
+const discord = require('./index');
+
+async function send(channelId, embed, files = []) {
+  const client = discord.getClient();
+  const channel = await client.channels.fetch(channelId);
+  if (!channel || !channel.isTextBased()) throw new Error('Invalid channel');
+  const options = { embeds: [embed] };
+  if (files.length) options.files = files;
+  const message = await enqueue(() => channel.send(options));
+  const mapped = discord.mapEmbed(message.embeds[0], message);
+  discord.broadcastEmbed(mapped);
+  return message;
+}
+
+async function edit(channelId, messageId, embed, files = []) {
+  const client = discord.getClient();
+  const channel = await client.channels.fetch(channelId);
+  if (!channel || !channel.isTextBased()) throw new Error('Invalid channel');
+  const message = await channel.messages.fetch(messageId);
+  const options = { embeds: [embed] };
+  if (files.length) {
+    options.files = files;
+  } else {
+    options.attachments = [];
+  }
+  const edited = await enqueue(() => message.edit(options));
+  const mapped = discord.mapEmbed(edited.embeds[0], edited);
+  discord.broadcastEmbed(mapped);
+  return edited;
+}
+
+module.exports = { send, edit };

--- a/bot/src/http/routes/events.js
+++ b/bot/src/http/routes/events.js
@@ -1,32 +1,45 @@
 const express = require('express');
-const enqueue = require('../../rateLimiter');
+const send = require('../../discord/send');
 
 module.exports = ({ db, discord, logger }) => {
   const router = express.Router();
-  const client = discord.getClient();
+
+  function buildEmbed(data, info, opts = {}) {
+    const {
+      title,
+      description,
+      time,
+      color,
+      url,
+      fields,
+      thumbnailUrl,
+      authorName,
+      authorIconUrl
+    } = data;
+    return {
+      title,
+      description,
+      url,
+      timestamp: time ? new Date(time) : undefined,
+      color,
+      footer: info.character ? { text: info.character } : undefined,
+      fields,
+      thumbnail: thumbnailUrl ? { url: thumbnailUrl } : undefined,
+      author: authorName ? { name: authorName, icon_url: authorIconUrl } : undefined,
+      image: opts.image ? { url: 'attachment://image.png' } : undefined
+    };
+  }
 
   router.post('/', async (req, res) => {
     const info = req.apiKey;
-    const { channelId, title, time, description, imageBase64 } = req.body;
+    const { channelId, title, time, description, imageBase64, color, url, fields, thumbnailUrl, authorName, authorIconUrl } = req.body;
     try {
-      const channel = await client.channels.fetch(channelId);
-      if (!channel || !channel.isTextBased()) {
-        return res.status(400).json({ error: 'Invalid channel' });
-      }
-      const embed = {
-        title,
-        description,
-        timestamp: time ? new Date(time) : undefined,
-        footer: info.character ? { text: info.character } : undefined,
-        image: imageBase64 ? { url: 'attachment://image.png' } : undefined
-      };
+      const embed = buildEmbed({ title, description, time, color, url, fields, thumbnailUrl, authorName, authorIconUrl }, info, { image: !!imageBase64 });
       const files = imageBase64 ? [{ attachment: Buffer.from(imageBase64, 'base64'), name: 'image.png' }] : [];
-      const message = await enqueue(() => channel.send({ embeds: [embed], files }));
-      const mapped = discord.mapEmbed(message.embeds[0], message);
-      discord.broadcastEmbed(mapped);
+      const message = await send.send(channelId, embed, files);
       await db.addEventChannel(channelId);
       discord.trackEventChannel(channelId);
-      await db.saveEvent({
+      const id = await db.saveEvent({
         userId: info.userId,
         channelId,
         messageId: message.id,
@@ -35,9 +48,55 @@ module.exports = ({ db, discord, logger }) => {
         time,
         metadata: imageBase64 ? 'image' : null
       });
-      res.json({ ok: true });
+      res.json({ ok: true, id });
     } catch (err) {
       if (logger) logger.error('Event creation failed', err);
+      res.status(500).json({ ok: false });
+    }
+  });
+
+  router.patch('/:id', async (req, res) => {
+    const info = req.apiKey;
+    const id = parseInt(req.params.id, 10);
+    try {
+      const existing = await db.getEvent(id);
+      if (!existing) return res.status(404).json({ error: 'Not found' });
+      if (existing.user_id !== info.userId && !info.isAdmin) return res.status(403).json({ error: 'Forbidden' });
+      const title = req.body.title ?? existing.title;
+      const description = req.body.description ?? existing.description;
+      const time = req.body.time ?? existing.time;
+      const imageBase64 = req.body.imageBase64;
+      const color = req.body.color;
+      const url = req.body.url;
+      const fields = req.body.fields;
+      const thumbnailUrl = req.body.thumbnailUrl;
+      const authorName = req.body.authorName;
+      const authorIconUrl = req.body.authorIconUrl;
+      const embed = buildEmbed({ title, description, time, color, url, fields, thumbnailUrl, authorName, authorIconUrl }, info, { image: !!imageBase64 });
+      const files = imageBase64 ? [{ attachment: Buffer.from(imageBase64, 'base64'), name: 'image.png' }] : [];
+      await send.edit(existing.channel_id, existing.message_id, embed, files);
+      await db.updateEvent({ id, title, description, time, metadata: imageBase64 ? 'image' : existing.metadata });
+      res.json({ ok: true });
+    } catch (err) {
+      if (logger) logger.error('Event update failed', err);
+      res.status(500).json({ ok: false });
+    }
+  });
+
+  router.delete('/:id', async (req, res) => {
+    const info = req.apiKey;
+    const id = parseInt(req.params.id, 10);
+    try {
+      const existing = await db.getEvent(id);
+      if (!existing) return res.status(404).json({ error: 'Not found' });
+      if (existing.user_id !== info.userId && !info.isAdmin) return res.status(403).json({ error: 'Forbidden' });
+      const title = existing.title.endsWith(' (Canceled)') ? existing.title : `${existing.title} (Canceled)`;
+      const embed = buildEmbed({ title, description: existing.description, time: existing.time, color: 0x808080 }, info);
+      await send.edit(existing.channel_id, existing.message_id, embed, []);
+      await db.updateEvent({ id, title, description: existing.description, time: existing.time, metadata: 'canceled' });
+      res.json({ ok: true });
+    } catch (err) {
+      if (logger) logger.error('Event delete failed', err);
       res.status(500).json({ ok: false });
     }
   });

--- a/bot/src/http/server.js
+++ b/bot/src/http/server.js
@@ -14,7 +14,7 @@ function start(config, db, discord, logger) {
       res.setHeader('Access-Control-Allow-Origin', origin);
       res.setHeader('Vary', 'Origin');
       res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Api-Key');
-      res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+      res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');
     }
     if (req.method === 'OPTIONS') {
       return res.sendStatus(200);


### PR DESCRIPTION
## Summary
- Add helper to send or edit Discord embeds and broadcast updates
- Support creating, updating, and canceling events through new /api/events routes
- Extend database and server CORS to handle event lifecycle

## Testing
- `npm test --prefix bot` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68955d8b172c83288469de79623731a9