### PR TITLE
Dispose textures before nulling

### DIFF
--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -197,8 +197,11 @@ public class EventView : IDisposable
 
     public void Dispose()
     {
+        _authorIcon?.Dispose();
         _authorIcon = null;
+        _thumbnail?.Dispose();
         _thumbnail = null;
+        _image?.Dispose();
         _image = null;
     }
 }


### PR DESCRIPTION
## Summary
- dispose textures in `EventView.Dispose` before clearing references

## Testing
- `dotnet build` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899d9317f4c832887137aea42d734f0