### PR TITLE
refactor: consolidate API base URL

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -126,7 +126,7 @@ public class ChatWindow : IDisposable
         try
         {
             var body = new { channelId = _channelId, content = _input, useCharacterName = _useCharacterName };
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/messages");
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/messages");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
             if (!string.IsNullOrEmpty(_config.AuthToken))
             {
@@ -154,7 +154,7 @@ public class ChatWindow : IDisposable
 
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/messages/{_channelId}");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/messages/{_channelId}");
             if (!string.IsNullOrEmpty(_config.AuthToken))
             {
                 request.Headers.Add("X-Api-Key", _config.AuthToken);
@@ -194,7 +194,7 @@ public class ChatWindow : IDisposable
         _channelsLoaded = true;
         try
         {
-            var response = await _httpClient.GetAsync($"{_config.HelperBaseUrl.TrimEnd('/')}/api/channels");
+            var response = await _httpClient.GetAsync($"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
             if (!response.IsSuccessStatusCode)
             {
                 return;
@@ -286,7 +286,7 @@ public class ChatWindow : IDisposable
 
     private Uri BuildWebSocketUri()
     {
-        var baseUri = _config.HelperBaseUrl.TrimEnd('/') + "/ws/messages";
+        var baseUri = _config.ApiBaseUrl.TrimEnd('/') + "/ws/messages";
         var builder = new UriBuilder(baseUri);
         if (builder.Scheme == "https")
         {

--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -6,8 +6,7 @@ namespace DemiCatPlugin;
 public class DeveloperWindow
 {
     private readonly Config _config;
-    private string _ip;
-    private int _port;
+    private string _apiBaseUrl;
     private string _wsPath;
 
     public bool IsOpen;
@@ -15,9 +14,7 @@ public class DeveloperWindow
     public DeveloperWindow(Config config)
     {
         _config = config;
-        var uri = new Uri(config.ServerAddress);
-        _ip = uri.Host;
-        _port = uri.Port;
+        _apiBaseUrl = config.ApiBaseUrl;
         _wsPath = config.WebSocketPath;
     }
 
@@ -34,13 +31,12 @@ public class DeveloperWindow
             return;
         }
 
-        ImGui.InputText("Server IP", ref _ip, 64);
-        ImGui.InputInt("Port", ref _port);
+        ImGui.InputText("API Base URL", ref _apiBaseUrl, 256);
         ImGui.InputText("WebSocket Path", ref _wsPath, 64);
 
         if (ImGui.Button("Save"))
         {
-            _config.ServerAddress = $"http://{_ip}:{_port}";
+            _config.ApiBaseUrl = _apiBaseUrl;
             _config.WebSocketPath = _wsPath;
             PluginServices.PluginInterface.SavePluginConfig(_config);
         }

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -212,7 +212,7 @@ public class EventCreateWindow
                 buttons = buttons.Count > 0 ? buttons : null
             };
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/events");
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
             if (!string.IsNullOrEmpty(_config.AuthToken))
             {

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -214,7 +214,7 @@ public class EventView : IDisposable
     {
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/interactions");
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/interactions");
             var body = new { MessageId = _dto.Id, ChannelId = _dto.ChannelId, CustomId = customId };
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
             if (!string.IsNullOrEmpty(_config.AuthToken))

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -71,7 +71,7 @@ public class FcChatWindow : ChatWindow
         try
         {
             var body = new { channelId = _channelId, content, useCharacterName = _useCharacterName };
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/messages");
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/messages");
             request.Content = new StringContent(JsonSerializer.Serialize(body), System.Text.Encoding.UTF8, "application/json");
             if (!string.IsNullOrEmpty(_config.AuthToken))
             {
@@ -94,7 +94,7 @@ public class FcChatWindow : ChatWindow
     {
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/users");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");
             if (!string.IsNullOrEmpty(_config.AuthToken))
             {
                 request.Headers.Add("X-Api-Key", _config.AuthToken);

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -155,7 +155,7 @@ public class MainWindow
         _channelsLoaded = true;
         try
         {
-            var response = await _httpClient.GetAsync($"{_config.HelperBaseUrl.TrimEnd('/')}/api/channels");
+            var response = await _httpClient.GetAsync($"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
             if (!response.IsSuccessStatusCode)
             {
                 return;

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -37,7 +37,7 @@ public class OfficerChatWindow : ChatWindow
         try
         {
             var body = new { channelId = _channelId, content = _input, useCharacterName = _useCharacterName };
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/officer-messages");
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/officer-messages");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
             if (!string.IsNullOrEmpty(_config.AuthToken))
             {
@@ -61,7 +61,7 @@ public class OfficerChatWindow : ChatWindow
         _channelsLoaded = true;
         try
         {
-            var response = await _httpClient.GetAsync($"{_config.HelperBaseUrl.TrimEnd('/')}/api/channels");
+            var response = await _httpClient.GetAsync($"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
             if (!response.IsSuccessStatusCode)
             {
                 return;

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -83,7 +83,7 @@ public class SettingsWindow : IDisposable
         {
             _apiKey = _apiKey.Trim();
             var key = _apiKey;
-            var url = $"{_config.ServerAddress.TrimEnd('/')}/validate";
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/validate";
             var request = new HttpRequestMessage(HttpMethod.Post, url)
             {
                 Content = new StringContent(JsonSerializer.Serialize(new { key }), Encoding.UTF8, "application/json")

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -174,7 +174,7 @@ public class TemplatesWindow
                     buttons = buttons != null && buttons.Count > 0 ? buttons : null
                 };
 
-                var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/events");
+                var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events");
                 request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
                 if (!string.IsNullOrEmpty(_config.AuthToken))
                 {
@@ -185,7 +185,7 @@ public class TemplatesWindow
             else
             {
                 var body = new { channelId = ChannelId, content = tmpl.Content, useCharacterName = _config.UseCharacterName };
-                var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/messages");
+                var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/messages");
                 request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
                 if (!string.IsNullOrEmpty(_config.AuthToken))
                 {

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -58,7 +58,7 @@ public class UiRenderer : IDisposable
     {
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.HelperBaseUrl.TrimEnd('/')}/api/embeds");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/embeds");
             if (!string.IsNullOrEmpty(_config.AuthToken))
             {
                 request.Headers.Add("X-Api-Key", _config.AuthToken);


### PR DESCRIPTION
## Summary
- merge HelperBaseUrl and ServerAddress into a single ApiBaseUrl in config
- update all HTTP requests and developer UI to use ApiBaseUrl
- add config migration for legacy settings

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68a29306402c8328a53896dfd54c4e88