### PR TITLE
Fail fast when configuration is incomplete

### DIFF
--- a/discord-demibot/src/config.js
+++ b/discord-demibot/src/config.js
@@ -7,21 +7,20 @@ dotenv.config({ path: envPath });
 
 function requireEnv(key, prompt) {
   let value = process.env[key];
-  if (value && value !== '') {
-    return value;
-  }
 
-  fs.writeSync(process.stdout.fd, `${prompt}: `);
-  const buf = Buffer.alloc(1);
-  let input = '';
-  while (true) {
-    const bytes = fs.readSync(process.stdin.fd, buf, 0, 1);
-    if (!bytes) break;
-    const ch = buf.toString();
-    if (ch === '\n') break;
-    input += ch;
+  while (!value || value.trim() === '') {
+    fs.writeSync(process.stdout.fd, `${prompt}: `);
+    const buf = Buffer.alloc(1);
+    let input = '';
+    while (true) {
+      const bytes = fs.readSync(process.stdin.fd, buf, 0, 1);
+      if (!bytes) return '';
+      const ch = buf.toString();
+      if (ch === '\n') break;
+      input += ch;
+    }
+    value = input.trim();
   }
-  value = input.trim();
 
   process.env[key] = value;
   fs.appendFileSync(envPath, `${key}=${value}\n`);

--- a/discord-demibot/src/index.js
+++ b/discord-demibot/src/index.js
@@ -5,6 +5,27 @@ const discord = require('./discord');
 const httpServer = require('./http');
 
 async function start() {
+  const missing = [];
+
+  // Validate discord config
+  for (const field of ['token', 'clientId', 'apolloBotId']) {
+    if (!config.discord || !config.discord[field]) {
+      missing.push(`discord.${field}`);
+    }
+  }
+
+  // Validate database config
+  for (const field of ['host', 'user', 'password', 'name']) {
+    if (!config.db || !config.db[field]) {
+      missing.push(`db.${field}`);
+    }
+  }
+
+  if (missing.length) {
+    logger.error(`Missing configuration values: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
   await db.init(config.db);
   await discord.init(config, db, logger);
   httpServer.start(config, db, discord, logger);


### PR DESCRIPTION
## Summary
- validate required Discord and database config values before startup
- reprompt interactive config questions until a non-empty value is provided

## Testing
- `npm test` *(fails: no test specified)*
- `node src/index.js` *(missing config values reported and process exits)*

------
https://chatgpt.com/codex/tasks/task_e_68995bda58cc8328a79ee36c8e0a7ad7