### PR TITLE
Remove redundant new keyword in OfficerChatWindow

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -111,7 +111,7 @@ public class OfficerChatWindow : ChatWindow
         }
     }
 
-    private new void SaveConfig()
+    private void SaveConfig()
     {
         PluginServices.PluginInterface.SavePluginConfig(_config);
     }


### PR DESCRIPTION
## Summary
- remove `new` modifier from `SaveConfig` in `OfficerChatWindow`

## Testing
- `/root/.dotnet9/dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68995f3a5e1083288d61f5967da1daaf