### PR TITLE
refactor: remove Task.Run for HTTP requests

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -74,7 +74,7 @@ public class SettingsWindow : IDisposable
                     "application/json")
             };
 
-            var response = await Task.Run(() => _httpClient.SendAsync(request));
+            var response = await _httpClient.SendAsync(request);
 
             if (response.IsSuccessStatusCode)
             {
@@ -117,7 +117,7 @@ public class SettingsWindow : IDisposable
                     "application/json")
             };
 
-            var response = await Task.Run(() => _httpClient.SendAsync(request));
+            var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
                 return;


### PR DESCRIPTION
## Summary
- streamline HTTP requests by removing Task.Run wrappers

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899252d87b08328b30412229b25783d