### PR TITLE
Add sync key validation and role-based tab visibility

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -12,6 +12,10 @@ public class Config
 
     public string SyncKey { get; set; } = string.Empty;
 
+    public string GuildId { get; set; } = string.Empty;
+
+    public string GuildName { get; set; } = string.Empty;
+
     public string ChatChannelId { get; set; } = string.Empty;
 
     public string EventChannelId { get; set; } = string.Empty;

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -22,6 +22,7 @@ public class MainWindow
 
     public bool IsOpen;
     public bool HasOfficerRole { get; set; }
+    public bool HasChatRole { get; set; }
 
     public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings)
     {
@@ -102,7 +103,7 @@ public class MainWindow
                 ImGui.EndTabItem();
             }
 
-            if (_chat != null && ImGui.BeginTabItem("Chat"))
+            if (HasChatRole && _chat != null && ImGui.BeginTabItem("Chat"))
             {
                 _chat.Draw();
                 ImGui.EndTabItem();
@@ -114,7 +115,7 @@ public class MainWindow
                 ImGui.EndTabItem();
             }
 
-            if (ImGui.BeginTabItem("Create"))
+            if (HasOfficerRole && ImGui.BeginTabItem("Create"))
             {
                 _create.ChannelId = _channelId;
                 _create.Draw();

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -243,6 +243,7 @@ public class Plugin : IDalamudPlugin
             PluginServices.Framework.RunOnTick(() =>
             {
                 _mainWindow.HasOfficerRole = roles.HasOfficerRole;
+                _mainWindow.HasChatRole = roles.HasChatRole;
             });
         }
         catch
@@ -259,6 +260,7 @@ public class Plugin : IDalamudPlugin
     private class RolesDto
     {
         public bool HasOfficerRole { get; set; }
+        public bool HasChatRole { get; set; }
     }
 }
 

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 
@@ -40,6 +40,11 @@ public class SettingsWindow : IDisposable
 
         ImGui.InputText("Key", ref _key, 64);
         ImGui.InputText("Sync Key", ref _syncKey, 64);
+        if (ImGui.Button("Connect/Sync"))
+        {
+            ConnectSync();
+        }
+        ImGui.SameLine();
         if (ImGui.Button("Validate"))
         {
             ValidateKey();
@@ -96,6 +101,58 @@ public class SettingsWindow : IDisposable
     public void Dispose()
     {
         _httpClient.Dispose();
+    }
+
+    private async void ConnectSync()
+    {
+        try
+        {
+            var character = PluginServices.ClientState.LocalPlayer?.Name ?? string.Empty;
+            var url = $"{_config.HelperBaseUrl.TrimEnd('/')}/validate";
+            var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new StringContent(
+                    JsonSerializer.Serialize(new { syncKey = _syncKey, characterName = character }),
+                    Encoding.UTF8,
+                    "application/json")
+            };
+
+            var response = await Task.Run(() => _httpClient.SendAsync(request));
+            if (!response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            var stream = await response.Content.ReadAsStreamAsync();
+            var dto = await JsonSerializer.DeserializeAsync<ValidateResponse>(stream) ?? new ValidateResponse();
+
+            PluginServices.Framework.RunOnTick(() =>
+            {
+                _key = dto.UserKey;
+                _config.AuthToken = dto.UserKey;
+                _config.SyncKey = _syncKey;
+                _config.GuildId = dto.Guild?.Id ?? string.Empty;
+                _config.GuildName = dto.Guild?.Name ?? string.Empty;
+                SaveConfig();
+                _refreshRoles();
+            });
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    private class ValidateResponse
+    {
+        [JsonPropertyName("userKey")] public string UserKey { get; set; } = string.Empty;
+        [JsonPropertyName("guild")] public GuildInfo? Guild { get; set; }
+    }
+
+    private class GuildInfo
+    {
+        [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+        [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
     }
 }
 


### PR DESCRIPTION
## Summary
- Add Connect/Sync flow that validates the sync key against the backend and saves user key and guild info
- Persist guild metadata in configuration
- Gate Chat, Officer and Create tabs by roles from backend validation

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899152272fc832897f86bf8e1c08434