### PR TITLE
Simplify sync status error handling

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -168,23 +168,13 @@ public class SettingsWindow : IDisposable
             }
             else if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
-
                 _log.Warning($"API key validation failed: unauthorized. Response Body: {responseBody}");
-                _authFailed = true;
-            }
-            else
-            {
-                _log.Warning($"API key validation failed with status {response.StatusCode}. Response Body: {responseBody}");
-                _networkError = true;
-
-                _log.Warning("API key validation failed: unauthorized.");
                 _syncStatus = "Authentication failed";
             }
             else
             {
-                _log.Warning($"API key validation failed with status {response.StatusCode}.");
+                _log.Warning($"API key validation failed with status {response.StatusCode}. Response Body: {responseBody}");
                 _syncStatus = "Network error";
-
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- simplify API key validation logic by removing unused flags
- consolidate error paths to report authentication or network issues via _syncStatus

## Testing
- `~/.dotnet/dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4534afe748328876449cda8dba039