### PR TITLE
Add FC chat window with user list and mentions

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -12,16 +12,16 @@ namespace DemiCatPlugin;
 
 public class ChatWindow : IDisposable
 {
-    private readonly Config _config;
-    private readonly HttpClient _httpClient = new();
-    private readonly List<ChatMessageDto> _messages = new();
-    private readonly List<string> _channels = new();
-    private int _selectedIndex;
-    private bool _channelsLoaded;
-    private string _channelId;
-    private string _input = string.Empty;
-    private bool _useCharacterName;
-    private DateTime _lastFetch = DateTime.MinValue;
+    protected readonly Config _config;
+    protected readonly HttpClient _httpClient = new();
+    protected readonly List<ChatMessageDto> _messages = new();
+    protected readonly List<string> _channels = new();
+    protected int _selectedIndex;
+    protected bool _channelsLoaded;
+    protected string _channelId;
+    protected string _input = string.Empty;
+    protected bool _useCharacterName;
+    protected DateTime _lastFetch = DateTime.MinValue;
 
     public ChatWindow(Config config)
     {
@@ -30,7 +30,7 @@ public class ChatWindow : IDisposable
         _useCharacterName = config.UseCharacterName;
     }
 
-    public void Draw()
+    public virtual void Draw()
     {
         if (!_channelsLoaded)
         {
@@ -78,7 +78,7 @@ public class ChatWindow : IDisposable
 
     }
 
-    private string FormatContent(ChatMessageDto msg)
+    protected string FormatContent(ChatMessageDto msg)
     {
         var text = msg.Content;
         if (msg.Mentions != null)
@@ -92,7 +92,7 @@ public class ChatWindow : IDisposable
         return text;
     }
 
-    private async void SendMessage()
+    protected virtual async void SendMessage()
     {
         if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
         {
@@ -192,7 +192,7 @@ public class ChatWindow : IDisposable
         }
     }
 
-    private class ChatMessageDto
+    protected class ChatMessageDto
     {
         public string Id { get; set; } = string.Empty;
         public string ChannelId { get; set; } = string.Empty;
@@ -201,13 +201,13 @@ public class ChatWindow : IDisposable
         public List<MentionDto>? Mentions { get; set; }
     }
 
-    private class MentionDto
+    protected class MentionDto
     {
         public string Id { get; set; } = string.Empty;
         public string Name { get; set; } = string.Empty;
     }
 
-    private class ChannelListDto
+    protected class ChannelListDto
     {
         public List<string> Event { get; set; } = new();
         public List<string> Chat { get; set; } = new();

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -14,5 +14,11 @@ public class Config
 
     public string EventChannelId { get; set; } = string.Empty;
 
+    public string FcChannelId { get; set; } = string.Empty;
+
+    public string FcChannelName { get; set; } = string.Empty;
+
+    public bool EnableFcChat { get; set; } = false;
+
     public bool UseCharacterName { get; set; } = false;
 }

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
+
+namespace DemiCatPlugin;
+
+public class FcChatWindow : ChatWindow
+{
+    private readonly List<UserDto> _users = new();
+    private DateTime _lastUserFetch = DateTime.MinValue;
+    private readonly string _channelName;
+
+    public FcChatWindow(Config config) : base(config)
+    {
+        _channelId = config.FcChannelId;
+        _channelName = string.IsNullOrEmpty(config.FcChannelName) ? config.FcChannelId : config.FcChannelName;
+    }
+
+    public override void Draw()
+    {
+        if (string.IsNullOrEmpty(_channelId))
+        {
+            ImGui.TextUnformatted("No FC channel configured");
+            return;
+        }
+
+        if (DateTime.UtcNow - _lastFetch > TimeSpan.FromSeconds(_config.PollIntervalSeconds))
+        {
+            RefreshMessages();
+        }
+
+        if (DateTime.UtcNow - _lastUserFetch > TimeSpan.FromSeconds(_config.PollIntervalSeconds))
+        {
+            RefreshUsers();
+        }
+
+        ImGui.TextUnformatted($"Channel: #{_channelName}");
+
+        ImGui.BeginChild("##chatScroll", new Vector2(-150, -30), true);
+        foreach (var msg in _messages)
+        {
+            ImGui.TextWrapped($"{msg.AuthorName}: {FormatContent(msg)}");
+        }
+        ImGui.EndChild();
+
+        ImGui.SameLine();
+
+        ImGui.BeginChild("##userList", new Vector2(150, -30), true);
+        foreach (var user in _users)
+        {
+            if (ImGui.Selectable(user.Name))
+            {
+                _input += $"@{user.Name} ";
+            }
+        }
+        ImGui.EndChild();
+
+        var send = ImGui.InputText("##chatInput", ref _input, 512, ImGuiInputTextFlags.EnterReturnsTrue);
+        ImGui.SameLine();
+        if (ImGui.Button("Send") || send)
+        {
+            SendMessage();
+        }
+    }
+
+    protected override async void SendMessage()
+    {
+        if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
+        {
+            return;
+        }
+
+        var content = _input;
+        foreach (var u in _users)
+        {
+            content = Regex.Replace(content, $"@{Regex.Escape(u.Name)}\\b", $"<@{u.Id}>");
+        }
+
+        try
+        {
+            var body = new { channelId = _channelId, content, useCharacterName = _useCharacterName };
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/messages");
+            request.Content = new StringContent(JsonSerializer.Serialize(body), System.Text.Encoding.UTF8, "application/json");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AuthToken);
+            }
+            var response = await _httpClient.SendAsync(request);
+            if (response.IsSuccessStatusCode)
+            {
+                _input = string.Empty;
+                RefreshMessages();
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    private async void RefreshUsers()
+    {
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.HelperBaseUrl.TrimEnd('/')}/users");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AuthToken);
+            }
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                return;
+            }
+            var stream = await response.Content.ReadAsStreamAsync();
+            var users = await JsonSerializer.DeserializeAsync<List<UserDto>>(stream) ?? new List<UserDto>();
+            _users.Clear();
+            _users.AddRange(users);
+            _lastUserFetch = DateTime.UtcNow;
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    private class UserDto
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+    }
+}
+

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -10,7 +10,7 @@ public class MainWindow
 {
     private readonly Config _config;
     private readonly UiRenderer _ui;
-    private readonly ChatWindow _chat;
+    private readonly ChatWindow? _chat;
     private readonly SettingsWindow _settings;
     private readonly EventCreateWindow _create;
     private readonly HttpClient _httpClient = new();
@@ -21,7 +21,7 @@ public class MainWindow
 
     public bool IsOpen;
 
-    public MainWindow(Config config, UiRenderer ui, ChatWindow chat, SettingsWindow settings)
+    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, SettingsWindow settings)
     {
         _config = config;
         _ui = ui;
@@ -99,7 +99,7 @@ public class MainWindow
                 ImGui.EndTabItem();
             }
 
-            if (ImGui.BeginTabItem("Chat"))
+            if (_chat != null && ImGui.BeginTabItem("Chat"))
             {
                 _chat.Draw();
                 ImGui.EndTabItem();

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -21,7 +21,7 @@ public class Plugin : IDalamudPlugin
 
     private readonly UiRenderer _ui;
     private readonly SettingsWindow _settings;
-    private readonly ChatWindow _chatWindow;
+    private readonly ChatWindow? _chatWindow;
     private readonly MainWindow _mainWindow;
     private Config _config;
     private readonly System.Timers.Timer _timer;
@@ -40,7 +40,7 @@ public class Plugin : IDalamudPlugin
 
         _ui = new UiRenderer(_config);
         _settings = new SettingsWindow(_config);
-        _chatWindow = new ChatWindow(_config);
+        _chatWindow = _config.EnableFcChat ? new FcChatWindow(_config) : null;
         _mainWindow = new MainWindow(_config, _ui, _chatWindow, _settings);
 
         _timer = new System.Timers.Timer(_config.PollIntervalSeconds * 1000);
@@ -197,6 +197,7 @@ public class Plugin : IDalamudPlugin
             _webSocket.Dispose();
         }
         _httpClient.Dispose();
+        _chatWindow?.Dispose();
         _ui.Dispose();
         _settings.Dispose();
         _chatWindow.Dispose();

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -39,6 +39,13 @@ public class SettingsWindow : IDisposable
             ValidateKey();
         }
 
+        var fc = _config.EnableFcChat;
+        if (ImGui.Checkbox("Enable FC Chat", ref fc))
+        {
+            _config.EnableFcChat = fc;
+            SaveConfig();
+        }
+
         ImGui.End();
     }
 

--- a/discord-demibot/src/discord/index.js
+++ b/discord-demibot/src/discord/index.js
@@ -56,6 +56,19 @@ function mapMessage(message) {
   };
 }
 
+function listOnlineUsers() {
+  if (!client) return [];
+  const users = [];
+  client.guilds.cache.forEach(guild => {
+    guild.members.cache.forEach(member => {
+      if (member.presence?.status === 'online') {
+        users.push({ id: member.user.id, name: member.user.username });
+      }
+    });
+  });
+  return users;
+}
+
 async function fetchInitialEmbeds(client, logger) {
   for (const channelId of eventChannels) {
     try {
@@ -146,7 +159,7 @@ async function registerCommands(clientId, logger) {
 
 async function init(config, db, logger) {
   apolloBotId = config.discord.apolloBotId;
-  client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent] });
+  client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent, GatewayIntentBits.GuildMembers, GatewayIntentBits.GuildPresences] });
   const token = config.discord.token;
   const clientId = config.discord.clientId;
   if (!token || !clientId) {
@@ -262,6 +275,7 @@ module.exports = {
   getClient: () => client,
   trackEventChannel,
   trackFcChannel,
-  trackOfficerChannel
+  trackOfficerChannel,
+  listOnlineUsers
 };
 

--- a/discord-demibot/src/http/routes/users.js
+++ b/discord-demibot/src/http/routes/users.js
@@ -1,0 +1,13 @@
+const express = require('express');
+
+module.exports = ({ discord }) => {
+  const router = express.Router();
+
+  router.get('/', (req, res) => {
+    const users = discord.listOnlineUsers();
+    res.json(users);
+  });
+
+  return router;
+};
+

--- a/discord-demibot/src/http/server.js
+++ b/discord-demibot/src/http/server.js
@@ -61,13 +61,15 @@ function start(config, db, discord, logger) {
   const events = require('./routes/events');
   const me = require('./routes/me');
   const adminSetup = require('./routes/admin/setup');
+  const users = require('./routes/users');
 
-  app.use('/api/channels', channels({ db, logger }));
+  app.use('/api/channels', channels({ db, discord, logger }));
   app.use('/api/messages', messages({ db, discord, logger }));
   app.use('/api/embeds', embeds({ discord }));
   app.use('/api/events', events({ db, discord, logger }));
   app.use('/api/me', me({ db, discord }));
   app.use('/api/admin/setup', adminSetup({ db, discord }));
+  app.use('/api/users', users({ discord }));
 
   const server = http.createServer(app);
 


### PR DESCRIPTION
## Summary
- extend config and settings to enable FC chat feature
- add FcChatWindow showing channel name, online users and mention support
- expose online users via new `/api/users` endpoint and support Discord presence intents

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -warnaserror` *(fails: command not found)*
- `sudo apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898d48c971083288aca7b1e16b2a20f