### PR TITLE
Inject shared logging into windows and role refresh

### DIFF
--- a/DemiCatPlugin/PluginServices.cs
+++ b/DemiCatPlugin/PluginServices.cs
@@ -20,5 +20,5 @@ internal static class PluginServices
     internal static IFramework Framework { get; private set; } = null!;
 
     [PluginService]
-    internal static IPluginLog PluginLog { get; private set; } = null!;
+    internal static IPluginLog Log { get; private set; } = null!;
 }


### PR DESCRIPTION
## Summary
- expose `IPluginLog Log` in `PluginServices` for shared logging
- inject logger into `SettingsWindow` and `RefreshRoles`
- log sync details and role retrieval

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*
- `pytest` *(fails: missing discord, sqlalchemy, demibot modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a28346fb888328b2b4a0eab64e5275