### PR TITLE
Prompt for DB credentials when missing

### DIFF
--- a/demibot/demibot/config.json
+++ b/demibot/demibot/config.json
@@ -3,14 +3,14 @@
     "host": "0.0.0.0",
     "port": 5000
   },
-  "database": {
-    "use_remote": false,
-    "host": "localhost",
-    "port": 3306,
-    "database": "demibot",
-    "user": "root",
-    "password": ""
-  },
+    "database": {
+      "use_remote": false,
+      "host": "localhost",
+      "port": 3306,
+      "database": "demibot",
+      "user": "",
+      "password": ""
+    },
   "discord_token": ""
 }
 

--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import asyncio
 import json
 import logging
+import getpass
 from urllib.parse import quote_plus
 
 from sqlalchemy import text
@@ -37,7 +38,7 @@ class DatabaseConfig:
     host: str = "localhost"
     port: int = 3306
     database: str = "demibot"
-    user: str = "root"
+    user: str = ""
     password: str = ""
 
     @property
@@ -109,6 +110,12 @@ def ensure_config(force_reconfigure: bool = False) -> AppConfig:
                 input(f"Database name [{cfg.database.database}]: ")
                 or cfg.database.database
             )
+        cfg.database.user = (
+            input(f"Username [{cfg.database.user}]: ") or cfg.database.user
+        )
+        pwd = getpass.getpass("Password: ")
+        if pwd:
+            cfg.database.password = pwd
 
     def _check_database() -> bool:
         try:
@@ -137,6 +144,9 @@ def ensure_config(force_reconfigure: bool = False) -> AppConfig:
         )
         changed = True
     else:
+        if not cfg.database.user or not cfg.database.password:
+            _prompt_database()
+            changed = True
         mode = "remote" if cfg.database.use_remote else "local"
         print(
             f"Using {mode} MySQL database at "


### PR DESCRIPTION
## Summary
- avoid shipping default database credentials
- prompt for username and password during configuration
- reconfigure database credentials when missing in existing configs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1497f45c48328ac302e6a381c83a8