### PR TITLE
Store UI open delegates for proper disposal

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -33,6 +33,8 @@ public class Plugin : IDalamudPlugin
     private readonly HttpClient _httpClient = new();
     private ClientWebSocket? _webSocket;
     private readonly List<EmbedDto> _embeds = new();
+    private readonly Action _openMainUi;
+    private readonly Action _openConfigUi;
 
     public Plugin()
     {
@@ -56,8 +58,10 @@ public class Plugin : IDalamudPlugin
 
         PluginInterface.UiBuilder.Draw += _mainWindow.Draw;
         PluginInterface.UiBuilder.Draw += _settings.Draw;
-        PluginInterface.UiBuilder.OpenMainUi += () => _mainWindow.IsOpen = true;
-        PluginInterface.UiBuilder.OpenConfigUi += () => _settings.IsOpen = true;
+        _openMainUi = () => _mainWindow.IsOpen = true;
+        PluginInterface.UiBuilder.OpenMainUi += _openMainUi;
+        _openConfigUi = () => _settings.IsOpen = true;
+        PluginInterface.UiBuilder.OpenConfigUi += _openConfigUi;
 
         Log.Info("DemiCat loaded.");
     }
@@ -183,6 +187,8 @@ public class Plugin : IDalamudPlugin
     {
         PluginInterface.UiBuilder.Draw -= _mainWindow.Draw;
         PluginInterface.UiBuilder.Draw -= _settings.Draw;
+        PluginInterface.UiBuilder.OpenMainUi -= _openMainUi;
+        PluginInterface.UiBuilder.OpenConfigUi -= _openConfigUi;
         _timer.Stop();
         _timer.Dispose();
         if (_webSocket != null)


### PR DESCRIPTION
## Summary
- track `OpenMainUi` and `OpenConfigUi` handlers
- unsubscribe UI open handlers during plugin disposal

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_e_68997d3cfde08328a46c92d9ff7478a7