### PR TITLE
Ensure channel fetch retry on failure

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -152,7 +152,6 @@ public class MainWindow
 
     private async Task FetchChannels()
     {
-        _channelsLoaded = true;
         try
         {
             var response = await _httpClient.GetAsync($"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
@@ -182,6 +181,8 @@ public class MainWindow
                 _create.ChannelId = _channelId;
                 _templates.ChannelId = _channelId;
             }
+
+            _channelsLoaded = true;
         }
         catch
         {


### PR DESCRIPTION
## Summary
- Set `_channelsLoaded` only after channels are fetched successfully to allow retry on failure

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: SDK 9.0.100 not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'sqlalchemy', 'demibot')*


------
https://chatgpt.com/codex/tasks/task_e_68a44d87d0ec83289c8e78952cabfb9d