### PR TITLE
feat: add event template saving

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -97,11 +97,84 @@ public class EventCreateWindow
         {
             _ = CreateEvent();
         }
+        ImGui.SameLine();
+        if (ImGui.Button("Save Template"))
+        {
+            SaveTemplate();
+        }
 
         if (!string.IsNullOrEmpty(_lastResult))
         {
             ImGui.TextUnformatted(_lastResult);
         }
+    }
+
+    public void LoadTemplate(Template template)
+    {
+        _title = template.Title;
+        _description = template.Description;
+        _time = string.IsNullOrEmpty(template.Time) ? DateTime.UtcNow.ToString("o") : template.Time;
+        _url = template.Url;
+        _imageUrl = template.ImageUrl;
+        _thumbnailUrl = template.ThumbnailUrl;
+        _color = template.Color;
+
+        _fields.Clear();
+        if (template.Fields != null)
+        {
+            foreach (var f in template.Fields)
+            {
+                _fields.Add(new Field { Name = f.Name, Value = f.Value, Inline = f.Inline });
+            }
+        }
+
+        if (template.Buttons != null)
+        {
+            foreach (var button in _buttons)
+            {
+                var tb = template.Buttons.FirstOrDefault(b => b.Tag == button.Tag);
+                if (tb != null)
+                {
+                    button.Include = tb.Include;
+                    button.Label = tb.Label;
+                    button.Emoji = tb.Emoji;
+                    button.Style = tb.Style;
+                }
+            }
+        }
+    }
+
+    private void SaveTemplate()
+    {
+        var tmpl = new Template
+        {
+            Name = _title,
+            Title = _title,
+            Description = _description,
+            Time = _time,
+            Url = _url,
+            ImageUrl = _imageUrl,
+            ThumbnailUrl = _thumbnailUrl,
+            Color = _color,
+            Fields = _fields.Select(f => new Template.TemplateField
+            {
+                Name = f.Name,
+                Value = f.Value,
+                Inline = f.Inline
+            }).ToList(),
+            Buttons = _buttons.Select(b => new Template.TemplateButton
+            {
+                Tag = b.Tag,
+                Include = b.Include,
+                Label = b.Label,
+                Emoji = b.Emoji,
+                Style = b.Style
+            }).ToList()
+        };
+
+        _config.Templates.Add(tmpl);
+        PluginServices.PluginInterface.SavePluginConfig(_config);
+        _lastResult = "Template saved";
     }
 
     private async Task CreateEvent()

--- a/DemiCatPlugin/Template.cs
+++ b/DemiCatPlugin/Template.cs
@@ -1,8 +1,38 @@
+using System.Collections.Generic;
+using DiscordHelper;
+
 namespace DemiCatPlugin;
 
 public class Template
 {
     public string Name { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
+
+    // Event template data
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Time { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public string ImageUrl { get; set; } = string.Empty;
+    public string ThumbnailUrl { get; set; } = string.Empty;
+    public int Color { get; set; }
+    public List<TemplateField> Fields { get; set; } = new();
+    public List<TemplateButton> Buttons { get; set; } = new();
+
+    public class TemplateField
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Value { get; set; } = string.Empty;
+        public bool Inline { get; set; }
+    }
+
+    public class TemplateButton
+    {
+        public string Tag { get; set; } = string.Empty;
+        public bool Include { get; set; } = true;
+        public string Label { get; set; } = string.Empty;
+        public string Emoji { get; set; } = string.Empty;
+        public ButtonStyle Style { get; set; } = ButtonStyle.Secondary;
+    }
 }
 


### PR DESCRIPTION
## Summary
- extend template model to store full event configuration
- allow saving current event parameters as templates
- add method to load templates into event creation form

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a135dfe2d083288f076688c2457f04