### PR TITLE
Handle StartNetworking asynchronously

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -17,7 +17,7 @@ public class SettingsWindow : IDisposable
     private readonly Config _config;
     private readonly HttpClient _httpClient;
     private readonly Func<Task<bool>> _refreshRoles;
-    private readonly Action _startNetworking;
+    private readonly Func<Task> _startNetworking;
     private readonly DeveloperWindow _devWindow;
     private readonly IPluginLog _log;
 
@@ -32,7 +32,7 @@ public class SettingsWindow : IDisposable
     public ChatWindow? ChatWindow { get; set; }
     public OfficerChatWindow? OfficerChatWindow { get; set; }
 
-    public SettingsWindow(Config config, HttpClient httpClient, Func<Task<bool>> refreshRoles, Action startNetworking, IPluginLog log, IDalamudPluginInterface pluginInterface)
+    public SettingsWindow(Config config, HttpClient httpClient, Func<Task<bool>> refreshRoles, Func<Task> startNetworking, IPluginLog log, IDalamudPluginInterface pluginInterface)
     {
         _config = config;
         _httpClient = httpClient;
@@ -193,7 +193,7 @@ public class SettingsWindow : IDisposable
                     _log.Warning("RefreshRoles delegate is not set; roles will not be refreshed.");
                 }
 
-                _startNetworking();
+                await _startNetworking();
                 if (MainWindow != null) MainWindow.ChannelsLoaded = false;
                 if (ChatWindow != null) ChatWindow.ChannelsLoaded = false;
                 if (OfficerChatWindow != null) OfficerChatWindow.ChannelsLoaded = false;

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -35,7 +35,7 @@ public class UiRenderer : IDisposable
 
         if (_config.Enabled && !string.IsNullOrEmpty(_config.AuthToken))
         {
-            StartNetworking();
+            _ = StartNetworking();
         }
     }
 
@@ -61,7 +61,7 @@ public class UiRenderer : IDisposable
         _pollCts = null;
     }
 
-    public void StartNetworking()
+    public async Task StartNetworking()
     {
         StopPolling();
 
@@ -71,7 +71,7 @@ public class UiRenderer : IDisposable
             {
                 if (_webSocket.State == WebSocketState.Open)
                 {
-                    _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).Wait();
+                    await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
                 }
             }
             catch


### PR DESCRIPTION
## Summary
- make StartNetworking async and await WebSocket.CloseAsync
- let SettingsWindow.Sync await networking restart and adjust delegate signatures

## Testing
- ⚠️ `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(missing .NET SDK 9.0)*
- ⚠️ `pytest` *(missing required Python packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c67b04d08328b64e1eebd660e320