### PR TITLE
Use IsDisposed when saving developer settings

### DIFF
--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -42,9 +42,9 @@ public class DeveloperWindow
             _config.ApiBaseUrl = _apiBaseUrl;
             _config.WebSocketPath = _wsPath;
 
-            if (_pluginInterface != null && !_pluginInterface.Disposed)
+            if (_pluginInterface != null && !_pluginInterface.IsDisposed)
             {
-                _pluginInterface.SavePluginConfig(_config);
+                _pluginInterface!.SavePluginConfig(_config);
             }
         }
 


### PR DESCRIPTION
## Summary
- Use `IsDisposed` property when checking plugin interface
- Add null-forgiving operator when saving plugin config

## Testing
- `pytest` *(fails: cannot import name 'cookies' from partially initialized module 'http')*

------
https://chatgpt.com/codex/tasks/task_e_68a2ad2549e883288569a624ae7b3d2a