### PR TITLE
Embed plugin icon

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -17,11 +17,15 @@
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="icon.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <PackageReference Include="StbImageSharp" Version="2.30.15" />
   </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="icon.png" />
+  </ItemGroup>
+  <PropertyGroup>
+    <DalamudIcon>icon.png</DalamudIcon>
+  </PropertyGroup>
 
   <!-- DO NOT import a custom DalamudPackager.targets for v13 -->
 </Project>


### PR DESCRIPTION
## Summary
- embed plugin icon as manifest resource and set Dalamud icon property

## Testing
- `~/dotnet/dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release`
- `pytest` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a2b79298008328966a2728c04c40cf