### PR TITLE
docs: update plugin repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Copy `bin/Debug/net9.0/DemiCatPlugin.dll` into your Dalamud plugins folder and e
 Alternatively, add this repository to Dalamud so it can install and update the plugin automatically:
 
 1. In-game, open **Dalamud Settings → Experimental → Custom Repositories**.
-2. Add `(https://raw.githubusercontent.com/jackandcarter/DemiCat/main/repo.json)`.
+2. Add `https://github.com/jackandcarter/DemiCat/raw/main/repo.json` (GitHub redirects automatically). Do **not** use `blob` links or the repository root.
 3. Enable the **DemiCat** plugin from the available plugin list.
 
 The plugin icon is hosted at `https://cdn.discordapp.com/attachments/1337791050294755380/1337854067560550422/Demi_Bot_Logo.png`.


### PR DESCRIPTION
## Summary
- update README with new raw repo link that redirects automatically and warn against blob or root URLs

## Testing
- `npm test` (fails: no test specified)
- `dotnet test` (fails: .NET SDK 8.0 cannot target .NET 9.0)


------
https://chatgpt.com/codex/tasks/task_e_68995652903083288ea2d4514df623f6