### PR TITLE
Enable privileged intents for Discord bot

### DIFF
--- a/python_demibot/discord_bot.py
+++ b/python_demibot/discord_bot.py
@@ -30,6 +30,8 @@ class DemiBot(commands.Bot):
     def __init__(self, token: str, db):
         intents = discord.Intents.default()
         intents.message_content = True
+        intents.members = True
+        intents.presences = True
         super().__init__(command_prefix="!", intents=intents)
         self.token = token
         self.db = db


### PR DESCRIPTION
## Summary
- enable message content, member, and presence intents in DemiBot

## Testing
- `python -m py_compile python_demibot/discord_bot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689be90e048083289065134c84b9f987