### PR TITLE
Improve WebSocket error handling and status messaging

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -263,6 +263,7 @@ public class ChatWindow : IDisposable
                 }
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
+                _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
 
                 var buffer = new byte[8192];
                 while (_ws.State == WebSocketState.Open && !token.IsCancellationRequested)
@@ -300,9 +301,11 @@ public class ChatWindow : IDisposable
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // ignored - reconnect
+                PluginServices.Instance!.Log.Error(ex, "WebSocket connection error");
+                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                    _statusMessage = $"Connection failed: {ex.Message}");
             }
             finally
             {
@@ -312,6 +315,8 @@ public class ChatWindow : IDisposable
 
             try
             {
+                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                    _statusMessage = "Reconnecting...");
                 await Task.Delay(TimeSpan.FromSeconds(5), token);
             }
             catch

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -163,8 +163,15 @@ public class UiRenderer : IDisposable
             StopPolling();
             await ReceiveLoop();
         }
-        catch
+        catch (WebSocketException ex)
         {
+            var status = ex.Data.Contains("StatusCode") ? ex.Data["StatusCode"] : ex.WebSocketErrorCode;
+            PluginServices.Instance!.Log.Error(ex, $"Failed to connect WebSocket. Status: {status}");
+            StartPolling();
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance!.Log.Error(ex, "Failed to connect WebSocket");
             StartPolling();
         }
     }


### PR DESCRIPTION
## Summary
- Log WebSocket connection failures and show UI status when chat connection fails
- Surface WebSocket connect errors (with status codes when available) before resuming polling

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(command not found: dotnet)*
- `apt-get install -y dotnet-sdk-9.0` *(unable to locate package)*
- `pytest` *(missing dependency: sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68a46e79d1c083289c76669964fcf1ed