### PR TITLE
Align channel DTOs with backend key names

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Numerics;
 using System.Threading.Tasks;
@@ -76,6 +77,22 @@ public class ChatWindow : IDisposable
             _ = SendMessage();
         }
 
+    }
+
+    public void SetChannels(List<string> channels)
+    {
+        _channelsLoaded = true;
+        _channels.Clear();
+        _channels.AddRange(channels);
+        if (!string.IsNullOrEmpty(_channelId))
+        {
+            _selectedIndex = _channels.IndexOf(_channelId);
+            if (_selectedIndex < 0) _selectedIndex = 0;
+        }
+        if (_channels.Count > 0)
+        {
+            _channelId = _channels[_selectedIndex];
+        }
     }
 
     protected string FormatContent(ChatMessageDto msg)
@@ -179,17 +196,7 @@ public class ChatWindow : IDisposable
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             _ = PluginServices.Framework.RunOnTick(() =>
             {
-                _channels.Clear();
-                _channels.AddRange(dto.Chat);
-                if (!string.IsNullOrEmpty(_channelId))
-                {
-                    _selectedIndex = _channels.IndexOf(_channelId);
-                    if (_selectedIndex < 0) _selectedIndex = 0;
-                }
-                if (_channels.Count > 0)
-                {
-                    _channelId = _channels[_selectedIndex];
-                }
+                SetChannels(dto.Chat);
             });
         }
         catch
@@ -215,7 +222,6 @@ public class ChatWindow : IDisposable
 
     protected class ChannelListDto
     {
-        public List<string> Event { get; set; } = new();
-        public List<string> Chat { get; set; } = new();
+        [JsonPropertyName("fc_chat")] public List<string> Chat { get; set; } = new();
     }
 }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Numerics;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
@@ -18,6 +19,8 @@ public class MainWindow
     private readonly TemplatesWindow _templates;
     private readonly HttpClient _httpClient = new();
     private readonly List<string> _channels = new();
+    private readonly List<string> _fcChatChannels = new();
+    private readonly List<string> _officerChatChannels = new();
     private bool _channelsLoaded;
     private int _selectedIndex;
     private string _channelId;
@@ -161,6 +164,12 @@ public class MainWindow
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             _channels.Clear();
             _channels.AddRange(dto.Event);
+            _fcChatChannels.Clear();
+            _fcChatChannels.AddRange(dto.FcChat);
+            _officerChatChannels.Clear();
+            _officerChatChannels.AddRange(dto.OfficerChat);
+            _chat?.SetChannels(_fcChatChannels);
+            _officer.SetChannels(_officerChatChannels);
             if (!string.IsNullOrEmpty(_channelId))
             {
                 _selectedIndex = _channels.IndexOf(_channelId);
@@ -182,7 +191,9 @@ public class MainWindow
 
     private class ChannelListDto
     {
-        public List<string> Event { get; set; } = new();
-        public List<string> Chat { get; set; } = new();
+        [JsonPropertyName("event")] public List<string> Event { get; set; } = new();
+        [JsonPropertyName("fc_chat")] public List<string> FcChat { get; set; } = new();
+        [JsonPropertyName("officer_chat")] public List<string> OfficerChat { get; set; } = new();
+        [JsonPropertyName("officer_visible")] public List<string> OfficerVisible { get; set; } = new();
     }
 }

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -147,17 +147,7 @@ public class OfficerChatWindow : ChatWindow
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             _ = PluginServices.Framework.RunOnTick(() =>
             {
-                _channels.Clear();
-                _channels.AddRange(dto.Officer);
-                if (!string.IsNullOrEmpty(_channelId))
-                {
-                    _selectedIndex = _channels.IndexOf(_channelId);
-                    if (_selectedIndex < 0) _selectedIndex = 0;
-                }
-                if (_channels.Count > 0)
-                {
-                    _channelId = _channels[_selectedIndex];
-                }
+                SetChannels(dto.Officer);
             });
         }
         catch
@@ -168,7 +158,7 @@ public class OfficerChatWindow : ChatWindow
 
     private class ChannelListDto
     {
-        [JsonPropertyName("officer_visible")]
+        [JsonPropertyName("officer_chat")]
         public List<string> Officer { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- map channel DTO properties to `event`, `fc_chat`, `officer_chat`, and `officer_visible`
- populate event channel list and propagate chat/officer channels to respective windows
- support channel injection in chat windows and deserialize `fc_chat`/`officer_chat` keys

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ba6515a308328b6e7dfd82a904a22