### PR TITLE
Inject plugin interface into DeveloperWindow

### DIFF
--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -42,7 +42,7 @@ public class DeveloperWindow
             _config.ApiBaseUrl = _apiBaseUrl;
             _config.WebSocketPath = _wsPath;
 
-            if (_pluginInterface != null)
+            if (_pluginInterface != null && !_pluginInterface.IsDisposed)
                 _pluginInterface.SavePluginConfig(_config);
         }
 

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -45,7 +45,7 @@ public class Plugin : IDalamudPlugin
         }
 
         _ui = new UiRenderer(_config, _httpClient);
-        _settings = new SettingsWindow(_config, _httpClient, () => RefreshRoles(_services.Log), _services.Log);
+        _settings = new SettingsWindow(_config, _httpClient, () => RefreshRoles(_services.Log), _services.Log, _services.PluginInterface);
         _chatWindow = _config.EnableFcChat ? new FcChatWindow(_config, _httpClient) : null;
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient);
         _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using System.Threading.Tasks;
 using System.Linq;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 
 namespace DemiCatPlugin;
@@ -25,13 +26,13 @@ public class SettingsWindow : IDisposable
 
     public bool IsOpen;
 
-    public SettingsWindow(Config config, HttpClient httpClient, Func<Task> refreshRoles, IPluginLog log)
+    public SettingsWindow(Config config, HttpClient httpClient, Func<Task> refreshRoles, IPluginLog log, IDalamudPluginInterface pluginInterface)
     {
         _config = config;
         _httpClient = httpClient;
         _refreshRoles = refreshRoles;
         _apiKey = config.AuthToken ?? string.Empty;
-        _devWindow = new DeveloperWindow(config, PluginServices.Instance!.PluginInterface);
+        _devWindow = new DeveloperWindow(config, pluginInterface);
         _log = log;
     }
 


### PR DESCRIPTION
## Summary
- inject and store plugin interface for DeveloperWindow
- guard config saving against disposed plugin interface
- construct DeveloperWindow only after PluginInterface is initialized

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a2bb13b8f8832887e42c2bfe44b5f3