### PR TITLE
Restrict config.json permissions and add security note

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Key environment variables include:
 - `DEMIBOT_WS_PATH` – WebSocket path (default `/ws/embeds`)
 - `DISCORD_TOKEN` – Discord bot token
 
+> **Security note:** The `.env` file and `demibot/demibot/config.json` contain the
+> Discord token and database credentials. Treat these files as secrets and set
+> restrictive permissions so only your user can read them (e.g. `chmod 600
+> demibot/demibot/config.json`).
+
 ## Setup
 
 ### 1. Install dependencies and initialize the database

--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 """Configuration handling for DemiBot.
 
 This module replaces the previous environment variable based configuration with a
-JSON file that is automatically created on first run.  The configuration file
+JSON file that is automatically created on first run. The configuration file
 stores database connection information, server options and the Discord bot
-token.  If any required value is missing the user will be prompted for it on
-startup and the resulting configuration will be written back to disk.
+token. If any required value is missing the user will be prompted for it on
+startup and the resulting configuration will be written back to disk with
+permissions ``0o600`` to restrict access.
 """
 
 from dataclasses import asdict, dataclass
@@ -75,6 +76,10 @@ def save_config(cfg: AppConfig) -> None:
         "discord_token": cfg.discord_token,
     }
     CFG_PATH.write_text(json.dumps(data, indent=2))
+    try:
+        CFG_PATH.chmod(0o600)
+    except OSError as exc:  # pragma: no cover - platform dependent
+        logging.warning("Unable to set permissions on %s: %s", CFG_PATH, exc)
 
 
 def ensure_config(force_reconfigure: bool = False) -> AppConfig:


### PR DESCRIPTION
## Summary
- safeguard configuration: write `config.json` with `0o600` permissions
- document sensitive token and DB credentials handling in the README

## Testing
- `python -m py_compile demibot/demibot/config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0cb1b47cc83289f4a4ce4fd507dd3