### PR TITLE
Add server owner command to purge guild data

### DIFF
--- a/discord-demibot/src/discord/index.js
+++ b/discord-demibot/src/discord/index.js
@@ -297,6 +297,15 @@ async function init(config, db, logger) {
         clearGuildCache(interaction.guild);
         await startDemibotSetupInteraction(interaction);
         await interaction.followUp({ content: 'DemiBot data reset.', ephemeral: true });
+      } else if (interaction.commandName === 'demibot_clear') {
+        const isOwner = interaction.guild.ownerId === interaction.user.id;
+        if (!isOwner) {
+          await enqueue(() => interaction.reply({ content: 'This command is restricted to the server owner', ephemeral: true }));
+          return;
+        }
+        await db.clearServer(interaction.guildId);
+        clearGuildCache(interaction.guild);
+        await enqueue(() => interaction.reply({ content: 'All guild data has been purged.', ephemeral: true }));
       }
     } else if (interaction.isStringSelectMenu()) {
       if (interaction.customId === 'setup_event') {


### PR DESCRIPTION
## Summary
- add server owner-only `demibot_clear` command that purges guild data and replies ephemerally

## Testing
- `cd discord-demibot && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68990cc3bc508328a2ecdb48a1622da9