### PR TITLE
Fix Dalamud plugin interface access

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -20,7 +20,7 @@ public class Plugin : IDalamudPlugin
 {
     public string Name => "DemiCat";
 
-    [PluginService] internal DalamudPluginInterface PluginInterface { get; private set; } = null!;
+    [PluginService] internal IDalamudPluginInterface PluginInterface { get; private set; } = null!;
     [PluginService] internal IPluginLog Log { get; private set; } = null!;
 
     private readonly UiRenderer _ui;
@@ -36,7 +36,7 @@ public class Plugin : IDalamudPlugin
 
     public Plugin()
     {
-        _config = PluginInterface.LoadPluginConfig() as Config ?? new Config();
+        _config = PluginInterface.GetPluginConfig() as Config ?? new Config();
 
         _ui = new UiRenderer(_config);
         _settings = new SettingsWindow(_config, CheckOfficerRole);


### PR DESCRIPTION
## Summary
- align plugin interface type with latest Dalamud SDK
- update configuration loading to use `GetPluginConfig`

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899756494808328937aa21df4996c98