### PR TITLE
Add shared signup preset API and plugin cache

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -38,6 +38,7 @@ public class EventCreateWindow
         _config = config;
         _httpClient = httpClient;
         ResetDefaultButtons();
+        _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
     }
 
     public void Draw()
@@ -143,21 +144,23 @@ public class EventCreateWindow
             _buttons.Add(new ButtonConfig($"opt{_buttons.Count + 1}", "Option", string.Empty, ButtonStyle.Secondary));
         }
 
-        if (_config.SignupPresets.Count > 0)
+        _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
+        var presets = SignupPresetService.Presets;
+        if (presets.Count > 0)
         {
-            var preview = _selectedPreset >= 0 && _selectedPreset < _config.SignupPresets.Count
-                ? _config.SignupPresets[_selectedPreset].Name
+            var preview = _selectedPreset >= 0 && _selectedPreset < presets.Count
+                ? presets[_selectedPreset].Name
                 : string.Empty;
             if (ImGui.BeginCombo("Presets", preview))
             {
-                for (var i = 0; i < _config.SignupPresets.Count; i++)
+                for (var i = 0; i < presets.Count; i++)
                 {
-                    var name = _config.SignupPresets[i].Name;
+                    var name = presets[i].Name;
                     var sel = i == _selectedPreset;
                     if (ImGui.Selectable(name, sel))
                     {
                         _selectedPreset = i;
-                        LoadPreset(_config.SignupPresets[i]);
+                        LoadPreset(presets[i]);
                     }
                     if (sel) ImGui.SetItemDefaultFocus();
                 }
@@ -415,8 +418,7 @@ public class EventCreateWindow
                 MaxSignups = b.MaxSignups
             }).ToList()
         };
-        _config.SignupPresets.Add(preset);
-        PluginServices.Instance!.PluginInterface.SavePluginConfig(_config);
+        _ = SignupPresetService.Create(preset, _httpClient, _config);
         _presetName = string.Empty;
     }
 

--- a/DemiCatPlugin/SignupPreset.cs
+++ b/DemiCatPlugin/SignupPreset.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace DemiCatPlugin;
 
 public class SignupPreset
 {
-    public string Name { get; set; } = string.Empty;
-    public List<Template.TemplateButton> Buttons { get; set; } = new();
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("buttons")] public List<Template.TemplateButton> Buttons { get; set; } = new();
 }

--- a/DemiCatPlugin/SignupPresetService.cs
+++ b/DemiCatPlugin/SignupPresetService.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace DemiCatPlugin;
+
+internal static class SignupPresetService
+{
+    private static List<SignupPreset> _presets = new();
+    private static bool _loaded;
+
+    internal static IReadOnlyList<SignupPreset> Presets => _presets;
+
+    internal static async Task EnsureLoaded(HttpClient httpClient, Config config)
+    {
+        if (!_loaded)
+        {
+            await Refresh(httpClient, config);
+        }
+    }
+
+    internal static async Task Refresh(HttpClient httpClient, Config config)
+    {
+        if (!ApiHelpers.ValidateApiBaseUrl(config)) return;
+        try
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets");
+            if (!string.IsNullOrEmpty(config.AuthToken))
+            {
+                req.Headers.Add("X-Api-Key", config.AuthToken);
+            }
+            var resp = await httpClient.SendAsync(req);
+            if (resp.IsSuccessStatusCode)
+            {
+                var stream = await resp.Content.ReadAsStreamAsync();
+                var presets = await JsonSerializer.DeserializeAsync<List<SignupPreset>>(stream) ?? new();
+                _presets = presets;
+                _loaded = true;
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    internal static async Task Create(SignupPreset preset, HttpClient httpClient, Config config)
+    {
+        if (!ApiHelpers.ValidateApiBaseUrl(config)) return;
+        try
+        {
+            var req = new HttpRequestMessage(HttpMethod.Post, $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets");
+            if (!string.IsNullOrEmpty(config.AuthToken))
+            {
+                req.Headers.Add("X-Api-Key", config.AuthToken);
+            }
+            req.Content = new StringContent(JsonSerializer.Serialize(preset), Encoding.UTF8, "application/json");
+            var resp = await httpClient.SendAsync(req);
+            if (resp.IsSuccessStatusCode)
+            {
+                await Refresh(httpClient, config);
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    internal static async Task Delete(string id, HttpClient httpClient, Config config)
+    {
+        if (!ApiHelpers.ValidateApiBaseUrl(config)) return;
+        try
+        {
+            var req = new HttpRequestMessage(HttpMethod.Delete, $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets/{id}");
+            if (!string.IsNullOrEmpty(config.AuthToken))
+            {
+                req.Headers.Add("X-Api-Key", config.AuthToken);
+            }
+            var resp = await httpClient.SendAsync(req);
+            if (resp.IsSuccessStatusCode)
+            {
+                await Refresh(httpClient, config);
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+}
+

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -30,6 +30,7 @@ public class TemplatesWindow
 
     public void Draw()
     {
+        _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
         ImGui.BeginChild("TemplateList", new Vector2(150, 0), true);
         var typeNames = Enum.GetNames<TemplateType>();
         var typeIndex = (int)_selectedType;

--- a/demibot/demibot/db/migrations/versions/0008_add_signup_presets.py
+++ b/demibot/demibot/db/migrations/versions/0008_add_signup_presets.py
@@ -1,0 +1,30 @@
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0008_add_signup_presets"
+down_revision = "0007_add_presence_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "signup_presets",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("guild_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("buttons_json", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["guild_id"], ["guilds.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_signup_presets_guild_id",
+        "signup_presets",
+        ["guild_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_signup_presets_guild_id", table_name="signup_presets")
+    op.drop_table("signup_presets")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -180,3 +180,12 @@ class RecurringEvent(Base):
     repeat: Mapped[str] = mapped_column(String(16))
     next_post_at: Mapped[datetime] = mapped_column(DateTime)
     payload_json: Mapped[str] = mapped_column(Text)
+
+
+class SignupPreset(Base):
+    __tablename__ = "signup_presets"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"), index=True)
+    name: Mapped[str] = mapped_column(String(255))
+    buttons_json: Mapped[str] = mapped_column(Text)

--- a/demibot/demibot/http/routes/signup_presets.py
+++ b/demibot/demibot/http/routes/signup_presets.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ...db.models import SignupPreset
+
+router = APIRouter(prefix="/api")
+
+
+class SignupPresetBody(BaseModel):
+    name: str
+    buttons: list[dict[str, Any]]
+
+
+@router.get("/signup-presets")
+async def list_signup_presets(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> list[dict[str, Any]]:
+    result = await db.execute(
+        select(SignupPreset).where(SignupPreset.guild_id == ctx.guild.id)
+    )
+    presets: list[dict[str, Any]] = []
+    for p in result.scalars():
+        try:
+            buttons = json.loads(p.buttons_json)
+        except Exception:
+            buttons = []
+        presets.append({"id": str(p.id), "name": p.name, "buttons": buttons})
+    return presets
+
+
+@router.post("/signup-presets")
+async def create_signup_preset(
+    body: SignupPresetBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    preset = SignupPreset(
+        guild_id=ctx.guild.id,
+        name=body.name,
+        buttons_json=json.dumps(body.buttons),
+    )
+    db.add(preset)
+    await db.commit()
+    await db.refresh(preset)
+    return {"id": str(preset.id)}
+
+
+@router.delete("/signup-presets/{preset_id}")
+async def delete_signup_preset(
+    preset_id: str,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    pid = int(preset_id)
+    preset = await db.get(SignupPreset, pid)
+    if preset and preset.guild_id == ctx.guild.id:
+        await db.delete(preset)
+        await db.commit()
+    return {"ok": True}

--- a/tests/test_signup_presets.py
+++ b/tests/test_signup_presets.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+from types import SimpleNamespace
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.db.models import Guild
+from demibot.db.session import init_db, get_session
+from demibot.http.routes.signup_presets import (
+    list_signup_presets,
+    create_signup_preset,
+    delete_signup_preset,
+    SignupPresetBody,
+)
+
+
+async def _run_test() -> None:
+    db_path = Path("test_signup_presets.db")
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    async for db in get_session():
+        guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
+        db.add(guild)
+        await db.commit()
+        ctx = SimpleNamespace(guild=guild)
+        body = SignupPresetBody(name="Raid", buttons=[{"tag": "yes", "label": "Yes"}])
+        res = await create_signup_preset(body=body, ctx=ctx, db=db)
+        pid = res["id"]
+        presets = await list_signup_presets(ctx=ctx, db=db)
+        assert presets == [{"id": pid, "name": "Raid", "buttons": [{"tag": "yes", "label": "Yes"}]}]
+        await delete_signup_preset(preset_id=pid, ctx=ctx, db=db)
+        presets = await list_signup_presets(ctx=ctx, db=db)
+        assert presets == []
+        break
+
+
+def test_signup_presets() -> None:
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- add `signup_presets` table and Alembic migration
- expose `/api/signup-presets` endpoints for listing, creating and deleting presets
- update plugin to fetch and store presets via new API with in-memory cache

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b6b33a7c832899b07621add6db45