### PR TITLE
Align plugin metadata versions

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -10,6 +10,9 @@
     <AssemblyName>DemiCatPlugin</AssemblyName>
     <RootNamespace>DemiCatPlugin</RootNamespace>
 
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+
     <!-- Stop CA1416 spam on macOS -->
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>

--- a/repo.json
+++ b/repo.json
@@ -6,7 +6,7 @@
       "InternalName": "DemiCatPlugin",
       "Punchline": "Discord-linked FC tools and chat.",
       "Description": "DemiCat Dalamud plugin.",
-      "AssemblyVersion": "1.0.0.0",
+      "AssemblyVersion": "1.1.0.0",
       "ApplicableVersion": "any",
       "DalamudApiLevel": 13,
       "DownloadLinkInstall": "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/latest.zip",


### PR DESCRIPTION
## Summary
- align repo metadata with manifest's assembly version 1.1.0.0
- explicitly set AssemblyVersion and FileVersion in the project file

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899557080c883289af6cfa21b8f920e