### PR TITLE
Log channel fetch failures

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -69,6 +69,10 @@ public class OfficerChatWindow : ChatWindow
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                PluginServices.Instance!.Log.Warning($"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}");
+                _channelFetchFailed = true;
+                _channelsLoaded = true;
                 return;
             }
             var stream = await response.Content.ReadAsStreamAsync();
@@ -77,11 +81,14 @@ public class OfficerChatWindow : ChatWindow
             {
                 SetChannels(dto.Officer);
                 _channelsLoaded = true;
+                _channelFetchFailed = false;
             });
         }
-        catch
+        catch (Exception ex)
         {
-            // ignored
+            PluginServices.Instance!.Log.Error(ex, "Error fetching channels");
+            _channelFetchFailed = true;
+            _channelsLoaded = true;
         }
     }
 


### PR DESCRIPTION
## Summary
- log HTTP status and body when channel fetch fails
- show a status message if channels fail to load

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a45873411c8328953d202da223be2b