### PR TITLE
Use GitHub-hosted icon in plugin manifest

### DIFF
--- a/DemiCatPlugin/manifest.json
+++ b/DemiCatPlugin/manifest.json
@@ -6,6 +6,6 @@
   "Description": "DemiCat Dalamud plugin.",
   "ApplicableVersion": "any",
   "DalamudApiLevel": 13,
-  "IconUrl": "https://cdn.discordapp.com/attachments/1337791050294755380/1337854067560550422/Demi_Bot_Logo.png?ex=689a37b1&is=6898e631&hm=1b96e426ca9dcd7f80395ecc7ca274e7ee71cee19c6bae73d20954fc13f6ce95&",
+  "IconUrl": "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/Demi_Bot_Logo.png",
   "RepoUrl": "https://github.com/jackandcarter/DemiCat"
 }


### PR DESCRIPTION
## Summary
- use the raw GitHub image URL in the plugin manifest to match repo.json

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68995170e6108328af3ca414247855eb