### PR TITLE
Use Dalamud ImGui binding in UI

### DIFF
--- a/dalamud-plugin/ChatWindow.cs
+++ b/dalamud-plugin/ChatWindow.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Numerics;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 
 namespace DalamudPlugin;
 

--- a/dalamud-plugin/EventCreateWindow.cs
+++ b/dalamud-plugin/EventCreateWindow.cs
@@ -6,7 +6,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Numerics;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 
 namespace DalamudPlugin;
 

--- a/dalamud-plugin/EventView.cs
+++ b/dalamud-plugin/EventView.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Text.Json;
 using DiscordHelper;
 using Dalamud.Interface.Textures;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 using StbImageSharp;
 
 namespace DalamudPlugin;

--- a/dalamud-plugin/MainWindow.cs
+++ b/dalamud-plugin/MainWindow.cs
@@ -1,5 +1,5 @@
 using System.Numerics;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 
 namespace DalamudPlugin;
 

--- a/dalamud-plugin/SettingsWindow.cs
+++ b/dalamud-plugin/SettingsWindow.cs
@@ -2,7 +2,7 @@ using System;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 
 namespace DalamudPlugin;
 

--- a/dalamud-plugin/UiRenderer.cs
+++ b/dalamud-plugin/UiRenderer.cs
@@ -6,7 +6,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Numerics;
 using DiscordHelper;
-using ImGuiNET;
+using Dalamud.Bindings.ImGui;
 
 namespace DalamudPlugin;
 


### PR DESCRIPTION
## Summary
- switch UI code to use Dalamud.Bindings.ImGui instead of ImGuiNET

## Testing
- `dotnet build` *(fails: Unable to find package Dalamud)*

------
https://chatgpt.com/codex/tasks/task_e_6898ac744ec88328ad02fc961dc20202