### PR TITLE
Build plugin in Release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Key environment variables include:
 
 Run the helper script to bootstrap both the Python and .NET parts of the
 project. It creates a virtual environment, installs dependencies from
-`demibot/pyproject.toml`, and builds the Dalamud plugin.
+`demibot/pyproject.toml`, and builds the Dalamud plugin in Release mode.
 
 ```bash
 bash scripts/setup_env.sh

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -67,6 +67,6 @@ if [ -d "$ROOT_DIR/.dotnet" ]; then
 fi
 
 "$DOTNET_CMD" restore DemiCatPlugin/DemiCatPlugin.csproj
-"$DOTNET_CMD" build DemiCatPlugin/DemiCatPlugin.csproj
+"$DOTNET_CMD" build DemiCatPlugin/DemiCatPlugin.csproj -c Release
 
 echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- build DemiCatPlugin in Release configuration when running setup script
- mention Release build in setup instructions

## Testing
- `bash scripts/setup_env.sh` *(fails: Dalamud installation not found)*
- `./.venv/bin/pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2288841e0832881636d4a413379fb