### PR TITLE
Simplify settings and add server config

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -11,9 +11,7 @@ public class Config : IPluginConfiguration
     public string HelperBaseUrl { get; set; } = "http://localhost:3000";
     public int PollIntervalSeconds { get; set; } = 5;
     public string? AuthToken { get; set; }
-    public string SyncKey { get; set; } = string.Empty;
-    public string GuildId { get; set; } = string.Empty;
-    public string GuildName { get; set; } = string.Empty;
+    public string ServerAddress { get; set; } = "http://localhost:3300";
     public string ChatChannelId { get; set; } = string.Empty;
     public string EventChannelId { get; set; } = string.Empty;
     public string FcChannelId { get; set; } = string.Empty;

--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -1,0 +1,46 @@
+using System;
+using Dalamud.Bindings.ImGui;
+
+namespace DemiCatPlugin;
+
+public class DeveloperWindow
+{
+    private readonly Config _config;
+    private string _ip;
+    private int _port;
+
+    public bool IsOpen;
+
+    public DeveloperWindow(Config config)
+    {
+        _config = config;
+        var uri = new Uri(config.ServerAddress);
+        _ip = uri.Host;
+        _port = uri.Port;
+    }
+
+    public void Draw()
+    {
+        if (!IsOpen)
+        {
+            return;
+        }
+
+        if (!ImGui.Begin("DemiCat Developer", ref IsOpen))
+        {
+            ImGui.End();
+            return;
+        }
+
+        ImGui.InputText("Server IP", ref _ip, 64);
+        ImGui.InputInt("Port", ref _port);
+
+        if (ImGui.Button("Save"))
+        {
+            _config.ServerAddress = $"http://{_ip}:{_port}";
+            PluginServices.PluginInterface.SavePluginConfig(_config);
+        }
+
+        ImGui.End();
+    }
+}


### PR DESCRIPTION
## Summary
- streamline configuration by dropping legacy fields and adding a `ServerAddress`
- redesign settings UI with a key sync workflow and hidden developer options

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689b4e4dfccc8328917ebb3b4fe62c0e