### PR TITLE
Add DemiBot backend skeleton

### DIFF
--- a/demibot/.env.example
+++ b/demibot/.env.example
@@ -1,0 +1,4 @@
+DISCORD_TOKEN=
+DATABASE_URL=mysql+aiomysql://user:pass@127.0.0.1:3306/demibot
+HOST=127.0.0.1
+PORT=8123

--- a/demibot/README.md
+++ b/demibot/README.md
@@ -1,0 +1,12 @@
+# DemiBot
+
+Backend helper for the DemiCat Dalamud plugin. Provides a Discord bot and HTTP+WebSocket
+API used by the plugin. See repository root README for plugin details.
+
+## Quickstart
+
+```bash
+python -m demibot.main
+```
+
+Configuration is stored in `~/.demibot/config.toml` and is created on first run.

--- a/demibot/demibot/__init__.py
+++ b/demibot/demibot/__init__.py
@@ -1,0 +1,4 @@
+"""DemiBot package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel
+
+CONFIG_PATH = Path.home() / ".demibot" / "config.toml"
+
+
+class DiscordConfig(BaseModel):
+    token: str
+
+
+class ServerConfig(BaseModel):
+    host: str = "127.0.0.1"
+    port: int = 8123
+    websocket_path: str = "/ws"
+
+
+class DatabaseConfig(BaseModel):
+    url: str
+
+
+class SecurityConfig(BaseModel):
+    require_api_key: bool = True
+
+
+class AppConfig(BaseModel):
+    discord: DiscordConfig
+    server: ServerConfig
+    database: DatabaseConfig
+    security: SecurityConfig = SecurityConfig()
+
+
+def load_config(path: Path = CONFIG_PATH) -> AppConfig:
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    return AppConfig.model_validate(data)
+
+
+def ensure_config(path: Path = CONFIG_PATH) -> AppConfig:
+    """Load config or raise if missing. CLI wizard should create it."""
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Config not found at {path}. Run scripts/first_run_wizard.py"
+        )
+    return load_config(path)

--- a/demibot/demibot/db/__init__.py
+++ b/demibot/demibot/db/__init__.py
@@ -1,0 +1,3 @@
+from .base import Base
+
+__all__ = ["Base"]

--- a/demibot/demibot/db/base.py
+++ b/demibot/demibot/db/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/demibot/demibot/db/migrations/env.py
+++ b/demibot/demibot/db/migrations/env.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+from pathlib import Path
+
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy import create_engine
+from alembic import context
+
+from ..base import Base
+from .. import models  # noqa: F401
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=Base.metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=Base.metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class Guild(Base):
+    __tablename__ = "guilds"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    discord_guild_id: Mapped[int] = mapped_column(BigInteger, unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    config: Mapped["GuildConfig"] = relationship(back_populates="guild", uselist=False)
+
+
+class GuildConfig(Base):
+    __tablename__ = "guild_config"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
+    event_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    fc_chat_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    officer_chat_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    officer_visible_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    officer_role_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    chat_role_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+
+    guild: Mapped[Guild] = relationship(back_populates="config")
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    discord_user_id: Mapped[int] = mapped_column(BigInteger, unique=True, index=True)
+    global_name: Mapped[Optional[str]] = mapped_column(String(255))
+    discriminator: Mapped[Optional[str]] = mapped_column(String(10))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+
+class UserKey(Base):
+    __tablename__ = "user_keys"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
+    token: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    roles_cached: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    last_used_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    discord_message_id: Mapped[int] = mapped_column(BigInteger, index=True)
+    channel_id: Mapped[int] = mapped_column(BigInteger, index=True)
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
+    author_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    author_name: Mapped[str] = mapped_column(String(255))
+    content_raw: Mapped[str] = mapped_column(Text)
+    content_display: Mapped[str] = mapped_column(Text)
+    mentions_json: Mapped[Optional[str]] = mapped_column(Text)
+    is_officer: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class Embed(Base):
+    __tablename__ = "embeds"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    discord_message_id: Mapped[int] = mapped_column(BigInteger, index=True)
+    channel_id: Mapped[int] = mapped_column(BigInteger, index=True)
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
+    payload_json: Mapped[str] = mapped_column(Text)
+    last_broadcast_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
+
+
+class RSVP(enum.Enum):
+    yes = "yes"
+    maybe = "maybe"
+    no = "no"
+
+
+class Attendance(Base):
+    __tablename__ = "attendance"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    discord_message_id: Mapped[int] = mapped_column(BigInteger, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    choice: Mapped[RSVP] = mapped_column(String(10))
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/demibot/demibot/db/session.py
+++ b/demibot/demibot/db/session.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+
+_engine: AsyncEngine | None = None
+_Session: async_sessionmaker[AsyncSession] | None = None
+
+
+def create_engine(url: str) -> AsyncEngine:
+    global _engine, _Session
+    _engine = create_async_engine(url, echo=False, future=True)
+    _Session = async_sessionmaker(_engine, expire_on_commit=False)
+    return _engine
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    if _Session is None:
+        raise RuntimeError("Engine not initialized")
+    async with _Session() as session:
+        yield session

--- a/demibot/demibot/discordbot/__init__.py
+++ b/demibot/demibot/discordbot/__init__.py
@@ -1,0 +1,3 @@
+from .bot import create_bot
+
+__all__ = ["create_bot"]

--- a/demibot/demibot/discordbot/bot.py
+++ b/demibot/demibot/discordbot/bot.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+
+from ..config import AppConfig
+
+
+class DemiBot(commands.Bot):
+    def __init__(self, cfg: AppConfig) -> None:
+        intents = discord.Intents.all()
+        super().__init__(command_prefix="!", intents=intents)
+        self.cfg = cfg
+
+    async def setup_hook(self) -> None:
+        base = Path(__file__).parent / "cogs"
+        for mod in pkgutil.iter_modules([str(base)]):
+            await self.load_extension(f"{__package__}.cogs.{mod.name}")
+
+        modules_base = Path(__file__).parent.parent / "modules"
+        for mod in pkgutil.iter_modules([str(modules_base)]):
+            await self.load_extension(f"{__package__}.modules.{mod.name}")
+
+
+def create_bot(cfg: AppConfig) -> DemiBot:
+    return DemiBot(cfg)

--- a/demibot/demibot/discordbot/cogs/events.py
+++ b/demibot/demibot/discordbot/cogs/events.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from .setup_wizard import demi
+
+
+class Events(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+
+@demi.command(name="event", description="Create a simple event")
+async def create_event(interaction: discord.Interaction) -> None:
+    await interaction.response.send_message("Event created (placeholder)", ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Events(bot))

--- a/demibot/demibot/discordbot/cogs/keygen.py
+++ b/demibot/demibot/discordbot/cogs/keygen.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import secrets
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from .setup_wizard import demi
+
+
+class KeyGen(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+
+@demi.command(name="key", description="Generate an API key")
+async def key_command(interaction: discord.Interaction) -> None:
+    token = secrets.token_hex(16)
+    try:
+        await interaction.user.send(f"Your API key: {token}")
+        await interaction.response.send_message("Sent you a DM with your key", ephemeral=True)
+    except discord.Forbidden:
+        await interaction.response.send_message("Unable to send DM", ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(KeyGen(bot))

--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import discord
+from discord.ext import commands
+
+
+class Mirror(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        if message.author.bot:
+            return
+        # Placeholder: store message, process mentions, etc.
+        
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Mirror(bot))

--- a/demibot/demibot/discordbot/cogs/setup_wizard.py
+++ b/demibot/demibot/discordbot/cogs/setup_wizard.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+
+demi = app_commands.Group(name="demi", description="DemiBot commands")
+
+
+@demi.command(name="status", description="Show current status")
+async def status(interaction: discord.Interaction) -> None:
+    await interaction.response.send_message("DemiBot is running", ephemeral=True)
+
+
+class SetupWizard(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(SetupWizard(bot))
+    bot.tree.add_command(demi)

--- a/demibot/demibot/http/__init__.py
+++ b/demibot/demibot/http/__init__.py
@@ -1,0 +1,3 @@
+from .api import create_app
+
+__all__ = ["create_app"]

--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from ..config import AppConfig
+from ..db.session import get_session
+from .routes import (
+    channels,
+    messages,
+    officer_messages,
+    users,
+    embeds,
+    events,
+    interactions,
+    validate_roles,
+)
+from .ws import websocket_endpoint
+
+
+def create_app(cfg: AppConfig, engine) -> FastAPI:
+    app = FastAPI(title="DemiBot API")
+    app.include_router(validate_roles.router)
+    app.include_router(channels.router)
+    app.include_router(messages.router)
+    app.include_router(officer_messages.router)
+    app.include_router(users.router)
+    app.include_router(embeds.router)
+    app.include_router(events.router)
+    app.include_router(interactions.router)
+
+    app.add_api_websocket_route(cfg.server.websocket_path, websocket_endpoint)
+    return app

--- a/demibot/demibot/http/deps.py
+++ b/demibot/demibot/http/deps.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import Depends, Header, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db.models import Guild, User, UserKey
+from ..db.session import get_session
+
+
+@dataclass
+class RequestContext:
+    user: User
+    guild: Guild
+    key: UserKey
+
+
+async def get_db() -> AsyncSession:
+    async for session in get_session():
+        yield session
+
+
+async def api_key_auth(
+    x_api_key: str = Header(alias="X-Api-Key"),
+    db: AsyncSession = Depends(get_db),
+) -> RequestContext:
+    stmt = (
+        select(User, Guild, UserKey)
+        .join(UserKey, User.id == UserKey.user_id)
+        .join(Guild, Guild.id == UserKey.guild_id)
+        .where(UserKey.token == x_api_key, UserKey.enabled)
+    )
+    result = await db.execute(stmt)
+    row = result.one_or_none()
+    if not row:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    user, guild, key = row
+    return RequestContext(user=user, guild=guild, key=key)

--- a/demibot/demibot/http/routes/__init__.py
+++ b/demibot/demibot/http/routes/__init__.py
@@ -1,0 +1,12 @@
+from . import channels, messages, officer_messages, users, embeds, events, interactions, validate_roles
+
+__all__ = [
+    "channels",
+    "messages",
+    "officer_messages",
+    "users",
+    "embeds",
+    "events",
+    "interactions",
+    "validate_roles",
+]

--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ...db.models import GuildConfig
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/channels")
+async def get_channels(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    stmt = select(GuildConfig).where(GuildConfig.guild_id == ctx.guild.id)
+    result = await db.execute(stmt)
+    cfg = result.scalar_one_or_none()
+    return {
+        "event": [str(cfg.event_channel_id)] if cfg and cfg.event_channel_id else [],
+        "fc_chat": [str(cfg.fc_chat_channel_id)] if cfg and cfg.fc_chat_channel_id else [],
+        "officer_chat": [str(cfg.officer_chat_channel_id)] if cfg and cfg.officer_chat_channel_id else [],
+        "officer_visible": [str(cfg.officer_visible_channel_id)] if cfg and cfg.officer_visible_channel_id else [],
+    }

--- a/demibot/demibot/http/routes/embeds.py
+++ b/demibot/demibot/http/routes/embeds.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ..schemas import EmbedDto
+from ...db.models import Embed
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/embeds", response_model=list[EmbedDto])
+async def get_embeds(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> list[EmbedDto]:
+    stmt = select(Embed).where(Embed.guild_id == ctx.guild.id)
+    result = await db.execute(stmt)
+    embeds = result.scalars().all()
+    out: list[EmbedDto] = []
+    for e in embeds:
+        out.append(EmbedDto(id=str(e.discord_message_id), channelId=e.channel_id))
+    return out

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from ..deps import RequestContext, api_key_auth
+
+router = APIRouter(prefix="/api")
+
+
+class EventRequest(BaseModel):
+    channelId: str
+    title: str
+    time: str
+    description: str | None = None
+
+
+@router.post("/events")
+async def create_event(
+    body: EventRequest,
+    ctx: RequestContext = Depends(api_key_auth),
+) -> dict:
+    # Placeholder: actual implementation would post to Discord and store
+    return {"status": "ok"}

--- a/demibot/demibot/http/routes/interactions.py
+++ b/demibot/demibot/http/routes/interactions.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from ..deps import RequestContext, api_key_auth
+
+router = APIRouter(prefix="/api")
+
+
+class InteractionRequest(BaseModel):
+    MessageId: str
+    ChannelId: int
+    CustomId: str
+
+
+@router.post("/interactions")
+async def interactions(
+    body: InteractionRequest,
+    ctx: RequestContext = Depends(api_key_auth),
+) -> dict:
+    # Placeholder: update attendance and broadcast
+    return {"status": "ok"}

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ..schemas import ChatMessage, Mention
+from ...db.models import Message
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/messages/{channel_id}", response_model=List[ChatMessage])
+async def get_messages(
+    channel_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> List[ChatMessage]:
+    stmt = (
+        select(Message)
+        .where(Message.channel_id == channel_id)
+        .order_by(Message.created_at.asc())
+        .limit(50)
+    )
+    result = await db.execute(stmt)
+    messages = result.scalars().all()
+    return [
+        ChatMessage(
+            id=str(m.discord_message_id),
+            channelId=str(m.channel_id),
+            authorName=m.author_name,
+            content=m.content_display,
+            mentions=None,
+        )
+        for m in messages
+    ]
+
+
+class PostMessage(BaseModel):
+    channelId: str
+    content: str
+    useCharacterName: bool = False
+
+
+@router.post("/messages")
+async def post_message(
+    body: PostMessage,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    msg = Message(
+        discord_message_id=int(datetime.utcnow().timestamp() * 1000),
+        channel_id=int(body.channelId),
+        guild_id=ctx.guild.id,
+        author_id=ctx.user.id,
+        author_name=ctx.user.global_name or "Unknown",
+        content_raw=body.content,
+        content_display=body.content,
+        mentions_json=None,
+        is_officer=False,
+    )
+    db.add(msg)
+    await db.commit()
+    return

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ..schemas import ChatMessage
+from ...db.models import Message
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/officer-messages/{channel_id}", response_model=List[ChatMessage])
+async def get_officer_messages(
+    channel_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> List[ChatMessage]:
+    stmt = (
+        select(Message)
+        .where(Message.channel_id == channel_id, Message.is_officer)
+        .order_by(Message.created_at.asc())
+        .limit(50)
+    )
+    result = await db.execute(stmt)
+    messages = result.scalars().all()
+    return [
+        ChatMessage(
+            id=str(m.discord_message_id),
+            channelId=str(m.channel_id),
+            authorName=m.author_name,
+            content=m.content_display,
+            mentions=None,
+        )
+        for m in messages
+    ]
+
+
+class PostMessage(BaseModel):
+    channelId: str
+    content: str
+    useCharacterName: bool = False
+
+
+@router.post("/officer-messages")
+async def post_officer_message(
+    body: PostMessage,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    msg = Message(
+        discord_message_id=int(datetime.utcnow().timestamp() * 1000),
+        channel_id=int(body.channelId),
+        guild_id=ctx.guild.id,
+        author_id=ctx.user.id,
+        author_name=ctx.user.global_name or "Unknown",
+        content_raw=body.content,
+        content_display=body.content,
+        mentions_json=None,
+        is_officer=True,
+    )
+    db.add(msg)
+    await db.commit()
+    return

--- a/demibot/demibot/http/routes/users.py
+++ b/demibot/demibot/http/routes/users.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ...db.models import User, UserKey
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/users")
+async def list_users(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> list[dict]:
+    stmt = (
+        select(User)
+        .join(UserKey, User.id == UserKey.user_id)
+        .where(UserKey.guild_id == ctx.guild.id)
+    )
+    result = await db.execute(stmt)
+    users = result.scalars().all()
+    return [{"id": str(u.discord_user_id), "name": u.global_name or "Unknown"} for u in users]

--- a/demibot/demibot/http/routes/validate_roles.py
+++ b/demibot/demibot/http/routes/validate_roles.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import api_key_auth, get_db, RequestContext
+from ...db.models import UserKey
+
+router = APIRouter()
+
+
+class ValidateRequest(BaseModel):
+    key: str
+
+
+@router.post("/validate")
+async def validate(body: ValidateRequest, db: AsyncSession = Depends(get_db)) -> None:
+    stmt = select(UserKey).where(UserKey.token == body.key, UserKey.enabled)
+    result = await db.execute(stmt)
+    key = result.scalar_one_or_none()
+    if not key:
+        raise HTTPException(status_code=401)
+    return
+
+
+class RolesResponse(BaseModel):
+    roles: list[str] = []
+
+
+@router.post("/roles", response_model=RolesResponse)
+async def roles(ctx: RequestContext = Depends(api_key_auth)) -> RolesResponse:
+    # For now, roles are not computed; placeholder empty list
+    return RolesResponse(roles=[])

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class Mention(BaseModel):
+    id: str
+    name: str
+
+
+class ChatMessage(BaseModel):
+    id: str
+    channelId: str
+    authorName: str
+    content: str
+    mentions: List[Mention] | None = None
+
+
+class EmbedButtonDto(BaseModel):
+    label: str
+    url: Optional[str] = None
+    customId: Optional[str] = None
+
+
+class EmbedFieldDto(BaseModel):
+    name: str
+    value: str
+
+
+class EmbedDto(BaseModel):
+    id: str
+    timestamp: Optional[datetime] = None
+    color: Optional[int] = None
+    authorName: Optional[str] = None
+    authorIconUrl: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    fields: List[EmbedFieldDto] | None = None
+    thumbnailUrl: Optional[str] = None
+    imageUrl: Optional[str] = None
+    buttons: List[EmbedButtonDto] | None = None
+    channelId: Optional[int] = None
+    mentions: List[int] | None = None

--- a/demibot/demibot/http/ws.py
+++ b/demibot/demibot/http/ws.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Set
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        self.connections: Set[WebSocket] = set()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.connections.add(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        self.connections.discard(websocket)
+
+    async def broadcast(self, message: str) -> None:
+        for ws in list(self.connections):
+            await ws.send_text(message)
+
+
+manager = ConnectionManager()
+
+
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    await manager.connect(websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)

--- a/demibot/demibot/logging.py
+++ b/demibot/demibot/logging.py
@@ -1,0 +1,20 @@
+import logging
+import sys
+
+import structlog
+
+
+def setup_logging() -> None:
+    """Configure structlog with JSON output."""
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.add_log_level,
+            structlog.processors.EventRenamer("message"),
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+    )

--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -1,0 +1,41 @@
+import asyncio
+import logging
+
+import uvicorn
+
+from .config import ensure_config
+from .logging import setup_logging
+from .db.session import create_engine
+from .discordbot.bot import create_bot
+from .http.api import create_app
+
+
+async def start() -> None:
+    cfg = ensure_config()
+    setup_logging()
+    engine = create_engine(cfg.database.url)
+
+    bot = create_bot(cfg)
+    app = create_app(cfg, engine)
+
+    config = uvicorn.Config(app, host=cfg.server.host, port=cfg.server.port, log_level="info")
+    server = uvicorn.Server(config)
+
+    async with engine.begin():
+        pass  # placeholder for migrations
+
+    await asyncio.gather(
+        bot.start(cfg.discord.token),
+        server.serve(),
+    )
+
+
+def main() -> None:
+    try:
+        asyncio.run(start())
+    except KeyboardInterrupt:
+        logging.info("Shutting down")
+
+
+if __name__ == "__main__":
+    main()

--- a/demibot/demibot/modules/__init__.py
+++ b/demibot/demibot/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Module namespace for DemiBot extensions."""

--- a/demibot/pyproject.toml
+++ b/demibot/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "demibot"
+version = "0.1.0"
+description = "Discord bot and FastAPI backend for DemiCat plugin"
+requires-python = ">=3.11"
+authors = [{name = "DemiCat"}]
+readme = "README.md"
+license = {text = "MIT"}
+
+[project.dependencies]
+fastapi = "^0.110.0"
+uvicorn = {version = "^0.27.0", extras=["standard"]}
+discord.py = "^2.3.2"
+sqlalchemy = {version = "^2.0.25", extras=["asyncio"]}
+aiomysql = "^0.2.0"
+alembic = "^1.12.0"
+pydantic = "^2.5.0"
+structlog = "^23.2.0"
+python-dotenv = "^1.0.0"
+uvloop = {version = "^0.19.0", optional = true}
+
+[project.optional-dependencies]
+uvloop = ["uvloop"]
+
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pdm]
+[tool.black]
+line-length = 88
+

--- a/demibot/scripts/first_run_wizard.py
+++ b/demibot/scripts/first_run_wizard.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from demibot.config import CONFIG_PATH, AppConfig, DatabaseConfig, DiscordConfig, SecurityConfig, ServerConfig
+
+
+def run_wizard() -> None:
+    token = input("Discord bot token: ")
+    db_url = input("Database URL [mysql+aiomysql://user:pass@127.0.0.1:3306/demibot]: ") or "mysql+aiomysql://user:pass@127.0.0.1:3306/demibot"
+    host = input("HTTP host [127.0.0.1]: ") or "127.0.0.1"
+    port = int(input("HTTP port [8123]: ") or "8123")
+
+    cfg = AppConfig(
+        discord=DiscordConfig(token=token),
+        server=ServerConfig(host=host, port=port),
+        database=DatabaseConfig(url=db_url),
+        security=SecurityConfig(),
+    )
+
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(cfg.model_dump_json(indent=2))
+    print(f"Wrote config to {CONFIG_PATH}")
+
+
+if __name__ == "__main__":
+    run_wizard()


### PR DESCRIPTION
## Summary
- scaffold DemiBot backend with FastAPI server and Discord bot
- add async SQLAlchemy models and session helpers
- implement basic REST routes, websocket manager, and Discord cogs

## Testing
- `python -m py_compile $(find demibot -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689c8ae5f35083289a45579c1cfb9b3b