### PR TITLE
Specify manifest file for plugin packaging

### DIFF
--- a/DemiCatPlugin/DalamudPackager.targets
+++ b/DemiCatPlugin/DalamudPackager.targets
@@ -5,6 +5,7 @@
       ProjectDir="$(ProjectDir)"
       OutputPath="$(OutputPath)"
       AssemblyName="$(AssemblyName)"
+      ManifestFile="manifest.json"
       ManifestType="json"
       MakeZip="true" />
   </Target>


### PR DESCRIPTION
## Summary
- configure DalamudPackager to use `manifest.json`

## Testing
- `dotnet build -c Release` *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68995f31c3e083289a82e6ef18feeeb1