### PR TITLE
feat: expose users route

### DIFF
--- a/python-demibot/python_demibot/api.py
+++ b/python-demibot/python_demibot/api.py
@@ -17,7 +17,8 @@ ws.start(app, bot)
 
 @app.middleware("http")
 async def api_key_middleware(request: Request, call_next):
-    if request.url.path.startswith("/api"):
+    path = request.url.path
+    if path.startswith("/api") or path.startswith("/users"):
         key = request.headers.get("X-Api-Key")
         if not key:
             return JSONResponse({"error": "Missing X-Api-Key"}, status_code=401)

--- a/python-demibot/python_demibot/discord_bot.py
+++ b/python-demibot/python_demibot/discord_bot.py
@@ -83,11 +83,14 @@ class DemiBot(commands.Bot):
         return self
 
     def list_online_users(self) -> List[Dict[str, str]]:
-        """Return a list of online users across all guilds."""
+        """Return a list of users that are currently online in any guild.
+
+        Members with any status other than ``offline`` are considered online.
+        """
         users: List[Dict[str, str]] = []
         for guild in self.guilds:
             for member in guild.members:
-                if str(member.status) == "online":
+                if member.status != discord.Status.offline:
                     users.append({"id": str(member.id), "name": member.display_name})
         return users
 

--- a/python-demibot/python_demibot/routes/users.py
+++ b/python-demibot/python_demibot/routes/users.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 
 from ..api import get_api_key_info, bot
 
-router = APIRouter(prefix="/api/users")
+router = APIRouter(prefix="/users")
 
 
 @router.get("/")


### PR DESCRIPTION
## Summary
- enumerate online users in discord bot
- expose /users API route secured by key middleware

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b6a601d94832885ebc2e5aeb8677c