### PR TITLE
chore: reference Flask and remove unused dotenv

### DIFF
--- a/demibot/pyproject.toml
+++ b/demibot/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "demibot"
 version = "0.1.0"
-description = "Discord bot and FastAPI backend for DemiCat plugin"
+description = "Discord bot and Flask backend for DemiCat plugin"
 requires-python = ">=3.11"
 authors = [{name = "DemiCat"}]
 readme = "README.md"
@@ -16,7 +16,6 @@ aiosqlite = "^0.19.0"
 alembic = "^1.12.0"
 pydantic = "^2.5.0"
 structlog = "^23.2.0"
-python-dotenv = "^1.0.0"
 uvloop = {version = "^0.19.0", optional = true}
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- describe DemiBot backend as Flask instead of FastAPI
- remove unused python-dotenv dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07a33ad9083289ba7132585e920d4