### PR TITLE
Add .NET build and test workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,33 @@
+name: .NET
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Restore .NET tools
+        if: ${{ hashFiles('**/dotnet-tools.json') != '' }}
+        run: dotnet tool restore
+      - name: Restore dependencies
+        run: dotnet restore DemiCatPlugin/DemiCatPlugin.csproj
+      - name: Build
+        run: dotnet build DemiCatPlugin/DemiCatPlugin.csproj --configuration Release --no-restore
+      - name: Test
+        run: |
+          test_projects=$(find . -name '*Tests.csproj')
+          if [ -z "$test_projects" ]; then
+            echo 'No test projects found.'
+          else
+            for proj in $test_projects; do
+              dotnet test "$proj" --no-build --configuration Release
+            done
+          fi
+


### PR DESCRIPTION
## Summary
- run .NET 9 build and test on push and PR
- restore dotnet tools, build DemiCatPlugin.csproj, and run test projects

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `if [ -n "$(find . -name '*Tests.csproj')" ]; then dotnet test; else echo 'No test projects found.'; fi`

------
https://chatgpt.com/codex/tasks/task_e_68a4a425c964832887e517747f1814d1