### PR TITLE
Fix roles JSON deserialization

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using DiscordHelper;
 using Dalamud.Plugin;
@@ -128,6 +129,7 @@ public class Plugin : IDalamudPlugin
 
     private class RolesDto
     {
+        [JsonPropertyName("roles")]
         public List<string> Roles { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- map roles DTO to lowercase JSON key

## Testing
- `pytest`
- manual `dotnet run` demonstrating: Roles received: officer, member

------
https://chatgpt.com/codex/tasks/task_e_68a4738876a0832881c34ade83ae7300