### PR TITLE
Add Discord role mapping and upsert in setup wizard

### DIFF
--- a/demibot/demibot/db/migrations/versions/0005_add_role_discord_role_id.py
+++ b/demibot/demibot/db/migrations/versions/0005_add_role_discord_role_id.py
@@ -1,0 +1,22 @@
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0005_add_role_discord_role_id"
+down_revision = "0004_drop_single_channel_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "roles", sa.Column("discord_role_id", sa.BigInteger(), nullable=False)
+    )
+    op.create_index(
+        op.f("ix_roles_discord_role_id"), "roles", ["discord_role_id"], unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_roles_discord_role_id"), table_name="roles")
+    op.drop_column("roles", "discord_role_id")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -95,6 +95,7 @@ class Role(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
+    discord_role_id: Mapped[int] = mapped_column(BigInteger, unique=True)
     name: Mapped[str] = mapped_column(String(255))
     is_officer: Mapped[bool] = mapped_column(Boolean, default=False)
     is_chat: Mapped[bool] = mapped_column(Boolean, default=False)
@@ -118,7 +119,9 @@ class Message(Base):
     discord_message_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     channel_id: Mapped[int] = mapped_column(BigInteger, index=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
-    author_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), ForeignKey("users.id"))
+    author_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id")
+    )
     author_name: Mapped[str] = mapped_column(String(255))
     content_raw: Mapped[str] = mapped_column(Text)
     content_display: Mapped[str] = mapped_column(Text)
@@ -151,8 +154,8 @@ class RSVP(enum.Enum):
 class Attendance(Base):
     __tablename__ = "attendance"
 
-    discord_message_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True
+    discord_message_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True
     )
-    user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True)
     choice: Mapped[RSVP] = mapped_column(String(10))

--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -477,6 +477,27 @@ class ConfigWizard(discord.ui.View):
                     config = GuildConfig(guild_id=guild.id)
                     db.add(config)
                 config.officer_role_id = self.officer_role_id
+                role_name = self.guild.get_role(self.officer_role_id)
+                role_name = role_name.name if role_name else "Officer"
+                role_res = await db.execute(
+                    select(Role).where(
+                        Role.guild_id == guild.id,
+                        Role.discord_role_id == self.officer_role_id,
+                    )
+                )
+                role = role_res.scalars().first()
+                if role is None:
+                    db.add(
+                        Role(
+                            guild_id=guild.id,
+                            name=role_name,
+                            discord_role_id=self.officer_role_id,
+                            is_officer=True,
+                        )
+                    )
+                else:
+                    role.name = role_name
+                    role.is_officer = True
                 await db.execute(
                     delete(GuildChannel).where(
                         GuildChannel.guild_id == guild.id,

--- a/tests/test_key_generation_roles.py
+++ b/tests/test_key_generation_roles.py
@@ -34,7 +34,9 @@ class DummyResponse:
         self.args = ()
         self.kwargs: dict | None = None
 
-    async def send_message(self, *args, **kwargs) -> None:  # pragma: no cover - simple stub
+    async def send_message(
+        self, *args, **kwargs
+    ) -> None:  # pragma: no cover - simple stub
         self.args = args
         self.kwargs = kwargs
 
@@ -64,7 +66,15 @@ async def _setup_db() -> None:
     async for db in get_session():
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
-        db.add(Role(id=10, guild_id=guild.id, name="Officer", is_officer=True))
+        db.add(
+            Role(
+                id=10,
+                guild_id=guild.id,
+                name="Officer",
+                is_officer=True,
+                discord_role_id=10,
+            )
+        )
         db.add(
             User(
                 id=1,
@@ -109,12 +119,16 @@ async def _generate(user_roles):
             )
         ).scalar_one()
         membership_roles = (
-            await db.execute(
-                select(MembershipRole.role_id).where(
-                    MembershipRole.membership_id == membership.id
+            (
+                await db.execute(
+                    select(MembershipRole.role_id).where(
+                        MembershipRole.membership_id == membership.id
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         key = (
             await db.execute(
                 select(UserKey).where(
@@ -140,4 +154,3 @@ def test_officer_generates_key_and_role_classified():
     assert membership_roles == [10]
     assert cached == "10"
     assert response.args and "Your sync key" in response.args[0]
-

--- a/tests/test_resync_membership_roles.py
+++ b/tests/test_resync_membership_roles.py
@@ -40,7 +40,14 @@ def _setup_db() -> None:
         async for db in get_session():
             guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
             db.add(guild)
-            db.add(Role(id=10, guild_id=guild.id, name="Officer"))
+            db.add(
+                Role(
+                    id=10,
+                    guild_id=guild.id,
+                    name="Officer",
+                    discord_role_id=10,
+                )
+            )
             user = User(
                 id=1, discord_user_id=2, global_name="Member", discriminator="0001"
             )


### PR DESCRIPTION
## Summary
- add `discord_role_id` to Role model
- upsert officer role in setup wizard
- add alembic migration and tests for new column

## Testing
- `alembic -c alembic_temp.ini upgrade head` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a22665f5bc832899e61eaf47c76716