### PR TITLE
Align schema with runtime table definitions

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -31,6 +31,15 @@ CREATE TABLE IF NOT EXISTS events (
   FOREIGN KEY (channel_id) REFERENCES channels(id)
 );
 
+CREATE TABLE IF NOT EXISTS event_attendance (
+  event_id INT,
+  user_id VARCHAR(255),
+  status ENUM('yes','maybe','no') NOT NULL,
+  PRIMARY KEY (event_id, user_id),
+  FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
 CREATE TABLE IF NOT EXISTS api_keys (
   api_key VARCHAR(255) PRIMARY KEY,
   user_id VARCHAR(255),
@@ -58,10 +67,7 @@ CREATE TABLE IF NOT EXISTS user_roles (
 );
 
 CREATE TABLE IF NOT EXISTS server_settings (
-  server_id VARCHAR(255),
-  setting_key VARCHAR(255),
-  setting_value TEXT,
-  PRIMARY KEY (server_id, setting_key),
-  FOREIGN KEY (server_id) REFERENCES servers(id),
-  INDEX (server_id)
+  guild_id VARCHAR(255) PRIMARY KEY,
+  settings TEXT
 );
+

--- a/database/setup.py
+++ b/database/setup.py
@@ -34,6 +34,20 @@ def apply_migrations(cursor):
         cursor.execute('ALTER TABLE users ADD INDEX (server_id)')
         cursor.execute('ALTER TABLE users ADD CONSTRAINT fk_users_server FOREIGN KEY (server_id) REFERENCES servers(id)')
 
+    cursor.execute("SHOW TABLES LIKE 'server_settings'")
+    if cursor.fetchone():
+        cursor.execute("SHOW COLUMNS FROM server_settings LIKE 'setting_key'")
+        if cursor.fetchone():
+            cursor.execute('DROP TABLE server_settings')
+            cursor.execute(
+                """
+                CREATE TABLE server_settings (
+                    guild_id VARCHAR(255) PRIMARY KEY,
+                    settings TEXT
+                )
+                """
+            )
+
 
 def main():
     parser = argparse.ArgumentParser(description='Initialize the DemiBot database')


### PR DESCRIPTION
## Summary
- add event_attendance table and JSON-based server_settings to schema
- drop legacy server_settings entries in setup script when initializing

## Testing
- `python -m py_compile database/setup.py`


------
https://chatgpt.com/codex/tasks/task_e_689bae931c4c8328bd45df4239f8af26