### PR TITLE
Add environment setup script and CI

### DIFF
--- a/.github/workflows/setup-env.yml
+++ b/.github/workflows/setup-env.yml
@@ -1,0 +1,13 @@
+name: Setup
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run setup script
+        run: bash scripts/setup_env.sh

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,10 @@ node_modules/
 database/*.db
 __pycache__/
 
+# Local development artifacts
+.venv/
+.dotnet/
+DemiCatPlugin/packages.lock.json
+
 # DemiBot configuration
 demibot/demibot/config.json

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Key environment variables include:
 
 ## Setup
 
+Run the helper script to bootstrap both the Python and .NET parts of the
+project. It creates a virtual environment, installs dependencies from
+`demibot/pyproject.toml`, and builds the Dalamud plugin.
+
+```bash
+bash scripts/setup_env.sh
+```
+
 ### 1. Install dependencies and initialize the database
 ```bash
 cd demibot

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repository root
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+cd "$ROOT_DIR"
+
+# -----------------------------
+# Python environment
+# -----------------------------
+PYTHON=${PYTHON:-python3}
+if [ ! -d ".venv" ]; then
+    "$PYTHON" -m venv .venv
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+pip install --upgrade pip
+
+# Install dependencies from demibot/pyproject.toml
+python <<'PY'
+import tomllib, subprocess
+from pathlib import Path
+toml_path = Path('demibot/pyproject.toml')
+data = tomllib.load(toml_path.open('rb'))
+
+def normalize(ver: str) -> str:
+    return ver.replace('^', '>=') if ver else ''
+
+def flatten(prefix, value):
+    if isinstance(value, dict) and not {'version', 'extras', 'optional'} & value.keys():
+        for k, v in value.items():
+            yield from flatten(f"{prefix}.{k}" if prefix else k, v)
+    else:
+        yield prefix, value
+
+deps = []
+for name, spec in flatten('', data.get('project', {}).get('dependencies', {})):
+    if isinstance(spec, str):
+        deps.append(f"{name}{normalize(spec)}")
+    elif isinstance(spec, dict):
+        extras = '[' + ','.join(spec.get('extras', [])) + ']' if spec.get('extras') else ''
+        version = normalize(spec.get('version', ''))
+        deps.append(f"{name}{extras}{version}")
+    else:
+        deps.append(name)
+if deps:
+    subprocess.check_call(['pip', 'install', *deps])
+PY
+
+# -----------------------------
+# .NET SDK and plugin build
+# -----------------------------
+DOTNET_CMD="dotnet"
+if ! command -v "$DOTNET_CMD" >/dev/null 2>&1; then
+    echo "Installing .NET SDK..."
+    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0 --install-dir "$ROOT_DIR/.dotnet"
+    export PATH="$ROOT_DIR/.dotnet:$PATH"
+    DOTNET_CMD="$ROOT_DIR/.dotnet/dotnet"
+else
+    echo ".NET SDK already installed."
+fi
+
+# Ensure local install is on PATH
+if [ -d "$ROOT_DIR/.dotnet" ]; then
+    export PATH="$ROOT_DIR/.dotnet:$PATH"
+    DOTNET_CMD="$ROOT_DIR/.dotnet/dotnet"
+fi
+
+"$DOTNET_CMD" restore DemiCatPlugin/DemiCatPlugin.csproj
+"$DOTNET_CMD" build DemiCatPlugin/DemiCatPlugin.csproj
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- add setup script to create Python venv, install deps, and build DemiCatPlugin
- document setup script usage in README
- add GitHub Actions workflow running setup script

## Testing
- `bash scripts/setup_env.sh` *(fails: Dalamud installation not found)*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68a153c10acc832885f3dc993f545913