### PR TITLE
Support multi-channel guild configuration

### DIFF
--- a/demibot/demibot/db/migrations/versions/0004_drop_single_channel_fields.py
+++ b/demibot/demibot/db/migrations/versions/0004_drop_single_channel_fields.py
@@ -1,0 +1,23 @@
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0004_drop_single_channel_fields"
+down_revision = "0003_unsigned_user_ids"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("guild_config", "event_channel_id")
+    op.drop_column("guild_config", "fc_chat_channel_id")
+    op.drop_column("guild_config", "officer_chat_channel_id")
+    op.drop_column("guild_config", "chat_role_id")
+
+
+def downgrade() -> None:
+    op.add_column("guild_config", sa.Column("event_channel_id", sa.BigInteger(), nullable=True))
+    op.add_column("guild_config", sa.Column("fc_chat_channel_id", sa.BigInteger(), nullable=True))
+    op.add_column("guild_config", sa.Column("officer_chat_channel_id", sa.BigInteger(), nullable=True))
+    op.add_column("guild_config", sa.Column("chat_role_id", sa.BigInteger(), nullable=True))
+

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 
 from sqlalchemy import (
     BigInteger,
@@ -39,12 +39,8 @@ class GuildConfig(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
-    event_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger)
-    fc_chat_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger)
-    officer_chat_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger)
     officer_visible_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger)
     officer_role_id: Mapped[Optional[int]] = mapped_column(BigInteger)
-    chat_role_id: Mapped[Optional[int]] = mapped_column(BigInteger)
 
     guild: Mapped[Guild] = relationship(back_populates="config")
 


### PR DESCRIPTION
## Summary
- Allow selecting multiple event, FC chat, and officer chat channels in the configuration wizard
- Persist selected channels to `GuildChannel` and keep only one officer role in `GuildConfig`
- Drop obsolete single-channel and chat role columns via new migration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1f7dd9c408328b64437327bae8f36