### PR TITLE
Handle sync task explicitly

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -52,7 +52,10 @@ public class SettingsWindow : IDisposable
 
                 if (ImGui.Button("Sync"))
                 {
-                    _ = Sync();
+                    Task.Run(Sync).ContinueWith(t =>
+                    {
+                        _log.Error(t.Exception!, "Unexpected error during sync");
+                    }, TaskContinuationOptions.OnlyOnFaulted);
                 }
 
                 if (_authFailed)
@@ -104,7 +107,7 @@ public class SettingsWindow : IDisposable
                 _config.AuthToken = key;
                 _apiKey = key;
                 SaveConfig();
-                _ = _refreshRoles();
+                await _refreshRoles();
             }
             else if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
@@ -121,6 +124,7 @@ public class SettingsWindow : IDisposable
         {
             _log.Error(ex, "Error validating API key.");
             _networkError = true;
+            throw;
         }
     }
 


### PR DESCRIPTION
## Summary
- run settings sync in a background task and observe errors
- await role refresh inside Sync and rethrow exceptions

## Testing
- `PYTHONPATH=demibot pytest -q`
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -nologo` *(fails: .NET SDK does not support target .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a9619638832889713f337e38003d