### PR TITLE
Quote DB credentials

### DIFF
--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import asyncio
 import json
 import logging
+from urllib.parse import quote_plus
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -42,7 +43,7 @@ class DatabaseConfig:
     @property
     def url(self) -> str:
         return (
-            f"mysql+aiomysql://{self.user}:{self.password}"
+            f"mysql+aiomysql://{quote_plus(self.user)}:{quote_plus(self.password)}"
             f"@{self.host}:{self.port}/{self.database}"
         )
 

--- a/demibot/demibot/db/session.py
+++ b/demibot/demibot/db/session.py
@@ -57,3 +57,22 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
         raise RuntimeError("Engine not initialized")
     async with _Session() as session:
         yield session
+
+
+def test_password_with_special_chars():
+    """Ensure engines handle credentials with special characters."""
+
+    from urllib.parse import quote_plus
+    import asyncio
+
+    password = "p@ss/w:rd?123"
+    url = f"sqlite+aiosqlite:///:memory:?password={quote_plus(password)}"
+
+    async def _check() -> None:
+        engine = await init_db(url)
+        async with engine.connect() as conn:
+            result = await conn.execute(text("SELECT 1"))
+            assert result.scalar_one() == 1
+        await engine.dispose()
+
+    asyncio.run(_check())


### PR DESCRIPTION
## Summary
- percent-encode database credentials in configuration URLs
- add regression test for special character passwords in DB URLs

## Testing
- `pytest demibot/demibot/db/session.py::test_password_with_special_chars -q`


------
https://chatgpt.com/codex/tasks/task_e_68a133bde6108328b26049c483297784