### PR TITLE
Config-based startup with MySQL verification and Flask server

### DIFF
--- a/demibot/demibot/config.json
+++ b/demibot/demibot/config.json
@@ -1,0 +1,16 @@
+{
+  "server": {
+    "host": "0.0.0.0",
+    "port": 5000
+  },
+  "database": {
+    "use_remote": false,
+    "host": "localhost",
+    "port": 3306,
+    "database": "demibot",
+    "user": "root",
+    "password": ""
+  },
+  "discord_token": ""
+}
+

--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -1,27 +1,106 @@
-
 from __future__ import annotations
-import os
-from dataclasses import dataclass
+
+"""Configuration handling for DemiBot.
+
+This module replaces the previous environment variable based configuration with a
+JSON file that is automatically created on first run.  The configuration file
+stores database connection information, server options and the Discord bot
+token.  If any required value is missing the user will be prompted for it on
+startup and the resulting configuration will be written back to disk.
+"""
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+import json
+
+CFG_PATH = Path(__file__).with_name("config.json")
+
 
 @dataclass
 class ServerConfig:
-    host: str = os.environ.get("DEMIBOT_HOST", "0.0.0.0")
-    port: int = int(os.environ.get("DEMIBOT_PORT", "8000"))
-    websocket_path: str = os.environ.get("DEMIBOT_WS_PATH", "/ws/embeds")
-
-@dataclass
-class SecurityConfig:
-    api_key: str = os.environ.get("DEMIBOT_API_KEY", "demo")
+    host: str = "0.0.0.0"
+    port: int = 5000
 
 
 @dataclass
 class DatabaseConfig:
-    url: str = os.environ.get(
-        "DEMIBOT_DB_URL", "sqlite+aiosqlite:///./demibot.db"
-    )
+    """Database configuration supporting local or remote MySQL instances."""
+
+    use_remote: bool = False
+    host: str = "localhost"
+    port: int = 3306
+    database: str = "demibot"
+    user: str = "root"
+    password: str = ""
+
+    @property
+    def url(self) -> str:
+        return (
+            f"mysql+aiomysql://{self.user}:{self.password}"
+            f"@{self.host}:{self.port}/{self.database}"
+        )
+
 
 @dataclass
 class AppConfig:
     server: ServerConfig = ServerConfig()
-    security: SecurityConfig = SecurityConfig()
     database: DatabaseConfig = DatabaseConfig()
+    discord_token: str = ""
+
+
+def load_config() -> AppConfig:
+    if CFG_PATH.exists():
+        data = json.loads(CFG_PATH.read_text())
+        return AppConfig(
+            server=ServerConfig(**data.get("server", {})),
+            database=DatabaseConfig(**data.get("database", {})),
+            discord_token=data.get("discord_token", ""),
+        )
+    return AppConfig()
+
+
+def save_config(cfg: AppConfig) -> None:
+    data = {
+        "server": asdict(cfg.server),
+        "database": asdict(cfg.database),
+        "discord_token": cfg.discord_token,
+    }
+    CFG_PATH.write_text(json.dumps(data, indent=2))
+
+
+def ensure_config() -> AppConfig:
+    """Load configuration, prompting the user for any missing values."""
+
+    cfg = load_config()
+    changed = False
+
+    # Determine database location
+    if CFG_PATH.exists():
+        mode = "remote" if cfg.database.use_remote else "local"
+        print(
+            f"Using {mode} MySQL database at "
+            f"{cfg.database.host}:{cfg.database.port}/{cfg.database.database}"
+        )
+    else:
+        resp = input("Use remote MySQL server? (y/N): ").strip().lower()
+        cfg.database.use_remote = resp.startswith("y")
+        if cfg.database.use_remote:
+            cfg.database.host = (
+                input(f"Remote host [{cfg.database.host}]: ") or cfg.database.host
+            )
+            port = input(f"Remote port [{cfg.database.port}]: ") or cfg.database.port
+            cfg.database.port = int(port)
+            cfg.database.database = (
+                input(f"Database name [{cfg.database.database}]: ")
+                or cfg.database.database
+            )
+        changed = True
+
+    if not cfg.discord_token:
+        cfg.discord_token = input("Enter Discord bot token: ").strip()
+        changed = True
+
+    if changed:
+        save_config(cfg)
+    return cfg
+

--- a/demibot/demibot/db/session.py
+++ b/demibot/demibot/db/session.py
@@ -2,16 +2,43 @@ from __future__ import annotations
 
 from typing import AsyncGenerator
 
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy import inspect, text
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from .base import Base
 
 _engine: AsyncEngine | None = None
 _Session: async_sessionmaker[AsyncSession] | None = None
 
 
-def create_engine(url: str) -> AsyncEngine:
+async def init_db(url: str) -> AsyncEngine:
+    """Create the database engine and ensure all tables and columns exist."""
+
     global _engine, _Session
     _engine = create_async_engine(url, echo=False, future=True)
     _Session = async_sessionmaker(_engine, expire_on_commit=False)
+
+    async with _engine.begin() as conn:
+        def _init(sync_conn):
+            Base.metadata.create_all(sync_conn)
+            inspector = inspect(sync_conn)
+            for table in Base.metadata.sorted_tables:
+                existing = {c["name"] for c in inspector.get_columns(table.name)}
+                for column in table.columns:
+                    if column.name not in existing:
+                        ddl = text(
+                            f"ALTER TABLE {table.name} ADD COLUMN "
+                            f"{column.compile(dialect=sync_conn.dialect)}"
+                        )
+                        sync_conn.execute(ddl)
+
+        await conn.run_sync(_init)
+
     return _engine
 
 

--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -1,23 +1,18 @@
-
 from __future__ import annotations
-from fastapi import FastAPI
+
+"""Minimal Flask application factory for DemiBot."""
+
+from flask import Flask
+
 from ..config import AppConfig
-from .ws import websocket_endpoint
-from .routes import channels, messages, officer_messages, users, embeds, events, interactions, validate_roles
 
-def create_app(cfg: AppConfig) -> FastAPI:
-    app = FastAPI(title="DemiBot API")
 
-    # Regular routes
-    app.include_router(validate_roles.router)
-    app.include_router(channels.router)
-    app.include_router(messages.router)
-    app.include_router(officer_messages.router)
-    app.include_router(users.router)
-    app.include_router(embeds.router)
-    app.include_router(events.router)
-    app.include_router(interactions.router)
+def create_app(cfg: AppConfig) -> Flask:
+    app = Flask(__name__)
 
-    # WebSocket
-    app.add_api_websocket_route(cfg.server.websocket_path, websocket_endpoint)
+    @app.route("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
     return app
+

--- a/demibot/pyproject.toml
+++ b/demibot/pyproject.toml
@@ -8,8 +8,7 @@ readme = "README.md"
 license = {text = "MIT"}
 
 [project.dependencies]
-fastapi = "^0.110.0"
-uvicorn = {version = "^0.27.0", extras=["standard"]}
+flask = "^3.0.0"
 discord.py = "^2.3.2"
 sqlalchemy = {version = "^2.0.25", extras=["asyncio"]}
 aiomysql = "^0.2.0"


### PR DESCRIPTION
## Summary
- Load configuration from a JSON file and prompt for missing MySQL/Discord settings
- Ensure MySQL tables and columns exist before starting services
- Replace FastAPI with a minimal Flask server and unified startup script

## Testing
- `python -m py_compile demibot/demibot/config.py demibot/demibot/db/session.py demibot/demibot/http/api.py demibot/demibot/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0535073c4832896a8c1207e5ffdfb