### PR TITLE
Add extended event embed support

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -4,6 +4,8 @@ using System.Text;
 using System.Text.Json;
 using System.Numerics;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
 using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
@@ -17,6 +19,10 @@ public class EventCreateWindow : IDisposable
     private string _description = string.Empty;
     private string _time = DateTime.UtcNow.ToString("o");
     private string _imageUrl = string.Empty;
+    private string _url = string.Empty;
+    private string _thumbnailUrl = string.Empty;
+    private int _color;
+    private readonly List<Field> _fields = new();
     private string? _lastResult;
 
     public string ChannelId { private get; set; } = string.Empty;
@@ -31,7 +37,32 @@ public class EventCreateWindow : IDisposable
         ImGui.InputText("Title", ref _title, 256);
         ImGui.InputText("Time", ref _time, 64);
         ImGui.InputTextMultiline("Description", ref _description, 4096, new Vector2(400, 100));
+        ImGui.InputText("URL", ref _url, 260);
         ImGui.InputText("Image URL", ref _imageUrl, 260);
+        ImGui.InputText("Thumbnail URL", ref _thumbnailUrl, 260);
+        ImGui.InputInt("Color", ref _color);
+
+        if (ImGui.TreeNode("Fields"))
+        {
+            for (var i = 0; i < _fields.Count; i++)
+            {
+                var field = _fields[i];
+                ImGui.InputText($"Name##{i}", ref field.Name, 256);
+                ImGui.InputTextMultiline($"Value##{i}", ref field.Value, 1024, new Vector2(400, 60));
+                ImGui.Checkbox($"Inline##{i}", ref field.Inline);
+                if (ImGui.Button($"Remove##{i}"))
+                {
+                    _fields.RemoveAt(i);
+                    i--;
+                }
+                ImGui.Separator();
+            }
+            if (ImGui.Button("Add Field"))
+            {
+                _fields.Add(new Field());
+            }
+            ImGui.TreePop();
+        }
         if (ImGui.Button("Create"))
         {
             _ = CreateEvent();
@@ -53,7 +84,16 @@ public class EventCreateWindow : IDisposable
                 title = _title,
                 time = _time,
                 description = _description,
-                imageUrl = string.IsNullOrWhiteSpace(_imageUrl) ? null : _imageUrl
+                url = string.IsNullOrWhiteSpace(_url) ? null : _url,
+                imageUrl = string.IsNullOrWhiteSpace(_imageUrl) ? null : _imageUrl,
+                thumbnailUrl = string.IsNullOrWhiteSpace(_thumbnailUrl) ? null : _thumbnailUrl,
+                color = _color > 0 ? (uint?)_color : null,
+                fields = _fields.Count > 0
+                    ? _fields
+                        .Where(f => !string.IsNullOrWhiteSpace(f.Name) && !string.IsNullOrWhiteSpace(f.Value))
+                        .Select(f => new { name = f.Name, value = f.Value, inline = f.Inline })
+                        .ToList()
+                    : null
             };
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/events");
@@ -75,5 +115,12 @@ public class EventCreateWindow : IDisposable
     public void Dispose()
     {
         _httpClient.Dispose();
+    }
+
+    private class Field
+    {
+        public string Name = string.Empty;
+        public string Value = string.Empty;
+        public bool Inline;
     }
 }

--- a/python_demibot/discord_bot.py
+++ b/python_demibot/discord_bot.py
@@ -119,8 +119,18 @@ class DemiBot(commands.Bot):
             "channelId": str(message.channel.id),
             "timestamp": embed.timestamp.isoformat() if embed.timestamp else None,
             "authorName": embed.author.name if embed.author else None,
+            "authorIconUrl": embed.author.icon_url if embed.author else None,
             "title": embed.title,
+            "url": embed.url,
             "description": embed.description,
+            "color": embed.color.value if embed.color else None,
+            "fields": [
+                {"name": f.name, "value": f.value, "inline": f.inline} for f in embed.fields
+            ]
+            if embed.fields
+            else None,
+            "thumbnailUrl": embed.thumbnail.url if embed.thumbnail else None,
+            "imageUrl": embed.image.url if embed.image else None,
         }
 
     # ------------------------------------------------------------------

--- a/python_demibot/routes/events.py
+++ b/python_demibot/routes/events.py
@@ -35,7 +35,9 @@ def build_embed(data: Dict[str, Any], info: Dict[str, Any], include_image: bool 
         embed.set_thumbnail(url=data["thumbnailUrl"])
     if data.get("authorName"):
         embed.set_author(name=data.get("authorName"), icon_url=data.get("authorIconUrl"))
-    if include_image:
+    if data.get("imageUrl"):
+        embed.set_image(url=data["imageUrl"])
+    elif include_image:
         embed.set_image(url="attachment://image.png")
     return embed
 
@@ -95,6 +97,7 @@ async def update_event(event_id: int, payload: Dict[str, Any], info: Dict[str, A
             "thumbnailUrl": payload.get("thumbnailUrl"),
             "authorName": payload.get("authorName"),
             "authorIconUrl": payload.get("authorIconUrl"),
+            "imageUrl": payload.get("imageUrl"),
         }
         image_base64 = payload.get("imageBase64")
         embed = build_embed(data, info, include_image=bool(image_base64))


### PR DESCRIPTION
## Summary
- allow EventCreateWindow to set color, URL, thumbnail, image and custom fields
- handle image URLs in event routes and forward embed details
- expose rich embed data (color, url, fields, images) via map_embed

## Testing
- `python -m py_compile python_demibot/routes/events.py python_demibot/discord_bot.py`
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689b7e0dbc7c83289d48f2a87ea375ea