### PR TITLE
Add guild channel table and role-based auth

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -147,7 +147,10 @@ public class Plugin : IDalamudPlugin
             _webSocket?.Dispose();
             _webSocket = new ClientWebSocket();
             var baseUrl = _config.HelperBaseUrl.TrimEnd('/');
-            var fullUrl = $"{baseUrl}{_config.WebSocketPath}";
+            var tokenPart = string.IsNullOrEmpty(_config.AuthToken)
+                ? string.Empty
+                : $"?token={Uri.EscapeDataString(_config.AuthToken)}";
+            var fullUrl = $"{baseUrl}{_config.WebSocketPath}{tokenPart}";
             var wsUri = new Uri(fullUrl
                 .Replace("http://", "ws://")
                 .Replace("https://", "wss://"));

--- a/demibot/README.md
+++ b/demibot/README.md
@@ -17,8 +17,26 @@ alembic -c demibot/db/migrations/env.py upgrade head
 Copy `.env.example` to `.env` and adjust values as needed. The default configuration
 uses a local SQLite database and a demo API key.
 
+Environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `DEMIBOT_DB_URL` | Database connection URL |
+| `DEMIBOT_WS_PATH` | WebSocket path (default `/ws`) |
+| `DISCORD_TOKEN` | Discord bot token |
+
+Run database migrations:
+
+```bash
+alembic -c demibot/db/migrations/env.py upgrade head
+```
+
 Run the API server (and Discord bot if configured) with:
 
 ```bash
 python -m demibot.main
 ```
+
+The Discord bot requires the `GUILD_MESSAGES` and `GUILD_MEMBERS` intents.
+After obtaining an API key, the plugin wizard can configure channels via
+the `/api/channels` endpoint.

--- a/demibot/demibot/db/migrations/versions/0001_initial.py
+++ b/demibot/demibot/db/migrations/versions/0001_initial.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
+import sqlalchemy as sa
 from alembic import op
-
-from .. import models
 
 # revision identifiers, used by Alembic.
 revision = "0001_initial"
@@ -12,10 +11,143 @@ depends_on = None
 
 
 def upgrade() -> None:
-    bind = op.get_bind()
-    models.Base.metadata.create_all(bind)
+    op.create_table(
+        "guilds",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("discord_guild_id", sa.BigInteger(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_guilds_discord_guild_id", "guilds", ["discord_guild_id"], unique=True
+    )
+
+    op.create_table(
+        "guild_config",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id")),
+        sa.Column("event_channel_id", sa.BigInteger()),
+        sa.Column("fc_chat_channel_id", sa.BigInteger()),
+        sa.Column("officer_chat_channel_id", sa.BigInteger()),
+        sa.Column("officer_visible_channel_id", sa.BigInteger()),
+        sa.Column("officer_role_id", sa.BigInteger()),
+        sa.Column("chat_role_id", sa.BigInteger()),
+    )
+
+    op.create_table(
+        "guild_channels",
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), primary_key=True),
+        sa.Column("channel_id", sa.BigInteger(), primary_key=True),
+        sa.Column("kind", sa.String(length=24), primary_key=True),
+    )
+
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("discord_user_id", sa.BigInteger(), nullable=False),
+        sa.Column("global_name", sa.String(length=255)),
+        sa.Column("discriminator", sa.String(length=10)),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_users_discord_user_id", "users", ["discord_user_id"], unique=True
+    )
+
+    op.create_table(
+        "user_keys",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column("token", sa.String(length=64), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("roles_cached", sa.Text()),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("last_used_at", sa.DateTime()),
+    )
+    op.create_index("ix_user_keys_token", "user_keys", ["token"], unique=True)
+
+    op.create_table(
+        "memberships",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+    )
+
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("is_officer", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("is_chat", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+    )
+
+    op.create_table(
+        "membership_roles",
+        sa.Column(
+            "membership_id",
+            sa.Integer(),
+            sa.ForeignKey("memberships.id"),
+            primary_key=True,
+        ),
+        sa.Column("role_id", sa.Integer(), sa.ForeignKey("roles.id"), primary_key=True),
+    )
+
+    op.create_table(
+        "messages",
+        sa.Column("discord_message_id", sa.BigInteger(), primary_key=True),
+        sa.Column("channel_id", sa.BigInteger(), nullable=False),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column("author_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("author_name", sa.String(length=255), nullable=False),
+        sa.Column("content_raw", sa.Text(), nullable=False),
+        sa.Column("content_display", sa.Text(), nullable=False),
+        sa.Column("is_officer", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_messages_channel_id_created_at",
+        "messages",
+        ["channel_id", "created_at"],
+    )
+
+    op.create_table(
+        "embeds",
+        sa.Column("discord_message_id", sa.BigInteger(), primary_key=True),
+        sa.Column("channel_id", sa.BigInteger(), nullable=False),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column("payload_json", sa.Text(), nullable=False),
+        sa.Column("source", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_embeds_channel_id", "embeds", ["channel_id"])
+
+    op.create_table(
+        "attendance",
+        sa.Column("discord_message_id", sa.BigInteger(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column("choice", sa.String(length=10), nullable=False),
+    )
 
 
 def downgrade() -> None:
-    bind = op.get_bind()
-    models.Base.metadata.drop_all(bind)
+    op.drop_table("attendance")
+    op.drop_index("ix_embeds_channel_id", table_name="embeds")
+    op.drop_table("embeds")
+    op.drop_index("ix_messages_channel_id_created_at", table_name="messages")
+    op.drop_table("messages")
+    op.drop_table("membership_roles")
+    op.drop_table("roles")
+    op.drop_table("memberships")
+    op.drop_index("ix_user_keys_token", table_name="user_keys")
+    op.drop_table("user_keys")
+    op.drop_index("ix_users_discord_user_id", table_name="users")
+    op.drop_table("users")
+    op.drop_table("guild_channels")
+    op.drop_table("guild_config")
+    op.drop_index("ix_guilds_discord_guild_id", table_name="guilds")
+    op.drop_table("guilds")

--- a/demibot/demibot/http/deps.py
+++ b/demibot/demibot/http/deps.py
@@ -6,7 +6,7 @@ from fastapi import Depends, Header, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..db.models import Guild, User, UserKey
+from ..db.models import Guild, User, UserKey, Membership, MembershipRole, Role
 from ..db.session import get_session
 
 
@@ -15,6 +15,7 @@ class RequestContext:
     user: User
     guild: Guild
     key: UserKey
+    roles: list[str]
 
 
 async def get_db() -> AsyncSession:
@@ -37,4 +38,17 @@ async def api_key_auth(
     if not row:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
     user, guild, key = row
-    return RequestContext(user=user, guild=guild, key=key)
+    roles_stmt = (
+        select(Role)
+        .join(MembershipRole, MembershipRole.role_id == Role.id)
+        .join(Membership, MembershipRole.membership_id == Membership.id)
+        .where(Membership.guild_id == guild.id, Membership.user_id == user.id)
+    )
+    roles_result = await db.execute(roles_stmt)
+    roles: list[str] = []
+    for r in roles_result.scalars():
+        if r.is_officer:
+            roles.append("officer")
+        if r.is_chat:
+            roles.append("chat")
+    return RequestContext(user=user, guild=guild, key=key, roles=roles)

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,6 +26,8 @@ async def get_officer_messages(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
+    if "officer" not in ctx.roles:
+        raise HTTPException(status_code=403)
     stmt = (
         select(Message)
         .where(
@@ -54,6 +56,8 @@ async def post_officer_message(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
+    if "officer" not in ctx.roles:
+        raise HTTPException(status_code=403)
     msg = Message(
         discord_message_id=int(datetime.utcnow().timestamp() * 1000),
         channel_id=int(body.channelId),

--- a/demibot/demibot/http/routes/validate_roles.py
+++ b/demibot/demibot/http/routes/validate_roles.py
@@ -18,9 +18,4 @@ async def validate(_: RequestContext = Depends(api_key_auth)):
 
 @router.post("/roles", response_model=RolesResponse)
 async def roles(ctx: RequestContext = Depends(api_key_auth)) -> RolesResponse:
-    roles = [
-        r.strip()
-        for r in (ctx.key.roles_cached or "officer,chat").split(",")
-        if r.strip()
-    ]
-    return RolesResponse(roles=roles)
+    return RolesResponse(roles=ctx.roles)

--- a/demibot/demibot/http/ws.py
+++ b/demibot/demibot/http/ws.py
@@ -1,23 +1,33 @@
 
 from __future__ import annotations
-from typing import Set
-from fastapi import WebSocket, WebSocketDisconnect
+from typing import Dict, List, Tuple
+
+from fastapi import HTTPException, WebSocket, WebSocketDisconnect
+
+from ..db.session import get_session
+from .deps import RequestContext, api_key_auth
 
 class ConnectionManager:
     def __init__(self) -> None:
-        self.connections: Set[WebSocket] = set()
+        self.connections: Dict[WebSocket, Tuple[int, List[str]]] = {}
 
-    async def connect(self, websocket: WebSocket) -> None:
+    async def connect(self, websocket: WebSocket, ctx: RequestContext) -> None:
         await websocket.accept()
-        self.connections.add(websocket)
+        self.connections[websocket] = (ctx.guild.id, ctx.roles)
 
     def disconnect(self, websocket: WebSocket) -> None:
         if websocket in self.connections:
-            self.connections.remove(websocket)
+            del self.connections[websocket]
 
-    async def broadcast_text(self, message: str) -> None:
+    async def broadcast_text(
+        self, message: str, guild_id: int, officer_only: bool = False
+    ) -> None:
         dead: list[WebSocket] = []
-        for ws in list(self.connections):
+        for ws, (gid, roles) in list(self.connections.items()):
+            if gid != guild_id:
+                continue
+            if officer_only and "officer" not in roles:
+                continue
             try:
                 await ws.send_text(message)
             except Exception:
@@ -28,7 +38,18 @@ class ConnectionManager:
 manager = ConnectionManager()
 
 async def websocket_endpoint(websocket: WebSocket) -> None:
-    await manager.connect(websocket)
+    token = websocket.headers.get("X-Api-Key") or websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=1008)
+        return
+    async for db in get_session():
+        try:
+            ctx = await api_key_auth(x_api_key=token, db=db)
+        except HTTPException:
+            await websocket.close(code=1008)
+            return
+        break
+    await manager.connect(websocket, ctx)
     try:
         while True:
             await websocket.receive_text()  # keep alive; plugin ignores inbound anyway


### PR DESCRIPTION
## Summary
- store multi-channel config in new `guild_channels` table
- enforce officer role for officer message routes
- resolve user roles and memberships from database
- document environment variables and setup steps
- filter WebSocket broadcasts and `/api/embeds` by guild and officer role
- compute RSVP display names with fallbacks and sort embeds by update time
- define all tables explicitly in initial Alembic migration
- connect plugin WebSocket using the API token for authentication

## Testing
- `python -m py_compile demibot/demibot/http/ws.py demibot/demibot/http/routes/events.py demibot/demibot/http/routes/interactions.py demibot/demibot/http/routes/embeds.py demibot/demibot/db/migrations/versions/0001_initial.py`
- `dotnet build` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e8f0ad0d08328b64e704877ff5c60