### PR TITLE
Add interactive channel setup flow and new channel types

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS servers (
 CREATE TABLE IF NOT EXISTS channels (
   id VARCHAR(255) PRIMARY KEY,
   server_id VARCHAR(255),
-  type VARCHAR(32) NOT NULL,
+  type ENUM('event','fc_chat','officer_chat') NOT NULL,
   FOREIGN KEY (server_id) REFERENCES servers(id)
 );
 

--- a/discord-demibot/src/db.js
+++ b/discord-demibot/src/db.js
@@ -26,7 +26,7 @@ async function init(config) {
   await pool.query(`CREATE TABLE IF NOT EXISTS channels (
     id VARCHAR(255) PRIMARY KEY,
     server_id VARCHAR(255),
-    type VARCHAR(32) NOT NULL,
+    type ENUM('event','fc_chat','officer_chat') NOT NULL,
     FOREIGN KEY (server_id) REFERENCES servers(id)
   )`);
 
@@ -110,13 +110,22 @@ async function addEventChannel(channelId) {
   await query('INSERT IGNORE INTO channels (id, type) VALUES (?, ?)', [channelId, 'event']);
 }
 
-async function getChatChannels() {
-  const rows = await query('SELECT id FROM channels WHERE type = ?', ['chat']);
+async function getFcChannels() {
+  const rows = await query('SELECT id FROM channels WHERE type = ?', ['fc_chat']);
   return rows.map(r => r.id);
 }
 
-async function addChatChannel(channelId) {
-  await query('INSERT IGNORE INTO channels (id, type) VALUES (?, ?)', [channelId, 'chat']);
+async function addFcChannel(channelId) {
+  await query('INSERT IGNORE INTO channels (id, type) VALUES (?, ?)', [channelId, 'fc_chat']);
+}
+
+async function getOfficerChannels() {
+  const rows = await query('SELECT id FROM channels WHERE type = ?', ['officer_chat']);
+  return rows.map(r => r.id);
+}
+
+async function addOfficerChannel(channelId) {
+  await query('INSERT IGNORE INTO channels (id, type) VALUES (?, ?)', [channelId, 'officer_chat']);
 }
 
 async function saveEvent(event) {
@@ -175,8 +184,10 @@ module.exports = {
   getUserByKey,
   getEventChannels,
   addEventChannel,
-  getChatChannels,
-  addChatChannel,
+  getFcChannels,
+  addFcChannel,
+  getOfficerChannels,
+  addOfficerChannel,
   saveEvent,
   getEvents,
   getEvent,

--- a/discord-demibot/src/http/routes/admin/setup.js
+++ b/discord-demibot/src/http/routes/admin/setup.js
@@ -17,9 +17,12 @@ module.exports = ({ db, discord }) => {
       if (type === 'event') {
         await db.addEventChannel(channelId);
         discord.trackEventChannel(channelId);
-      } else if (type === 'chat') {
-        await db.addChatChannel(channelId);
-        discord.trackChatChannel(channelId);
+      } else if (type === 'fc_chat') {
+        await db.addFcChannel(channelId);
+        discord.trackFcChannel(channelId);
+      } else if (type === 'officer_chat') {
+        await db.addOfficerChannel(channelId);
+        discord.trackOfficerChannel(channelId);
       } else {
         return res.status(400).json({ error: 'Invalid type' });
       }

--- a/discord-demibot/src/http/routes/channels.js
+++ b/discord-demibot/src/http/routes/channels.js
@@ -5,11 +5,12 @@ module.exports = ({ db, logger }) => {
 
   router.get('/', async (req, res) => {
     try {
-      const [event, chat] = await Promise.all([
+      const [event, fc_chat, officer_chat] = await Promise.all([
         db.getEventChannels(),
-        db.getChatChannels()
+        db.getFcChannels(),
+        db.getOfficerChannels()
       ]);
-      res.json({ event, chat });
+      res.json({ event, fc_chat, officer_chat });
     } catch (err) {
       if (logger) logger.error('Failed to fetch channels', err);
       res.status(500).json({ error: 'Failed to fetch channels' });

--- a/discord-demibot/src/http/routes/messages.js
+++ b/discord-demibot/src/http/routes/messages.js
@@ -33,8 +33,8 @@ module.exports = ({ db, discord, logger }) => {
         hook = await channel.createWebhook({ name: 'DemiCat' });
       }
       await enqueue(() => hook.send({ content, username: displayName }));
-      await db.addChatChannel(channelId);
-      discord.trackChatChannel(channelId);
+      await db.addFcChannel(channelId);
+      discord.trackFcChannel(channelId);
       res.json({ ok: true });
     } catch (err) {
       if (logger) logger.error('Message send failed', err);


### PR DESCRIPTION
## Summary
- Support new channel types `fc_chat` and `officer_chat` in schema and database helpers
- Add multi-step `/setup` flow using select menus to configure event, FC chat, and officer chat channels, including guild-join trigger
- Persist selected channels and expose them via updated admin and public endpoints

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898cd8eec988328b1e687a529b753c1