### PR TITLE
feat: enrich messages with avatars and attachments

### DIFF
--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -123,8 +123,10 @@ class Message(Base):
         BIGINT(unsigned=True), ForeignKey("users.id")
     )
     author_name: Mapped[str] = mapped_column(String(255))
+    author_avatar_url: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     content_raw: Mapped[str] = mapped_column(Text)
     content_display: Mapped[str] = mapped_column(Text)
+    attachments_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     is_officer: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ..schemas import ChatMessage
+from ..schemas import ChatMessage, AttachmentDto
 from ..ws import manager
 from ...db.models import Message
 from ..discord_client import discord_client
@@ -43,12 +43,22 @@ async def get_officer_messages(
     result = await db.execute(stmt)
     out: list[ChatMessage] = []
     for m in result.scalars():
+        attachments = None
+        if m.attachments_json:
+            try:
+                data = json.loads(m.attachments_json)
+                attachments = [AttachmentDto(**a) for a in data]
+            except Exception:
+                attachments = None
         out.append(
             ChatMessage(
                 id=str(m.discord_message_id),
                 channelId=str(m.channel_id),
                 authorName=m.author_name,
+                authorAvatarUrl=m.author_avatar_url,
+                timestamp=m.created_at,
                 content=m.content_display,
+                attachments=attachments,
             )
         )
     return [o.model_dump() for o in out]
@@ -85,11 +95,14 @@ async def post_officer_message(
     )
     db.add(msg)
     await db.commit()
+    await db.refresh(msg)
 
     dto = ChatMessage(
         id=str(discord_msg_id),
         channelId=str(channel_id),
         authorName=msg.author_name,
+        authorAvatarUrl=msg.author_avatar_url,
+        timestamp=msg.created_at,
         content=msg.content_display,
     )
     await manager.broadcast_text(

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -51,11 +51,21 @@ class Mention(BaseModel):
     id: str
     name: str
 
+
+class AttachmentDto(BaseModel):
+    url: str
+    filename: Optional[str] = None
+    contentType: Optional[str] = None
+
+
 class ChatMessage(BaseModel):
     id: str
     channelId: str
     authorName: str
+    authorAvatarUrl: Optional[str] = None
+    timestamp: Optional[datetime] = None
     content: str
+    attachments: List[AttachmentDto] | None = None
     mentions: List[Mention] | None = None
 
 # ---- Presence ----


### PR DESCRIPTION
## Summary
- include avatar URLs, timestamps, and attachment info in message API and schema
- render avatars, timestamps, and attachment previews in chat windows

## Testing
- `pytest`
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b08453c88328ae49b632a19b875a