### PR TITLE
Replace async void with Task

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Numerics;
+using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
@@ -34,7 +35,7 @@ public class ChatWindow : IDisposable
     {
         if (!_channelsLoaded)
         {
-            FetchChannels();
+            _ = FetchChannels();
         }
 
         if (_channels.Count > 0)
@@ -44,7 +45,7 @@ public class ChatWindow : IDisposable
                 _channelId = _channels[_selectedIndex];
                 _config.ChatChannelId = _channelId;
                 SaveConfig();
-                RefreshMessages();
+                _ = RefreshMessages();
             }
         }
         else
@@ -59,7 +60,7 @@ public class ChatWindow : IDisposable
 
         if (DateTime.UtcNow - _lastFetch > TimeSpan.FromSeconds(_config.PollIntervalSeconds))
         {
-            RefreshMessages();
+            _ = RefreshMessages();
         }
 
         ImGui.BeginChild("##chatScroll", new Vector2(0, -30), true);
@@ -73,7 +74,7 @@ public class ChatWindow : IDisposable
         ImGui.SameLine();
         if (ImGui.Button("Send") || send)
         {
-            SendMessage();
+            _ = SendMessage();
         }
 
     }
@@ -92,7 +93,7 @@ public class ChatWindow : IDisposable
         return text;
     }
 
-    protected virtual async void SendMessage()
+    protected virtual async Task SendMessage()
     {
         if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
         {
@@ -112,7 +113,7 @@ public class ChatWindow : IDisposable
             if (response.IsSuccessStatusCode)
             {
                 _input = string.Empty;
-                RefreshMessages();
+                await RefreshMessages();
             }
         }
         catch
@@ -121,7 +122,7 @@ public class ChatWindow : IDisposable
         }
     }
 
-    public async void RefreshMessages()
+    public async Task RefreshMessages()
     {
         if (string.IsNullOrEmpty(_channelId))
         {
@@ -162,7 +163,7 @@ public class ChatWindow : IDisposable
         PluginServices.PluginInterface.SavePluginConfig(_config);
     }
 
-    private async void FetchChannels()
+    private async Task FetchChannels()
     {
         _channelsLoaded = true;
         try

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Numerics;
+using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
@@ -34,7 +35,7 @@ public class EventCreateWindow : IDisposable
         ImGui.InputText("Image URL", ref _imageUrl, 260);
         if (ImGui.Button("Create"))
         {
-            CreateEvent();
+            _ = CreateEvent();
         }
 
         if (!string.IsNullOrEmpty(_lastResult))
@@ -43,7 +44,7 @@ public class EventCreateWindow : IDisposable
         }
     }
 
-    private async void CreateEvent()
+    private async Task CreateEvent()
     {
         try
         {

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -17,7 +17,7 @@ public class EventView : IDisposable
 {
     private readonly Config _config;
     private readonly HttpClient _httpClient;
-    private readonly Action _refresh;
+    private readonly Func<Task> _refresh;
 
     private EmbedDto _dto;
     private ISharedImmediateTexture? _authorIcon;
@@ -25,7 +25,7 @@ public class EventView : IDisposable
     private ISharedImmediateTexture? _image;
     private string? _lastResult;
 
-    public EventView(EmbedDto dto, Config config, HttpClient httpClient, Action refresh)
+    public EventView(EmbedDto dto, Config config, HttpClient httpClient, Func<Task> refresh)
     {
         _config = config;
         _httpClient = httpClient;
@@ -186,7 +186,7 @@ public class EventView : IDisposable
             _lastResult = response.IsSuccessStatusCode ? "Signup updated" : "Signup failed";
             if (response.IsSuccessStatusCode)
             {
-                _refresh();
+                await _refresh();
             }
         }
         catch

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Numerics;
+using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
@@ -31,12 +32,12 @@ public class FcChatWindow : ChatWindow
 
         if (DateTime.UtcNow - _lastFetch > TimeSpan.FromSeconds(_config.PollIntervalSeconds))
         {
-            RefreshMessages();
+            _ = RefreshMessages();
         }
 
         if (DateTime.UtcNow - _lastUserFetch > TimeSpan.FromSeconds(_config.PollIntervalSeconds))
         {
-            RefreshUsers();
+            _ = RefreshUsers();
         }
 
         ImGui.TextUnformatted($"Channel: #{_channelName}");
@@ -64,11 +65,11 @@ public class FcChatWindow : ChatWindow
         ImGui.SameLine();
         if (ImGui.Button("Send") || send)
         {
-            SendMessage();
+            _ = SendMessage();
         }
     }
 
-    protected override async void SendMessage()
+    protected override async Task SendMessage()
     {
         if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
         {
@@ -94,7 +95,7 @@ public class FcChatWindow : ChatWindow
             if (response.IsSuccessStatusCode)
             {
                 _input = string.Empty;
-                RefreshMessages();
+                await RefreshMessages();
             }
         }
         catch
@@ -103,7 +104,7 @@ public class FcChatWindow : ChatWindow
         }
     }
 
-    private async void RefreshUsers()
+    private async Task RefreshUsers()
     {
         try
         {

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
 using System.Numerics;
+using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
@@ -71,7 +72,7 @@ public class MainWindow
         ImGui.BeginChild("ChannelList", new Vector2(150, 0), true);
         if (!_channelsLoaded)
         {
-            FetchChannels();
+            _ = FetchChannels();
         }
         if (_channels.Count > 0)
         {
@@ -82,7 +83,7 @@ public class MainWindow
                 _config.EventChannelId = _channelId;
                 SaveConfig();
                 _ui.ChannelId = _channelId;
-                _ui.RefreshEmbeds();
+                _ = _ui.RefreshEmbeds();
                 _create.ChannelId = _channelId;
             }
         }
@@ -135,7 +136,7 @@ public class MainWindow
         PluginServices.PluginInterface.SavePluginConfig(_config);
     }
 
-    private async void FetchChannels()
+    private async Task FetchChannels()
     {
         _channelsLoaded = true;
         try

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Numerics;
+using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
@@ -32,7 +33,7 @@ public class OfficerChatWindow : ChatWindow
 
         if (DateTime.UtcNow - _lastFetch > TimeSpan.FromSeconds(_config.PollIntervalSeconds))
         {
-            RefreshMessages();
+            _ = RefreshMessages();
         }
 
         ImGui.BeginChild("##chatScroll", new Vector2(0, -30), true);
@@ -46,11 +47,11 @@ public class OfficerChatWindow : ChatWindow
         ImGui.SameLine();
         if (ImGui.Button("Send") || send)
         {
-            SendMessage();
+            _ = SendMessage();
         }
     }
 
-    protected override async void SendMessage()
+    protected override async Task SendMessage()
     {
         if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
         {
@@ -70,7 +71,7 @@ public class OfficerChatWindow : ChatWindow
             if (response.IsSuccessStatusCode)
             {
                 _input = string.Empty;
-                RefreshMessages();
+                await RefreshMessages();
             }
         }
         catch
@@ -79,7 +80,7 @@ public class OfficerChatWindow : ChatWindow
         }
     }
 
-    public new async void RefreshMessages()
+    public new async Task RefreshMessages()
     {
         if (string.IsNullOrEmpty(_channelId))
         {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -52,7 +52,7 @@ public class Plugin : IDalamudPlugin
         if (_config.Enabled)
         {
             _ = ConnectWebSocket();
-            CheckOfficerRole();
+            _ = CheckOfficerRole();
         }
 
         _uiBuilder.Draw += _mainWindow.Draw;
@@ -206,7 +206,7 @@ public class Plugin : IDalamudPlugin
         _settings.Dispose();
     }
 
-    private async void CheckOfficerRole()
+    private async Task CheckOfficerRole()
     {
         if (string.IsNullOrEmpty(_config.AuthToken))
         {

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -14,10 +14,10 @@ public class SettingsWindow : IDisposable
     private readonly HttpClient _httpClient = new();
     private string _key = string.Empty;
     private string _syncKey = string.Empty;
-    private readonly Action _refreshRoles;
+    private readonly Func<Task> _refreshRoles;
     public bool IsOpen;
 
-    public SettingsWindow(Config config, Action refreshRoles)
+    public SettingsWindow(Config config, Func<Task> refreshRoles)
     {
         _config = config;
         _refreshRoles = refreshRoles;
@@ -42,12 +42,12 @@ public class SettingsWindow : IDisposable
         ImGui.InputText("Sync Key", ref _syncKey, 64);
         if (ImGui.Button("Connect/Sync"))
         {
-            ConnectSync();
+            _ = ConnectSync();
         }
         ImGui.SameLine();
         if (ImGui.Button("Validate"))
         {
-            ValidateKey();
+            _ = ValidateKey();
         }
 
         var fc = _config.EnableFcChat;
@@ -60,7 +60,7 @@ public class SettingsWindow : IDisposable
         ImGui.End();
     }
 
-    private async void ValidateKey()
+    private async Task ValidateKey()
     {
         try
         {
@@ -83,7 +83,7 @@ public class SettingsWindow : IDisposable
                     _config.AuthToken = _key;
                     _config.SyncKey = _syncKey;
                     SaveConfig();
-                    _refreshRoles();
+                    _ = _refreshRoles();
                 });
             }
         }
@@ -103,7 +103,7 @@ public class SettingsWindow : IDisposable
         _httpClient.Dispose();
     }
 
-    private async void ConnectSync()
+    private async Task ConnectSync()
     {
         try
         {
@@ -134,7 +134,7 @@ public class SettingsWindow : IDisposable
                 _config.GuildId = dto.Guild?.Id ?? string.Empty;
                 _config.GuildName = dto.Guild?.Name ?? string.Empty;
                 SaveConfig();
-                _refreshRoles();
+                _ = _refreshRoles();
             });
         }
         catch

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Numerics;
+using System.Threading.Tasks;
 using DiscordHelper;
 using Dalamud.Bindings.ImGui;
 
@@ -53,7 +54,7 @@ public class UiRenderer : IDisposable
         }
     }
 
-    public async void RefreshEmbeds()
+    public async Task RefreshEmbeds()
     {
         try
         {


### PR DESCRIPTION
## Summary
- migrate non-event `async void` methods to `async Task`
- update callers to await tasks or explicitly ignore the result
- adjust related callbacks to support async tasks

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899261d536083288a250ac6a0a33b38