### PR TITLE
chore: update plugin to .NET 9

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Dalamud.NET.Sdk/13.0.0">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Use the value from `api_key` as the `X-Api-Key` header when calling the REST API
 cd DemiCatPlugin
 dotnet build
 ```
-Copy `bin/Debug/net9.0/DemiCatPlugin.dll` into your Dalamud plugins folder and enable it.
+The build output `DemiCatPlugin.dll` can be found under `bin/Debug/net9.0/`. Copy it into your Dalamud plugins folder and enable it.
 
 Alternatively, add this repository to Dalamud so it can install and update the plugin automatically:
 


### PR DESCRIPTION
## Summary
- target .NET 9 for DemiCat plugin
- document new build output location in README

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Debug` *(fails: Dalamud.NET.Sdk: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_6899dcb4879483289326e3566cc0e872