### PR TITLE
Mirror Discord messages and relay plugin chat

### DIFF
--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -1,19 +1,87 @@
 from __future__ import annotations
 
+import json
 import discord
 from discord.ext import commands
+from sqlalchemy import select
+
+from ...db.models import GuildChannel, Message
+from ...db.session import create_engine, get_session
+from ...http.schemas import ChatMessage, Mention
+from ...http.ws import manager
 
 
 class Mirror(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
+        # Ensure the database engine is available for this cog
+        create_engine(bot.cfg.database.url)
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:
+        """Mirror Discord messages into the database and notify plugins.
+
+        Messages are only recorded if the channel is registered in the
+        ``guild_channels`` table.  Officer chat messages are flagged so that
+        they can be broadcast only to officer clients.
+        """
+
+        # Ignore messages from bots (including ourselves)
         if message.author.bot:
             return
-        # Placeholder: store message, process mentions, etc.
-        
+
+        channel_id = message.channel.id
+
+        async for db in get_session():
+            result = await db.execute(
+                select(GuildChannel.kind, GuildChannel.guild_id).where(
+                    GuildChannel.channel_id == channel_id
+                )
+            )
+            row = result.one_or_none()
+            if row is None:
+                return  # channel not registered
+
+            kind, guild_id = row
+            is_officer = kind == "officer_chat"
+
+            # Persist the message
+            db.add(
+                Message(
+                    discord_message_id=message.id,
+                    channel_id=channel_id,
+                    guild_id=guild_id,
+                    author_id=message.author.id,
+                    author_name=message.author.display_name
+                    or message.author.name,
+                    content_raw=message.content,
+                    content_display=message.content,
+                    is_officer=is_officer,
+                )
+            )
+            await db.commit()
+
+            mentions = [
+                Mention(
+                    id=str(m.id),
+                    name=m.display_name or m.name,
+                )
+                for m in message.mentions
+                if not m.bot
+            ]
+
+            dto = ChatMessage(
+                id=str(message.id),
+                channelId=str(channel_id),
+                authorName=message.author.display_name or message.author.name,
+                content=message.content,
+                mentions=mentions or None,
+            )
+            await manager.broadcast_text(
+                json.dumps(dto.model_dump()), guild_id, officer_only=is_officer
+            )
+            break
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(Mirror(bot))

--- a/demibot/demibot/http/discord_client.py
+++ b/demibot/demibot/http/discord_client.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from discord.ext import commands
+
+
+discord_client: commands.Bot | None = None
+
+
+def set_discord_client(client: commands.Bot) -> None:
+    """Register the Discord client used for sending messages.
+
+    The HTTP routes rely on this client to forward messages to Discord
+    channels.  The function can be called during application startup to supply
+    the running :class:`commands.Bot` instance.
+    """
+
+    global discord_client
+    discord_client = client
+

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime
+import json
 
+import discord
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -9,7 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
 from ..schemas import ChatMessage
+from ..ws import manager
 from ...db.models import Message
+from ..discord_client import discord_client
 
 router = APIRouter(prefix="/api")
 
@@ -54,9 +58,20 @@ async def post_message(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
+    channel_id = int(body.channelId)
+    discord_msg_id: int | None = None
+    if discord_client:
+        channel = discord_client.get_channel(channel_id)
+        if isinstance(channel, discord.abc.Messageable):
+            sent = await channel.send(body.content)
+            discord_msg_id = sent.id
+
+    if discord_msg_id is None:
+        discord_msg_id = int(datetime.utcnow().timestamp() * 1000)
+
     msg = Message(
-        discord_message_id=int(datetime.utcnow().timestamp() * 1000),
-        channel_id=int(body.channelId),
+        discord_message_id=discord_msg_id,
+        channel_id=channel_id,
         guild_id=ctx.guild.id,
         author_id=ctx.user.id,
         author_name=ctx.user.global_name or "Player",
@@ -66,4 +81,15 @@ async def post_message(
     )
     db.add(msg)
     await db.commit()
-    return {"ok": True}
+
+    dto = ChatMessage(
+        id=str(discord_msg_id),
+        channelId=str(channel_id),
+        authorName=msg.author_name,
+        content=msg.content_display,
+    )
+    await manager.broadcast_text(
+        json.dumps(dto.model_dump()), ctx.guild.id, officer_only=False
+    )
+
+    return {"ok": True, "id": str(discord_msg_id)}

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime
+import json
 
+import discord
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -9,7 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
 from ..schemas import ChatMessage
+from ..ws import manager
 from ...db.models import Message
+from ..discord_client import discord_client
 
 router = APIRouter(prefix="/api")
 
@@ -58,9 +62,20 @@ async def post_officer_message(
 ):
     if "officer" not in ctx.roles:
         raise HTTPException(status_code=403)
+    channel_id = int(body.channelId)
+    discord_msg_id: int | None = None
+    if discord_client:
+        channel = discord_client.get_channel(channel_id)
+        if isinstance(channel, discord.abc.Messageable):
+            sent = await channel.send(body.content)
+            discord_msg_id = sent.id
+
+    if discord_msg_id is None:
+        discord_msg_id = int(datetime.utcnow().timestamp() * 1000)
+
     msg = Message(
-        discord_message_id=int(datetime.utcnow().timestamp() * 1000),
-        channel_id=int(body.channelId),
+        discord_message_id=discord_msg_id,
+        channel_id=channel_id,
         guild_id=ctx.guild.id,
         author_id=ctx.user.id,
         author_name=ctx.user.global_name or "Officer",
@@ -70,4 +85,15 @@ async def post_officer_message(
     )
     db.add(msg)
     await db.commit()
-    return {"ok": True}
+
+    dto = ChatMessage(
+        id=str(discord_msg_id),
+        channelId=str(channel_id),
+        authorName=msg.author_name,
+        content=msg.content_display,
+    )
+    await manager.broadcast_text(
+        json.dumps(dto.model_dump()), ctx.guild.id, officer_only=True
+    )
+
+    return {"ok": True, "id": str(discord_msg_id)}


### PR DESCRIPTION
## Summary
- Capture Discord channel messages via a new Mirror cog, storing them in the DB and broadcasting through WebSocket.
- Forward plugin chat posts to Discord and persist them, covering both public and officer channels.
- Provide a shared helper to register the running Discord client for HTTP routes.

## Testing
- `python -m py_compile demibot/discordbot/cogs/mirror.py demibot/http/routes/messages.py demibot/http/routes/officer_messages.py demibot/http/discord_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc7a1b8208328a74ee867bd1de4f5