### PR TITLE
Use BigInteger for user IDs

### DIFF
--- a/demibot/demibot/db/migrations/versions/0002_user_id_bigint.py
+++ b/demibot/demibot/db/migrations/versions/0002_user_id_bigint.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0002_user_id_bigint"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("users", "id", existing_type=sa.Integer(), type_=sa.BigInteger())
+    op.alter_column(
+        "user_keys",
+        "user_id",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+    )
+    op.alter_column(
+        "memberships",
+        "user_id",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+    )
+    op.alter_column(
+        "messages",
+        "author_id",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+    )
+    op.alter_column(
+        "attendance",
+        "user_id",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+    )
+
+
+def downgrade() -> None:
+    op.alter_column("users", "id", existing_type=sa.BigInteger(), type_=sa.Integer())
+    op.alter_column(
+        "user_keys",
+        "user_id",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+    )
+    op.alter_column(
+        "memberships",
+        "user_id",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+    )
+    op.alter_column(
+        "messages",
+        "author_id",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+    )
+    op.alter_column(
+        "attendance",
+        "user_id",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+    )
+

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -59,7 +59,7 @@ class GuildChannel(Base):
 class User(Base):
     __tablename__ = "users"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     discord_user_id: Mapped[int] = mapped_column(BigInteger, unique=True, index=True)
     global_name: Mapped[Optional[str]] = mapped_column(String(255))
     discriminator: Mapped[Optional[str]] = mapped_column(String(10))
@@ -73,7 +73,7 @@ class UserKey(Base):
     __tablename__ = "user_keys"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"))
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
     token: Mapped[str] = mapped_column(String(64), unique=True, index=True)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
@@ -90,7 +90,7 @@ class Membership(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"))
 
 
 class Role(Base):
@@ -121,7 +121,7 @@ class Message(Base):
     discord_message_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     channel_id: Mapped[int] = mapped_column(BigInteger, index=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
-    author_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    author_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"))
     author_name: Mapped[str] = mapped_column(String(255))
     content_raw: Mapped[str] = mapped_column(Text)
     content_display: Mapped[str] = mapped_column(Text)
@@ -157,5 +157,5 @@ class Attendance(Base):
     discord_message_id: Mapped[int] = mapped_column(
         BigInteger, primary_key=True
     )
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), primary_key=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"), primary_key=True)
     choice: Mapped[RSVP] = mapped_column(String(10))


### PR DESCRIPTION
## Summary
- Store Discord IDs in BigInteger by default
- Update user-related foreign keys to BigInteger
- Add Alembic migration for new column types

## Testing
- `pytest -q`
- `python - <<'PY'
import asyncio, sys
sys.path.insert(0, './demibot')
from demibot.db.session import init_db
async def main():
    await init_db('sqlite+aiosqlite:////tmp/test.db')
    print('initialized')
asyncio.run(main())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a14d56d9008328ba39121dec0c9d97