### PR TITLE
Prompt for missing DB credentials and log masked DB URL

### DIFF
--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -63,8 +63,8 @@ class DatabaseConfig:
 
 @dataclass
 class AppConfig:
-    server: ServerConfig = ServerConfig()
-    database: DatabaseConfig = DatabaseConfig()
+    server: ServerConfig = field(default_factory=ServerConfig)
+    database: DatabaseConfig = field(default_factory=DatabaseConfig)
     discord_token: str = ""
     dev_guild_id: int | None = None
 
@@ -171,8 +171,12 @@ def ensure_config(force_reconfigure: bool = False) -> AppConfig:
             return False
 
     active_profile = cfg.database.active()
-    needs_prompt = force_reconfigure or not (
-        cfg.discord_token and active_profile.user and active_profile.password
+    # Reconfigure if any required credentials are missing
+    needs_prompt = (
+        force_reconfigure
+        or not cfg.discord_token
+        or not active_profile.user
+        or not active_profile.password
     )
 
     if needs_prompt:

--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -7,6 +7,7 @@ import asyncio
 from threading import Thread
 
 import logging
+import re
 import sys
 
 from demibot import log_config
@@ -37,9 +38,11 @@ def main() -> None:
     log_config.setup_logging()
     cfg = ensure_config(force_reconfigure=args.reconfigure)
 
-    logging.info("Initialising database")
+    db_url = cfg.database.url
+    masked_url = re.sub(r":[^:@/]+@", ":***@", db_url)
+    logging.info("Initialising database at %s", masked_url)
     try:
-        asyncio.run(init_db(cfg.database.url))
+        asyncio.run(init_db(db_url))
     except Exception:
         logging.exception("Database initialization failed")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- force ensure_config to re-prompt when username or password is missing
- mask password when logging database URL during startup
- use default_factory for AppConfig to allow package imports

## Testing
- `pytest`
- `python - <<'PY'
import asyncio, logging, re
from demibot.config import ensure_config
from demibot.db.session import init_db

logging.basicConfig(level=logging.INFO)
cfg = ensure_config()
url = cfg.database.url
print('URL:', url)
masked = re.sub(r':[^^@/]+@', ':***@', url)
logging.info('Initialising database at %s', masked)
try:
    asyncio.run(init_db(url))
except Exception:
    logging.exception('init_db failed')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a225f48e288328bc434b7e72263ea0