### PR TITLE
Delay networking until API key sync and restart on token updates

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -45,7 +45,7 @@ public class Plugin : IDalamudPlugin
         }
 
         _ui = new UiRenderer(_config, _httpClient);
-        _settings = new SettingsWindow(_config, _httpClient, () => RefreshRoles(_services.Log), _services.Log, _services.PluginInterface);
+        _settings = new SettingsWindow(_config, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
         _chatWindow = _config.EnableFcChat ? new FcChatWindow(_config, _httpClient) : null;
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient);
         _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -17,6 +17,7 @@ public class SettingsWindow : IDisposable
     private readonly Config _config;
     private readonly HttpClient _httpClient;
     private readonly Func<Task> _refreshRoles;
+    private readonly Action _startNetworking;
     private readonly DeveloperWindow _devWindow;
     private readonly IPluginLog _log;
 
@@ -27,11 +28,12 @@ public class SettingsWindow : IDisposable
 
     public bool IsOpen;
 
-    public SettingsWindow(Config config, HttpClient httpClient, Func<Task> refreshRoles, IPluginLog log, IDalamudPluginInterface pluginInterface)
+    public SettingsWindow(Config config, HttpClient httpClient, Func<Task> refreshRoles, Action startNetworking, IPluginLog log, IDalamudPluginInterface pluginInterface)
     {
         _config = config;
         _httpClient = httpClient;
         _refreshRoles = refreshRoles;
+        _startNetworking = startNetworking;
         _apiKey = config.AuthToken ?? string.Empty;
         _apiBaseUrl = config.ApiBaseUrl;
         _devWindow = new DeveloperWindow(config, pluginInterface);
@@ -153,6 +155,8 @@ public class SettingsWindow : IDisposable
                 {
                     _log.Warning("RefreshRoles delegate is not set; roles will not be refreshed.");
                 }
+
+                _startNetworking();
             }
             else if (response.StatusCode == HttpStatusCode.Unauthorized)
             {


### PR DESCRIPTION
## Summary
- Defer polling and WebSocket startup until the plugin is enabled **and** an API key is present
- Add `StartNetworking` to restart polling and WebSocket connections when the token changes
- Trigger networking startup from settings after a successful sync

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: .NET SDK 9.0 missing)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a319b06a3483289d558ef86097ded6