### PR TITLE
Store and broadcast Apollo embeds

### DIFF
--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import discord
 from discord.ext import commands
 from sqlalchemy import select
 
-from ...db.models import GuildChannel, Message
-from ...db.session import create_engine, get_session
-from ...http.schemas import ChatMessage, Mention
+from ...db.models import Embed, GuildChannel, Message
+from ...db.session import get_session, init_db
+from ...http.schemas import ChatMessage, EmbedDto, EmbedFieldDto, Mention
 from ...http.ws import manager
 
 
@@ -15,7 +16,7 @@ class Mirror(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         # Ensure the database engine is available for this cog
-        create_engine(bot.cfg.database.url)
+        asyncio.create_task(init_db(bot.cfg.database.url))
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:
@@ -26,11 +27,70 @@ class Mirror(commands.Cog):
         they can be broadcast only to officer clients.
         """
 
-        # Ignore messages from bots (including ourselves)
-        if message.author.bot:
-            return
-
         channel_id = message.channel.id
+
+        # Ignore messages from bots (including ourselves) unless they are Apollo
+        if message.author.bot:
+            async for db in get_session():
+                result = await db.execute(
+                    select(GuildChannel.kind, GuildChannel.guild_id).where(
+                        GuildChannel.channel_id == channel_id
+                    )
+                )
+                row = result.one_or_none()
+                if row is None:
+                    return  # channel not registered
+
+                kind, guild_id = row
+                is_officer = kind == "officer_chat"
+
+                stored = False
+                for emb in message.embeds:
+                    data = emb.to_dict()
+                    footer = data.get("footer", {}).get("text", "").lower()
+                    author = data.get("author", {}).get("name", "")
+                    if "apollo" not in footer and author != "Apollo":
+                        continue
+                    dto = EmbedDto(
+                        id=str(message.id),
+                        timestamp=emb.timestamp,
+                        color=emb.color.value if emb.color else None,
+                        authorName=emb.author.name if emb.author else None,
+                        authorIconUrl=str(emb.author.icon_url)
+                        if emb.author and emb.author.icon_url
+                        else None,
+                        title=emb.title,
+                        description=emb.description,
+                        fields=[
+                            EmbedFieldDto(name=f.name, value=f.value, inline=f.inline)
+                            for f in emb.fields
+                        ]
+                        or None,
+                        thumbnailUrl=emb.thumbnail.url if emb.thumbnail else None,
+                        imageUrl=emb.image.url if emb.image else None,
+                        buttons=None,
+                        channelId=channel_id,
+                        mentions=[m.id for m in message.mentions] or None,
+                    )
+                    db.add(
+                        Embed(
+                            discord_message_id=message.id,
+                            channel_id=channel_id,
+                            guild_id=guild_id,
+                            payload_json=json.dumps(dto.model_dump()),
+                            source="apollo",
+                        )
+                    )
+                    await manager.broadcast_text(
+                        json.dumps(dto.model_dump()),
+                        guild_id,
+                        officer_only=is_officer,
+                    )
+                    stored = True
+                if stored:
+                    await db.commit()
+                break
+            return
 
         async for db in get_session():
             result = await db.execute(

--- a/demibot/demibot/http/routes/embeds.py
+++ b/demibot/demibot/http/routes/embeds.py
@@ -24,4 +24,11 @@ async def get_embeds(
         ).where(GuildChannel.kind != "officer_chat")
     stmt = stmt.order_by(Embed.updated_at.desc())
     result = await db.execute(stmt)
-    return [json.loads(e.payload_json) for e in result.scalars().all()]
+    embeds = []
+    for e in result.scalars().all():
+        payload = json.loads(e.payload_json)
+        if not payload.get("channelId"):
+            payload["channelId"] = e.channel_id
+        payload["guildId"] = e.guild_id
+        embeds.append(payload)
+    return embeds

--- a/tests/test_apollo_embed.py
+++ b/tests/test_apollo_embed.py
@@ -1,0 +1,98 @@
+import json
+from types import SimpleNamespace
+
+import sys
+from pathlib import Path
+import types
+
+import asyncio
+import discord
+from sqlalchemy import select
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+discordbot_pkg = types.ModuleType("demibot.discordbot")
+discordbot_pkg.__path__ = [str(root / "demibot/discordbot")]
+sys.modules.setdefault("demibot.discordbot", discordbot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.discordbot.cogs.mirror import Mirror
+from demibot.db.models import Embed, Guild, GuildChannel
+from demibot.db.session import get_session, init_db
+from demibot.http.routes.embeds import get_embeds
+
+
+class DummyBot:
+    def __init__(self, url: str) -> None:
+        self.cfg = SimpleNamespace(database=SimpleNamespace(url=url))
+
+
+class DummyAuthor:
+    def __init__(self) -> None:
+        self.bot = True
+        self.id = 999
+        self.display_name = "Apollo"
+        self.name = "Apollo"
+
+
+class DummyChannel:
+    def __init__(self, cid: int) -> None:
+        self.id = cid
+
+
+class DummyMessage:
+    def __init__(self, channel_id: int, embed: discord.Embed) -> None:
+        self.author = DummyAuthor()
+        self.channel = DummyChannel(channel_id)
+        self.id = 42
+        self.content = ""
+        self.mentions = []
+        self.embeds = [embed]
+async def _run_test() -> None:
+    db_path = Path("test.db")
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    bot = DummyBot(url)
+    Mirror(bot)  # initializes DB
+
+    async for db in get_session():
+        guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
+        db.add(guild)
+        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
+        await db.commit()
+        break
+
+    emb = discord.Embed(title="Raid Night", description="Prepare")
+    emb.set_footer(text="Powered by Apollo")
+    msg = DummyMessage(123, emb)
+
+    mirror = Mirror(bot)
+    await mirror.on_message(msg)
+
+    async for db in get_session():
+        row = (
+            await db.execute(
+                select(Embed).where(Embed.discord_message_id == msg.id)
+            )
+        ).scalar_one()
+        assert row.source == "apollo"
+        ctx = SimpleNamespace(guild=SimpleNamespace(id=1), roles=["officer"])
+        result = await get_embeds(ctx=ctx, db=db)
+        assert result and result[0]["id"] == str(msg.id)
+        assert result[0]["guildId"] == 1
+        assert result[0]["channelId"] == 123
+        break
+
+
+def test_apollo_embed_stored_and_retrieved() -> None:
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- Mirror Apollo-generated embeds into the Embed table and broadcast them over websockets
- Include guild and channel identifiers when retrieving embeds via `/api/embeds`
- Add regression test to ensure Apollo embeds are stored and fetchable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a13ab6e564832893452b151608205f