### PR TITLE
Allow guild owner to post key embed before roles exist

### DIFF
--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -81,11 +81,19 @@ async def key_embed(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Guild only", ephemeral=True)
         return
 
-    allowed_roles = await _authorized_role_ids(interaction.guild.id)
-    member_role_ids = {r.id for r in interaction.user.roles}
-    if not (member_role_ids & allowed_roles):
-        await interaction.response.send_message("You are not authorized", ephemeral=True)
-        return
+    if (
+        interaction.user.id != interaction.guild.owner_id
+        and not interaction.user.guild_permissions.administrator
+    ):
+        allowed_roles = await _authorized_role_ids(interaction.guild.id)
+        member_role_ids = {r.id for r in interaction.user.roles}
+        if not (member_role_ids & allowed_roles):
+            await interaction.response.send_message(
+                "You are not authorized", ephemeral=True
+            )
+            return
+    else:
+        allowed_roles = await _authorized_role_ids(interaction.guild.id)
 
     cfg = getattr(interaction.client, "cfg", None)
     image_url = None

--- a/tests/test_key_embed_owner.py
+++ b/tests/test_key_embed_owner.py
@@ -1,0 +1,40 @@
+import asyncio
+from types import SimpleNamespace
+
+import asyncio
+from types import SimpleNamespace
+
+from demibot.discordbot.cogs import admin as admin_module
+
+
+class DummyResponse:
+    def __init__(self) -> None:
+        self.kwargs = None
+
+    async def send_message(self, **kwargs) -> None:
+        self.kwargs = kwargs
+
+
+class DummyInteraction:
+    def __init__(self, owner_id: int, user_id: int) -> None:
+        self.guild = SimpleNamespace(id=1, owner_id=owner_id, name="Test Guild")
+        perms = SimpleNamespace(administrator=False)
+        self.user = SimpleNamespace(id=user_id, roles=[], guild_permissions=perms)
+        self.response = DummyResponse()
+        self.client = SimpleNamespace(cfg=None)
+
+
+def test_owner_can_post_embed(monkeypatch):
+    async def stub_authorized_role_ids(_guild_id: int) -> set[int]:
+        return set()
+
+    monkeypatch.setattr(
+        admin_module, "_authorized_role_ids", stub_authorized_role_ids
+    )
+
+    inter = DummyInteraction(owner_id=1, user_id=1)
+    asyncio.run(admin_module.key_embed.callback(inter))
+
+    assert inter.response.kwargs is not None
+    assert inter.response.kwargs.get("content") is None
+    assert inter.response.kwargs.get("embed") is not None


### PR DESCRIPTION
## Summary
- let guild owners and admins post the key generation embed without roles
- add test ensuring the guild owner can invoke `/demibot embed`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1f513fb9083289dfc367ab115e4fd