### PR TITLE
Add event creation tab and toolbar access

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -18,14 +16,10 @@ public class EventCreateWindow : IDisposable
     private string _title = string.Empty;
     private string _description = string.Empty;
     private string _time = DateTime.UtcNow.ToString("o");
-    private readonly List<string> _channels = new();
-    private int _selectedIndex;
-    private bool _channelsLoaded;
-    private string _channelId = string.Empty;
-    private string _imagePath = string.Empty;
+    private string _imageUrl = string.Empty;
     private string? _lastResult;
 
-    public bool IsOpen;
+    public string ChannelId { private get; set; } = string.Empty;
 
     public EventCreateWindow(Config config)
     {
@@ -34,37 +28,10 @@ public class EventCreateWindow : IDisposable
 
     public void Draw()
     {
-        if (!IsOpen)
-        {
-            return;
-        }
-
-        if (!ImGui.Begin("Create Event", ref IsOpen))
-        {
-            ImGui.End();
-            return;
-        }
-
-        if (!_channelsLoaded)
-        {
-            FetchChannels();
-        }
-
         ImGui.InputText("Title", ref _title, 256);
-        if (_channels.Count > 0)
-        {
-            if (ImGui.Combo("Channel", ref _selectedIndex, _channels.ToArray(), _channels.Count))
-            {
-                _channelId = _channels[_selectedIndex];
-            }
-        }
-        else
-        {
-            ImGui.TextUnformatted("No channels available");
-        }
         ImGui.InputText("Time", ref _time, 64);
         ImGui.InputTextMultiline("Description", ref _description, 4096, new Vector2(400, 100));
-        ImGui.InputText("Image Path", ref _imagePath, 260);
+        ImGui.InputText("Image URL", ref _imageUrl, 260);
         if (ImGui.Button("Create"))
         {
             CreateEvent();
@@ -74,28 +41,19 @@ public class EventCreateWindow : IDisposable
         {
             ImGui.TextUnformatted(_lastResult);
         }
-
-        ImGui.End();
     }
 
     private async void CreateEvent()
     {
         try
         {
-            string? imageBase64 = null;
-            if (!string.IsNullOrEmpty(_imagePath) && File.Exists(_imagePath))
-            {
-                var bytes = await File.ReadAllBytesAsync(_imagePath);
-                imageBase64 = Convert.ToBase64String(bytes);
-            }
-
             var body = new
             {
-                channelId = _channelId,
+                channelId = ChannelId,
                 title = _title,
                 time = _time,
                 description = _description,
-                imageBase64
+                imageUrl = string.IsNullOrWhiteSpace(_imageUrl) ? null : _imageUrl
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/events");
@@ -117,36 +75,5 @@ public class EventCreateWindow : IDisposable
     public void Dispose()
     {
         _httpClient.Dispose();
-    }
-
-    private async void FetchChannels()
-    {
-        _channelsLoaded = true;
-        try
-        {
-            var response = await _httpClient.GetAsync($"{_config.HelperBaseUrl.TrimEnd('/')}/channels");
-            if (!response.IsSuccessStatusCode)
-            {
-                return;
-            }
-            var stream = await response.Content.ReadAsStreamAsync();
-            var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
-            _channels.Clear();
-            _channels.AddRange(dto.Event);
-            if (_channels.Count > 0)
-            {
-                _channelId = _channels[_selectedIndex];
-            }
-        }
-        catch
-        {
-            // ignored
-        }
-    }
-
-    private class ChannelListDto
-    {
-        public List<string> Event { get; set; } = new();
-        public List<string> Chat { get; set; } = new();
     }
 }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -12,6 +12,7 @@ public class MainWindow
     private readonly UiRenderer _ui;
     private readonly ChatWindow _chat;
     private readonly SettingsWindow _settings;
+    private readonly EventCreateWindow _create;
     private readonly HttpClient _httpClient = new();
     private readonly List<string> _channels = new();
     private bool _channelsLoaded;
@@ -26,9 +27,10 @@ public class MainWindow
         _ui = ui;
         _chat = chat;
         _settings = settings;
+        _create = new EventCreateWindow(config);
         _channelId = config.EventChannelId;
-        IsOpen = true;
         _ui.ChannelId = _channelId;
+        _create.ChannelId = _channelId;
     }
 
     public void Draw()
@@ -77,6 +79,7 @@ public class MainWindow
                 SaveConfig();
                 _ui.ChannelId = _channelId;
                 _ui.RefreshEmbeds();
+                _create.ChannelId = _channelId;
             }
         }
         else
@@ -99,6 +102,13 @@ public class MainWindow
             if (ImGui.BeginTabItem("Chat"))
             {
                 _chat.Draw();
+                ImGui.EndTabItem();
+            }
+
+            if (ImGui.BeginTabItem("Create"))
+            {
+                _create.ChannelId = _channelId;
+                _create.Draw();
                 ImGui.EndTabItem();
             }
 
@@ -138,6 +148,7 @@ public class MainWindow
             {
                 _channelId = _channels[_selectedIndex];
                 _ui.ChannelId = _channelId;
+                _create.ChannelId = _channelId;
             }
         }
         catch

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -21,7 +21,6 @@ public class Plugin : IDalamudPlugin
 
     private readonly UiRenderer _ui;
     private readonly SettingsWindow _settings;
-    private readonly EventCreateWindow _createWindow;
     private readonly ChatWindow _chatWindow;
     private readonly MainWindow _mainWindow;
     private Config _config;
@@ -41,9 +40,8 @@ public class Plugin : IDalamudPlugin
 
         _ui = new UiRenderer(_config);
         _settings = new SettingsWindow(_config);
-        _createWindow = new EventCreateWindow(_config) { IsOpen = true };
         _chatWindow = new ChatWindow(_config);
-        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _settings) { IsOpen = true };
+        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _settings);
 
         _timer = new System.Timers.Timer(_config.PollIntervalSeconds * 1000);
         _timer.Elapsed += OnPollTimer;
@@ -56,7 +54,8 @@ public class Plugin : IDalamudPlugin
 
         _uiBuilder.Draw += _mainWindow.Draw;
         _uiBuilder.Draw += _settings.Draw;
-        _uiBuilder.Draw += _createWindow.Draw;
+        _uiBuilder.OpenMainUi += () => _mainWindow.IsOpen = true;
+        _uiBuilder.OpenConfigUi += () => _settings.IsOpen = true;
     }
 
     private async void OnPollTimer(object? sender, ElapsedEventArgs e)
@@ -180,7 +179,6 @@ public class Plugin : IDalamudPlugin
     {
         _uiBuilder.Draw -= _mainWindow.Draw;
         _uiBuilder.Draw -= _settings.Draw;
-        _uiBuilder.Draw -= _createWindow.Draw;
         _timer.Stop();
         _timer.Dispose();
         if (_webSocket != null)
@@ -201,7 +199,6 @@ public class Plugin : IDalamudPlugin
         _httpClient.Dispose();
         _ui.Dispose();
         _settings.Dispose();
-        _createWindow.Dispose();
         _chatWindow.Dispose();
     }
 }


### PR DESCRIPTION
## Summary
- integrate event creation UI into main window as new "Create" tab
- support title, time, description, and optional image URL when posting events
- expose toolbar handlers instead of auto-opening windows

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6898d2ab08848328836937f50e8e499b