### PR TITLE
Expose websocket route for chat message broadcasts

### DIFF
--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -15,6 +15,8 @@ import pkgutil
 
 from fastapi import FastAPI
 
+from .ws import websocket_endpoint
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
@@ -25,6 +27,7 @@ def create_app(cfg: "AppConfig | None") -> FastAPI:
     """Create and configure the FastAPI application."""
 
     app = FastAPI()
+    app.add_api_websocket_route("/ws/messages", websocket_endpoint)
 
     @app.get("/health")
     async def health() -> dict[str, str]:


### PR DESCRIPTION
## Summary
- import websocket_endpoint and register `/ws/messages` websocket route

## Testing
- `pytest -q`
- connect to `/ws/messages` and confirm broadcast delivery

------
https://chatgpt.com/codex/tasks/task_e_68a29550600083289a0a9d5efe47c86f