### PR TITLE
Support dynamic RSVP options with limits

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -24,6 +24,7 @@ public class Config : IPluginConfiguration
     public bool UseCharacterName { get; set; } = false;
     public List<string> Roles { get; set; } = new();
     public List<Template> Templates { get; set; } = new();
+    public List<SignupPreset> SignupPresets { get; set; } = new();
 
     [JsonExtensionData]
     public Dictionary<string, JsonElement>? ExtensionData { get; set; }

--- a/DemiCatPlugin/EmbedDto.cs
+++ b/DemiCatPlugin/EmbedDto.cs
@@ -35,6 +35,7 @@ public class EmbedButtonDto
     public string? CustomId { get; set; }
     public string? Emoji { get; set; }
     public ButtonStyle? Style { get; set; }
+    public int? MaxSignups { get; set; }
 }
 
 public enum ButtonStyle

--- a/DemiCatPlugin/SignupPreset.cs
+++ b/DemiCatPlugin/SignupPreset.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace DemiCatPlugin;
+
+public class SignupPreset
+{
+    public string Name { get; set; } = string.Empty;
+    public List<Template.TemplateButton> Buttons { get; set; } = new();
+}

--- a/DemiCatPlugin/Template.cs
+++ b/DemiCatPlugin/Template.cs
@@ -36,6 +36,7 @@ public class Template
         public string Label { get; set; } = string.Empty;
         public string Emoji { get; set; } = string.Empty;
         public ButtonStyle Style { get; set; } = ButtonStyle.Secondary;
+        public int? MaxSignups { get; set; }
     }
 }
 

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -130,7 +130,8 @@ public class TemplatesWindow
                 Label = b.Label,
                 CustomId = $"rsvp:{b.Tag}",
                 Emoji = string.IsNullOrWhiteSpace(b.Emoji) ? null : b.Emoji,
-                Style = b.Style
+                Style = b.Style,
+                MaxSignups = b.MaxSignups
             }).ToList(),
             Mentions = tmpl.Mentions != null && tmpl.Mentions.Count > 0 ? tmpl.Mentions : null
         };
@@ -153,7 +154,8 @@ public class TemplatesWindow
                         label = b.Label,
                         customId = $"rsvp:{b.Tag}",
                         emoji = string.IsNullOrWhiteSpace(b.Emoji) ? null : b.Emoji,
-                        style = (int)b.Style
+                        style = (int)b.Style,
+                        maxSignups = b.MaxSignups
                     })
                     .ToList();
 

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import enum
 from datetime import datetime
 from typing import Optional
 
@@ -146,12 +145,6 @@ class Embed(Base):
     )
 
 
-class RSVP(enum.Enum):
-    yes = "yes"
-    maybe = "maybe"
-    no = "no"
-
-
 class Attendance(Base):
     __tablename__ = "attendance"
 
@@ -159,4 +152,4 @@ class Attendance(Base):
     user_id: Mapped[int] = mapped_column(
         BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True
     )
-    choice: Mapped[RSVP] = mapped_column(String(10))
+    choice: Mapped[str] = mapped_column(String(50))

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -27,6 +27,7 @@ class EmbedButtonDto(BaseModel):
     customId: Optional[str] = None
     emoji: Optional[str] = None
     style: Optional[ButtonStyle] = None
+    maxSignups: Optional[int] = None
 
 class EmbedDto(BaseModel):
     id: str

--- a/tests/test_rsvp_max_signups.py
+++ b/tests/test_rsvp_max_signups.py
@@ -1,0 +1,75 @@
+import sys
+from pathlib import Path
+import types
+from types import SimpleNamespace
+import asyncio
+import json
+from fastapi.responses import JSONResponse
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.db.models import Guild, GuildChannel, User
+from demibot.db.session import init_db, get_session
+from demibot.http.routes.events import create_event, CreateEventBody
+from demibot.http.routes.interactions import post_interaction, InteractionBody
+from unittest.mock import patch
+
+
+async def _run_test() -> None:
+    db_path = Path("test_rsvp.db")
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    async for db in get_session():
+        guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
+        db.add(guild)
+        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
+        db.add(User(id=1, discord_user_id=1))
+        db.add(User(id=2, discord_user_id=2))
+        await db.commit()
+
+        body = CreateEventBody(
+            channelId="123",
+            title="Test",
+            time="2024-01-01T00:00:00Z",
+            description="desc",
+            buttons=[{"label": "Join", "customId": "rsvp:join", "maxSignups": 1}],
+        )
+        ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
+        original_dumps = json.dumps
+        with patch(
+            "demibot.http.routes.events.json.dumps",
+            lambda obj, *a, **k: original_dumps(obj, default=str, *a, **k),
+        ):
+            result = await create_event(body=body, ctx=ctx, db=db)
+
+        ctx1 = SimpleNamespace(user=SimpleNamespace(id=1), guild=SimpleNamespace(id=1))
+        await post_interaction(
+            body=InteractionBody(MessageId=result["id"], CustomId="rsvp:join"),
+            ctx=ctx1,
+            db=db,
+        )
+
+        ctx2 = SimpleNamespace(user=SimpleNamespace(id=2), guild=SimpleNamespace(id=1))
+        resp = await post_interaction(
+            body=InteractionBody(MessageId=result["id"], CustomId="rsvp:join"),
+            ctx=ctx2,
+            db=db,
+        )
+        assert isinstance(resp, JSONResponse)
+        assert resp.status_code == 400
+        break
+
+
+def test_max_signups_enforced() -> None:
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- Allow event creators to define custom RSVP buttons with style, emoji and optional signup limits
- Store RSVP choices generically and enforce per-option limits on interactions
- Save reusable RSVP option presets and test max-signup handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ac3ebc0c8328893e9ddfbc29bdcb