### PR TITLE
Increase API key input capacity

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -52,7 +52,8 @@ public class SettingsWindow : IDisposable
                     SaveConfig();
                 }
 
-                ImGui.InputText("API Key", ref _apiKey, 64);
+                // Allow room for longer server-generated API keys
+                ImGui.InputText("API Key", ref _apiKey, 256);
                 ImGui.SameLine();
                 ImGui.TextDisabled("\u03C0");
                 var io = ImGui.GetIO();


### PR DESCRIPTION
## Summary
- allow longer API keys in settings window by increasing input buffer

## Testing
- `dotnet build DemiCatPlugin` *(fails: .NET SDK 9.0 not installed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68a44db199bc8328901574dc08671731