### PR TITLE
Add templates window and config

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -21,4 +21,5 @@ public class Config : IPluginConfiguration
     public bool EnableFcChat { get; set; } = false;
     public bool UseCharacterName { get; set; } = false;
     public List<string> Roles { get; set; } = new();
+    public List<Template> Templates { get; set; } = new();
 }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -15,6 +15,7 @@ public class MainWindow
     private readonly OfficerChatWindow _officer;
     private readonly SettingsWindow _settings;
     private readonly EventCreateWindow _create;
+    private readonly TemplatesWindow _templates;
     private readonly HttpClient _httpClient = new();
     private readonly List<string> _channels = new();
     private bool _channelsLoaded;
@@ -33,9 +34,11 @@ public class MainWindow
         _officer = officer;
         _settings = settings;
         _create = new EventCreateWindow(config);
+        _templates = new TemplatesWindow(config);
         _channelId = config.EventChannelId;
         _ui.ChannelId = _channelId;
         _create.ChannelId = _channelId;
+        _templates.ChannelId = _channelId;
     }
 
     public void Draw()
@@ -85,6 +88,7 @@ public class MainWindow
                 _ui.ChannelId = _channelId;
                 _ = _ui.RefreshEmbeds();
                 _create.ChannelId = _channelId;
+                _templates.ChannelId = _channelId;
             }
         }
         else
@@ -113,6 +117,13 @@ public class MainWindow
             if (HasOfficerRole && ImGui.BeginTabItem("Officer"))
             {
                 _officer.Draw();
+                ImGui.EndTabItem();
+            }
+
+            if (HasOfficerRole && ImGui.BeginTabItem("Templates"))
+            {
+                _templates.ChannelId = _channelId;
+                _templates.Draw();
                 ImGui.EndTabItem();
             }
 
@@ -160,6 +171,7 @@ public class MainWindow
                 _channelId = _channels[_selectedIndex];
                 _ui.ChannelId = _channelId;
                 _create.ChannelId = _channelId;
+                _templates.ChannelId = _channelId;
             }
         }
         catch

--- a/DemiCatPlugin/Template.cs
+++ b/DemiCatPlugin/Template.cs
@@ -1,0 +1,8 @@
+namespace DemiCatPlugin;
+
+public class Template
+{
+    public string Name { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+}
+

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Numerics;
+using System.Threading.Tasks;
+using Dalamud.Bindings.ImGui;
+
+namespace DemiCatPlugin;
+
+public class TemplatesWindow : IDisposable
+{
+    private readonly Config _config;
+    private readonly HttpClient _httpClient = new();
+    private int _selectedIndex = -1;
+    private bool _showPreview;
+    private string _previewContent = string.Empty;
+
+    public string ChannelId { get; set; } = string.Empty;
+
+    public TemplatesWindow(Config config)
+    {
+        _config = config;
+    }
+
+    public void Draw()
+    {
+        ImGui.BeginChild("TemplateList", new Vector2(150, 0), true);
+        for (var i = 0; i < _config.Templates.Count; i++)
+        {
+            var name = _config.Templates[i].Name;
+            if (ImGui.Selectable(name, _selectedIndex == i))
+            {
+                _selectedIndex = i;
+                _showPreview = false;
+            }
+        }
+        ImGui.EndChild();
+
+        ImGui.SameLine();
+
+        ImGui.BeginChild("TemplateContent", new Vector2(0, 0), false);
+        if (_selectedIndex >= 0)
+        {
+            var tmpl = _config.Templates[_selectedIndex];
+            if (ImGui.Button("Preview"))
+            {
+                _previewContent = tmpl.Content;
+                _showPreview = true;
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Post"))
+            {
+                _ = PostTemplate(tmpl.Content);
+            }
+        }
+        else
+        {
+            ImGui.TextUnformatted("Select a template");
+        }
+        ImGui.EndChild();
+
+        if (_showPreview)
+        {
+            if (ImGui.Begin("Template Preview", ref _showPreview))
+            {
+                ImGui.TextUnformatted(_previewContent);
+            }
+            ImGui.End();
+        }
+    }
+
+    private async Task PostTemplate(string content)
+    {
+        if (string.IsNullOrWhiteSpace(ChannelId))
+        {
+            return;
+        }
+        try
+        {
+            var body = new { channelId = ChannelId, content, useCharacterName = _config.UseCharacterName };
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/messages");
+            request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Add("X-Api-Key", _config.AuthToken);
+            }
+            await _httpClient.SendAsync(request);
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add TemplatesWindow for selecting, previewing, and posting templates
- wire Templates tab into main window and channel selection
- persist templates via new config list

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_e_689b81d0cf4c8328981f90de35830476