### PR TITLE
doc: clarify environment setup and admin endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,35 @@ DemiCat/
 - A Discord bot token and Apollo-managed channels
 - FFXIV with the [Dalamud](https://github.com/goatcorp/Dalamud) plugin framework
 
+## Environment Variables
+
+Copy `bot/.env.example` to `bot/.env` and fill in the required values.
+
+- `DISCORD_TOKEN` – Discord bot token
+- `DISCORD_APOLLO_BOT_ID` – Apollo bot ID used for event embeds
+- `PORT` – HTTP server port (defaults to 3000)
+- `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME` – MySQL connection settings
+
 ## Setup
 
 ### 1. Configure the bot
-```
+```bash
 cd bot
-npm install
-npm start
+cp .env.example .env
+npm i
+node src/index.js
 ```
-On first run you will be prompted for the Discord bot credentials and MySQL connection details. They are stored in `bot/.env`.
 
 ### 2. Configure the Dalamud plugin
 Update `dalamud-plugin/manifest.json` with the usual plugin metadata. In-game, open the plugin configuration and set the **Helper Base URL** if needed (defaults to `http://localhost:3000`).
+
+### 3. Insert API keys
+Insert API keys into the `api_keys` table to authorize HTTP requests:
+
+```sql
+INSERT INTO api_keys (api_key, user_id, is_admin) VALUES ('your-api-key', 'discord-user-id', 1);
+```
+Use the value from `api_key` as the `X-Api-Key` header when calling the REST API.
 
 ## Building and Running
 
@@ -40,6 +57,14 @@ Copy `bin/Debug/net6.0/dalamud-plugin.dll` into your Dalamud plugins folder and 
 ## Usage
 
 With the bot running and the plugin enabled, open the in-game **Events** window to view live Apollo embeds. Players can click the RSVP buttons to respond directly from FFXIV.
+
+## Admin Setup Endpoints
+
+The bot exposes setup endpoints for configuring Discord channels. All requests require an admin `X-Api-Key` header.
+
+- `POST /api/admin/setup`
+  - **Body:** `{ "channelId": "123", "type": "event" | "chat" }`
+  - Registers a Discord channel as an event or chat channel.
 
 ## Extensibility
 

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,0 +1,7 @@
+DISCORD_TOKEN=your_discord_token
+DISCORD_APOLLO_BOT_ID=apollo_bot_id
+PORT=3000
+DB_HOST=localhost
+DB_USER=username
+DB_PASSWORD=password
+DB_NAME=demicat


### PR DESCRIPTION
## Summary
- add example env file for Discord and MySQL settings
- expand README with env vars, API key instructions, run command, and admin setup endpoint docs

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6895637f84c08328af6057e358a0914d