### PR TITLE
feat: manage recurring events

### DIFF
--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -174,7 +174,7 @@ class Presence(Base):
 class RecurringEvent(Base):
     __tablename__ = "recurring_events"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
     channel_id: Mapped[int] = mapped_column(BigInteger)
     repeat: Mapped[str] = mapped_column(String(16))

--- a/demibot/demibot/repeat_events.py
+++ b/demibot/demibot/repeat_events.py
@@ -11,30 +11,43 @@ from sqlalchemy import select
 from .db.session import get_session
 from .db.models import RecurringEvent
 from .http.routes.events import create_event, CreateEventBody
+from .http.discord_client import discord_client
 
 
 async def process_recurring_events_once() -> None:
     async for db in get_session():
         now = datetime.utcnow()
-        res = await db.execute(
-            select(RecurringEvent).where(RecurringEvent.next_post_at <= now)
-        )
+        res = await db.execute(select(RecurringEvent))
         events = list(res.scalars())
         for ev in events:
-            payload = json.loads(ev.payload_json)
-            payload["time"] = ev.next_post_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-            payload["repeat"] = None
-            body = CreateEventBody(**payload)
-            ctx = SimpleNamespace(guild=SimpleNamespace(id=ev.guild_id))
-            try:
-                await create_event(body=body, ctx=ctx, db=db)
-            except Exception:
-                logging.exception("Failed to repost event %s", ev.id)
+            remove = False
+            if discord_client:
+                channel = discord_client.get_channel(ev.channel_id)
+                if channel is None:
+                    remove = True
+                else:
+                    try:
+                        await channel.fetch_message(ev.id)
+                    except Exception:
+                        remove = True
+            if remove:
+                await db.delete(ev)
                 continue
-            if ev.repeat == "daily":
-                ev.next_post_at += timedelta(days=1)
-            elif ev.repeat == "weekly":
-                ev.next_post_at += timedelta(days=7)
+            if ev.next_post_at <= now:
+                payload = json.loads(ev.payload_json)
+                payload["time"] = ev.next_post_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                payload["repeat"] = None
+                body = CreateEventBody(**payload)
+                ctx = SimpleNamespace(guild=SimpleNamespace(id=ev.guild_id))
+                try:
+                    await create_event(body=body, ctx=ctx, db=db)
+                except Exception:
+                    logging.exception("Failed to repost event %s", ev.id)
+                    continue
+                if ev.repeat == "daily":
+                    ev.next_post_at += timedelta(days=1)
+                elif ev.repeat == "weekly":
+                    ev.next_post_at += timedelta(days=7)
         await db.commit()
         break
 

--- a/tests/test_recurring_event_management.py
+++ b/tests/test_recurring_event_management.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+import sys
+import types
+import asyncio
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.db.models import Guild, GuildChannel, RecurringEvent
+from demibot.db.session import init_db, get_session
+from demibot.http.routes.events import (
+    create_event,
+    CreateEventBody,
+    RepeatPatchBody,
+    update_recurring_event,
+    delete_recurring_event,
+)
+from demibot import repeat_events
+from demibot.repeat_events import process_recurring_events_once
+
+
+async def _setup_db(path: Path) -> None:
+    if path.exists():
+        path.unlink()
+    url = f"sqlite+aiosqlite:///{path}"
+    await init_db(url)
+    async for db in get_session():
+        guild = Guild(id=1, discord_guild_id=1, name="Test")
+        db.add(guild)
+        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
+        await db.commit()
+        break
+
+
+async def _test_patch_delete() -> None:
+    db_path = Path("test_recurring_api.db")
+    await _setup_db(db_path)
+
+    body = CreateEventBody(
+        channelId="123",
+        title="Test",
+        time="2024-01-01T00:00:00Z",
+        description="desc",
+        repeat="daily",
+    )
+    ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
+    async for db in get_session():
+        res = await create_event(body=body, ctx=ctx, db=db)
+        ev_id = int(res["id"])
+        await db.commit()
+        break
+
+    new_time = (datetime.utcnow() + timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    patch_body = RepeatPatchBody(time=new_time, repeat="weekly")
+    async for db in get_session():
+        await update_recurring_event(str(ev_id), patch_body, ctx=ctx, db=db)
+        row = await db.get(RecurringEvent, ev_id)
+        assert row.repeat == "weekly"
+        assert row.next_post_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ") == new_time
+        await delete_recurring_event(str(ev_id), ctx=ctx, db=db)
+        row = await db.get(RecurringEvent, ev_id)
+        assert row is None
+        break
+
+
+async def _test_cleanup() -> None:
+    db_path = Path("test_recurring_cleanup.db")
+    await _setup_db(db_path)
+
+    async for db in get_session():
+        db.add(
+            RecurringEvent(
+                id=111,
+                guild_id=1,
+                channel_id=123,
+                repeat="daily",
+                next_post_at=datetime.utcnow() + timedelta(days=1),
+                payload_json="{}",
+            )
+        )
+        await db.commit()
+        break
+
+    repeat_events.discord_client = SimpleNamespace(get_channel=lambda _: None)
+    await process_recurring_events_once()
+    async for db in get_session():
+        assert (await db.get(RecurringEvent, 111)) is None
+        break
+
+    async for db in get_session():
+        db.add(
+            RecurringEvent(
+                id=222,
+                guild_id=1,
+                channel_id=123,
+                repeat="daily",
+                next_post_at=datetime.utcnow() + timedelta(days=1),
+                payload_json="{}",
+            )
+        )
+        await db.commit()
+        break
+
+    class DummyChannel:
+        async def fetch_message(self, _):
+            raise Exception()
+
+    repeat_events.discord_client = SimpleNamespace(get_channel=lambda _: DummyChannel())
+    await process_recurring_events_once()
+    async for db in get_session():
+        assert (await db.get(RecurringEvent, 222)) is None
+        break
+
+    repeat_events.discord_client = None
+
+
+def test_recurring_event_patch_delete() -> None:
+    asyncio.run(_test_patch_delete())
+
+
+def test_recurring_event_cleanup() -> None:
+    asyncio.run(_test_cleanup())


### PR DESCRIPTION
## Summary
- allow updating or cancelling event repeat schedules via new endpoints
- clean up missing recurring events and expose them in the event creation UI
- add regression tests for recurring event management

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4bab5090c83288d9fe3b9338b0e43