### PR TITLE
Refresh roles on key generation and sync

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -84,7 +84,7 @@ public class SettingsWindow : IDisposable
                 _invalidKey = false;
                 _config.AuthToken = _apiKey;
                 SaveConfig();
-                _ = _refreshRoles();
+                await _refreshRoles();
             }
             else
             {

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Update `DemiCatPlugin/DemiCatPlugin.json` with the usual plugin metadata. In-gam
 
 Use the **Key** and **Sync Key** obtained from `/demibot embed` and enter both values in the
 plugin settings. Press **Connect/Sync** (or **Validate** if you already have a key) to link the
-plugin with the bot.
+plugin with the bot. Entering a new key later requires reconnecting or pressing **Sync** again so
+your roles refresh; otherwise the officer tab will not appear until roles are reloaded.
 
 ### 4. Insert API keys
 Insert API keys into the `api_keys` table to authorize HTTP requests:

--- a/demibot/demibot/discordbot/cogs/keygen.py
+++ b/demibot/demibot/discordbot/cogs/keygen.py
@@ -5,9 +5,16 @@ import secrets
 import discord
 from discord import app_commands
 from discord.ext import commands
-from sqlalchemy import select
+from sqlalchemy import select, delete
 
-from ...db.models import Guild, User, UserKey
+from ...db.models import (
+    Guild,
+    Membership,
+    MembershipRole,
+    Role,
+    User,
+    UserKey,
+)
 from ...db.session import get_session
 from .setup_wizard import demi
 
@@ -47,7 +54,45 @@ async def key_command(interaction: discord.Interaction) -> None:
                 db.add(user)
                 await db.flush()
 
-            db.add(UserKey(user_id=user.id, guild_id=guild.id, token=token))
+            member_roles = [
+                r for r in interaction.user.roles if r.name != "@everyone"
+            ]
+            roles_cached = ",".join(str(r.id) for r in member_roles)
+
+            membership_res = await db.execute(
+                select(Membership).where(
+                    Membership.guild_id == guild.id,
+                    Membership.user_id == user.id,
+                )
+            )
+            membership = membership_res.scalars().first()
+            if membership is None:
+                membership = Membership(guild_id=guild.id, user_id=user.id)
+                db.add(membership)
+                await db.flush()
+
+            await db.execute(
+                delete(MembershipRole).where(
+                    MembershipRole.membership_id == membership.id
+                )
+            )
+
+            member_role_ids = {r.id for r in member_roles}
+            stored_roles = await db.execute(
+                select(Role.id).where(Role.guild_id == guild.id)
+            )
+            stored_role_ids = {row[0] for row in stored_roles}
+            for role_id in member_role_ids & stored_role_ids:
+                db.add(MembershipRole(membership_id=membership.id, role_id=role_id))
+
+            db.add(
+                UserKey(
+                    user_id=user.id,
+                    guild_id=guild.id,
+                    token=token,
+                    roles_cached=roles_cached,
+                )
+            )
             await db.commit()
     except Exception:
         await interaction.response.send_message(


### PR DESCRIPTION
## Summary
- cache member roles when generating API keys so /roles reflects officer status
- refresh plugin roles immediately after syncing a new key
- note that reconnecting or syncing again is required for officer tab to appear

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a22a2f09d88328a0a373af060e9c92