### PR TITLE
Add icon URL to plugin manifest

### DIFF
--- a/DemiCatPlugin/manifest.json
+++ b/DemiCatPlugin/manifest.json
@@ -5,5 +5,6 @@
   "AssemblyVersion": "1.1.0.0",
   "Description": "DemiCat Dalamud plugin.",
   "ApplicableVersion": "any",
-  "DalamudApiLevel": 13
+  "DalamudApiLevel": 13,
+  "IconUrl": "https://cdn.discordapp.com/attachments/1337791050294755380/1337854067560550422/Demi_Bot_Logo.png?ex=689a37b1&is=6898e631&hm=1b96e426ca9dcd7f80395ecc7ca274e7ee71cee19c6bae73d20954fc13f6ce95&"
 }


### PR DESCRIPTION
## Summary
- add IconUrl to manifest so installer can fetch and display plugin thumbnail

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68992669c44083289878246de6b42202