### PR TITLE
feat: add officer role check endpoint

### DIFF
--- a/bot/src/db.js
+++ b/bot/src/db.js
@@ -49,6 +49,10 @@ async function init(config) {
     is_admin BOOLEAN DEFAULT FALSE,
     FOREIGN KEY (user_id) REFERENCES users(id)
   )`);
+
+  await pool.query(`CREATE TABLE IF NOT EXISTS officer_roles (
+    role_id VARCHAR(255) PRIMARY KEY
+  )`);
 }
 
 async function query(sql, params) {
@@ -153,6 +157,11 @@ async function getApiKey(key) {
   );
 }
 
+async function getOfficerRoles() {
+  const rows = await query('SELECT role_id FROM officer_roles');
+  return rows.map(r => r.role_id);
+}
+
 module.exports = {
   init,
   query,
@@ -172,6 +181,7 @@ module.exports = {
   getEvents,
   getEvent,
   updateEvent,
-  getApiKey
+  getApiKey,
+  getOfficerRoles
 };
 

--- a/bot/src/http/routes/me.js
+++ b/bot/src/http/routes/me.js
@@ -1,11 +1,32 @@
 const express = require('express');
 
-module.exports = () => {
+module.exports = ({ db, discord }) => {
   const router = express.Router();
+  const client = discord.getClient();
 
   router.get('/', (req, res) => {
     const info = req.apiKey || {};
     res.json({ userId: info.userId, isAdmin: !!info.isAdmin });
+  });
+
+  router.get('/roles', async (req, res) => {
+    const { userId } = req.query;
+    if (!userId) {
+      return res.status(400).json({ error: 'Missing userId' });
+    }
+    try {
+      const guild = client.guilds.cache.first();
+      if (!guild) {
+        return res.status(500).json({ hasOfficerRole: false });
+      }
+      const member = await guild.members.fetch(userId);
+      const roles = Array.from(member.roles.cache.keys());
+      const officerRoles = await db.getOfficerRoles();
+      const hasOfficerRole = roles.some(r => officerRoles.includes(r));
+      res.json({ hasOfficerRole });
+    } catch (err) {
+      res.status(500).json({ hasOfficerRole: false });
+    }
   });
 
   return router;

--- a/bot/src/http/server.js
+++ b/bot/src/http/server.js
@@ -66,7 +66,7 @@ function start(config, db, discord, logger) {
   app.use('/api/messages', messages({ db, discord, logger }));
   app.use('/api/embeds', embeds({ discord }));
   app.use('/api/events', events({ db, discord, logger }));
-  app.use('/api/me', me());
+  app.use('/api/me', me({ db, discord }));
   app.use('/api/admin/setup', adminSetup({ db, discord }));
 
   const server = http.createServer(app);


### PR DESCRIPTION
## Summary
- add `/api/me/roles` endpoint to verify if a user holds an officer role
- store officer role IDs in new `officer_roles` table

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6895631c5a708328bebc02a91d47ee22