### PR TITLE
Add officer-only websocket channel for officers

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -284,7 +284,7 @@ public class ChatWindow : IDisposable
         }
     }
 
-    private Uri BuildWebSocketUri()
+    protected virtual Uri BuildWebSocketUri()
     {
         var baseUri = _config.ApiBaseUrl.TrimEnd('/') + "/ws/messages";
         var builder = new UriBuilder(baseUri);

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
@@ -77,6 +78,21 @@ public class OfficerChatWindow : ChatWindow
         {
             // ignored
         }
+    }
+
+    protected override Uri BuildWebSocketUri()
+    {
+        var baseUri = _config.ApiBaseUrl.TrimEnd('/') + "/ws/officer-messages";
+        var builder = new UriBuilder(baseUri);
+        if (builder.Scheme == "https")
+        {
+            builder.Scheme = "wss";
+        }
+        else if (builder.Scheme == "http")
+        {
+            builder.Scheme = "ws";
+        }
+        return builder.Uri;
     }
 
     private class OfficerChannelListDto

--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -29,6 +29,7 @@ def create_app(cfg: "AppConfig | None") -> FastAPI:
     app = FastAPI()
     app.add_api_websocket_route("/ws/messages", websocket_endpoint)
     app.add_api_websocket_route("/ws/embeds", websocket_endpoint)
+    app.add_api_websocket_route("/ws/officer-messages", websocket_endpoint)
 
     @app.get("/health")
     async def health() -> dict[str, str]:

--- a/tests/test_officer_ws.py
+++ b/tests/test_officer_ws.py
@@ -1,0 +1,48 @@
+import types
+import pytest
+
+from demibot.http.ws import ConnectionManager
+
+class StubWebSocket:
+    def __init__(self, path: str):
+        self.scope = {"path": path}
+        self.sent: list[str] = []
+    async def accept(self):
+        pass
+    async def send_text(self, message: str):
+        self.sent.append(message)
+
+class StubContext:
+    def __init__(self, guild_id: int, roles):
+        self.guild = types.SimpleNamespace(id=guild_id)
+        self.roles = roles
+
+@pytest.mark.anyio("asyncio")
+async def test_officer_broadcast_filtered_by_path_and_role():
+    manager = ConnectionManager()
+    # Officer connected to officer path
+    ws_officer = StubWebSocket("/ws/officer-messages")
+    ctx_officer = StubContext(1, ["officer"])
+    await manager.connect(ws_officer, ctx_officer)
+
+    # Officer connected to general path
+    ws_general = StubWebSocket("/ws/messages")
+    ctx_general = StubContext(1, ["officer"])
+    await manager.connect(ws_general, ctx_general)
+
+    # Non-officer connected to officer path
+    ws_non_officer = StubWebSocket("/ws/officer-messages")
+    ctx_non_officer = StubContext(1, [])
+    await manager.connect(ws_non_officer, ctx_non_officer)
+
+    # Officer from another guild
+    ws_other_guild = StubWebSocket("/ws/officer-messages")
+    ctx_other_guild = StubContext(2, ["officer"])
+    await manager.connect(ws_other_guild, ctx_other_guild)
+
+    await manager.broadcast_text("hi", 1, officer_only=True)
+
+    assert ws_officer.sent == ["hi"]
+    assert ws_general.sent == []
+    assert ws_non_officer.sent == []
+    assert ws_other_guild.sent == []


### PR DESCRIPTION
## Summary
- expose `/ws/officer-messages` websocket and filter broadcasts
- point officer chat window to officer websocket path
- test officer-only websocket broadcasts

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `PYTHONPATH=demibot pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a298284f408328ae824045ea178e6a