### PR TITLE
Add sync status feedback in settings window

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -23,8 +23,7 @@ public class SettingsWindow : IDisposable
 
     private string _apiKey = string.Empty;
     private string _apiBaseUrl = string.Empty;
-    private bool _authFailed;
-    private bool _networkError;
+    private string _syncStatus = string.Empty;
 
     public bool IsOpen;
 
@@ -64,19 +63,27 @@ public class SettingsWindow : IDisposable
 
                 if (ImGui.Button("Sync"))
                 {
+                    _syncStatus = "Validating API key...";
                     Task.Run(Sync).ContinueWith(t =>
                     {
                         _log.Error(t.Exception!, "Unexpected error during sync");
                     }, TaskContinuationOptions.OnlyOnFaulted);
                 }
 
-                if (_authFailed)
+                if (!string.IsNullOrEmpty(_syncStatus))
                 {
-                    ImGui.TextColored(new Vector4(1, 0, 0, 1), "Authentication failed");
-                }
-                else if (_networkError)
-                {
-                    ImGui.TextColored(new Vector4(1, 0, 0, 1), "Network error");
+                    if (_syncStatus == "API key validated")
+                    {
+                        ImGui.TextColored(new Vector4(0, 1, 0, 1), _syncStatus);
+                    }
+                    else if (_syncStatus == "Authentication failed" || _syncStatus == "Network error")
+                    {
+                        ImGui.TextColored(new Vector4(1, 0, 0, 1), _syncStatus);
+                    }
+                    else
+                    {
+                        ImGui.Text(_syncStatus);
+                    }
                 }
                 ImGui.End();
             }
@@ -91,27 +98,24 @@ public class SettingsWindow : IDisposable
 
     private async Task Sync()
     {
-        _authFailed = false;
-        _networkError = false;
-
         if (_httpClient == null)
         {
             _log.Error("Cannot sync: HTTP client is not initialized.");
-            _networkError = true;
+            _syncStatus = "Network error";
             return;
         }
 
         if (string.IsNullOrEmpty(_config.ApiBaseUrl))
         {
             _log.Error("Cannot sync: API base URL is not configured.");
-            _networkError = true;
+            _syncStatus = "Network error";
             return;
         }
 
         if (PluginServices.Instance?.PluginInterface == null)
         {
             _log.Error("Cannot sync: plugin interface is not available.");
-            _networkError = true;
+            _syncStatus = "Network error";
             return;
         }
 
@@ -158,22 +162,23 @@ public class SettingsWindow : IDisposable
                 }
 
                 _startNetworking();
+                _syncStatus = "API key validated";
             }
             else if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 _log.Warning("API key validation failed: unauthorized.");
-                _authFailed = true;
+                _syncStatus = "Authentication failed";
             }
             else
             {
                 _log.Warning($"API key validation failed with status {response.StatusCode}.");
-                _networkError = true;
+                _syncStatus = "Network error";
             }
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Error validating API key.");
-            _networkError = true;
+            _syncStatus = "Network error";
             return;
         }
     }


### PR DESCRIPTION
## Summary
- track sync progress and outcome with a `_syncStatus` field
- show color-coded status messages during API key validation

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `PYTHONPATH=demibot pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a450226af48328aa2fe20fb972f5b3