### PR TITLE
Remove duplicate chat window dispose call

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -204,7 +204,6 @@ public class Plugin : IDalamudPlugin
         _officerChatWindow.Dispose();
         _ui.Dispose();
         _settings.Dispose();
-        _chatWindow.Dispose();
     }
 
     private async void CheckOfficerRole()


### PR DESCRIPTION
## Summary
- Remove redundant `_chatWindow.Dispose()` invocation in `Plugin.Dispose`

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899207662b88328b898f0d4fe5c0716