### PR TITLE
chore: add setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ obj/
 node_modules/
 .env
 database/*.db
+test*.db
 __pycache__/
 
 # Local development artifacts

--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ DemiCat/
 
 ## Prerequisites
 
-- [Python 3.10+](https://www.python.org/)
+- [Python 3.11+](https://www.python.org/)
 - A database (SQLite by default, MySQL optional)
 - A Discord bot token and Apollo-managed channels
 - FFXIV with the [Dalamud](https://github.com/goatcorp/Dalamud) plugin framework
+
+Optional tools for automated setup:
+- [uv](https://github.com/astral-sh/uv) or [Homebrew](https://brew.sh/) for installing Python/.NET if missing
 
 ## Configuration
 
@@ -36,11 +39,13 @@ bot token and server options such as the WebSocket path (default
 ## Setup
 
 Run the helper script to bootstrap both the Python and .NET parts of the
-project. It creates a virtual environment, installs dependencies from
-`demibot/pyproject.toml`, and builds the Dalamud plugin in Release mode.
+project. It ensures Python 3.11+ and the latest .NET SDK are installed (using
+`uv` or `brew` when available), creates a virtual environment, installs
+dependencies from `demibot/pyproject.toml`, and builds the Dalamud plugin in
+Release mode.
 
 ```bash
-bash scripts/setup_env.sh
+bash scripts/setup_env.sh [--unit-tests] [--integration-tests]
 ```
 
 ### 1. Install dependencies and initialize the database

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,15 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+    cat <<'USAGE'
+Usage: setup_env.sh [--unit-tests] [--integration-tests]
+
+Bootstraps the development environment by ensuring Python 3.11+ and the
+latest .NET SDK are available, creating a virtual environment, installing
+Python dependencies, and building the Dalamud plugin.
+
+Optional flags:
+  --unit-tests          Run unit tests (pytest -m "not integration")
+  --integration-tests   Run integration tests (pytest -m integration)
+USAGE
+}
+
+run_unit=false
+run_integration=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --unit-tests) run_unit=true; shift ;;
+        --integration-tests) run_integration=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
 # Determine repository root
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 cd "$ROOT_DIR"
 
 # -----------------------------
-# Python environment
+# Python 3.11+ detection/installation
 # -----------------------------
 PYTHON=${PYTHON:-python3}
-if [ ! -d ".venv" ]; then
+if ! command -v "$PYTHON" >/dev/null 2>&1 || ! "$PYTHON" -c 'import sys; exit(0 if sys.version_info >= (3,11) else 1)'; then
+    echo "Python 3.11+ not found. Attempting installation..."
+    if command -v uv >/dev/null 2>&1; then
+        uv python install 3.11
+        PYTHON="$(uv python find 3.11)"
+    elif command -v brew >/dev/null 2>&1; then
+        brew install python@3.11
+        PYTHON="$(brew --prefix python@3.11)/bin/python3.11"
+    else
+        echo "Neither 'uv' nor 'brew' is available to install Python." >&2
+        exit 1
+    fi
+fi
+
+# -----------------------------
+# Virtual environment and dependencies
+# -----------------------------
+if [ ! -d .venv ]; then
     "$PYTHON" -m venv .venv
 fi
 # shellcheck disable=SC1091
@@ -20,6 +62,7 @@ pip install --upgrade pip
 python <<'PY'
 import tomllib, subprocess
 from pathlib import Path
+
 toml_path = Path('demibot/pyproject.toml')
 data = tomllib.load(toml_path.open('rb'))
 
@@ -50,23 +93,34 @@ PY
 # -----------------------------
 # .NET SDK and plugin build
 # -----------------------------
-DOTNET_CMD="dotnet"
-if ! command -v "$DOTNET_CMD" >/dev/null 2>&1; then
-    echo "Installing .NET SDK..."
-    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 9.0 --install-dir "$ROOT_DIR/.dotnet"
-    export PATH="$ROOT_DIR/.dotnet:$PATH"
-    DOTNET_CMD="$ROOT_DIR/.dotnet/dotnet"
+if command -v dotnet >/dev/null 2>&1; then
+    DOTNET_CMD="$(command -v dotnet)"
 else
-    echo ".NET SDK already installed."
-fi
-
-# Ensure local install is on PATH
-if [ -d "$ROOT_DIR/.dotnet" ]; then
-    export PATH="$ROOT_DIR/.dotnet:$PATH"
-    DOTNET_CMD="$ROOT_DIR/.dotnet/dotnet"
+    echo ".NET SDK not found. Attempting installation..."
+    if command -v brew >/dev/null 2>&1; then
+        brew install dotnet-sdk
+        DOTNET_CMD="$(command -v dotnet)"
+    else
+        curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+        bash /tmp/dotnet-install.sh --version latest --install-dir "$ROOT_DIR/.dotnet"
+        DOTNET_CMD="$ROOT_DIR/.dotnet/dotnet"
+        export PATH="$ROOT_DIR/.dotnet:$PATH"
+    fi
 fi
 
 "$DOTNET_CMD" restore DemiCatPlugin/DemiCatPlugin.csproj
 "$DOTNET_CMD" build DemiCatPlugin/DemiCatPlugin.csproj -c Release
 
+# -----------------------------
+# Optional tests
+# -----------------------------
+if $run_unit; then
+    pytest -m "not integration"
+fi
+
+if $run_integration; then
+    pytest -m integration
+fi
+
 echo "Environment setup complete."
+


### PR DESCRIPTION
## Summary
- add environment bootstrap script that installs Python, .NET, dependencies, builds plugin, and optionally runs tests
- document setup script usage and optional tools in README
- ignore test database artifacts

## Testing
- `pytest -m "not integration"`
- `pytest -m integration`


------
https://chatgpt.com/codex/tasks/task_e_68a2b5bb3b6c83288892087f3454805b