### PR TITLE
feat: add global generatekey command

### DIFF
--- a/demibot/demibot/discordbot/cogs/keygen.py
+++ b/demibot/demibot/discordbot/cogs/keygen.py
@@ -64,5 +64,11 @@ async def key_command(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Unable to send DM", ephemeral=True)
 
 
+@app_commands.command(name="generatekey", description="Generate an API key")
+async def generatekey(interaction: discord.Interaction) -> None:
+    await key_command.callback(interaction)
+
+
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(KeyGen(bot))
+    bot.tree.add_command(generatekey)


### PR DESCRIPTION
## Summary
- expose `/generatekey` slash command mirroring existing key generation logic
- register slash command globally in keygen cog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1e13c5fd483289743bfdc91c08a63