### PR TITLE
Add debug logging for auth and role endpoints

### DIFF
--- a/demibot/demibot/http/routes/validate_roles.py
+++ b/demibot/demibot/http/routes/validate_roles.py
@@ -1,6 +1,7 @@
-
 from __future__ import annotations
-from fastapi import APIRouter, Depends
+
+import logging
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 from ..deps import RequestContext, api_key_auth
 
@@ -12,10 +13,22 @@ class RolesResponse(BaseModel):
 
 
 @router.post("/validate")
-async def validate(_: RequestContext = Depends(api_key_auth)):
-    return {"ok": True}
+async def validate(
+    ctx: RequestContext = Depends(api_key_auth), request: Request = None
+):
+    client_ip = request.client.host if request and request.client else "unknown"
+    logging.info("/validate request from %s", client_ip)
+    response = {"ok": True}
+    logging.info("/validate response status=200")
+    return response
 
 
 @router.post("/roles", response_model=RolesResponse)
-async def roles(ctx: RequestContext = Depends(api_key_auth)) -> RolesResponse:
-    return RolesResponse(roles=ctx.roles)
+async def roles(
+    ctx: RequestContext = Depends(api_key_auth), request: Request = None
+) -> RolesResponse:
+    client_ip = request.client.host if request and request.client else "unknown"
+    logging.info("/roles request from %s", client_ip)
+    response = RolesResponse(roles=ctx.roles)
+    logging.info("/roles response status=200")
+    return response

--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -35,6 +35,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    logging.basicConfig(level=logging.DEBUG)
     log_config.setup_logging()
     cfg = ensure_config(force_reconfigure=args.reconfigure)
 


### PR DESCRIPTION
## Summary
- log client IP, API token and lookup result during auth
- log requests and responses for role validation endpoints
- enable DEBUG level logging at service startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a28e6ee8188328bad1ebaca3f0cf65