### PR TITLE
refactor: move password engine test

### DIFF
--- a/demibot/demibot/db/session.py
+++ b/demibot/demibot/db/session.py
@@ -57,22 +57,3 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
         raise RuntimeError("Engine not initialized")
     async with _Session() as session:
         yield session
-
-
-def test_password_with_special_chars():
-    """Ensure engines handle credentials with special characters."""
-
-    from urllib.parse import quote_plus
-    import asyncio
-
-    password = "p@ss/w:rd?123"
-    url = f"sqlite+aiosqlite:///:memory:?password={quote_plus(password)}"
-
-    async def _check() -> None:
-        engine = await init_db(url)
-        async with engine.connect() as conn:
-            result = await conn.execute(text("SELECT 1"))
-            assert result.scalar_one() == 1
-        await engine.dispose()
-
-    asyncio.run(_check())

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: tests that require integration resources

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,16 @@
+from urllib.parse import quote_plus
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+@pytest.mark.integration
+def test_password_with_special_chars() -> None:
+    """Engine parses credentials with special characters."""
+    password = "p@ss/w:rd?123"
+    url = f"mysql+aiomysql://user:{quote_plus(password)}@localhost/test"
+
+    engine = create_async_engine(url)
+    assert engine.url.password == password
+    # Engine was never connected, but dispose to satisfy SQLAlchemy
+    engine.sync_engine.dispose()


### PR DESCRIPTION
## Summary
- clean up session module by removing inline test
- add integration test verifying MySQL password quoting
- register pytest integration marker

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a142d3828c8328bbed541ab3289336