### PR TITLE
docs: clarify setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ The script prompts for MySQL host, port, user, and password. It will create a `D
 and run any pending migrations. Re-run the script after pulling updates to ensure the schema (e.g. the `server_id` column on
 `users`) stays current. Use `--local` to quickly target a local MySQL server.
 
-### 2. Configure the bot
+### 2. Configure and start the bot
 ```bash
 cd discord-demibot
 cp .env.example .env
-npm i
-node src/index.js
+# Populate .env with the required environment variables
+npm install
+npm start
 ```
+Ensure `.env` is populated with all required values before running `npm start`.
 
 ### 3. Configure the Dalamud plugin
 Update `DemiCatPlugin/manifest.json` with the usual plugin metadata. In-game, open the plugin configuration and set the


### PR DESCRIPTION
## Summary
- clarify bot setup with npm install and npm start
- remind users to populate .env from .env.example

## Testing
- `cd discord-demibot && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689956b37d388328ba4cef974e348aad