### PR TITLE
Add event channel filter and button panel

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -12,5 +12,7 @@ public class Config
 
     public string ChatChannelId { get; set; } = string.Empty;
 
+    public string EventChannelId { get; set; } = string.Empty;
+
     public bool UseCharacterName { get; set; } = false;
 }

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Numerics;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 using DiscordHelper;
 using Dalamud.Interface.Textures;
 using Dalamud.Bindings.ImGui;
@@ -51,6 +52,10 @@ public class EventView : IDisposable
         }
         _dto = dto;
     }
+
+    public string ChannelId => _dto.ChannelId?.ToString() ?? string.Empty;
+
+    public IReadOnlyList<EmbedButtonDto>? Buttons => _dto.Buttons;
 
     public void Draw()
     {
@@ -120,26 +125,27 @@ public class EventView : IDisposable
             ImGui.Text($"Mentions: {string.Join(", ", dto.Mentions)}");
         }
 
-        if (dto.Buttons != null)
+        ImGui.Separator();
+    }
+
+    public void DrawButtons()
+    {
+        if (Buttons != null)
         {
-            foreach (var button in dto.Buttons)
+            foreach (var button in Buttons)
             {
                 var id = button.CustomId ?? button.Label;
-                if (ImGui.Button($"{button.Label}##{id}{dto.Id}"))
+                if (ImGui.Button($"{button.Label}##{id}{_dto.Id}", new Vector2(-1, 0)))
                 {
                     _ = SendInteraction(id);
                 }
-                ImGui.SameLine();
             }
-            ImGui.NewLine();
         }
 
         if (!string.IsNullOrEmpty(_lastResult))
         {
             ImGui.TextUnformatted(_lastResult);
         }
-
-        ImGui.Separator();
     }
 
     private ISharedImmediateTexture? LoadTexture(string? url)
@@ -165,7 +171,7 @@ public class EventView : IDisposable
         }
     }
 
-    private async System.Threading.Tasks.Task SendInteraction(string customId)
+    public async Task SendInteraction(string customId)
     {
         try
         {


### PR DESCRIPTION
## Summary
- add event channel config and selection combo in main window
- filter events by channel and show signup buttons in synced side panel
- expose event button metadata for separate rendering

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Unable to find package Dalamud)*

------
https://chatgpt.com/codex/tasks/task_e_6898cfa41ab883288e849c8838455b6c