### PR TITLE
Remove CA1416 suppression from plugin project

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -13,8 +13,6 @@
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>
 
-    <!-- Stop CA1416 spam on macOS -->
-    <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- stop ignoring CA1416 warnings in project file

## Testing
- `dotnet build` *(fails: Dalamud.NET.Sdk: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68996c7cd78483289a7429e7261e5157