### PR TITLE
Expose API base URL in settings

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -11,7 +11,7 @@ public class Config : IPluginConfiguration
     public int Version { get; set; } = 3;
 
     public bool Enabled { get; set; } = true;
-    public string ApiBaseUrl { get; set; } = "http://localhost:8000";
+    public string ApiBaseUrl { get; set; } = "http://localhost:5050";
     public string WebSocketPath { get; set; } = "/ws/embeds";
     public int PollIntervalSeconds { get; set; } = 5;
     public string? AuthToken { get; set; }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -21,6 +21,7 @@ public class SettingsWindow : IDisposable
     private readonly IPluginLog _log;
 
     private string _apiKey = string.Empty;
+    private string _apiBaseUrl = string.Empty;
     private bool _authFailed;
     private bool _networkError;
 
@@ -32,6 +33,7 @@ public class SettingsWindow : IDisposable
         _httpClient = httpClient;
         _refreshRoles = refreshRoles;
         _apiKey = config.AuthToken ?? string.Empty;
+        _apiBaseUrl = config.ApiBaseUrl;
         _devWindow = new DeveloperWindow(config, pluginInterface);
         _log = log;
     }
@@ -42,6 +44,12 @@ public class SettingsWindow : IDisposable
         {
             if (ImGui.Begin("DemiCat Settings", ref IsOpen))
             {
+                if (ImGui.InputText("API Base URL", ref _apiBaseUrl, 256))
+                {
+                    _config.ApiBaseUrl = _apiBaseUrl;
+                    SaveConfig();
+                }
+
                 ImGui.InputText("API Key", ref _apiKey, 64);
                 ImGui.SameLine();
                 ImGui.TextDisabled("\u03C0");

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ plugin authentication.
 ### 3. Configure the Dalamud plugin
 Update `DemiCatPlugin/DemiCatPlugin.json` with the usual plugin metadata. In-game,
 open the plugin configuration and set the `ApiBaseUrl` if needed (default
-`http://localhost:8000`).
+`http://localhost:5050`).
 
 Use the API key obtained from `/demibot embed` and enter it in the plugin
 **Settings** window under **API Key**. Press **Sync** to validate the key and


### PR DESCRIPTION
## Summary
- default API base URL now uses http://localhost:5050
- allow editing API base URL directly from settings window

## Testing
- `pytest`
- `python - <<'PY'
import requests
api_base = "http://localhost:5050"
url = f"{api_base.rstrip('/')}/validate"
print("Sync URL:", url)
resp = requests.post(url, json={"key": ""})
print("Status:", resp.status_code)
print("Body:", resp.text)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a30818ef148328bb21378462a432c8