### PR TITLE
feat: expand database schema and helpers

### DIFF
--- a/python-demibot/python_demibot/database.py
+++ b/python-demibot/python_demibot/database.py
@@ -10,6 +10,8 @@ class Database:
         self.pool: aiomysql.Pool | None = None
 
     async def connect(self) -> None:
+        """Create the connection pool and ensure required tables exist."""
+
         self.pool = await aiomysql.create_pool(
             host=self._cfg["mysql_host"],
             user=self._cfg["mysql_user"],
@@ -17,6 +19,102 @@ class Database:
             db=self._cfg["mysql_db"],
             autocommit=True,
         )
+
+        # Lazily create the schema so the application can operate against a
+        # clean database without requiring a separate migration step.  This
+        # mirrors the behaviour of the JavaScript implementation.
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS servers (
+                        id VARCHAR(255) PRIMARY KEY
+                    )
+                    """
+                )
+                await cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS users (
+                        id VARCHAR(255) PRIMARY KEY,
+                        `key` VARCHAR(255),
+                        character_name VARCHAR(255),
+                        server_id VARCHAR(255),
+                        FOREIGN KEY (server_id) REFERENCES servers(id),
+                        INDEX (server_id)
+                    )
+                    """
+                )
+                await cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS channels (
+                        id VARCHAR(255) PRIMARY KEY,
+                        server_id VARCHAR(255),
+                        type ENUM('event','fc_chat','officer_chat') NOT NULL,
+                        FOREIGN KEY (server_id) REFERENCES servers(id)
+                    )
+                    """
+                )
+                await cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS events (
+                        id INT AUTO_INCREMENT PRIMARY KEY,
+                        user_id VARCHAR(255),
+                        channel_id VARCHAR(255),
+                        message_id VARCHAR(255),
+                        title TEXT,
+                        description TEXT,
+                        time TEXT,
+                        metadata TEXT,
+                        FOREIGN KEY (user_id) REFERENCES users(id),
+                        FOREIGN KEY (channel_id) REFERENCES channels(id)
+                    )
+                    """
+                )
+                await cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS api_keys (
+                        api_key VARCHAR(255) PRIMARY KEY,
+                        user_id VARCHAR(255),
+                        is_admin BOOLEAN DEFAULT FALSE,
+                        FOREIGN KEY (user_id) REFERENCES users(id)
+                    )
+                    """
+                )
+                await cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS officer_roles (
+                        server_id VARCHAR(255),
+                        role_id VARCHAR(255),
+                        PRIMARY KEY (server_id, role_id),
+                        FOREIGN KEY (server_id) REFERENCES servers(id),
+                        INDEX (server_id)
+                    )
+                    """
+                )
+                await cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS user_roles (
+                        server_id VARCHAR(255),
+                        user_id VARCHAR(255),
+                        role_id VARCHAR(255),
+                        PRIMARY KEY (server_id, user_id, role_id),
+                        FOREIGN KEY (server_id) REFERENCES servers(id),
+                        FOREIGN KEY (user_id) REFERENCES users(id),
+                        INDEX (server_id),
+                        INDEX (user_id)
+                    )
+                    """
+                )
+                # Settings are stored as a JSON blob per guild similar to the
+                # original Python implementation.
+                await cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS server_settings (
+                        guild_id VARCHAR(255) PRIMARY KEY,
+                        settings TEXT
+                    )
+                    """
+                )
 
     async def close(self) -> None:
         if self.pool:
@@ -48,6 +146,184 @@ class Database:
                     """,
                     (guild_id, data),
                 )
+
+    # ------------------------------------------------------------------
+    # User and key management
+    # ------------------------------------------------------------------
+
+    async def set_key(self, user_id: str, key: str, server_id: str) -> None:
+        """Associate ``key`` with ``user_id`` on ``server_id``."""
+        if not self.pool:
+            return
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT IGNORE INTO servers (id) VALUES (%s)",
+                    (server_id,),
+                )
+                await cur.execute(
+                    """
+                    INSERT INTO users (id, `key`, server_id)
+                    VALUES (%s, %s, %s)
+                    ON DUPLICATE KEY UPDATE `key`=VALUES(`key`),
+                                            server_id=VALUES(server_id)
+                    """,
+                    (user_id, key, server_id),
+                )
+
+    async def get_key(self, user_id: str) -> str | None:
+        """Return the key associated with ``user_id`` if present."""
+        if not self.pool:
+            return None
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT `key` FROM users WHERE id=%s",
+                    (user_id,),
+                )
+                row = await cur.fetchone()
+                return row[0] if row else None
+
+    async def set_character(self, user_id: str, character_name: str) -> None:
+        """Persist the user's character name."""
+        if not self.pool:
+            return
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    """
+                    INSERT INTO users (id, character_name)
+                    VALUES (%s, %s)
+                    ON DUPLICATE KEY UPDATE character_name=VALUES(character_name)
+                    """,
+                    (user_id, character_name),
+                )
+
+    async def get_user_by_key(self, key: str) -> dict | None:
+        """Return user information for the given API ``key``."""
+        if not self.pool:
+            return None
+        async with self.pool.acquire() as conn:
+            async with conn.cursor(aiomysql.DictCursor) as cur:
+                await cur.execute(
+                    """
+                    SELECT id AS userId, character_name AS characterName,
+                           server_id AS serverId
+                    FROM users
+                    WHERE `key`=%s
+                    """,
+                    (key,),
+                )
+                row = await cur.fetchone()
+                if not row:
+                    return None
+                return {
+                    "userId": str(row["userId"]),
+                    "characterName": row["characterName"],
+                    "serverId": str(row["serverId"]),
+                }
+
+    async def set_user_roles(self, server_id: str, user_id: str, roles: list[str]) -> None:
+        """Persist the list of ``roles`` for ``user_id`` on ``server_id``."""
+        if not self.pool:
+            return
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT IGNORE INTO servers (id) VALUES (%s)",
+                    (server_id,),
+                )
+                await cur.execute(
+                    """
+                    INSERT INTO users (id, server_id)
+                    VALUES (%s, %s)
+                    ON DUPLICATE KEY UPDATE server_id=VALUES(server_id)
+                    """,
+                    (user_id, server_id),
+                )
+                await cur.execute(
+                    "DELETE FROM user_roles WHERE server_id=%s AND user_id=%s",
+                    (server_id, user_id),
+                )
+                for role_id in roles:
+                    await cur.execute(
+                        "INSERT INTO user_roles (server_id, user_id, role_id) VALUES (%s, %s, %s)",
+                        (server_id, user_id, role_id),
+                    )
+
+    async def get_user_roles_for_user(self, server_id: str, user_id: str) -> list[str]:
+        """Return role IDs for ``user_id`` on ``server_id``."""
+        if not self.pool:
+            return []
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT role_id FROM user_roles WHERE server_id=%s AND user_id=%s",
+                    (server_id, user_id),
+                )
+                rows = await cur.fetchall()
+                return [r[0] for r in rows]
+
+    # ------------------------------------------------------------------
+    # Channel helpers
+    # ------------------------------------------------------------------
+
+    async def get_event_channels(self) -> list[str]:
+        """Return all channel IDs configured for events across servers."""
+        if not self.pool:
+            return []
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT settings FROM server_settings")
+                rows = await cur.fetchall()
+                channels: list[str] = []
+                for row in rows:
+                    try:
+                        data = json.loads(row[0])
+                        arr = data.get("eventChannels")
+                        if isinstance(arr, list):
+                            channels.extend(str(c) for c in arr)
+                    except Exception:
+                        continue
+                return channels
+
+    async def get_fc_channels(self) -> list[str]:
+        """Return all FC chat channel IDs."""
+        if not self.pool:
+            return []
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT settings FROM server_settings")
+                rows = await cur.fetchall()
+                channels: list[str] = []
+                for row in rows:
+                    try:
+                        data = json.loads(row[0])
+                        ch = data.get("fcChatChannel")
+                        if ch:
+                            channels.append(str(ch))
+                    except Exception:
+                        continue
+                return channels
+
+    async def get_officer_channels(self) -> list[str]:
+        """Return all officer chat channel IDs."""
+        if not self.pool:
+            return []
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute("SELECT settings FROM server_settings")
+                rows = await cur.fetchall()
+                channels: list[str] = []
+                for row in rows:
+                    try:
+                        data = json.loads(row[0])
+                        ch = data.get("officerChatChannel")
+                        if ch:
+                            channels.append(str(ch))
+                    except Exception:
+                        continue
+                return channels
 
     async def get_user_roles(self, key: str) -> list[str] | None:
         """Return a list of role IDs for the user associated with ``key``.
@@ -102,6 +378,26 @@ class Database:
                     "serverId": str(row["serverId"]),
                 }
 
+    async def set_officer_roles(self, server_id: str, roles: list[str]) -> None:
+        """Replace officer roles for ``server_id`` with ``roles``."""
+        if not self.pool:
+            return
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT IGNORE INTO servers (id) VALUES (%s)",
+                    (server_id,),
+                )
+                await cur.execute(
+                    "DELETE FROM officer_roles WHERE server_id=%s",
+                    (server_id,),
+                )
+                for role_id in roles:
+                    await cur.execute(
+                        "INSERT INTO officer_roles (server_id, role_id) VALUES (%s, %s)",
+                        (server_id, role_id),
+                    )
+
     async def get_officer_roles(self, server_id: str) -> list[str]:
         """Return a list of role IDs marked as officer roles for ``server_id``."""
         if not self.pool:
@@ -138,6 +434,18 @@ class Database:
                 )
                 return cur.lastrowid or 0
 
+    async def get_events(self, channel_id: str) -> list[dict]:
+        """Return all events for ``channel_id``."""
+        if not self.pool:
+            return []
+        async with self.pool.acquire() as conn:
+            async with conn.cursor(aiomysql.DictCursor) as cur:
+                await cur.execute(
+                    "SELECT * FROM events WHERE channel_id=%s",
+                    (channel_id,),
+                )
+                return await cur.fetchall()
+
     async def get_event(self, event_id: int) -> dict | None:
         """Return event information by ID."""
         if not self.pool:
@@ -168,4 +476,43 @@ class Database:
                         event.get("metadata"),
                         event["id"],
                     ),
+                )
+
+    async def clear_server(self, server_id: str) -> None:
+        """Remove all data associated with ``server_id``."""
+        if not self.pool:
+            return
+        async with self.pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "DELETE e FROM events e JOIN channels c ON e.channel_id=c.id WHERE c.server_id=%s",
+                    (server_id,),
+                )
+                await cur.execute(
+                    "DELETE ak FROM api_keys ak JOIN users u ON ak.user_id=u.id WHERE u.server_id=%s",
+                    (server_id,),
+                )
+                await cur.execute(
+                    "DELETE FROM server_settings WHERE guild_id=%s",
+                    (server_id,),
+                )
+                await cur.execute(
+                    "DELETE FROM officer_roles WHERE server_id=%s",
+                    (server_id,),
+                )
+                await cur.execute(
+                    "DELETE FROM user_roles WHERE server_id=%s",
+                    (server_id,),
+                )
+                await cur.execute(
+                    "DELETE FROM channels WHERE server_id=%s",
+                    (server_id,),
+                )
+                await cur.execute(
+                    "DELETE FROM users WHERE server_id=%s",
+                    (server_id,),
+                )
+                await cur.execute(
+                    "DELETE FROM servers WHERE id=%s",
+                    (server_id,),
                 )


### PR DESCRIPTION
## Summary
- initialize database tables for servers, users, channels, events, api_keys, officer roles and user roles
- add key and role management helpers plus channel lookups
- support event queries and server cleanup

## Testing
- `python -m py_compile python-demibot/python_demibot/database.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689b56f2749c83288c4b3bd48d0ea40f