### PR TITLE
Attach API key when fetching channel lists

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -194,7 +194,12 @@ public class ChatWindow : IDisposable
         _channelsLoaded = true;
         try
         {
-            var response = await _httpClient.GetAsync($"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Add("X-Api-Key", _config.AuthToken);
+            }
+            var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
                 return;

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -154,7 +154,12 @@ public class MainWindow
     {
         try
         {
-            var response = await _httpClient.GetAsync($"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Add("X-Api-Key", _config.AuthToken);
+            }
+            var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
                 return;

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -62,7 +62,12 @@ public class OfficerChatWindow : ChatWindow
         _channelsLoaded = true;
         try
         {
-            var response = await _httpClient.GetAsync($"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Add("X-Api-Key", _config.AuthToken);
+            }
+            var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
                 return;


### PR DESCRIPTION
## Summary
- add X-Api-Key header to channel list requests
- send channel fetch via HttpRequestMessage and SendAsync

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: A compatible .NET SDK was not found; repo requires SDK 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_68a454cd9c2c8328a650c1e78f5a868a