### PR TITLE
Add presence tracking and member list UI

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -10,7 +10,7 @@ using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
 
-public class MainWindow
+public class MainWindow : IDisposable
 {
     private readonly Config _config;
     private readonly UiRenderer _ui;
@@ -19,6 +19,7 @@ public class MainWindow
     private readonly SettingsWindow _settings;
     private readonly EventCreateWindow _create;
     private readonly TemplatesWindow _templates;
+    private readonly PresencePane _presence;
     private readonly HttpClient _httpClient;
     private readonly List<ChannelDto> _channels = new();
     private readonly List<ChannelDto> _fcChatChannels = new();
@@ -47,6 +48,7 @@ public class MainWindow
         _httpClient = httpClient;
         _create = new EventCreateWindow(config, httpClient);
         _templates = new TemplatesWindow(config, httpClient);
+        _presence = new PresencePane(config, httpClient);
         _channelId = config.EventChannelId;
         _ui.ChannelId = _channelId;
         _create.ChannelId = _channelId;
@@ -151,6 +153,9 @@ public class MainWindow
         }
         ImGui.EndChild();
 
+        ImGui.SameLine();
+        _presence.Draw();
+
         ImGui.End();
         ImGui.PopStyleColor(5);
     }
@@ -158,6 +163,11 @@ public class MainWindow
     private void SaveConfig()
     {
         PluginServices.Instance!.PluginInterface.SavePluginConfig(_config);
+    }
+
+    public void Dispose()
+    {
+        _presence.Dispose();
     }
 
     private async Task FetchChannels()

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -85,6 +85,7 @@ public class Plugin : IDalamudPlugin
         _httpClient.Dispose();
         _chatWindow?.Dispose();
         _officerChatWindow.Dispose();
+        _mainWindow.Dispose();
         _ui.Dispose();
         _settings.Dispose();
     }

--- a/DemiCatPlugin/PresenceDto.cs
+++ b/DemiCatPlugin/PresenceDto.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace DemiCatPlugin;
+
+public class PresenceDto
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("status")] public string Status { get; set; } = string.Empty;
+}

--- a/DemiCatPlugin/PresencePane.cs
+++ b/DemiCatPlugin/PresencePane.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
+
+namespace DemiCatPlugin;
+
+public class PresencePane : IDisposable
+{
+    private readonly Config _config;
+    private readonly HttpClient _httpClient;
+    private readonly List<PresenceDto> _presences = new();
+    private ClientWebSocket? _ws;
+    private Task? _wsTask;
+    private CancellationTokenSource? _wsCts;
+    private bool _loaded;
+
+    public PresencePane(Config config, HttpClient httpClient)
+    {
+        _config = config;
+        _httpClient = httpClient;
+    }
+
+    public void Draw()
+    {
+        if (_wsTask == null)
+        {
+            _wsCts = new CancellationTokenSource();
+            _wsTask = RunWebSocket(_wsCts.Token);
+        }
+        if (!_loaded)
+        {
+            _ = Refresh();
+        }
+
+        ImGui.BeginChild("PresenceList", new Vector2(150, 0), true);
+        var online = _presences.Where(p => p.Status != "offline").OrderBy(p => p.Name).ToList();
+        var offline = _presences.Where(p => p.Status == "offline").OrderBy(p => p.Name).ToList();
+        ImGui.TextUnformatted($"Online - {online.Count}");
+        foreach (var p in online)
+        {
+            ImGui.TextUnformatted(p.Name);
+        }
+        ImGui.Spacing();
+        ImGui.TextUnformatted($"Offline - {offline.Count}");
+        foreach (var p in offline)
+        {
+            ImGui.TextUnformatted(p.Name);
+        }
+        ImGui.EndChild();
+    }
+
+    public void Dispose()
+    {
+        _wsCts?.Cancel();
+        _ws?.Dispose();
+    }
+
+    private async Task Refresh()
+    {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            _loaded = true;
+            return;
+        }
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/presences");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Add("X-Api-Key", _config.AuthToken);
+            }
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                _loaded = true;
+                return;
+            }
+            var stream = await response.Content.ReadAsStreamAsync();
+            var list = await JsonSerializer.DeserializeAsync<List<PresenceDto>>(stream) ?? new List<PresenceDto>();
+            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+            {
+                _presences.Clear();
+                _presences.AddRange(list);
+            });
+        }
+        catch
+        {
+            // ignore
+        }
+        finally
+        {
+            _loaded = true;
+        }
+    }
+
+    private async Task RunWebSocket(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                _ws?.Dispose();
+                _ws = new ClientWebSocket();
+                if (!string.IsNullOrEmpty(_config.AuthToken))
+                {
+                    _ws.Options.SetRequestHeader("X-Api-Key", _config.AuthToken);
+                }
+                var uri = BuildWebSocketUri();
+                await _ws.ConnectAsync(uri, token);
+                var buffer = new byte[1024];
+                while (_ws.State == WebSocketState.Open && !token.IsCancellationRequested)
+                {
+                    var result = await _ws.ReceiveAsync(new ArraySegment<byte>(buffer), token);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        break;
+                    }
+                    var json = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                    PresenceDto? dto = null;
+                    try
+                    {
+                        dto = JsonSerializer.Deserialize<PresenceDto>(json);
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                    if (dto != null)
+                    {
+                        _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                        {
+                            var idx = _presences.FindIndex(p => p.Id == dto.Id);
+                            if (idx >= 0)
+                            {
+                                _presences[idx] = dto;
+                            }
+                            else
+                            {
+                                _presences.Add(dto);
+                            }
+                        });
+                    }
+                }
+            }
+            catch
+            {
+                // ignore errors
+            }
+            finally
+            {
+                _ws?.Dispose();
+                _ws = null;
+            }
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), token);
+            }
+            catch
+            {
+                // ignore cancellation
+            }
+        }
+    }
+
+    private Uri BuildWebSocketUri()
+    {
+        var baseUri = _config.ApiBaseUrl.TrimEnd('/') + "/ws/presences";
+        var builder = new UriBuilder(baseUri);
+        if (builder.Scheme == "https") builder.Scheme = "wss";
+        else if (builder.Scheme == "http") builder.Scheme = "ws";
+        return builder.Uri;
+    }
+}

--- a/demibot/demibot/discordbot/cogs/presence.py
+++ b/demibot/demibot/discordbot/cogs/presence.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import discord
+from discord.ext import commands
+
+from ...http.ws import manager
+from ..presence_store import Presence, set_presence
+
+
+class PresenceTracker(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    def _status(self, member: discord.Member) -> str:
+        status = str(member.status)
+        if status in ("offline", "invisible"):
+            return "offline"
+        return "online"
+
+    def _update(self, member: discord.Member) -> dict[str, str]:
+        data = Presence(
+            id=member.id,
+            name=member.display_name or member.name,
+            status=self._status(member),
+        )
+        set_presence(member.guild.id, data)
+        return {"id": str(member.id), "name": data.name, "status": data.status}
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        for guild in self.bot.guilds:
+            for member in guild.members:
+                self._update(member)
+
+    @commands.Cog.listener()
+    async def on_presence_update(
+        self, before: discord.Member, after: discord.Member
+    ) -> None:
+        payload = self._update(after)
+        await manager.broadcast_text(
+            json.dumps(payload), after.guild.id, path="/ws/presences"
+        )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(PresenceTracker(bot))

--- a/demibot/demibot/discordbot/presence_store.py
+++ b/demibot/demibot/discordbot/presence_store.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class Presence:
+    id: int
+    name: str
+    status: str
+
+
+_presences: Dict[int, Dict[int, Presence]] = {}
+
+
+def set_presence(guild_id: int, presence: Presence) -> None:
+    guild = _presences.setdefault(guild_id, {})
+    guild[presence.id] = presence
+
+
+def get_presences(guild_id: int) -> List[Presence]:
+    return list(_presences.get(guild_id, {}).values())

--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -30,6 +30,7 @@ def create_app(cfg: "AppConfig | None") -> FastAPI:
     app.add_api_websocket_route("/ws/messages", websocket_endpoint)
     app.add_api_websocket_route("/ws/embeds", websocket_endpoint)
     app.add_api_websocket_route("/ws/officer-messages", websocket_endpoint)
+    app.add_api_websocket_route("/ws/presences", websocket_endpoint)
 
     @app.get("/health")
     async def health() -> dict[str, str]:

--- a/demibot/demibot/http/routes/presences.py
+++ b/demibot/demibot/http/routes/presences.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ..deps import RequestContext, api_key_auth
+from ...discordbot.presence_store import get_presences
+
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/presences")
+async def list_presences(ctx: RequestContext = Depends(api_key_auth)) -> list[dict[str, str]]:
+    presences = [
+        {"id": str(p.id), "name": p.name, "status": p.status}
+        for p in get_presences(ctx.guild.id)
+    ]
+    return presences

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -56,3 +56,11 @@ class ChatMessage(BaseModel):
     authorName: str
     content: str
     mentions: List[Mention] | None = None
+
+# ---- Presence ----
+
+
+class PresenceDto(BaseModel):
+    id: str
+    name: str
+    status: str

--- a/demibot/demibot/http/ws.py
+++ b/demibot/demibot/http/ws.py
@@ -24,16 +24,23 @@ class ConnectionManager:
             del self.connections[websocket]
 
     async def broadcast_text(
-        self, message: str, guild_id: int, officer_only: bool = False
+        self,
+        message: str,
+        guild_id: int,
+        officer_only: bool = False,
+        path: str | None = None,
     ) -> None:
         dead: list[WebSocket] = []
-        for ws, (gid, roles, path) in list(self.connections.items()):
+        for ws, (gid, roles, ws_path) in list(self.connections.items()):
             if gid != guild_id:
                 continue
             if officer_only:
-                if "officer" not in roles or path != "/ws/officer-messages":
+                if "officer" not in roles or ws_path != "/ws/officer-messages":
                     continue
-            elif path == "/ws/officer-messages":
+            elif path is not None:
+                if ws_path != path:
+                    continue
+            elif ws_path == "/ws/officer-messages":
                 continue
             try:
                 await ws.send_text(message)

--- a/tests/test_presences.py
+++ b/tests/test_presences.py
@@ -1,0 +1,63 @@
+import types
+from pathlib import Path
+import sys
+import pytest
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.http.ws import ConnectionManager
+from demibot.http.routes.presences import list_presences
+from demibot.discordbot.presence_store import set_presence, Presence
+import asyncio
+
+
+class StubWebSocket:
+    def __init__(self, path: str):
+        self.scope = {"path": path}
+        self.sent: list[str] = []
+
+    async def accept(self):
+        pass
+
+    async def send_text(self, message: str):
+        self.sent.append(message)
+
+
+class StubContext:
+    def __init__(self, guild_id: int):
+        self.guild = types.SimpleNamespace(id=guild_id)
+        self.roles = []
+
+
+def test_presence_broadcast_filtered_by_path():
+    async def _run():
+        manager = ConnectionManager()
+        ws_presence = StubWebSocket("/ws/presences")
+        ctx = StubContext(1)
+        await manager.connect(ws_presence, ctx)
+        ws_other = StubWebSocket("/ws/messages")
+        await manager.connect(ws_other, ctx)
+
+        await manager.broadcast_text("hi", 1, path="/ws/presences")
+        assert ws_presence.sent == ["hi"]
+        assert ws_other.sent == []
+
+    asyncio.run(_run())
+
+
+def test_list_presences_returns_data():
+    async def _run():
+        set_presence(1, Presence(id=10, name="Alice", status="online"))
+        set_presence(1, Presence(id=20, name="Bob", status="offline"))
+        ctx = StubContext(1)
+        res = await list_presences(ctx=ctx)
+        assert {(p["id"], p["status"]) for p in res} == {("10", "online"), ("20", "offline")}
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Track Discord user presences and broadcast updates via `/api/presences` and `/ws/presences`
- Add client-side presence pane listing online/offline members
- Allow websocket broadcasts to target specific paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a980628c83289ecb287a4e7240cd