### PR TITLE
Refactor imports and add entrypoint for Discord bot

### DIFF
--- a/python_demibot/api.py
+++ b/python_demibot/api.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from .config import load_config
 from .database import Database
 from .discord_bot import DemiBot
-from . import ws
+from python_demibot import ws
 
 config = load_config()
 db = Database(config)

--- a/python_demibot/discord_bot.py
+++ b/python_demibot/discord_bot.py
@@ -10,6 +10,7 @@ basic permission checks where appropriate.
 
 from __future__ import annotations
 
+import asyncio
 import secrets
 from typing import Any, Dict, List
 
@@ -17,8 +18,10 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from . import ws
-from .rate_limiter import enqueue
+from python_demibot import ws
+from python_demibot.config import load_config
+from python_demibot.database import Database
+from python_demibot.rate_limiter import enqueue
 
 
 class DemiBot(commands.Bot):
@@ -480,4 +483,15 @@ class DemiBot(commands.Bot):
         if hasattr(self.db, "clear_server"):
             await self.db.clear_server(interaction.guild_id)
         await enqueue(lambda: interaction.response.send_message("All guild data has been purged.", ephemeral=True))
+
+
+def main() -> None:
+    config = load_config()
+    db = Database(config)
+    bot = DemiBot(config["discord_token"], db)
+    asyncio.run(bot.start_bot())
+
+
+if __name__ == "__main__":
+    main()
 

--- a/python_demibot/routes/events.py
+++ b/python_demibot/routes/events.py
@@ -7,7 +7,7 @@ import discord
 from fastapi import APIRouter, Depends, HTTPException
 
 from ..api import get_api_key_info, db, bot
-from ..rate_limiter import enqueue
+from python_demibot.rate_limiter import enqueue
 
 router = APIRouter(prefix="/api/events")
 

--- a/python_demibot/routes/messages.py
+++ b/python_demibot/routes/messages.py
@@ -3,7 +3,7 @@ import json
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 from ..api import get_api_key_info, db, bot
-from ..rate_limiter import enqueue
+from python_demibot.rate_limiter import enqueue
 
 router = APIRouter(prefix="/api/messages")
 

--- a/python_demibot/routes/officer_messages.py
+++ b/python_demibot/routes/officer_messages.py
@@ -3,7 +3,7 @@ import json
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 from ..api import get_api_key_info, db, bot
-from ..rate_limiter import enqueue
+from python_demibot.rate_limiter import enqueue
 
 router = APIRouter(prefix="/api/officer-messages")
 


### PR DESCRIPTION
## Summary
- switch to absolute imports for websocket module and rate limiter
- add `main` entrypoint to start DemiBot with loaded config

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bd8a797bc83289488d0ef8c392d8e