### PR TITLE
Switch to FastAPI with Uvicorn backend

### DIFF
--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -10,6 +10,8 @@ import logging
 import re
 import sys
 
+import uvicorn
+
 from demibot import log_config
 
 from .config import ensure_config
@@ -18,11 +20,12 @@ from .discordbot.bot import create_bot
 from .http.api import create_app
 
 
-def _run_flask(app, host: str, port: int) -> None:
+def _run_uvicorn(app, host: str, port: int) -> None:
+    """Run the FastAPI application using Uvicorn."""
     try:
-        app.run(host=host, port=port)
+        uvicorn.run(app, host=host, port=port, log_level="info")
     except Exception:
-        logging.exception("Flask server failed")
+        logging.exception("FastAPI server failed")
         sys.exit(1)
 
 
@@ -49,20 +52,20 @@ def main() -> None:
         sys.exit(1)
 
     logging.info(
-        "Starting Flask server on %s:%s",
+        "Starting FastAPI server on %s:%s",
         cfg.server.host,
         cfg.server.port,
     )
     try:
         app = create_app(cfg)
-        flask_thread = Thread(
-            target=_run_flask,
+        api_thread = Thread(
+            target=_run_uvicorn,
             args=(app, cfg.server.host, cfg.server.port),
             daemon=True,
         )
-        flask_thread.start()
+        api_thread.start()
     except Exception:
-        logging.exception("Failed to start Flask server")
+        logging.exception("Failed to start FastAPI server")
         sys.exit(1)
 
     logging.info("Starting Discord bot")

--- a/demibot/pyproject.toml
+++ b/demibot/pyproject.toml
@@ -1,14 +1,15 @@
 [project]
 name = "demibot"
 version = "0.1.0"
-description = "Discord bot and Flask backend for DemiCat plugin"
+description = "Discord bot and FastAPI backend for DemiCat plugin"
 requires-python = ">=3.11"
 authors = [{name = "DemiCat"}]
 readme = "README.md"
 license = {text = "MIT"}
 
 [project.dependencies]
-flask = "^3.0.0"
+fastapi = "^0.116.1"
+uvicorn = "^0.35.0"
 discord.py = "^2.3.2"
 sqlalchemy = {version = "^2.0.25", extras=["asyncio"]}
 aiomysql = "^0.2.0"


### PR DESCRIPTION
## Summary
- Replace Flask API with FastAPI and automatically mount all route modules
- Run the HTTP server via Uvicorn alongside the Discord bot
- Add FastAPI/Uvicorn dependencies

## Testing
- `PYTHONPATH=demibot python - <<'PY' ...` (verify /validate, /roles and /api/messages endpoints)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a292bc5a54832889e63093ae5dd5fb