### PR TITLE
Map stored Discord roles to logical tags

### DIFF
--- a/python_demibot/api.py
+++ b/python_demibot/api.py
@@ -72,10 +72,10 @@ async def validate(req: ValidateRequest):
 
 @app.post("/roles")
 async def roles(req: RolesRequest):
-    roles = await db.get_user_roles(req.key)
-    if roles is None:
+    role_tags = await db.get_user_roles(req.key)
+    if role_tags is None:
         raise HTTPException(status_code=401, detail="invalid key")
-    return {"roles": roles}
+    return {"roles": role_tags}
 
 
 class SetupRequest(BaseModel):

--- a/python_demibot/discord_bot.py
+++ b/python_demibot/discord_bot.py
@@ -219,9 +219,10 @@ class DemiBot(commands.Bot):
 
         updated = []
         for member in members:
-            roles = [r.id for r in member.roles if r != interaction.guild.default_role]
-            if hasattr(self.db, "set_user_roles"):
-                await self.db.set_user_roles(interaction.guild_id, member.id, roles)
+            role_ids = [str(r.id) for r in member.roles if r != interaction.guild.default_role]
+            if hasattr(self.db, "map_role_ids_to_tags") and hasattr(self.db, "set_user_roles"):
+                tags = await self.db.map_role_ids_to_tags(interaction.guild_id, role_ids)
+                await self.db.set_user_roles(interaction.guild_id, member.id, tags)
             updated.append(member.display_name)
 
         summary = (


### PR DESCRIPTION
## Summary
- derive logical role tags from stored Discord role IDs
- expose role tags via `/roles`
- tag user roles during `/demibot_resync`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b77300ee88328bf4dcc1ebffc4d14