### PR TITLE
Add button data to embed WebSocket payloads

### DIFF
--- a/python_demibot/discord_bot.py
+++ b/python_demibot/discord_bot.py
@@ -116,6 +116,18 @@ class DemiBot(commands.Bot):
 
     @staticmethod
     def map_embed(embed: discord.Embed, message: discord.Message) -> Dict[str, Any]:
+        buttons = []
+        for row in getattr(message, "components", []):
+            for component in getattr(row, "children", []):
+                if getattr(component, "type", None) == discord.ComponentType.button:
+                    buttons.append(
+                        {
+                            "label": getattr(component, "label", None),
+                            "customId": getattr(component, "custom_id", None),
+                            "url": getattr(component, "url", None),
+                        }
+                    )
+
         return {
             "id": str(message.id),
             "channelId": str(message.channel.id),
@@ -134,6 +146,7 @@ class DemiBot(commands.Bot):
             else None,
             "thumbnailUrl": embed.thumbnail.url if embed.thumbnail else None,
             "imageUrl": embed.image.url if embed.image else None,
+            "buttons": buttons if buttons else None,
         }
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Capture button metadata when mapping Discord embeds
- Attach mapped buttons to cached embeds and broadcast payloads

## Testing
- `python -m py_compile python_demibot/discord_bot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba8be31fc83289490bee58a58a792