### PR TITLE
Use raw GitHub link for plugin icon

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -11,7 +11,7 @@
       "DalamudApiLevel": 13,
       "DownloadLinkInstall": "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/latest.zip",
       "DownloadLinkUpdate":  "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/latest.zip",
-      "IconUrl": "https://github.com/jackandcarter/DemiCat/main/Demi_Bot_Logo.png"
+      "IconUrl": "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/Demi_Bot_Logo.png"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- point `IconUrl` to raw GitHub image in `repo.json`

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689950613f4c83289a6483f0832ae53a