### PR TITLE
Improve API key sync diagnostics

### DIFF
--- a/DemiCatPlugin/PluginServices.cs
+++ b/DemiCatPlugin/PluginServices.cs
@@ -18,4 +18,7 @@ internal static class PluginServices
 
     [PluginService]
     internal static IFramework Framework { get; private set; } = null!;
+
+    [PluginService]
+    internal static IPluginLog PluginLog { get; private set; } = null!;
 }


### PR DESCRIPTION
## Summary
- Expose `IPluginLog` via `PluginServices`
- Trim API key, log validation outcomes, and show specific auth/network errors in settings

## Testing
- `~/.dotnet/dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'sqlalchemy', 'demibot')*


------
https://chatgpt.com/codex/tasks/task_e_68a27eb5d2e88328b40ffa81084a6b77