### PR TITLE
Extend DemiBot setup wizard with persistent guild config

### DIFF
--- a/discord-demibot/src/http/routes/admin/setup.js
+++ b/discord-demibot/src/http/routes/admin/setup.js
@@ -14,14 +14,18 @@ module.exports = ({ db, discord }) => {
       if (!channel || !channel.isTextBased()) {
         return res.status(400).json({ error: 'Invalid channel' });
       }
+      const guildId = req.apiKey.serverId;
       if (type === 'event') {
-        await db.addEventChannel(channelId);
+        const settings = await db.getServerSettings(guildId);
+        const events = new Set(settings.eventChannels || []);
+        events.add(channelId);
+        await db.setServerSettings(guildId, { eventChannels: Array.from(events) });
         discord.trackEventChannel(channelId);
       } else if (type === 'fc_chat') {
-        await db.addFcChannel(channelId);
+        await db.setServerSettings(guildId, { fcChatChannel: channelId });
         discord.trackFcChannel(channelId);
       } else if (type === 'officer_chat') {
-        await db.addOfficerChannel(channelId);
+        await db.setServerSettings(guildId, { officerChatChannel: channelId });
         discord.trackOfficerChannel(channelId);
       } else {
         return res.status(400).json({ error: 'Invalid type' });

--- a/discord-demibot/src/http/routes/channels.js
+++ b/discord-demibot/src/http/routes/channels.js
@@ -5,11 +5,11 @@ module.exports = ({ db, logger }) => {
 
   router.get('/', async (req, res) => {
     try {
-      const [event, fc_chat, officer_chat] = await Promise.all([
-        db.getEventChannels(),
-        db.getFcChannels(),
-        db.getOfficerChannels()
-      ]);
+      const serverId = req.apiKey.serverId;
+      const settings = await db.getServerSettings(serverId);
+      const event = settings.eventChannels || [];
+      const fc_chat = settings.fcChatChannel ? [settings.fcChatChannel] : [];
+      const officer_chat = settings.officerChatChannel ? [settings.officerChatChannel] : [];
       res.json({ event, fc_chat, officer_chat });
     } catch (err) {
       if (logger) logger.error('Failed to fetch channels', err);

--- a/discord-demibot/src/http/routes/events.js
+++ b/discord-demibot/src/http/routes/events.js
@@ -41,7 +41,10 @@ module.exports = ({ db, discord, logger }) => {
       const embed = buildEmbed({ title, description, time, color, url, fields, thumbnailUrl, authorName, authorIconUrl }, info, { image: !!imageBase64 });
       const files = imageBase64 ? [{ attachment: Buffer.from(imageBase64, 'base64'), name: 'image.png' }] : [];
       const message = await send.send(channelId, embed, files);
-      await db.addEventChannel(channelId);
+      const settings = await db.getServerSettings(info.serverId);
+      const events = new Set(settings.eventChannels || []);
+      events.add(channelId);
+      await db.setServerSettings(info.serverId, { eventChannels: Array.from(events) });
       discord.trackEventChannel(channelId);
       const id = await db.saveEvent({
         userId: info.userId,

--- a/discord-demibot/src/http/routes/me.js
+++ b/discord-demibot/src/http/routes/me.js
@@ -22,7 +22,7 @@ module.exports = ({ db, discord }) => {
       }
       const member = await guild.members.fetch(userId);
       const roles = Array.from(member.roles.cache.keys());
-      const officerRoles = await db.getOfficerRoles();
+      const officerRoles = await db.getOfficerRoles(info.serverId);
       const hasOfficerRole = roles.some(r => officerRoles.includes(r));
       res.json({ hasOfficerRole });
     } catch (err) {

--- a/discord-demibot/src/http/routes/messages.js
+++ b/discord-demibot/src/http/routes/messages.js
@@ -42,7 +42,7 @@ module.exports = ({ db, discord, logger }) => {
         hook = await channel.createWebhook({ name: 'DemiCat' });
       }
       await enqueue(() => hook.send({ content, username: displayName }));
-      await db.addFcChannel(channelId);
+      await db.setServerSettings(info.serverId, { fcChatChannel: channelId });
       discord.trackFcChannel(channelId);
       res.json({ ok: true });
     } catch (err) {

--- a/discord-demibot/src/http/routes/officerMessages.js
+++ b/discord-demibot/src/http/routes/officerMessages.js
@@ -42,7 +42,7 @@ module.exports = ({ db, discord, logger }) => {
         hook = await channel.createWebhook({ name: 'DemiCat' });
       }
       await enqueue(() => hook.send({ content, username: displayName }));
-      await db.addOfficerChannel(channelId);
+      await db.setServerSettings(info.serverId, { officerChatChannel: channelId });
       discord.trackOfficerChannel(channelId);
       res.json({ ok: true });
     } catch (err) {


### PR DESCRIPTION
## Summary
- Replace legacy setup command with **/demibot_setup**
- Add wizard steps for event, FC chat, officer chat channels, and officer roles
- Persist guild configuration using new database helpers

## Testing
- `npm test` (fails: Error: no test specified)
- `dotnet build DemiCatPlugin` (fails: command not found: dotnet)


------
https://chatgpt.com/codex/tasks/task_e_6898f792dfe48328a7b9b339e5e968e2