### PR TITLE
Register additional DemiBot slash commands

### DIFF
--- a/discord-demibot/src/discord/index.js
+++ b/discord-demibot/src/discord/index.js
@@ -145,7 +145,13 @@ const commands = [
   { name: 'link', description: 'Link your account' },
   { name: 'createevent', description: 'Create an event' },
   { name: 'generatekey', description: 'Generate a key for DemiCat' },
-  { name: 'setup', description: 'Configure DemiCat channels' }
+  { name: 'setup', description: 'Configure DemiCat channels' },
+  { name: 'demibot_setup', description: 'Set up DemiBot in this server' },
+  { name: 'demibot_resync', description: 'Resync DemiBot data' },
+  { name: 'demibot_embed', description: 'Create a DemiBot embed' },
+  { name: 'demibot_reset', description: 'Reset DemiBot data' },
+  { name: 'demibot_settings', description: 'View or change DemiBot settings' },
+  { name: 'demibot_clear', description: 'Clear DemiBot configuration' }
 ];
 
 async function registerCommands(clientId, logger) {


### PR DESCRIPTION
## Summary
- extend Discord command registration with demibot_setup, demibot_resync, demibot_embed, demibot_reset, demibot_settings, and demibot_clear

## Testing
- `npm test` (fails: no test specified)
- `node - <<EOF ... EOF` to invoke registration logic (fails: ENETUNREACH contacting Discord)


------
https://chatgpt.com/codex/tasks/task_e_6898ece7891483289246d6aa272b21ea