### PR TITLE
Update manifest for Dalamud API 13

### DIFF
--- a/dalamud-plugin/dalamud-plugin.csproj
+++ b/dalamud-plugin/dalamud-plugin.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>DemiCat</AssemblyName>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
     <Description>DemiCat Dalamud plugin.</Description>
     <Authors>DemiCat</Authors>
   </PropertyGroup>

--- a/dalamud-plugin/manifest.json
+++ b/dalamud-plugin/manifest.json
@@ -2,7 +2,8 @@
   "Author": "DemiCat",
   "Name": "DemiCat",
   "InternalName": "DemiCat",
-  "AssemblyVersion": "1.0.0.0",
+  "AssemblyVersion": "1.1.0.0",
   "Description": "DemiCat Dalamud plugin.",
-  "ApplicableVersion": "any"
+  "ApplicableVersion": "any",
+  "DalamudApiLevel": 13
 }


### PR DESCRIPTION
## Summary
- add Dalamud API level 13 support
- bump plugin and assembly versions

## Testing
- `dotnet build dalamud-plugin/dalamud-plugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689899ddfe708328baa689f130ce4e44