### PR TITLE
feat: add python demibot package with api and setup wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 node_modules/
 .env
 database/*.db
+__pycache__/

--- a/python-demibot/python_demibot/__init__.py
+++ b/python-demibot/python_demibot/__init__.py
@@ -1,0 +1,1 @@
+"""Python implementation of DemiBot with Discord and FastAPI."""

--- a/python-demibot/python_demibot/__main__.py
+++ b/python-demibot/python_demibot/__main__.py
@@ -1,0 +1,17 @@
+import asyncio
+import uvicorn
+
+from .api import app, bot, config
+
+
+async def main() -> None:
+    bot_task = asyncio.create_task(bot.start_bot())
+    config_host = config.get("api_host", "0.0.0.0")
+    config_port = int(config.get("api_port", 8000))
+    server = uvicorn.Server(uvicorn.Config(app, host=config_host, port=config_port, log_level="info"))
+    api_task = asyncio.create_task(server.serve())
+    await asyncio.gather(bot_task, api_task)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python-demibot/python_demibot/api.py
+++ b/python-demibot/python_demibot/api.py
@@ -1,0 +1,59 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from .config import load_config
+from .database import Database
+from .discord_bot import DemiBot
+
+config = load_config()
+db = Database(config)
+bot = DemiBot(config["discord_token"], db)
+
+app = FastAPI()
+
+
+class ValidateRequest(BaseModel):
+    key: str | None = None
+    syncKey: str | None = None
+    characterName: str | None = None
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    await db.connect()
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    await db.close()
+
+
+@app.post("/validate")
+async def validate(req: ValidateRequest):
+    if (req.key and req.key == config["user_key"]) or (req.syncKey and req.syncKey == config["sync_key"]):
+        guild = {"id": config.get("guild_id", ""), "name": config.get("guild_name", "")}
+        return {"userKey": config["user_key"], "guild": guild}
+    raise HTTPException(status_code=401, detail="invalid key")
+
+
+class SetupRequest(BaseModel):
+    channelId: str
+    type: str
+
+
+@app.post("/admin/setup")
+async def admin_setup(req: SetupRequest):
+    valid_types = {"event", "fc_chat", "officer_chat"}
+    if req.type not in valid_types:
+        raise HTTPException(status_code=400, detail="Invalid type")
+    settings = await db.get_server_settings(config["guild_id"])
+    if req.type == "event":
+        events = set(settings.get("eventChannels", []))
+        events.add(req.channelId)
+        settings["eventChannels"] = list(events)
+    elif req.type == "fc_chat":
+        settings["fcChatChannel"] = req.channelId
+    elif req.type == "officer_chat":
+        settings["officerChatChannel"] = req.channelId
+    await db.set_server_settings(config["guild_id"], settings)
+    return {"ok": True}

--- a/python-demibot/python_demibot/config.py
+++ b/python-demibot/python_demibot/config.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+from uuid import uuid4
+
+CONFIG_PATH = Path(__file__).resolve().parent / "config.json"
+
+# Default configuration structure
+DEFAULT_CONFIG = {
+    "mysql_host": "localhost",
+    "mysql_user": "",
+    "mysql_password": "",
+    "mysql_db": "",
+    "discord_token": "",
+    "guild_id": "",
+    "guild_name": "",
+    "user_key": "",
+    "sync_key": ""
+}
+
+
+def load_config() -> dict:
+    """Load configuration from disk or run the setup wizard."""
+    if not CONFIG_PATH.exists():
+        return run_setup_wizard()
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def run_setup_wizard() -> dict:
+    """Interactively prompt the user for configuration values."""
+    cfg = DEFAULT_CONFIG.copy()
+    print("DemiBot initial setup - values will be saved to", CONFIG_PATH)
+    cfg["mysql_host"] = input("MySQL host [localhost]: ") or "localhost"
+    cfg["mysql_user"] = input("MySQL user: ")
+    cfg["mysql_password"] = input("MySQL password: ")
+    cfg["mysql_db"] = input("MySQL database: ")
+    cfg["discord_token"] = input("Discord bot token: ")
+    cfg["guild_id"] = input("Discord guild id: ")
+    cfg["guild_name"] = input("Discord guild name: ")
+
+    # Keys used for plugin authentication
+    cfg["user_key"] = uuid4().hex
+    cfg["sync_key"] = uuid4().hex
+
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+    print("Configuration saved.")
+    return cfg

--- a/python-demibot/python_demibot/database.py
+++ b/python-demibot/python_demibot/database.py
@@ -1,0 +1,50 @@
+import json
+import aiomysql
+
+
+class Database:
+    """Simple wrapper around an aiomysql connection pool."""
+
+    def __init__(self, config: dict):
+        self._cfg = config
+        self.pool: aiomysql.Pool | None = None
+
+    async def connect(self) -> None:
+        self.pool = await aiomysql.create_pool(
+            host=self._cfg["mysql_host"],
+            user=self._cfg["mysql_user"],
+            password=self._cfg["mysql_password"],
+            db=self._cfg["mysql_db"],
+            autocommit=True,
+        )
+
+    async def close(self) -> None:
+        if self.pool:
+            self.pool.close()
+            await self.pool.wait_closed()
+
+    async def get_server_settings(self, guild_id: str) -> dict:
+        if not self.pool:
+            return {}
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT settings FROM server_settings WHERE guild_id=%s", (guild_id,))
+                row = await cur.fetchone()
+                if row and row[0]:
+                    return json.loads(row[0])
+        return {}
+
+    async def set_server_settings(self, guild_id: str, settings: dict) -> None:
+        if not self.pool:
+            return
+        data = json.dumps(settings)
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    INSERT INTO server_settings (guild_id, settings)
+                    VALUES (%s, %s)
+                    ON DUPLICATE KEY UPDATE settings=VALUES(settings)
+                    """,
+                    (guild_id, data),
+                )

--- a/python-demibot/python_demibot/discord_bot.py
+++ b/python-demibot/python_demibot/discord_bot.py
@@ -1,0 +1,19 @@
+import discord
+from discord.ext import commands
+
+
+class DemiBot(commands.Bot):
+    """Minimal discord.py bot wrapper."""
+
+    def __init__(self, token: str, db):
+        intents = discord.Intents.default()
+        intents.message_content = True
+        super().__init__(command_prefix="!", intents=intents)
+        self.token = token
+        self.db = db
+
+    async def on_ready(self):
+        print(f"Logged in as {self.user} (ID: {self.user.id})")
+
+    async def start_bot(self) -> None:
+        await self.start(self.token)


### PR DESCRIPTION
## Summary
- add new `python_demibot` package with discord.py bot and FastAPI API
- include interactive setup wizard for MySQL and token configuration
- implement `/validate` and `/admin/setup` REST routes and MySQL-backed server settings

## Testing
- `python -m py_compile python-demibot/python_demibot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_689b4d0bfa80832898500c1b898facd8