### PR TITLE
Expose channel names and update plugin channel DTOs

### DIFF
--- a/DemiCatPlugin/ChannelDto.cs
+++ b/DemiCatPlugin/ChannelDto.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace DemiCatPlugin;
+
+public class ChannelDto
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+}

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
 using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
@@ -18,7 +19,7 @@ public class ChatWindow : IDisposable
     protected readonly Config _config;
     protected readonly HttpClient _httpClient;
     protected readonly List<ChatMessageDto> _messages = new();
-    protected readonly List<string> _channels = new();
+    protected readonly List<ChannelDto> _channels = new();
     protected int _selectedIndex;
     protected bool _channelsLoaded;
     protected bool _channelFetchFailed;
@@ -59,9 +60,10 @@ public class ChatWindow : IDisposable
 
         if (_channels.Count > 0)
         {
-            if (ImGui.Combo("Channel", ref _selectedIndex, _channels.ToArray(), _channels.Count))
+            var channelNames = _channels.Select(c => c.Name).ToArray();
+            if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
             {
-                _channelId = _channels[_selectedIndex];
+                _channelId = _channels[_selectedIndex].Id;
                 _config.ChatChannelId = _channelId;
                 SaveConfig();
                 _ = RefreshMessages();
@@ -98,18 +100,18 @@ public class ChatWindow : IDisposable
 
     }
 
-    public void SetChannels(List<string> channels)
+    public void SetChannels(List<ChannelDto> channels)
     {
         _channels.Clear();
         _channels.AddRange(channels);
         if (!string.IsNullOrEmpty(_channelId))
         {
-            _selectedIndex = _channels.IndexOf(_channelId);
+            _selectedIndex = _channels.FindIndex(c => c.Id == _channelId);
             if (_selectedIndex < 0) _selectedIndex = 0;
         }
         if (_channels.Count > 0)
         {
-            _channelId = _channels[_selectedIndex];
+            _channelId = _channels[_selectedIndex].Id;
             _ = RefreshMessages();
         }
     }
@@ -366,6 +368,6 @@ public class ChatWindow : IDisposable
 
     protected class ChannelListDto
     {
-        [JsonPropertyName("fc_chat")] public List<string> Chat { get; set; } = new();
+        [JsonPropertyName("fc_chat")] public List<ChannelDto> Chat { get; set; } = new();
     }
 }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Numerics;
 using System.Threading.Tasks;
+using System.Linq;
 using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
@@ -19,9 +20,9 @@ public class MainWindow
     private readonly EventCreateWindow _create;
     private readonly TemplatesWindow _templates;
     private readonly HttpClient _httpClient;
-    private readonly List<string> _channels = new();
-    private readonly List<string> _fcChatChannels = new();
-    private readonly List<string> _officerChatChannels = new();
+    private readonly List<ChannelDto> _channels = new();
+    private readonly List<ChannelDto> _fcChatChannels = new();
+    private readonly List<ChannelDto> _officerChatChannels = new();
     private bool _channelsLoaded;
     private bool _channelFetchFailed;
     private int _selectedIndex;
@@ -91,9 +92,10 @@ public class MainWindow
         if (_channels.Count > 0)
         {
             ImGui.SetNextItemWidth(-1);
-            if (ImGui.Combo("Event", ref _selectedIndex, _channels.ToArray(), _channels.Count))
+            var channelNames = _channels.Select(c => c.Name).ToArray();
+            if (ImGui.Combo("Event", ref _selectedIndex, channelNames, channelNames.Length))
             {
-                _channelId = _channels[_selectedIndex];
+                _channelId = _channels[_selectedIndex].Id;
                 _config.EventChannelId = _channelId;
                 SaveConfig();
                 _ui.ChannelId = _channelId;
@@ -200,12 +202,12 @@ public class MainWindow
                 _officer.ChannelsLoaded = true;
                 if (!string.IsNullOrEmpty(_channelId))
                 {
-                    _selectedIndex = _channels.IndexOf(_channelId);
+                    _selectedIndex = _channels.FindIndex(c => c.Id == _channelId);
                     if (_selectedIndex < 0) _selectedIndex = 0;
                 }
                 if (_channels.Count > 0)
                 {
-                    _channelId = _channels[_selectedIndex];
+                    _channelId = _channels[_selectedIndex].Id;
                     _ui.ChannelId = _channelId;
                     _create.ChannelId = _channelId;
                     _templates.ChannelId = _channelId;
@@ -225,9 +227,9 @@ public class MainWindow
 
     private class ChannelListDto
     {
-        [JsonPropertyName("event")] public List<string> Event { get; set; } = new();
-        [JsonPropertyName("fc_chat")] public List<string> FcChat { get; set; } = new();
-        [JsonPropertyName("officer_chat")] public List<string> OfficerChat { get; set; } = new();
-        [JsonPropertyName("officer_visible")] public List<string> OfficerVisible { get; set; } = new();
+        [JsonPropertyName("event")] public List<ChannelDto> Event { get; set; } = new();
+        [JsonPropertyName("fc_chat")] public List<ChannelDto> FcChat { get; set; } = new();
+        [JsonPropertyName("officer_chat")] public List<ChannelDto> OfficerChat { get; set; } = new();
+        [JsonPropertyName("officer_visible")] public List<ChannelDto> OfficerVisible { get; set; } = new();
     }
 }

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -129,7 +129,7 @@ public class OfficerChatWindow : ChatWindow
     private class OfficerChannelListDto
     {
         [JsonPropertyName("officer_chat")]
-        public List<string> Officer { get; set; } = new();
+        public List<ChannelDto> Officer { get; set; } = new();
     }
 }
 

--- a/demibot/demibot/db/migrations/versions/0006_add_guild_channel_name.py
+++ b/demibot/demibot/db/migrations/versions/0006_add_guild_channel_name.py
@@ -1,0 +1,19 @@
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0006_add_guild_channel_name"
+down_revision = "0005_add_role_discord_role_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "guild_channels", sa.Column("name", sa.String(length=255), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("guild_channels", "name")
+

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -51,6 +51,7 @@ class GuildChannel(Base):
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"), primary_key=True)
     channel_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     kind: Mapped[str] = mapped_column(String(24), primary_key=True)
+    name: Mapped[Optional[str]] = mapped_column(String(255))
 
 
 class User(Base):

--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
+from ..discord_client import discord_client
 from ...db.models import GuildChannel
 
 router = APIRouter(prefix="/api")
@@ -16,16 +17,38 @@ async def get_channels(
     db: AsyncSession = Depends(get_db),
 ):
     result = await db.execute(
-        select(GuildChannel.kind, GuildChannel.channel_id).where(
+        select(GuildChannel.kind, GuildChannel.channel_id, GuildChannel.name).where(
             GuildChannel.guild_id == ctx.guild.id
         )
     )
-    by_kind: dict[str, list[str]] = {
+    by_kind: dict[str, list[dict[str, str]]] = {
         "event": [],
         "fc_chat": [],
         "officer_chat": [],
         "officer_visible": [],
     }
-    for kind, channel_id in result.all():
-        by_kind.setdefault(kind, []).append(str(channel_id))
+    updated = False
+    for kind, channel_id, name in result.all():
+        if not name and discord_client:
+            channel = discord_client.get_channel(channel_id)
+            if channel is None:
+                try:
+                    channel = await discord_client.fetch_channel(channel_id)  # type: ignore[attr-defined]
+                except Exception:  # pragma: no cover - network errors
+                    channel = None
+            if channel is not None:
+                name = channel.name
+                await db.execute(
+                    update(GuildChannel)
+                    .where(
+                        GuildChannel.guild_id == ctx.guild.id,
+                        GuildChannel.channel_id == channel_id,
+                        GuildChannel.kind == kind,
+                    )
+                    .values(name=name)
+                )
+                updated = True
+        by_kind.setdefault(kind, []).append({"id": str(channel_id), "name": name or ""})
+    if updated:
+        await db.commit()
     return by_kind


### PR DESCRIPTION
## Summary
- add name column for GuildChannel and expose ids/names from /api/channels
- provide migration and fetch names from Discord if missing
- update plugin to handle ChannelDto objects and show channel names

## Testing
- `pytest`
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a494fc16cc8328ac40da3f8e0efccf