### PR TITLE
Remove unused WebSocket connection flag

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -27,7 +27,6 @@ public class ChatWindow : IDisposable
     private ClientWebSocket? _ws;
     private Task? _wsTask;
     private CancellationTokenSource? _wsCts;
-    private bool _wsConnected;
 
     public ChatWindow(Config config, HttpClient httpClient)
     {
@@ -227,7 +226,6 @@ public class ChatWindow : IDisposable
                 }
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
-                _wsConnected = true;
 
                 var buffer = new byte[8192];
                 while (_ws.State == WebSocketState.Open && !token.IsCancellationRequested)
@@ -271,7 +269,6 @@ public class ChatWindow : IDisposable
             }
             finally
             {
-                _wsConnected = false;
                 _ws?.Dispose();
                 _ws = null;
             }


### PR DESCRIPTION
## Summary
- drop unused `_wsConnected` flag in `ChatWindow`
- rely on existing loop for WebSocket reconnection

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1ef3b23508328b2fb489de6a1d302