### PR TITLE
Ensure FC user refresh runs on main thread

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -106,9 +106,12 @@ public class FcChatWindow : ChatWindow
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var users = await JsonSerializer.DeserializeAsync<List<UserDto>>(stream) ?? new List<UserDto>();
-            _users.Clear();
-            _users.AddRange(users);
-            _lastUserFetch = DateTime.UtcNow;
+            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+            {
+                _users.Clear();
+                _users.AddRange(users);
+                _lastUserFetch = DateTime.UtcNow;
+            });
         }
         catch
         {


### PR DESCRIPTION
## Summary
- Wrap FC chat user list updates in a Framework.RunOnTick block to synchronize with the main thread

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a44daa87a88328a5fdc5fd7d7b4d21