### PR TITLE
refactor: use property pattern for plugin check

### DIFF
--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -42,10 +42,8 @@ public class DeveloperWindow
             _config.ApiBaseUrl = _apiBaseUrl;
             _config.WebSocketPath = _wsPath;
 
-            if (_pluginInterface != null && !_pluginInterface.IsDisposed)
-            {
+            if (_pluginInterface is { IsDisposed: false })
                 _pluginInterface!.SavePluginConfig(_config);
-            }
         }
 
         ImGui.End();


### PR DESCRIPTION
## Summary
- simplify plugin interface condition using property pattern
- ensure SavePluginConfig is called on a non-disposed interface

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68a2b08847d0832894788d1bf569ec7a