### PR TITLE
refactor: simplify plugin interface check

### DIFF
--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -42,8 +42,8 @@ public class DeveloperWindow
             _config.ApiBaseUrl = _apiBaseUrl;
             _config.WebSocketPath = _wsPath;
 
-            if (_pluginInterface is { IsDisposed: false })
-                _pluginInterface!.SavePluginConfig(_config);
+            if (_pluginInterface != null)
+                _pluginInterface.SavePluginConfig(_config);
         }
 
         ImGui.End();


### PR DESCRIPTION
## Summary
- simplify plugin interface check to guard config save with a null test

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68a2b304bc8c8328a524819b1527a15e