### PR TITLE
Sync slash commands during bot setup

### DIFF
--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -66,6 +66,7 @@ class AppConfig:
     server: ServerConfig = ServerConfig()
     database: DatabaseConfig = DatabaseConfig()
     discord_token: str = ""
+    dev_guild_id: int | None = None
 
 
 def load_config() -> AppConfig:
@@ -84,6 +85,7 @@ def load_config() -> AppConfig:
                 remote=DBProfile(**db_data.get("remote", {})),
             ),
             discord_token=data.get("discord_token", ""),
+            dev_guild_id=data.get("dev_guild_id"),
         )
     return AppConfig()
 
@@ -93,6 +95,7 @@ def save_config(cfg: AppConfig) -> None:
         "server": asdict(cfg.server),
         "database": asdict(cfg.database),
         "discord_token": cfg.discord_token,
+        "dev_guild_id": cfg.dev_guild_id,
     }
     CFG_PATH.parent.mkdir(parents=True, exist_ok=True)
     CFG_PATH.write_text(json.dumps(data, indent=2))

--- a/demibot/demibot/discordbot/bot.py
+++ b/demibot/demibot/discordbot/bot.py
@@ -39,6 +39,19 @@ class DemiBot(commands.Bot):
             else:
                 logger.info("Loaded extension %s", module_path)
 
+        try:
+            synced = await self.tree.sync()
+            logger.info("Synced %d global command(s)", len(synced))
+            dev_guild_id = getattr(self.cfg, "dev_guild_id", None)
+            if dev_guild_id:
+                guild = discord.Object(id=dev_guild_id)
+                self.tree.copy_global_to(guild=guild)
+                guild_synced = await self.tree.sync(guild=guild)
+                logger.info(
+                    "Synced %d command(s) to guild %s", len(guild_synced), dev_guild_id
+                )
+        except Exception:
+            logger.exception("Failed to sync application commands")
 
 def create_bot(cfg: AppConfig) -> DemiBot:
     return DemiBot(cfg)


### PR DESCRIPTION
## Summary
- add optional `dev_guild_id` setting
- sync application commands after loading cogs
- log sync success or failure and optionally copy globals to a dev guild

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1ce004b348328832d12d7ade6f5f0