### PR TITLE
Add API route for button interactions

### DIFF
--- a/python_demibot/api.py
+++ b/python_demibot/api.py
@@ -107,7 +107,7 @@ async def admin_setup(req: SetupRequest, info: dict = Depends(require_admin)):
     return {"ok": True}
 
 
-from .routes import channels, messages, officer_messages, embeds, events, me, users
+from .routes import channels, messages, officer_messages, embeds, events, me, users, interactions
 
 app.include_router(channels.router)
 app.include_router(messages.router)
@@ -116,3 +116,4 @@ app.include_router(embeds.router)
 app.include_router(events.router)
 app.include_router(me.router)
 app.include_router(users.router)
+app.include_router(interactions.router)

--- a/python_demibot/routes/interactions.py
+++ b/python_demibot/routes/interactions.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..api import get_api_key_info, bot
+
+router = APIRouter(prefix="/api/interactions")
+
+
+@router.post("/")
+async def post_interaction(payload: dict, info: dict = Depends(get_api_key_info)):
+    channel_id = payload.get("channelId")
+    message_id = payload.get("messageId")
+    custom_id = payload.get("customId")
+    try:
+        channel = await bot.get_client().fetch_channel(channel_id)
+        if not channel or channel.guild.id != int(info["serverId"]):
+            raise HTTPException(status_code=400, detail="Invalid channel")
+        message = await channel.fetch_message(message_id)
+
+        view_store = bot._connection._view_store  # type: ignore[attr-defined]
+        class DummyResponse:
+            async def send_message(self, *args, **kwargs):
+                pass
+
+            async def edit_message(self, *args, **kwargs):
+                pass
+
+            async def defer(self, *args, **kwargs):
+                pass
+
+        class DummyInteraction:
+            def __init__(self, message, user):
+                self.message = message
+                self.user = user
+                self.channel = message.channel
+                self.guild = getattr(message.channel, "guild", None)
+                self.data = {"custom_id": custom_id, "component_type": 2}
+                self.client = bot.get_client()
+                self.response = DummyResponse()
+
+        user = await bot.get_client().fetch_user(int(info["userId"]))
+        interaction = DummyInteraction(message, user)
+        view_store.dispatch_view(2, custom_id, interaction)
+        return {"ok": True}
+    except HTTPException:
+        raise
+    except Exception as err:  # pragma: no cover - defensive
+        raise HTTPException(status_code=500, detail={"ok": False}) from err


### PR DESCRIPTION
## Summary
- handle POST /api/interactions to dispatch button custom IDs using the Discord client
- register the interactions router in the main FastAPI app

## Testing
- `python -m py_compile python_demibot/routes/interactions.py python_demibot/api.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b75239fe88328a3b81eb1ea5826f9