### PR TITLE
feat: stream embeds via websocket

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -1,11 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.WebSockets;
-using System.Text;
 using System.Text.Json;
-using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using DiscordHelper;
 using Dalamud.Plugin;
@@ -27,10 +23,7 @@ public class Plugin : IDalamudPlugin
     private readonly OfficerChatWindow _officerChatWindow;
     private readonly MainWindow _mainWindow;
     private Config _config;
-    private CancellationTokenSource? _pollCts;
     private readonly HttpClient _httpClient = new();
-    private ClientWebSocket? _webSocket;
-    private readonly List<EmbedDto> _embeds = new();
     private readonly Action _openMainUi;
     private readonly Action _openConfigUi;
 
@@ -53,13 +46,9 @@ public class Plugin : IDalamudPlugin
 
         _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
 
-        if (_config.Enabled)
+        if (_config.Enabled && _config.Roles.Count == 0)
         {
-            _ = ConnectWebSocket();
-            if (_config.Roles.Count == 0)
-            {
-                _ = RefreshRoles(PluginServices.Log);
-            }
+            _ = RefreshRoles(PluginServices.Log);
         }
 
         PluginInterface.UiBuilder.Draw += _mainWindow.Draw;
@@ -72,160 +61,6 @@ public class Plugin : IDalamudPlugin
         Log.Info("DemiCat loaded.");
     }
 
-    private void StartPolling()
-    {
-        if (_pollCts != null)
-        {
-            return;
-        }
-
-        _pollCts = new CancellationTokenSource();
-        _ = PollLoop(_pollCts.Token);
-    }
-
-    private void StopPolling()
-    {
-        _pollCts?.Cancel();
-        _pollCts = null;
-    }
-
-    private async Task PollLoop(CancellationToken token)
-    {
-        var interval = TimeSpan.FromSeconds(_config.PollIntervalSeconds);
-        using var timer = new PeriodicTimer(interval);
-        try
-        {
-            while (await timer.WaitForNextTickAsync(token))
-            {
-                await PollEmbeds();
-                if (_webSocket == null || _webSocket.State != WebSocketState.Open)
-                {
-                    _ = ConnectWebSocket();
-                }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // ignored
-        }
-    }
-
-    private async Task PollEmbeds()
-    {
-        try
-        {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/embeds");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
-
-            var response = await _httpClient.SendAsync(request);
-            if (!response.IsSuccessStatusCode)
-            {
-                return;
-            }
-
-            var stream = await response.Content.ReadAsStreamAsync();
-            var embeds = await JsonSerializer.DeserializeAsync<List<EmbedDto>>(stream) ?? new List<EmbedDto>();
-            _ = PluginServices.Framework.RunOnTick(() =>
-            {
-                _embeds.Clear();
-                _embeds.AddRange(embeds);
-                _ui.SetEmbeds(_embeds);
-            });
-        }
-        catch
-        {
-            // ignored
-        }
-    }
-
-    private async Task ConnectWebSocket()
-    {
-        if (_webSocket != null && _webSocket.State == WebSocketState.Open)
-        {
-            return;
-        }
-
-        try
-        {
-            _webSocket?.Dispose();
-            _webSocket = new ClientWebSocket();
-            var baseUrl = _config.ApiBaseUrl.TrimEnd('/');
-            var tokenPart = string.IsNullOrEmpty(_config.AuthToken)
-                ? string.Empty
-                : $"?token={Uri.EscapeDataString(_config.AuthToken)}";
-            var fullUrl = $"{baseUrl}{_config.WebSocketPath}{tokenPart}";
-            var wsUri = new Uri(fullUrl
-                .Replace("http://", "ws://")
-                .Replace("https://", "wss://"));
-            await _webSocket.ConnectAsync(wsUri, CancellationToken.None);
-            StopPolling();
-            await ReceiveLoop();
-        }
-        catch
-        {
-            StartPolling();
-        }
-    }
-
-    private async Task ReceiveLoop()
-    {
-        if (_webSocket == null)
-        {
-            return;
-        }
-
-        var buffer = new byte[8192];
-        try
-        {
-            while (_webSocket.State == WebSocketState.Open)
-            {
-                var ms = new MemoryStream();
-                WebSocketReceiveResult result;
-                do
-                {
-                    result = await _webSocket.ReceiveAsync(buffer, CancellationToken.None);
-                    if (result.MessageType == WebSocketMessageType.Close)
-                    {
-                        await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
-                        return;
-                    }
-                    ms.Write(buffer, 0, result.Count);
-                } while (!result.EndOfMessage);
-
-                var json = Encoding.UTF8.GetString(ms.ToArray());
-                var embed = JsonSerializer.Deserialize<EmbedDto>(json);
-                if (embed != null)
-                {
-                    _ = PluginServices.Framework.RunOnTick(() =>
-                    {
-                        var index = _embeds.FindIndex(e => e.Id == embed.Id);
-                        if (index >= 0)
-                        {
-                            _embeds[index] = embed;
-                        }
-                        else
-                        {
-                            _embeds.Add(embed);
-                        }
-                        _ui.SetEmbeds(_embeds);
-                    });
-                }
-            }
-        }
-        catch
-        {
-            // ignored
-        }
-        finally
-        {
-            _webSocket?.Dispose();
-            _webSocket = null;
-            StartPolling();
-        }
-    } // ✅ properly closes ReceiveLoop
 
     public void Dispose()
     {
@@ -237,32 +72,6 @@ public class Plugin : IDalamudPlugin
         PluginInterface.UiBuilder.OpenMainUi -= _openMainUi;
         PluginInterface.UiBuilder.OpenConfigUi -= _openConfigUi;
 
-        // Stop background work
-        StopPolling();
-
-        // Close and dispose websocket safely
-        if (_webSocket != null)
-        {
-            try
-            {
-                if (_webSocket.State == WebSocketState.Open)
-                {
-                    _webSocket.CloseAsync(
-                        WebSocketCloseStatus.NormalClosure,
-                        string.Empty,
-                        CancellationToken.None
-                    ).Wait();
-                }
-            }
-            catch
-            {
-                // ignored
-            }
-            _webSocket.Dispose();
-            _webSocket = null;
-        }
-
-        // Dispose remaining resources
         _httpClient.Dispose();
         _chatWindow?.Dispose();
         _officerChatWindow.Dispose();

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -5,6 +5,10 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Numerics;
 using System.Threading.Tasks;
+using System.IO;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
 using DiscordHelper;
 using Dalamud.Bindings.ImGui;
 
@@ -15,20 +19,181 @@ public class UiRenderer : IDisposable
     private readonly HttpClient _httpClient;
     private readonly Config _config;
     private readonly Dictionary<string, EventView> _embeds = new();
+    private readonly List<EmbedDto> _embedDtos = new();
     private string _channelId;
     private EventView? _current;
+    private ClientWebSocket? _webSocket;
+    private CancellationTokenSource? _pollCts;
 
     public UiRenderer(Config config, HttpClient httpClient)
     {
         _config = config;
         _httpClient = httpClient;
         _channelId = config.EventChannelId;
+
+        if (_config.Enabled)
+        {
+            StartPolling();
+            _ = ConnectWebSocket();
+        }
     }
 
     public string ChannelId
     {
         get => _channelId;
         set => _channelId = value;
+    }
+
+    private void StartPolling()
+    {
+        if (_pollCts != null)
+        {
+            return;
+        }
+        _pollCts = new CancellationTokenSource();
+        _ = PollLoop(_pollCts.Token);
+    }
+
+    private void StopPolling()
+    {
+        _pollCts?.Cancel();
+        _pollCts = null;
+    }
+
+    private async Task PollLoop(CancellationToken token)
+    {
+        var interval = TimeSpan.FromSeconds(_config.PollIntervalSeconds);
+        using var timer = new PeriodicTimer(interval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(token))
+            {
+                await PollEmbeds();
+                if (_webSocket == null || _webSocket.State != WebSocketState.Open)
+                {
+                    _ = ConnectWebSocket();
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // ignored
+        }
+    }
+
+    private async Task PollEmbeds()
+    {
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/embeds");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Add("X-Api-Key", _config.AuthToken);
+            }
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                return;
+            }
+            var stream = await response.Content.ReadAsStreamAsync();
+            var embeds = await JsonSerializer.DeserializeAsync<List<EmbedDto>>(stream) ?? new List<EmbedDto>();
+            _ = PluginServices.Framework.RunOnTick(() =>
+            {
+                _embedDtos.Clear();
+                _embedDtos.AddRange(embeds);
+                SetEmbeds(_embedDtos);
+            });
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    private async Task ConnectWebSocket()
+    {
+        if (_webSocket != null && _webSocket.State == WebSocketState.Open)
+        {
+            return;
+        }
+
+        try
+        {
+            _webSocket?.Dispose();
+            _webSocket = new ClientWebSocket();
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                _webSocket.Options.SetRequestHeader("X-Api-Key", _config.AuthToken);
+            }
+            var baseUrl = _config.ApiBaseUrl.TrimEnd('/');
+            var wsUrl = new Uri(($"{baseUrl}/ws/embeds")
+                .Replace("http://", "ws://")
+                .Replace("https://", "wss://"));
+            await _webSocket.ConnectAsync(wsUrl, CancellationToken.None);
+            StopPolling();
+            await ReceiveLoop();
+        }
+        catch
+        {
+            StartPolling();
+        }
+    }
+
+    private async Task ReceiveLoop()
+    {
+        if (_webSocket == null)
+        {
+            return;
+        }
+
+        var buffer = new byte[8192];
+        try
+        {
+            while (_webSocket.State == WebSocketState.Open)
+            {
+                var ms = new MemoryStream();
+                WebSocketReceiveResult result;
+                do
+                {
+                    result = await _webSocket.ReceiveAsync(buffer, CancellationToken.None);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+                        return;
+                    }
+                    ms.Write(buffer, 0, result.Count);
+                } while (!result.EndOfMessage);
+
+                var json = Encoding.UTF8.GetString(ms.ToArray());
+                var embed = JsonSerializer.Deserialize<EmbedDto>(json);
+                if (embed != null)
+                {
+                    _ = PluginServices.Framework.RunOnTick(() =>
+                    {
+                        var index = _embedDtos.FindIndex(e => e.Id == embed.Id);
+                        if (index >= 0)
+                        {
+                            _embedDtos[index] = embed;
+                        }
+                        else
+                        {
+                            _embedDtos.Add(embed);
+                        }
+                        SetEmbeds(_embedDtos);
+                    });
+                }
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+        finally
+        {
+            _webSocket?.Dispose();
+            _webSocket = null;
+            StartPolling();
+        }
     }
 
     public void SetEmbeds(IEnumerable<EmbedDto> embeds)
@@ -70,7 +235,12 @@ public class UiRenderer : IDisposable
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var embeds = await JsonSerializer.DeserializeAsync<List<EmbedDto>>(stream) ?? new List<EmbedDto>();
-            SetEmbeds(embeds);
+            _ = PluginServices.Framework.RunOnTick(() =>
+            {
+                _embedDtos.Clear();
+                _embedDtos.AddRange(embeds);
+                SetEmbeds(_embedDtos);
+            });
         }
         catch
         {
@@ -107,6 +277,24 @@ public class UiRenderer : IDisposable
 
     public void Dispose()
     {
+        StopPolling();
+        if (_webSocket != null)
+        {
+            try
+            {
+                if (_webSocket.State == WebSocketState.Open)
+                {
+                    _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).Wait();
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+            _webSocket.Dispose();
+            _webSocket = null;
+        }
+
         foreach (var view in _embeds.Values)
         {
             view.Dispose();

--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -28,6 +28,7 @@ def create_app(cfg: "AppConfig | None") -> FastAPI:
 
     app = FastAPI()
     app.add_api_websocket_route("/ws/messages", websocket_endpoint)
+    app.add_api_websocket_route("/ws/embeds", websocket_endpoint)
 
     @app.get("/health")
     async def health() -> dict[str, str]:


### PR DESCRIPTION
## Summary
- stream event embeds over a websocket and keep UI data in sync on the framework tick
- drop plugin-level polling and websocket handling
- expose `/ws/embeds` endpoint alongside message websocket

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2966a13508328b66bd7fe1339fddc