### PR TITLE
Rename Officer chat DTO to avoid name hiding

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -67,7 +67,7 @@ public class OfficerChatWindow : ChatWindow
                 return;
             }
             var stream = await response.Content.ReadAsStreamAsync();
-            var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
+            var dto = await JsonSerializer.DeserializeAsync<OfficerChannelListDto>(stream) ?? new OfficerChannelListDto();
             _ = PluginServices.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Officer);
@@ -79,7 +79,7 @@ public class OfficerChatWindow : ChatWindow
         }
     }
 
-    private class ChannelListDto
+    private class OfficerChannelListDto
     {
         [JsonPropertyName("officer_chat")]
         public List<string> Officer { get; set; } = new();


### PR DESCRIPTION
## Summary
- avoid hiding base ChannelListDto by renaming Officer-specific DTO
- update channel fetch deserialization to the new type

## Testing
- `/usr/share/dotnet9/dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a14642a74c8328aebf8a0e71dbcfd3