### PR TITLE
Simplify plugin config save in DeveloperWindow

### DIFF
--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -42,8 +42,8 @@ public class DeveloperWindow
             _config.ApiBaseUrl = _apiBaseUrl;
             _config.WebSocketPath = _wsPath;
 
-            if (_pluginInterface != null && !_pluginInterface.IsDisposed)
-                _pluginInterface.SavePluginConfig(_config);
+            if (_pluginInterface != null)
+                _pluginInterface!.SavePluginConfig(_config);
         }
 
         ImGui.End();


### PR DESCRIPTION
## Summary
- simplify plugin interface null check in DeveloperWindow
- use null-forgiving operator when saving config

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*
- `pip install -e demibot` *(fails: configuration error: `project.dependencies` must be array)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68a301cec778832898c285db76f3b1d0