### PR TITLE
Ensure Dalamud operations run on the main thread

### DIFF
--- a/dalamud-plugin/PluginServices.cs
+++ b/dalamud-plugin/PluginServices.cs
@@ -15,4 +15,7 @@ internal static class PluginServices
 
     [PluginService]
     internal static ITextureProvider TextureProvider { get; private set; } = null!;
+
+    [PluginService]
+    internal static IFramework Framework { get; private set; } = null!;
 }


### PR DESCRIPTION
## Summary
- capture character name before async network call
- run HttpClient request on a background thread
- schedule config save through Framework.RunOnTick

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6898b0259f58832884270f2bd5de25e9