### PR TITLE
Add interactive key generation embed for DemiBot

### DIFF
--- a/discord-demibot/src/db.js
+++ b/discord-demibot/src/db.js
@@ -118,6 +118,11 @@ async function setKey(userId, key, serverId) {
   );
 }
 
+async function getKey(userId) {
+  const row = await one('SELECT `key` FROM users WHERE id = ?', [userId]);
+  return row ? row.key : null;
+}
+
 async function setCharacter(userId, character) {
   await query(
     'INSERT INTO users (id, character) VALUES (?, ?) ON DUPLICATE KEY UPDATE character = VALUES(character)',
@@ -278,6 +283,7 @@ module.exports = {
     return pool;
   },
   setKey,
+  getKey,
   setCharacter,
   getUserByKey,
   getEventChannels,


### PR DESCRIPTION
## Summary
- add `/demibot_embed` command that sends a key generation embed
- handle button interactions to generate or show keys
- store and fetch keys via new `getKey` DB helper

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899027ffb548328828a1bd3bad632c0