### PR TITLE
Add guild channel table and role-based auth

### DIFF
--- a/demibot/README.md
+++ b/demibot/README.md
@@ -17,8 +17,26 @@ alembic -c demibot/db/migrations/env.py upgrade head
 Copy `.env.example` to `.env` and adjust values as needed. The default configuration
 uses a local SQLite database and a demo API key.
 
+Environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `DEMIBOT_DB_URL` | Database connection URL |
+| `DEMIBOT_WS_PATH` | WebSocket path (default `/ws`) |
+| `DISCORD_TOKEN` | Discord bot token |
+
+Run database migrations:
+
+```bash
+alembic -c demibot/db/migrations/env.py upgrade head
+```
+
 Run the API server (and Discord bot if configured) with:
 
 ```bash
 python -m demibot.main
 ```
+
+The Discord bot requires the `GUILD_MESSAGES` and `GUILD_MEMBERS` intents.
+After obtaining an API key, the plugin wizard can configure channels via
+the `/api/channels` endpoint.

--- a/demibot/demibot/http/deps.py
+++ b/demibot/demibot/http/deps.py
@@ -6,7 +6,7 @@ from fastapi import Depends, Header, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..db.models import Guild, User, UserKey
+from ..db.models import Guild, User, UserKey, Membership, MembershipRole, Role
 from ..db.session import get_session
 
 
@@ -15,6 +15,7 @@ class RequestContext:
     user: User
     guild: Guild
     key: UserKey
+    roles: list[str]
 
 
 async def get_db() -> AsyncSession:
@@ -37,4 +38,17 @@ async def api_key_auth(
     if not row:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     user, guild, key = row
-    return RequestContext(user=user, guild=guild, key=key)
+    roles_stmt = (
+        select(Role)
+        .join(MembershipRole, MembershipRole.role_id == Role.id)
+        .join(Membership, MembershipRole.membership_id == Membership.id)
+        .where(Membership.guild_id == guild.id, Membership.user_id == user.id)
+    )
+    roles_result = await db.execute(roles_stmt)
+    roles: list[str] = []
+    for r in roles_result.scalars():
+        if r.is_officer:
+            roles.append("officer")
+        if r.is_chat:
+            roles.append("chat")
+    return RequestContext(user=user, guild=guild, key=key, roles=roles)

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,6 +26,8 @@ async def get_officer_messages(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
+    if "officer" not in ctx.roles:
+        raise HTTPException(status_code=403)
     stmt = (
         select(Message)
         .where(
@@ -54,6 +56,8 @@ async def post_officer_message(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
+    if "officer" not in ctx.roles:
+        raise HTTPException(status_code=403)
     msg = Message(
         discord_message_id=int(datetime.utcnow().timestamp() * 1000),
         channel_id=int(body.channelId),

--- a/demibot/demibot/http/routes/validate_roles.py
+++ b/demibot/demibot/http/routes/validate_roles.py
@@ -18,9 +18,4 @@ async def validate(_: RequestContext = Depends(api_key_auth)):
 
 @router.post("/roles", response_model=RolesResponse)
 async def roles(ctx: RequestContext = Depends(api_key_auth)) -> RolesResponse:
-    roles = [
-        r.strip()
-        for r in (ctx.key.roles_cached or "officer,chat").split(",")
-        if r.strip()
-    ]
-    return RolesResponse(roles=roles)
+    return RolesResponse(roles=ctx.roles)


### PR DESCRIPTION
## Summary
- store multi-channel config in new `guild_channels` table
- enforce officer role for officer message routes
- resolve user roles and memberships from database
- document environment variables and setup steps

## Testing
- `python -m py_compile demibot/demibot/http/routes/validate_roles.py demibot/demibot/http/deps.py demibot/demibot/http/routes/users.py demibot/demibot/http/routes/channels.py demibot/demibot/http/routes/officer_messages.py demibot/demibot/db/models.py`

------
https://chatgpt.com/codex/tasks/task_e_689e8f0ad0d08328b64e704877ff5c60