### PR TITLE
Validate API base URL before channel fetch

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -216,6 +216,14 @@ public class ChatWindow : IDisposable
 
     protected virtual async Task FetchChannels()
     {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
+            _channelFetchFailed = true;
+            _channelsLoaded = true;
+            return;
+        }
+
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -160,6 +160,14 @@ public class MainWindow
 
     private async Task FetchChannels()
     {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
+            _channelFetchFailed = true;
+            _channelsLoaded = true;
+            return;
+        }
+
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -70,6 +70,14 @@ public class OfficerChatWindow : ChatWindow
 
     protected override async Task FetchChannels()
     {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
+            _channelFetchFailed = true;
+            _channelsLoaded = true;
+            return;
+        }
+
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");


### PR DESCRIPTION
## Summary
- validate API base URL at start of channel fetching in main, chat, and officer windows
- warn and abort channel loading when the API base URL is missing

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: A compatible .NET SDK was not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48aedbc488328a6773a82b7d814fa