### PR TITLE
Add officer channel selection

### DIFF
--- a/python_demibot/routes/channels.py
+++ b/python_demibot/routes/channels.py
@@ -12,6 +12,18 @@ async def get_channels(info: dict = Depends(get_api_key_info)):
         event = settings.get("eventChannels", [])
         fc = [settings["fcChatChannel"]] if settings.get("fcChatChannel") else []
         officer = [settings["officerChatChannel"]] if settings.get("officerChatChannel") else []
-        return {"event": event, "fc_chat": fc, "officer_chat": officer}
+
+        # ``officer_visible`` combines all channels that an officer is allowed
+        # to view.  This includes the FC chat channel as well as the dedicated
+        # officer chat channel.  The list is de-duplicated to avoid returning
+        # the same channel twice if both settings point to the same ID.
+        officer_visible = list(dict.fromkeys(fc + officer))
+
+        return {
+            "event": event,
+            "fc_chat": fc,
+            "officer_chat": officer,
+            "officer_visible": officer_visible,
+        }
     except Exception as err:  # pragma: no cover - defensive
         raise HTTPException(status_code=500, detail="Failed to fetch channels") from err


### PR DESCRIPTION
## Summary
- include officer-visible channel IDs in `/api/channels`
- allow officer chat window to switch channels and persist selection

## Testing
- `pytest`
- `python -m py_compile python_demibot/routes/channels.py`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b833a2bb08328aefa4af7899ff8d3