### PR TITLE
Prefix RunOnTick calls with discard

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -78,7 +78,7 @@ public class SettingsWindow : IDisposable
 
             if (response.IsSuccessStatusCode)
             {
-                PluginServices.Framework.RunOnTick(() =>
+                _ = PluginServices.Framework.RunOnTick(() =>
                 {
                     _config.AuthToken = _key;
                     _config.SyncKey = _syncKey;
@@ -126,7 +126,7 @@ public class SettingsWindow : IDisposable
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ValidateResponse>(stream) ?? new ValidateResponse();
 
-            PluginServices.Framework.RunOnTick(() =>
+            _ = PluginServices.Framework.RunOnTick(() =>
             {
                 _key = dto.UserKey;
                 _config.AuthToken = dto.UserKey;


### PR DESCRIPTION
## Summary
- avoid unobserved tasks by explicitly discarding RunOnTick results in SettingsWindow

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689922f95ac88328beb27c0cb09df037