### PR TITLE
feat: prompt for missing env vars

### DIFF
--- a/discord-demibot/src/config.js
+++ b/discord-demibot/src/config.js
@@ -1,7 +1,42 @@
+const fs = require('fs');
 const path = require('path');
 const dotenv = require('dotenv');
 
-dotenv.config({ path: path.join(__dirname, '..', '.env') });
+const envPath = path.join(__dirname, '..', '.env');
+dotenv.config({ path: envPath });
+
+function requireEnv(key, prompt) {
+  let value = process.env[key];
+  if (value && value !== '') {
+    return value;
+  }
+
+  fs.writeSync(process.stdout.fd, `${prompt}: `);
+  const buf = Buffer.alloc(1);
+  let input = '';
+  while (true) {
+    const bytes = fs.readSync(process.stdin.fd, buf, 0, 1);
+    if (!bytes) break;
+    const ch = buf.toString();
+    if (ch === '\n') break;
+    input += ch;
+  }
+  value = input.trim();
+
+  process.env[key] = value;
+  fs.appendFileSync(envPath, `${key}=${value}\n`);
+
+  return value;
+}
+
+requireEnv('DISCORD_BOT_TOKEN', 'Enter Discord bot token');
+requireEnv('DISCORD_CLIENT_ID', 'Enter Discord client ID');
+requireEnv('APOLLO_BOT_ID', 'Enter Apollo bot ID');
+requireEnv('DB_HOST', 'Enter database host');
+requireEnv('DB_USER', 'Enter database user');
+requireEnv('DB_PASSWORD', 'Enter database password');
+requireEnv('DB_NAME', 'Enter database name');
+requireEnv('PLUGIN_PORT', 'Enter plugin port');
 
 module.exports = {
   port: process.env.PLUGIN_PORT || 3000,


### PR DESCRIPTION
## Summary
- interactively request required configuration values when missing
- persist provided values to .env and expose them through config

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node src/index.js`
- `node src/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68995a851c9c8328b587cd27017dda49