### PR TITLE
Fix Dalamud plugin interface access

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -20,7 +20,7 @@ public class Plugin : IDalamudPlugin
 {
     public string Name => "DemiCat";
 
-    [PluginService] internal DalamudPluginInterface PluginInterface { get; private set; } = null!;
+    [PluginService] internal IDalamudPluginInterface PluginInterface { get; private set; } = null!;
     [PluginService] internal IPluginLog Log { get; private set; } = null!;
 
     private readonly UiRenderer _ui;


### PR DESCRIPTION
## Summary
- align plugin interface type with latest Dalamud SDK

## Testing
- `~/.dotnet/dotnet build` *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_6899756494808328937aa21df4996c98