### PR TITLE
Add database setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ Copy `discord-demibot/.env.example` to `discord-demibot/.env` and fill in the re
 
 ## Setup
 
-### 1. Configure the bot
+### 1. Initialize the database
+```bash
+python database/setup.py
+```
+The script prompts for MySQL host, port, user, and password. It will create a `DemiBot` database and apply `database/schema.sql`. Use `--local` to quickly target a local MySQL server.
+
+### 2. Configure the bot
 ```bash
 cd discord-demibot
 cp .env.example .env
@@ -34,10 +40,10 @@ npm i
 node src/index.js
 ```
 
-### 2. Configure the Dalamud plugin
+### 3. Configure the Dalamud plugin
 Update `DemiCatPlugin/manifest.json` with the usual plugin metadata. In-game, open the plugin configuration and set the **Helper Base URL** if needed (defaults to `http://localhost:3000`).
 
-### 3. Insert API keys
+### 4. Insert API keys
 Insert API keys into the `api_keys` table to authorize HTTP requests:
 
 ```sql

--- a/database/setup.py
+++ b/database/setup.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import argparse
+from getpass import getpass
+from pathlib import Path
+
+try:
+    import mysql.connector as mysql
+    CONNECTOR = 'mysql.connector'
+except ImportError:
+    try:
+        import pymysql as mysql
+        CONNECTOR = 'pymysql'
+    except ImportError:
+        raise SystemExit('Install mysql-connector-python or PyMySQL')
+
+
+def get_connection(host: str, port: int, user: str, password: str):
+    if CONNECTOR == 'mysql.connector':
+        return mysql.connect(host=host, port=port, user=user, password=password)
+    return mysql.connect(host=host, port=port, user=user, password=password)
+
+
+def execute_schema(cursor, schema_path: Path):
+    sql = schema_path.read_text()
+    statements = [s.strip() for s in sql.split(';') if s.strip()]
+    for stmt in statements:
+        cursor.execute(stmt)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Initialize the DemiBot database')
+    parser.add_argument('--local', action='store_true', help='Use localhost with default port 3306')
+    parser.add_argument('--host', help='MySQL host')
+    parser.add_argument('--port', type=int, help='MySQL port')
+    parser.add_argument('--user', help='MySQL user')
+    parser.add_argument('--password', help='MySQL password')
+    parser.add_argument('--schema', default=str(Path(__file__).with_name('schema.sql')), help='Path to schema.sql')
+    args = parser.parse_args()
+
+    host = 'localhost' if args.local else args.host
+    if not host:
+        use_local = input('Use localhost? [Y/n]: ').strip().lower()
+        if use_local in ('', 'y', 'yes'):
+            host = 'localhost'
+        else:
+            host = input('MySQL host: ').strip()
+
+    port = args.port
+    if not port:
+        port_input = input('MySQL port [3306]: ').strip()
+        port = int(port_input) if port_input else 3306
+
+    user = args.user or input('MySQL user: ').strip()
+    password = args.password or getpass('MySQL password: ')
+
+    conn = get_connection(host, port, user, password)
+    cursor = conn.cursor()
+
+    cursor.execute('CREATE DATABASE IF NOT EXISTS DemiBot')
+    conn.commit()
+    cursor.execute('USE DemiBot')
+    conn.commit()
+
+    execute_schema(cursor, Path(args.schema))
+    conn.commit()
+
+    cursor.close()
+    conn.close()
+    print('Database DemiBot initialized.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python helper to create DemiBot database and run schema.sql
- document database initialization in README

## Testing
- `python -m py_compile database/setup.py`
- `cd discord-demibot && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898ce39d57483288581caa68bc26690