### PR TITLE
Remove unused timer disposal

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -223,10 +223,6 @@ public void Dispose()
     // Stop background work (from main)
     StopPolling();
 
-    // Stop and dispose timer (from codex/add-fields-for-ui-delegate-subscriptions)
-    _timer?.Stop();
-    _timer?.Dispose();
-
     // Close and dispose websocket safely
     if (_webSocket != null)
     {


### PR DESCRIPTION
## Summary
- drop stale timer stop/dispose calls

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud.NET.Sdk: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_6899d8daf9048328a0d735d8d89db074