### PR TITLE
Map template buttons and inline fields in embed previews

### DIFF
--- a/DemiCatPlugin/EmbedDto.cs
+++ b/DemiCatPlugin/EmbedDto.cs
@@ -24,6 +24,7 @@ public class EmbedFieldDto
 {
     public string Name { get; set; } = string.Empty;
     public string Value { get; set; } = string.Empty;
+    public bool? Inline { get; set; }
 }
 
 public class EmbedButtonDto

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -124,7 +124,14 @@ public class TemplatesWindow
             ImageUrl = string.IsNullOrWhiteSpace(tmpl.ImageUrl) ? null : tmpl.ImageUrl,
             ThumbnailUrl = string.IsNullOrWhiteSpace(tmpl.ThumbnailUrl) ? null : tmpl.ThumbnailUrl,
             Color = tmpl.Color > 0 ? (uint?)tmpl.Color : null,
-            Fields = tmpl.Fields?.Select(f => new EmbedFieldDto { Name = f.Name, Value = f.Value }).ToList()
+            Fields = tmpl.Fields?.Select(f => new EmbedFieldDto { Name = f.Name, Value = f.Value, Inline = f.Inline }).ToList(),
+            Buttons = tmpl.Buttons?.Where(b => b.Include).Select(b => new EmbedButtonDto
+            {
+                Label = b.Label,
+                CustomId = $"rsvp:{b.Tag}",
+                Emoji = string.IsNullOrWhiteSpace(b.Emoji) ? null : b.Emoji,
+                Style = b.Style
+            }).ToList()
         };
     }
 


### PR DESCRIPTION
## Summary
- Preserve inline flag when converting template fields to `EmbedFieldDto`
- Map template buttons into `EmbedButtonDto` instances for embed previews

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a141ca87f083289bea19b3187bccd1