### PR TITLE
Align plugin defaults with bot port

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -9,11 +9,11 @@ public class Config : IPluginConfiguration
     public int Version { get; set; } = 1;
 
     public bool Enabled { get; set; } = true;
-    public string HelperBaseUrl { get; set; } = "http://localhost:3000";
+    public string HelperBaseUrl { get; set; } = "http://localhost:8000";
     public string WebSocketPath { get; set; } = "/ws/embeds";
     public int PollIntervalSeconds { get; set; } = 5;
     public string? AuthToken { get; set; }
-    public string ServerAddress { get; set; } = "http://localhost:3300";
+    public string ServerAddress { get; set; } = "http://localhost:8000";
     public string ChatChannelId { get; set; } = string.Empty;
     public string EventChannelId { get; set; } = string.Empty;
     public string FcChannelId { get; set; } = string.Empty;

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ command for plugin authentication.
 
 ### 3. Configure the Dalamud plugin
 Update `DemiCatPlugin/DemiCatPlugin.json` with the usual plugin metadata. In-game, open the plugin configuration and set the
-**Helper Base URL** if needed (defaults to `http://localhost:8000`).
+**Helper Base URL** and **Server Address** if needed (both default to `http://localhost:8000`).
 
 Use the **Key** and **Sync Key** obtained from `/demibot_embed` and enter both values in the
 plugin settings. Press **Connect/Sync** (or **Validate** if you already have a key) to link the


### PR DESCRIPTION
## Summary
- Default HelperBaseUrl and ServerAddress to http://localhost:8000 in plugin config
- Document matching defaults for Helper Base URL and Server Address in README

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f27044e548328a8e1582b75f173ef