### PR TITLE
chore: target .net 8 for plugin

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Dalamud.NET.Sdk/13.0.0">
   <PropertyGroup>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
## Summary
- target .NET 8 for the plugin project

## Testing
- `dotnet build` *(fails: Dalamud assembly uses System.Runtime 9.0.0.0 while project references 8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68997cdf21f48328ae31a4f8dd798f0a