### PR TITLE
Add host configuration and show API base URL

### DIFF
--- a/demibot/README.md
+++ b/demibot/README.md
@@ -22,6 +22,7 @@ python -m demibot.main --reconfigure
 
 You will be prompted for required settings:
 
+* `Server host` (default 127.0.0.1)
 * `Server port` (default 5050)
 * `Use remote MySQL server? (y/N)`
 * `Remote host`, `Remote port` and `Database name` (if remote is selected)

--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -26,7 +26,7 @@ CFG_PATH = Path.home() / ".config" / "demibot" / "config.json"
 
 @dataclass
 class ServerConfig:
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 5050
 
 
@@ -118,6 +118,9 @@ def ensure_config(force_reconfigure: bool = False) -> AppConfig:
     cfg = load_config()
 
     def _prompt_server() -> None:
+        host = input(f"Server host [{cfg.server.host}]: ").strip()
+        if host:
+            cfg.server.host = host
         port = input(f"Server port [{cfg.server.port}]: ").strip()
         if port:
             cfg.server.port = int(port)

--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -64,6 +64,7 @@ def main() -> None:
             daemon=True,
         )
         api_thread.start()
+        logging.info("ApiBaseUrl: http://%s:%s", cfg.server.host, cfg.server.port)
     except Exception:
         logging.exception("Failed to start FastAPI server")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- allow setting server host with default 127.0.0.1
- launch FastAPI with configured host/port and log ApiBaseUrl
- document host option in DemiBot README

## Testing
- `PYTHONPATH=demibot pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a30bfdd1fc8328b0cd36d4e763c09e