### PR TITLE
Defer channel cache flags and reset after sync

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -28,6 +28,12 @@ public class ChatWindow : IDisposable
     private Task? _wsTask;
     private CancellationTokenSource? _wsCts;
 
+    public bool ChannelsLoaded
+    {
+        get => _channelsLoaded;
+        set => _channelsLoaded = value;
+    }
+
     public ChatWindow(Config config, HttpClient httpClient)
     {
         _config = config;
@@ -87,7 +93,6 @@ public class ChatWindow : IDisposable
 
     public void SetChannels(List<string> channels)
     {
-        _channelsLoaded = true;
         _channels.Clear();
         _channels.AddRange(channels);
         if (!string.IsNullOrEmpty(_channelId))
@@ -191,7 +196,6 @@ public class ChatWindow : IDisposable
 
     protected virtual async Task FetchChannels()
     {
-        _channelsLoaded = true;
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
@@ -209,6 +213,7 @@ public class ChatWindow : IDisposable
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Chat);
+                _channelsLoaded = true;
             });
         }
         catch

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -28,6 +28,12 @@ public class MainWindow
     public bool IsOpen;
     public bool HasOfficerRole { get; set; }
 
+    public bool ChannelsLoaded
+    {
+        get => _channelsLoaded;
+        set => _channelsLoaded = value;
+    }
+
     public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient)
     {
         _config = config;
@@ -173,7 +179,9 @@ public class MainWindow
             _officerChatChannels.Clear();
             _officerChatChannels.AddRange(dto.OfficerChat);
             _chat?.SetChannels(_fcChatChannels);
+            if (_chat != null) _chat.ChannelsLoaded = true;
             _officer.SetChannels(_officerChatChannels);
+            _officer.ChannelsLoaded = true;
             if (!string.IsNullOrEmpty(_channelId))
             {
                 _selectedIndex = _channels.IndexOf(_channelId);

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -59,7 +59,6 @@ public class OfficerChatWindow : ChatWindow
 
     protected override async Task FetchChannels()
     {
-        _channelsLoaded = true;
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
@@ -77,6 +76,7 @@ public class OfficerChatWindow : ChatWindow
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Officer);
+                _channelsLoaded = true;
             });
         }
         catch

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -49,6 +49,9 @@ public class Plugin : IDalamudPlugin
         _chatWindow = _config.EnableFcChat ? new FcChatWindow(_config, _httpClient) : null;
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient);
         _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);
+        _settings.MainWindow = _mainWindow;
+        _settings.ChatWindow = _chatWindow;
+        _settings.OfficerChatWindow = _officerChatWindow;
 
         _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
 

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -27,6 +27,10 @@ public class SettingsWindow : IDisposable
 
     public bool IsOpen;
 
+    public MainWindow? MainWindow { get; set; }
+    public ChatWindow? ChatWindow { get; set; }
+    public OfficerChatWindow? OfficerChatWindow { get; set; }
+
     public SettingsWindow(Config config, HttpClient httpClient, Func<Task> refreshRoles, Action startNetworking, IPluginLog log, IDalamudPluginInterface pluginInterface)
     {
         _config = config;
@@ -164,6 +168,9 @@ public class SettingsWindow : IDisposable
                 }
 
                 _startNetworking();
+                if (MainWindow != null) MainWindow.ChannelsLoaded = false;
+                if (ChatWindow != null) ChatWindow.ChannelsLoaded = false;
+                if (OfficerChatWindow != null) OfficerChatWindow.ChannelsLoaded = false;
                 _syncStatus = "API key validated";
             }
             else if (response.StatusCode == HttpStatusCode.Unauthorized)


### PR DESCRIPTION
## Summary
- Set channel-loaded flags only after successful FetchChannels calls
- Allow SettingsWindow to reset channel fetch flags and trigger refetch
- Wire SettingsWindow with Main, Chat, and Officer windows for refetch after API key validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a455d005588328b09551ade265140f