### PR TITLE
Align websocket path configuration

### DIFF
--- a/demibot/.env.example
+++ b/demibot/.env.example
@@ -2,5 +2,5 @@ DEMIBOT_DB_URL=sqlite+aiosqlite:///./demibot.db
 DEMIBOT_API_KEY=demo
 DEMIBOT_HOST=0.0.0.0
 DEMIBOT_PORT=8000
-DEMIBOT_WS_PATH=/ws
+DEMIBOT_WS_PATH=/ws/embeds
 DISCORD_TOKEN=your_token_here

--- a/demibot/README.md
+++ b/demibot/README.md
@@ -22,7 +22,7 @@ Environment variables:
 | Variable | Description |
 | --- | --- |
 | `DEMIBOT_DB_URL` | Database connection URL |
-| `DEMIBOT_WS_PATH` | WebSocket path (default `/ws`) |
+| `DEMIBOT_WS_PATH` | WebSocket path (default `/ws/embeds`) |
 | `DISCORD_TOKEN` | Discord bot token |
 
 Run database migrations:

--- a/demibot/demibot/README.md
+++ b/demibot/demibot/README.md
@@ -13,7 +13,7 @@ Environment variables (optional):
 
 - DEMIBOT_HOST (default: 0.0.0.0)
 - DEMIBOT_PORT (default: 8000)
-- DEMIBOT_WS_PATH (default: /ws)
+ - DEMIBOT_WS_PATH (default: /ws/embeds)
 - DEMIBOT_API_KEY (default: demo)  # Use this same key in the plugin Settings → Sync
 ```
 
@@ -27,4 +27,4 @@ Endpoints implemented:
 - GET /api/embeds
 - POST /api/events
 - POST /api/interactions
-- WebSocket at /ws
+- WebSocket at /ws/embeds

--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 class ServerConfig:
     host: str = os.environ.get("DEMIBOT_HOST", "0.0.0.0")
     port: int = int(os.environ.get("DEMIBOT_PORT", "8000"))
-    websocket_path: str = os.environ.get("DEMIBOT_WS_PATH", "/ws")
+    websocket_path: str = os.environ.get("DEMIBOT_WS_PATH", "/ws/embeds")
 
 @dataclass
 class SecurityConfig:


### PR DESCRIPTION
## Summary
- default server websocket path is now `/ws/embeds`
- update documentation and env example to match new path

## Testing
- `pytest`
- `dotnet build DemiCatPlugin` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f20f8dc3883288fff4b6aae22c739