### PR TITLE
Add API base URL validation for network methods

### DIFF
--- a/DemiCatPlugin/ApiHelpers.cs
+++ b/DemiCatPlugin/ApiHelpers.cs
@@ -1,0 +1,15 @@
+namespace DemiCatPlugin;
+
+internal static class ApiHelpers
+{
+    internal static bool ValidateApiBaseUrl(Config config)
+    {
+        if (string.IsNullOrWhiteSpace(config.ApiBaseUrl))
+        {
+            PluginServices.Instance!.Log.Error("API base URL is not configured.");
+            return false;
+        }
+        return true;
+    }
+}
+

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -130,7 +130,7 @@ public class ChatWindow : IDisposable
 
     protected virtual async Task SendMessage()
     {
-        if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
+        if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
         {
             return;
         }
@@ -170,7 +170,7 @@ public class ChatWindow : IDisposable
 
     public async Task RefreshMessages()
     {
-        if (string.IsNullOrEmpty(_channelId))
+        if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrEmpty(_channelId))
         {
             return;
         }

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -180,6 +180,10 @@ public class EventCreateWindow
 
     private async Task CreateEvent()
     {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            return;
+        }
         try
         {
             var buttons = _buttons

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -30,7 +30,7 @@ public class OfficerChatWindow : ChatWindow
 
     protected override async Task SendMessage()
     {
-        if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
+        if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
         {
             return;
         }

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -137,7 +137,7 @@ public class TemplatesWindow
 
     private async Task PostTemplate(Template tmpl)
     {
-        if (string.IsNullOrWhiteSpace(ChannelId))
+        if (string.IsNullOrWhiteSpace(ChannelId) || !ApiHelpers.ValidateApiBaseUrl(_config))
         {
             return;
         }


### PR DESCRIPTION
## Summary
- Guard API base URL before sending or fetching messages
- Guard API base URL in event creation and template posting
- Centralize API base URL validation helper

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68a46d1de5e88328b18a8e036ecb17d1