### PR TITLE
Align environment variables and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ DemiCat/
 
 ## Environment Variables
 
-Copy `discord-demibot/.env.example` to `discord-demibot/.env` and fill in the required values.
+Copy `discord-demibot/.env.example` to `discord-demibot/.env` and fill in each value.
 
-- `DISCORD_TOKEN` – Discord bot token
-- `DISCORD_APOLLO_BOT_ID` – Apollo bot ID used for event embeds
-- `PORT` – HTTP server port (defaults to 3000)
+- `DISCORD_BOT_TOKEN` – Discord bot token
+- `DISCORD_CLIENT_ID` – Application client ID
+- `APOLLO_BOT_ID` – Apollo bot ID used for event embeds
+- `PLUGIN_PORT` – HTTP server port (defaults to 3000)
 - `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME` – MySQL connection settings
 
 ## Setup

--- a/discord-demibot/.env.example
+++ b/discord-demibot/.env.example
@@ -1,6 +1,7 @@
-DISCORD_TOKEN=your_discord_token
-DISCORD_APOLLO_BOT_ID=apollo_bot_id
-PORT=3000
+DISCORD_BOT_TOKEN=your_discord_token
+DISCORD_CLIENT_ID=your_client_id
+APOLLO_BOT_ID=apollo_bot_id
+PLUGIN_PORT=3000
 DB_HOST=localhost
 DB_USER=username
 DB_PASSWORD=password

--- a/discord-demibot/src/discord/embeds.js
+++ b/discord-demibot/src/discord/embeds.js
@@ -1,4 +1,4 @@
-const APOLLO_BOT_ID = process.env.DISCORD_APOLLO_BOT_ID;
+const APOLLO_BOT_ID = process.env.APOLLO_BOT_ID;
 
 // Emojis commonly used by Apollo for RSVP
 const RSVP_EMOJIS = ['✅', '❌', '❓', '❔', '🤷'];

--- a/discord-demibot/src/discord/events.js
+++ b/discord-demibot/src/discord/events.js
@@ -1,6 +1,6 @@
 const client = require('./client');
 
-const DISCORD_APOLLO_BOT_ID = process.env.DISCORD_APOLLO_BOT_ID;
+const APOLLO_BOT_ID = process.env.APOLLO_BOT_ID;
 const RING_BUFFER_SIZE = 10;
 
 // Map of channelId -> array of latest embeds
@@ -16,8 +16,8 @@ function getBuffer(channelId) {
 }
 
 function isApollo(message) {
-  if (!DISCORD_APOLLO_BOT_ID) return true;
-  return message.author && message.author.id === DISCORD_APOLLO_BOT_ID;
+  if (!APOLLO_BOT_ID) return true;
+  return message.author && message.author.id === APOLLO_BOT_ID;
 }
 
 function mapEmbed(message) {


### PR DESCRIPTION
## Summary
- Standardize environment variable names across the bot
- Update example env file and docs to include client ID
- Reference Apollo bot ID consistently in Discord helpers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68995030ebec832896ccf7aabe2925d8