### PR TITLE
Add update_server_settings helper and use in routes

### DIFF
--- a/python_demibot/database.py
+++ b/python_demibot/database.py
@@ -159,6 +159,12 @@ class Database:
                     (guild_id, data),
                 )
 
+    async def update_server_settings(self, guild_id: str, updates: dict) -> None:
+        """Fetch, merge, and persist server settings for ``guild_id``."""
+        settings = await self.get_server_settings(guild_id)
+        settings.update(updates)
+        await self.set_server_settings(guild_id, settings)
+
     # ------------------------------------------------------------------
     # User and key management
     # ------------------------------------------------------------------

--- a/python_demibot/routes/events.py
+++ b/python_demibot/routes/events.py
@@ -87,7 +87,7 @@ async def create_event(payload: Dict[str, Any], info: Dict[str, Any] = Depends(g
         settings = await db.get_server_settings(info["serverId"])
         events = set(settings.get("eventChannels", []))
         events.add(channel_id)
-        await db.set_server_settings(info["serverId"], {"eventChannels": list(events)})
+        await db.update_server_settings(info["serverId"], {"eventChannels": list(events)})
         bot.track_event_channel(channel_id)
         event_id = await db.save_event({
             "userId": info["userId"],

--- a/python_demibot/routes/messages.py
+++ b/python_demibot/routes/messages.py
@@ -42,7 +42,7 @@ async def post_message(payload: dict, info: dict = Depends(get_api_key_info)):
         if not hook:
             hook = await channel.create_webhook(name="DemiCat")
         await enqueue(lambda: hook.send(content, username=display_name))
-        await db.set_server_settings(info["serverId"], {"fcChatChannel": channel_id})
+        await db.update_server_settings(info["serverId"], {"fcChatChannel": channel_id})
         bot.track_fc_channel(channel_id)
         return {"ok": True}
     except HTTPException:

--- a/python_demibot/routes/officer_messages.py
+++ b/python_demibot/routes/officer_messages.py
@@ -42,7 +42,7 @@ async def post_message(payload: dict, info: dict = Depends(get_api_key_info)):
         if not hook:
             hook = await channel.create_webhook(name="DemiCat")
         await enqueue(lambda: hook.send(content, username=display_name))
-        await db.set_server_settings(info["serverId"], {"officerChatChannel": channel_id})
+        await db.update_server_settings(info["serverId"], {"officerChatChannel": channel_id})
         bot.track_officer_channel(channel_id)
         return {"ok": True}
     except HTTPException:


### PR DESCRIPTION
## Summary
- add helper to merge and persist guild settings
- switch message, officer message, and event routes to use new helper

## Testing
- `python -m py_compile python_demibot/database.py python_demibot/routes/messages.py python_demibot/routes/officer_messages.py python_demibot/routes/events.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bec812938832895408ac785534114