### PR TITLE
feat: prompt for server port and set new default

### DIFF
--- a/demibot/README.md
+++ b/demibot/README.md
@@ -22,13 +22,14 @@ python -m demibot.main --reconfigure
 
 You will be prompted for required settings:
 
+* `Server port` (default 5050)
 * `Use remote MySQL server? (y/N)`
 * `Remote host`, `Remote port` and `Database name` (if remote is selected)
 * `Enter Discord bot token`
 
 The answers are written to `demibot/demibot/config.json`. Edit this file to
-adjust `server`, `database` or `discord_token` values, or rerun the command
-with `--reconfigure` to update it.
+adjust `server`, `database` or `discord_token` values (for example, change
+`server.port`), or rerun the command with `--reconfigure` to update it.
 
 Run database migrations:
 

--- a/demibot/demibot/README.md
+++ b/demibot/demibot/README.md
@@ -12,8 +12,8 @@ python -m demibot.main
 Environment variables (optional):
 
 - DEMIBOT_HOST (default: 0.0.0.0)
-- DEMIBOT_PORT (default: 8000)
- - DEMIBOT_WS_PATH (default: /ws/embeds)
+- DEMIBOT_PORT (default: 5050)
+- DEMIBOT_WS_PATH (default: /ws/embeds)
 - DEMIBOT_API_KEY (default: demo)  # Use this same key in the plugin Settings → Sync
 ```
 

--- a/demibot/demibot/config.json
+++ b/demibot/demibot/config.json
@@ -1,7 +1,7 @@
 {
   "server": {
     "host": "0.0.0.0",
-    "port": 5000
+    "port": 5050
   },
     "database": {
       "use_remote": false,

--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -27,7 +27,7 @@ CFG_PATH = Path(__file__).with_name("config.json")
 @dataclass
 class ServerConfig:
     host: str = "0.0.0.0"
-    port: int = 5000
+    port: int = 5050
 
 
 @dataclass
@@ -97,6 +97,11 @@ def ensure_config(force_reconfigure: bool = False) -> AppConfig:
     cfg = load_config() if CFG_PATH.exists() else AppConfig()
     changed = False
 
+    def _prompt_server() -> None:
+        port = input(f"Server port [{cfg.server.port}]: ").strip()
+        if port:
+            cfg.server.port = int(port)
+
     def _prompt_database() -> None:
         resp = input("Use remote MySQL server? (y/N): ").strip().lower()
         cfg.database.use_remote = resp.startswith("y")
@@ -134,6 +139,7 @@ def ensure_config(force_reconfigure: bool = False) -> AppConfig:
     needs_prompt = force_reconfigure or not CFG_PATH.exists()
 
     if needs_prompt:
+        _prompt_server()
         while True:
             _prompt_database()
             if _check_database():


### PR DESCRIPTION
## Summary
- default DemiBot server port to 5050
- prompt for server port during configuration
- document server port configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a14d3e827083288d3fb627f1824238