### PR TITLE
Refactor EventView texture handling for shared textures

### DIFF
--- a/dalamud-plugin/PluginServices.cs
+++ b/dalamud-plugin/PluginServices.cs
@@ -1,6 +1,7 @@
 using Dalamud.Game.ClientState;
 using Dalamud.IoC;
 using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
 
 namespace DalamudPlugin;
 
@@ -11,4 +12,7 @@ internal static class PluginServices
 
     [PluginService]
     internal static IClientState ClientState { get; private set; } = null!;
+
+    [PluginService]
+    internal static ITextureProvider TextureProvider { get; private set; } = null!;
 }


### PR DESCRIPTION
## Summary
- replace `IDalamudTextureWrap` fields with `ISharedImmediateTexture`
- load textures via `ITextureProvider` and use `.Handle` for ImGui
- adjust dispose logic for shared textures

## Testing
- `dotnet build dalamud-plugin/dalamud-plugin.csproj` *(fails: Unable to find package Dalamud)*

------
https://chatgpt.com/codex/tasks/task_e_6898ae12132c83288aa79c6ad458d55c