### PR TITLE
Remove chat role gating

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -27,7 +27,6 @@ public class MainWindow
 
     public bool IsOpen;
     public bool HasOfficerRole { get; set; }
-    public bool HasChatRole { get; set; }
 
     public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient)
     {
@@ -112,7 +111,7 @@ public class MainWindow
                 ImGui.EndTabItem();
             }
 
-            if (HasChatRole && _chat != null && ImGui.BeginTabItem("Chat"))
+            if (_chat != null && ImGui.BeginTabItem("Chat"))
             {
                 _chat.Draw();
                 ImGui.EndTabItem();

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -37,6 +37,10 @@ public class Plugin : IDalamudPlugin
     public Plugin()
     {
         _config = PluginInterface.GetPluginConfig() as Config ?? new Config();
+        if (_config.Roles.RemoveAll(r => r == "chat") > 0)
+        {
+            PluginInterface.SavePluginConfig(_config);
+        }
 
         _ui = new UiRenderer(_config, _httpClient);
         _settings = new SettingsWindow(_config, _httpClient, RefreshRoles);
@@ -45,7 +49,6 @@ public class Plugin : IDalamudPlugin
         _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);
 
         _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
-        _mainWindow.HasChatRole = _config.Roles.Contains("chat");
 
         if (_config.Enabled)
         {
@@ -287,9 +290,9 @@ public class Plugin : IDalamudPlugin
             var dto = await JsonSerializer.DeserializeAsync<RolesDto>(stream) ?? new RolesDto();
             _ = PluginServices.Framework.RunOnTick(() =>
             {
+                dto.Roles.RemoveAll(r => r == "chat");
                 _config.Roles = dto.Roles;
                 _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
-                _mainWindow.HasChatRole = _config.Roles.Contains("chat");
                 PluginServices.PluginInterface.SavePluginConfig(_config);
             });
         }


### PR DESCRIPTION
## Summary
- Show Chat tab whenever a chat window is present
- Strip deprecated `chat` role from configuration and stop checking for it

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68a20f0908ac83288f488f6d33ae520f