### PR TITLE
refactor: share HttpClient instance across windows

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -14,7 +14,7 @@ namespace DemiCatPlugin;
 public class ChatWindow : IDisposable
 {
     protected readonly Config _config;
-    protected readonly HttpClient _httpClient = new();
+    protected readonly HttpClient _httpClient;
     protected readonly List<ChatMessageDto> _messages = new();
     protected readonly List<string> _channels = new();
     protected int _selectedIndex;
@@ -24,9 +24,10 @@ public class ChatWindow : IDisposable
     protected bool _useCharacterName;
     protected DateTime _lastFetch = DateTime.MinValue;
 
-    public ChatWindow(Config config)
+    public ChatWindow(Config config, HttpClient httpClient)
     {
         _config = config;
+        _httpClient = httpClient;
         _channelId = config.ChatChannelId;
         _useCharacterName = config.UseCharacterName;
     }
@@ -174,7 +175,6 @@ public class ChatWindow : IDisposable
 
     public void Dispose()
     {
-        _httpClient.Dispose();
     }
 
     private void SaveConfig()

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -10,10 +10,10 @@ using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
 
-public class EventCreateWindow : IDisposable
+public class EventCreateWindow
 {
     private readonly Config _config;
-    private readonly HttpClient _httpClient = new();
+    private readonly HttpClient _httpClient;
 
     private string _title = string.Empty;
     private string _description = string.Empty;
@@ -30,9 +30,10 @@ public class EventCreateWindow : IDisposable
 
     public string ChannelId { private get; set; } = string.Empty;
 
-    public EventCreateWindow(Config config)
+    public EventCreateWindow(Config config, HttpClient httpClient)
     {
         _config = config;
+        _httpClient = httpClient;
     }
 
     public void Draw()
@@ -125,10 +126,6 @@ public class EventCreateWindow : IDisposable
         }
     }
 
-    public void Dispose()
-    {
-        _httpClient.Dispose();
-    }
 
     private class Field
     {

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -15,7 +15,7 @@ public class FcChatWindow : ChatWindow
     private DateTime _lastUserFetch = DateTime.MinValue;
     private readonly string _channelName;
 
-    public FcChatWindow(Config config) : base(config)
+    public FcChatWindow(Config config, HttpClient httpClient) : base(config, httpClient)
     {
         _channelId = config.FcChannelId;
         _channelName = string.IsNullOrEmpty(config.FcChannelName) ? config.FcChannelId : config.FcChannelName;

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -17,7 +17,7 @@ public class MainWindow
     private readonly SettingsWindow _settings;
     private readonly EventCreateWindow _create;
     private readonly TemplatesWindow _templates;
-    private readonly HttpClient _httpClient = new();
+    private readonly HttpClient _httpClient;
     private readonly List<string> _channels = new();
     private readonly List<string> _fcChatChannels = new();
     private readonly List<string> _officerChatChannels = new();
@@ -29,15 +29,16 @@ public class MainWindow
     public bool HasOfficerRole { get; set; }
     public bool HasChatRole { get; set; }
 
-    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings)
+    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient)
     {
         _config = config;
         _ui = ui;
         _chat = chat;
         _officer = officer;
         _settings = settings;
-        _create = new EventCreateWindow(config);
-        _templates = new TemplatesWindow(config);
+        _httpClient = httpClient;
+        _create = new EventCreateWindow(config, httpClient);
+        _templates = new TemplatesWindow(config, httpClient);
         _channelId = config.EventChannelId;
         _ui.ChannelId = _channelId;
         _create.ChannelId = _channelId;

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -12,7 +12,7 @@ namespace DemiCatPlugin;
 
 public class OfficerChatWindow : ChatWindow
 {
-    public OfficerChatWindow(Config config) : base(config)
+    public OfficerChatWindow(Config config, HttpClient httpClient) : base(config, httpClient)
     {
         _channelId = config.OfficerChannelId;
     }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -38,11 +38,11 @@ public class Plugin : IDalamudPlugin
     {
         _config = PluginInterface.GetPluginConfig() as Config ?? new Config();
 
-        _ui = new UiRenderer(_config);
-        _settings = new SettingsWindow(_config, RefreshRoles);
-        _chatWindow = _config.EnableFcChat ? new FcChatWindow(_config) : null;
-        _officerChatWindow = new OfficerChatWindow(_config);
-        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings);
+        _ui = new UiRenderer(_config, _httpClient);
+        _settings = new SettingsWindow(_config, _httpClient, RefreshRoles);
+        _chatWindow = _config.EnableFcChat ? new FcChatWindow(_config, _httpClient) : null;
+        _officerChatWindow = new OfficerChatWindow(_config, _httpClient);
+        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);
 
         _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
         _mainWindow.HasChatRole = _config.Roles.Contains("chat");

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -11,7 +11,7 @@ namespace DemiCatPlugin;
 public class SettingsWindow : IDisposable
 {
     private readonly Config _config;
-    private readonly HttpClient _httpClient = new();
+    private readonly HttpClient _httpClient;
     private readonly Func<Task> _refreshRoles;
     private readonly DeveloperWindow _devWindow;
 
@@ -20,9 +20,10 @@ public class SettingsWindow : IDisposable
 
     public bool IsOpen;
 
-    public SettingsWindow(Config config, Func<Task> refreshRoles)
+    public SettingsWindow(Config config, HttpClient httpClient, Func<Task> refreshRoles)
     {
         _config = config;
+        _httpClient = httpClient;
         _refreshRoles = refreshRoles;
         _apiKey = config.AuthToken ?? string.Empty;
         _devWindow = new DeveloperWindow(config);
@@ -103,6 +104,5 @@ public class SettingsWindow : IDisposable
 
     public void Dispose()
     {
-        _httpClient.Dispose();
     }
 }

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -8,19 +8,20 @@ using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
 
-public class TemplatesWindow : IDisposable
+public class TemplatesWindow
 {
     private readonly Config _config;
-    private readonly HttpClient _httpClient = new();
+    private readonly HttpClient _httpClient;
     private int _selectedIndex = -1;
     private bool _showPreview;
     private string _previewContent = string.Empty;
 
     public string ChannelId { get; set; } = string.Empty;
 
-    public TemplatesWindow(Config config)
+    public TemplatesWindow(Config config, HttpClient httpClient)
     {
         _config = config;
+        _httpClient = httpClient;
     }
 
     public void Draw()
@@ -93,9 +94,5 @@ public class TemplatesWindow : IDisposable
         }
     }
 
-    public void Dispose()
-    {
-        _httpClient.Dispose();
-    }
 }
 

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -12,15 +12,16 @@ namespace DemiCatPlugin;
 
 public class UiRenderer : IDisposable
 {
-    private readonly HttpClient _httpClient = new();
+    private readonly HttpClient _httpClient;
     private readonly Config _config;
     private readonly Dictionary<string, EventView> _embeds = new();
     private string _channelId;
     private EventView? _current;
 
-    public UiRenderer(Config config)
+    public UiRenderer(Config config, HttpClient httpClient)
     {
         _config = config;
+        _httpClient = httpClient;
         _channelId = config.EventChannelId;
     }
 
@@ -111,7 +112,6 @@ public class UiRenderer : IDisposable
             view.Dispose();
         }
         _embeds.Clear();
-        _httpClient.Dispose();
     }
 }
 


### PR DESCRIPTION
## Summary
- Introduce a single HttpClient in Plugin and provide it to UI components
- Remove per-window HttpClient creation and disposal

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689f21eb8d1c83288f7f7656071cde85