### PR TITLE
Use unsigned MySQL BIGINT for user identifiers

### DIFF
--- a/demibot/demibot/db/migrations/env.py
+++ b/demibot/demibot/db/migrations/env.py
@@ -7,11 +7,11 @@ from sqlalchemy import engine_from_config, pool
 from sqlalchemy import create_engine
 from alembic import context
 
-from ..base import Base
-from .. import models  # noqa: F401
+from demibot.db.base import Base
+from demibot.db import models  # noqa: F401
 
 config = context.config
-if config.config_file_name is not None:
+if config.config_file_name is not None and config.get_section("loggers"):
     fileConfig(config.config_file_name)
 
 def run_migrations_offline() -> None:

--- a/demibot/demibot/db/migrations/versions/0003_unsigned_user_ids.py
+++ b/demibot/demibot/db/migrations/versions/0003_unsigned_user_ids.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0003_unsigned_user_ids"
+down_revision = "0002_user_id_bigint"
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.alter_column("users", "id", existing_type=sa.BigInteger(), type_=mysql.BIGINT(unsigned=True))
+    op.alter_column("user_keys", "user_id", existing_type=sa.BigInteger(), type_=mysql.BIGINT(unsigned=True))
+    op.alter_column("memberships", "user_id", existing_type=sa.BigInteger(), type_=mysql.BIGINT(unsigned=True))
+    op.alter_column("messages", "author_id", existing_type=sa.BigInteger(), type_=mysql.BIGINT(unsigned=True))
+    op.alter_column("attendance", "user_id", existing_type=sa.BigInteger(), type_=mysql.BIGINT(unsigned=True))
+
+def downgrade() -> None:
+    op.alter_column("users", "id", existing_type=mysql.BIGINT(unsigned=True), type_=sa.BigInteger())
+    op.alter_column("user_keys", "user_id", existing_type=mysql.BIGINT(unsigned=True), type_=sa.BigInteger())
+    op.alter_column("memberships", "user_id", existing_type=mysql.BIGINT(unsigned=True), type_=sa.BigInteger())
+    op.alter_column("messages", "author_id", existing_type=mysql.BIGINT(unsigned=True), type_=sa.BigInteger())
+    op.alter_column("attendance", "user_id", existing_type=mysql.BIGINT(unsigned=True), type_=sa.BigInteger())

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Text,
     Index,
 )
+from sqlalchemy.dialects.mysql import BIGINT
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base
@@ -59,7 +60,7 @@ class GuildChannel(Base):
 class User(Base):
     __tablename__ = "users"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
     discord_user_id: Mapped[int] = mapped_column(BigInteger, unique=True, index=True)
     global_name: Mapped[Optional[str]] = mapped_column(String(255))
     discriminator: Mapped[Optional[str]] = mapped_column(String(10))
@@ -73,7 +74,7 @@ class UserKey(Base):
     __tablename__ = "user_keys"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"))
+    user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), ForeignKey("users.id"))
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
     token: Mapped[str] = mapped_column(String(64), unique=True, index=True)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
@@ -90,7 +91,7 @@ class Membership(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"))
+    user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), ForeignKey("users.id"))
 
 
 class Role(Base):
@@ -121,7 +122,7 @@ class Message(Base):
     discord_message_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     channel_id: Mapped[int] = mapped_column(BigInteger, index=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
-    author_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"))
+    author_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), ForeignKey("users.id"))
     author_name: Mapped[str] = mapped_column(String(255))
     content_raw: Mapped[str] = mapped_column(Text)
     content_display: Mapped[str] = mapped_column(Text)
@@ -157,5 +158,5 @@ class Attendance(Base):
     discord_message_id: Mapped[int] = mapped_column(
         BigInteger, primary_key=True
     )
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id"), primary_key=True)
+    user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True)
     choice: Mapped[RSVP] = mapped_column(String(10))


### PR DESCRIPTION
## Summary
- import MySQL `BIGINT` and use unsigned type for `User.id` and related foreign keys
- add Alembic migration to convert existing columns to unsigned BIGINT
- adjust Alembic environment imports for standalone execution

## Testing
- `alembic -c alembic.ini upgrade head` *(fails: sqlite3.OperationalError near "ALTER": syntax error)*
- `PYTHONPATH=. python - <<'PY' ... Base.metadata.create_all(engine) ... PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a151d786f08328836b3282c2bfe168