### PR TITLE
Ensure sync status updates occur on main thread

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -105,21 +105,21 @@ public class SettingsWindow : IDisposable
         if (_httpClient == null)
         {
             _log.Error("Cannot sync: HTTP client is not initialized.");
-            _syncStatus = "Network error";
+            PluginServices.Instance.Framework.RunOnTick(() => _syncStatus = "Network error");
             return;
         }
 
         if (string.IsNullOrEmpty(_config.ApiBaseUrl))
         {
             _log.Error("Cannot sync: API base URL is not configured.");
-            _syncStatus = "Network error";
+            PluginServices.Instance.Framework.RunOnTick(() => _syncStatus = "Network error");
             return;
         }
 
         if (PluginServices.Instance?.PluginInterface == null)
         {
             _log.Error("Cannot sync: plugin interface is not available.");
-            _syncStatus = "Network error";
+            PluginServices.Instance.Framework.RunOnTick(() => _syncStatus = "Network error");
             return;
         }
 
@@ -171,23 +171,23 @@ public class SettingsWindow : IDisposable
                 if (MainWindow != null) MainWindow.ChannelsLoaded = false;
                 if (ChatWindow != null) ChatWindow.ChannelsLoaded = false;
                 if (OfficerChatWindow != null) OfficerChatWindow.ChannelsLoaded = false;
-                _syncStatus = "API key validated";
+                PluginServices.Instance.Framework.RunOnTick(() => _syncStatus = "API key validated");
             }
             else if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 _log.Warning($"API key validation failed: unauthorized. Response Body: {responseBody}");
-                _syncStatus = "Authentication failed";
+                PluginServices.Instance.Framework.RunOnTick(() => _syncStatus = "Authentication failed");
             }
             else
             {
                 _log.Warning($"API key validation failed with status {response.StatusCode}. Response Body: {responseBody}");
-                _syncStatus = "Network error";
+                PluginServices.Instance.Framework.RunOnTick(() => _syncStatus = "Network error");
             }
         }
         catch (Exception ex)
         {
             _log.Error(ex, "Error validating API key.");
-            _syncStatus = "Network error";
+            PluginServices.Instance.Framework.RunOnTick(() => _syncStatus = "Network error");
             return;
         }
     }


### PR DESCRIPTION
## Summary
- Wrap sync status assignments with `PluginServices.Instance.Framework.RunOnTick` to ensure updates run on the main thread
- Keep initial "Validating API key..." message and transition to final status through main thread delegate

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: A compatible .NET SDK was not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a4796d751483288b14be3354b22287