### PR TITLE
Ensure config saves on main thread

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -180,13 +180,20 @@ public class SettingsWindow : IDisposable
 
     private void SaveConfig()
     {
-        var pluginInterface = PluginServices.Instance?.PluginInterface;
-        if (pluginInterface == null)
+        var services = PluginServices.Instance;
+        if (services?.PluginInterface == null)
         {
             _log.Error("Plugin interface is not available; cannot save configuration.");
             return;
         }
-        pluginInterface.SavePluginConfig(_config);
+
+        if (services.Framework == null)
+        {
+            _log.Error("Framework is not available; cannot save configuration.");
+            return;
+        }
+
+        _ = services.Framework.RunOnTick(() => services.PluginInterface.SavePluginConfig(_config));
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- marshal SavePluginConfig calls via Framework.RunOnTick to ensure execution on the main thread

## Testing
- ⚠️ `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(missing .NET SDK 9.0)*
- ⚠️ `pytest` *(missing dependencies: discord, sqlalchemy, demibot)*

------
https://chatgpt.com/codex/tasks/task_e_68a4503811208328bb9ae7cb22a30b82