### PR TITLE
Add configurable WebSocket path for plugin

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -10,6 +10,7 @@ public class Config : IPluginConfiguration
 
     public bool Enabled { get; set; } = true;
     public string HelperBaseUrl { get; set; } = "http://localhost:3000";
+    public string WebSocketPath { get; set; } = "/ws/embeds";
     public int PollIntervalSeconds { get; set; } = 5;
     public string? AuthToken { get; set; }
     public string ServerAddress { get; set; } = "http://localhost:3300";

--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -8,6 +8,7 @@ public class DeveloperWindow
     private readonly Config _config;
     private string _ip;
     private int _port;
+    private string _wsPath;
 
     public bool IsOpen;
 
@@ -17,6 +18,7 @@ public class DeveloperWindow
         var uri = new Uri(config.ServerAddress);
         _ip = uri.Host;
         _port = uri.Port;
+        _wsPath = config.WebSocketPath;
     }
 
     public void Draw()
@@ -34,10 +36,12 @@ public class DeveloperWindow
 
         ImGui.InputText("Server IP", ref _ip, 64);
         ImGui.InputInt("Port", ref _port);
+        ImGui.InputText("WebSocket Path", ref _wsPath, 64);
 
         if (ImGui.Button("Save"))
         {
             _config.ServerAddress = $"http://{_ip}:{_port}";
+            _config.WebSocketPath = _wsPath;
             PluginServices.PluginInterface.SavePluginConfig(_config);
         }
 

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -146,7 +146,9 @@ public class Plugin : IDalamudPlugin
         {
             _webSocket?.Dispose();
             _webSocket = new ClientWebSocket();
-            var wsUri = new Uri(_config.HelperBaseUrl.TrimEnd('/')
+            var baseUrl = _config.HelperBaseUrl.TrimEnd('/');
+            var fullUrl = $"{baseUrl}{_config.WebSocketPath}";
+            var wsUri = new Uri(fullUrl
                 .Replace("http://", "ws://")
                 .Replace("https://", "wss://"));
             await _webSocket.ConnectAsync(wsUri, CancellationToken.None);


### PR DESCRIPTION
## Summary
- append `/ws/embeds` to WebSocket URI
- allow configuring WebSocket path in Config and developer window

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689b9ec602248328835ed1ab9e8dd497