### PR TITLE
Avoid variable shadowing in TemplatesWindow.Draw

### DIFF
--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -58,7 +58,6 @@ public class TemplatesWindow
         ImGui.BeginChild("TemplateContent", new Vector2(0, 0), false);
         if (_selectedIndex >= 0)
         {
-            var templates = _config.Templates.Where(t => t.Type == _selectedType).ToList();
             if (_selectedIndex < templates.Count)
             {
                 var tmpl = templates[_selectedIndex];


### PR DESCRIPTION
## Summary
- Reuse the template list in `TemplatesWindow.Draw` instead of redeclaring it

## Testing
- `dotnet build` *(fails: Dalamud.NET.Sdk: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68a14619d6188328a4a25569d2969db0