### PR TITLE
Pass plugin interface to DeveloperWindow

### DIFF
--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -1,19 +1,22 @@
 using System;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Plugin;
 
 namespace DemiCatPlugin;
 
 public class DeveloperWindow
 {
     private readonly Config _config;
+    private readonly IDalamudPluginInterface? _pluginInterface;
     private string _apiBaseUrl;
     private string _wsPath;
 
     public bool IsOpen;
 
-    public DeveloperWindow(Config config)
+    public DeveloperWindow(Config config, IDalamudPluginInterface? pluginInterface)
     {
         _config = config;
+        _pluginInterface = pluginInterface;
         _apiBaseUrl = config.ApiBaseUrl;
         _wsPath = config.WebSocketPath;
     }
@@ -38,7 +41,11 @@ public class DeveloperWindow
         {
             _config.ApiBaseUrl = _apiBaseUrl;
             _config.WebSocketPath = _wsPath;
-            PluginServices.PluginInterface.SavePluginConfig(_config);
+
+            if (_pluginInterface != null && !_pluginInterface.Disposed)
+            {
+                _pluginInterface.SavePluginConfig(_config);
+            }
         }
 
         ImGui.End();

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -31,7 +31,7 @@ public class SettingsWindow : IDisposable
         _httpClient = httpClient;
         _refreshRoles = refreshRoles;
         _apiKey = config.AuthToken ?? string.Empty;
-        _devWindow = new DeveloperWindow(config);
+        _devWindow = new DeveloperWindow(config, PluginServices.PluginInterface);
         _log = log;
     }
 


### PR DESCRIPTION
## Summary
- inject `IDalamudPluginInterface` into `DeveloperWindow`
- guard saving configuration when interface is null or disposed
- forward plugin interface when creating `DeveloperWindow`

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68a2ab11c18083288d02b416faf3fad2