### PR TITLE
Add server sync key support

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -10,6 +10,8 @@ public class Config
 
     public string? AuthToken { get; set; }
 
+    public string SyncKey { get; set; } = string.Empty;
+
     public string ChatChannelId { get; set; } = string.Empty;
 
     public string EventChannelId { get; set; } = string.Empty;

--- a/discord-demibot/src/discord/index.js
+++ b/discord-demibot/src/discord/index.js
@@ -190,11 +190,15 @@ async function init(config, db, logger) {
         await enqueue(() => interaction.reply({ content: 'Create event command received', ephemeral: true }));
       } else if (interaction.commandName === 'generatekey') {
         const key = crypto.randomBytes(16).toString('hex');
-        await db.setKey(interaction.user.id, key);
+        const guildId = interaction.guildId;
+        await db.setKey(interaction.user.id, key, guildId);
         await enqueue(() => interaction.reply({ content: 'Sent you a DM with your key!', ephemeral: true }));
         const embed = {
           title: 'DemiCat Link Key',
-          description: key
+          fields: [
+            { name: 'Key', value: key },
+            { name: 'Sync Key', value: guildId }
+          ]
         };
         try {
           await enqueue(() => interaction.user.send({ embeds: [embed] }));

--- a/discord-demibot/src/http/routes/me.js
+++ b/discord-demibot/src/http/routes/me.js
@@ -10,16 +10,17 @@ module.exports = ({ db, discord }) => {
   });
 
   router.get('/roles', async (req, res) => {
-    const { userId } = req.query;
-    if (!userId) {
-      return res.status(400).json({ error: 'Missing userId' });
+    const { syncKey } = req.query;
+    const info = req.apiKey;
+    if (!syncKey || syncKey !== info.serverId) {
+      return res.status(403).json({ hasOfficerRole: false });
     }
     try {
-      const guild = client.guilds.cache.first();
+      const guild = client.guilds.cache.get(syncKey);
       if (!guild) {
         return res.status(500).json({ hasOfficerRole: false });
       }
-      const member = await guild.members.fetch(userId);
+      const member = await guild.members.fetch(info.userId);
       const roles = Array.from(member.roles.cache.keys());
       const officerRoles = await db.getOfficerRoles();
       const hasOfficerRole = roles.some(r => officerRoles.includes(r));


### PR DESCRIPTION
## Summary
- Associate generated keys with their Discord guild and DM sync key with link key
- Track server IDs in database and API to scope messages, events, and role checks
- Surface sync key in plugin settings and include it in role verification

## Testing
- `npm test` *(fails: Error: no test specified)*
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6898d89d074083289e44db532ac5049a