### PR TITLE
Use latest C# language version for plugin

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>latest</LangVersion>
 
     <DalamudApiLevel>13</DalamudApiLevel>
     <AssemblyName>DemiCatPlugin</AssemblyName>


### PR DESCRIPTION
## Summary
- stop using preview C# features by switching LangVersion to `latest`

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -warnaserror` *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_6899de075f6883288d65ccd858f04591