### PR TITLE
Simplify roles request to header-only authorization

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -273,10 +273,7 @@ public class Plugin : IDalamudPlugin
 
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ServerAddress.TrimEnd('/')}/roles")
-            {
-                Content = new StringContent(JsonSerializer.Serialize(new { key = _config.AuthToken }), Encoding.UTF8, "application/json")
-            };
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ServerAddress.TrimEnd('/')}/roles");
             if (!string.IsNullOrEmpty(_config.AuthToken))
             {
                 request.Headers.Add("X-Api-Key", _config.AuthToken);


### PR DESCRIPTION
## Summary
- remove JSON body from roles refresh request so only X-Api-Key header is sent

## Testing
- `dotnet build` *(fails: command not found)*
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_689f21e01a748328bf8c87f8fb75e9e0