### PR TITLE
Use color picker for event RGB and serialize template color

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -48,7 +48,16 @@ public class EventCreateWindow
         ImGui.InputText("URL", ref _url, 260);
         ImGui.InputText("Image URL", ref _imageUrl, 260);
         ImGui.InputText("Thumbnail URL", ref _thumbnailUrl, 260);
-        ImGui.InputInt("Color", ref _color);
+        var colorVec = new Vector3(
+            ((_color >> 16) & 0xFF) / 255f,
+            ((_color >> 8) & 0xFF) / 255f,
+            (_color & 0xFF) / 255f);
+        if (ImGui.ColorEdit3("Color", ref colorVec))
+        {
+            _color = ((int)(colorVec.X * 255) << 16) |
+                     ((int)(colorVec.Y * 255) << 8) |
+                     (int)(colorVec.Z * 255);
+        }
         foreach (var button in _buttons)
         {
             ImGui.PushID(button.Tag);
@@ -119,7 +128,7 @@ public class EventCreateWindow
         _url = template.Url;
         _imageUrl = template.ImageUrl;
         _thumbnailUrl = template.ThumbnailUrl;
-        _color = template.Color;
+        _color = (int)template.Color;
 
         _fields.Clear();
         if (template.Fields != null)
@@ -158,7 +167,7 @@ public class EventCreateWindow
             Url = _url,
             ImageUrl = _imageUrl,
             ThumbnailUrl = _thumbnailUrl,
-            Color = _color,
+            Color = (uint)_color,
             Fields = _fields.Select(f => new Template.TemplateField
             {
                 Name = f.Name,

--- a/DemiCatPlugin/Template.cs
+++ b/DemiCatPlugin/Template.cs
@@ -17,7 +17,7 @@ public class Template
     public string Url { get; set; } = string.Empty;
     public string ImageUrl { get; set; } = string.Empty;
     public string ThumbnailUrl { get; set; } = string.Empty;
-    public int Color { get; set; }
+    public uint Color { get; set; }
     public List<TemplateField> Fields { get; set; } = new();
     public List<TemplateButton> Buttons { get; set; } = new();
 

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -123,7 +123,7 @@ public class TemplatesWindow
             Timestamp = ts,
             ImageUrl = string.IsNullOrWhiteSpace(tmpl.ImageUrl) ? null : tmpl.ImageUrl,
             ThumbnailUrl = string.IsNullOrWhiteSpace(tmpl.ThumbnailUrl) ? null : tmpl.ThumbnailUrl,
-            Color = tmpl.Color > 0 ? (uint?)tmpl.Color : null,
+            Color = tmpl.Color != 0 ? (uint?)tmpl.Color : null,
             Fields = tmpl.Fields?.Select(f => new EmbedFieldDto { Name = f.Name, Value = f.Value, Inline = f.Inline }).ToList(),
             Buttons = tmpl.Buttons?.Where(b => b.Include).Select(b => new EmbedButtonDto
             {
@@ -167,7 +167,7 @@ public class TemplatesWindow
                     url = string.IsNullOrWhiteSpace(tmpl.Url) ? null : tmpl.Url,
                     imageUrl = string.IsNullOrWhiteSpace(tmpl.ImageUrl) ? null : tmpl.ImageUrl,
                     thumbnailUrl = string.IsNullOrWhiteSpace(tmpl.ThumbnailUrl) ? null : tmpl.ThumbnailUrl,
-                    color = tmpl.Color > 0 ? (uint?)tmpl.Color : null,
+                    color = tmpl.Color != 0 ? (uint?)tmpl.Color : null,
                     fields = tmpl.Fields != null && tmpl.Fields.Count > 0
                         ? tmpl.Fields
                             .Where(f => !string.IsNullOrWhiteSpace(f.Name) && !string.IsNullOrWhiteSpace(f.Value))


### PR DESCRIPTION
## Summary
- replace integer color input with ImGui color picker storing RGB as 24-bit int
- store template color as uint and adjust template usage to new color format

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite', 'aiomysql')*


------
https://chatgpt.com/codex/tasks/task_e_68a4a262592c832883fc7b3db41caae5