### PR TITLE
Refactor officer chat window to reuse base draw

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -191,12 +191,12 @@ public class ChatWindow : IDisposable
         _ws?.Dispose();
     }
 
-    private void SaveConfig()
+    protected void SaveConfig()
     {
         PluginServices.PluginInterface.SavePluginConfig(_config);
     }
 
-    private async Task FetchChannels()
+    protected virtual async Task FetchChannels()
     {
         _channelsLoaded = true;
         try


### PR DESCRIPTION
## Summary
- Reuse `ChatWindow.Draw` in officer chat by calling `base.Draw` and restoring officer channel config
- Allow channel list fetching and config saving to be overridden
- Implement officer-specific channel fetch and message post endpoints

## Testing
- `dotnet build DemiCatPlugin` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68a1417894ec8328938d5b65245ca8b8