### PR TITLE
Validate API base URL before building requests

### DIFF
--- a/DemiCatPlugin/ApiHelpers.cs
+++ b/DemiCatPlugin/ApiHelpers.cs
@@ -1,12 +1,15 @@
+using System;
+
 namespace DemiCatPlugin;
 
 internal static class ApiHelpers
 {
     internal static bool ValidateApiBaseUrl(Config config)
     {
-        if (string.IsNullOrWhiteSpace(config.ApiBaseUrl))
+        if (!Uri.TryCreate(config.ApiBaseUrl, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
         {
-            PluginServices.Instance!.Log.Error("API base URL is not configured.");
+            PluginServices.Instance!.Log.Error($"Invalid API base URL: {config.ApiBaseUrl}");
             return false;
         }
         return true;

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -257,6 +257,12 @@ public class EventView : IDisposable
 
     public async Task SendInteraction(string customId)
     {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            _lastResult = "Signup failed";
+            return;
+        }
+
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/interactions");

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -57,7 +57,7 @@ public class FcChatWindow : ChatWindow
 
     protected override async Task SendMessage()
     {
-        if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
+        if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
         {
             return;
         }
@@ -92,6 +92,8 @@ public class FcChatWindow : ChatWindow
 
     private async Task RefreshUsers()
     {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
+
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -92,7 +92,7 @@ public class Plugin : IDalamudPlugin
 
     private async Task<bool> RefreshRoles(IPluginLog log)
     {
-        if (string.IsNullOrEmpty(_config.AuthToken))
+        if (string.IsNullOrEmpty(_config.AuthToken) || !ApiHelpers.ValidateApiBaseUrl(_config))
         {
             return false;
         }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -130,9 +130,8 @@ public class SettingsWindow : IDisposable
             return;
         }
 
-        if (string.IsNullOrEmpty(_config.ApiBaseUrl))
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
-            _log.Error("Cannot sync: API base URL is not configured.");
             _ = framework.RunOnTick(() => _syncStatus = "Network error");
             return;
         }

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -114,6 +114,8 @@ public class UiRenderer : IDisposable
 
     private async Task PollEmbeds()
     {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
+
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/embeds");
@@ -144,6 +146,11 @@ public class UiRenderer : IDisposable
     private async Task ConnectWebSocket()
     {
         if (_webSocket != null && _webSocket.State == WebSocketState.Open)
+        {
+            return;
+        }
+
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
             return;
         }
@@ -274,6 +281,8 @@ public class UiRenderer : IDisposable
 
     public async Task RefreshEmbeds()
     {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
+
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/embeds");


### PR DESCRIPTION
## Summary
- ensure ApiBaseUrl is a valid absolute http/https URI
- guard HTTP operations against invalid configuration

## Testing
- `pytest`
- `dotnet build` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bda8bf7c832899328a8a93677bfa