### PR TITLE
Clarify fire-and-forget tasks

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -262,7 +262,7 @@ public class EventCreateWindow
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var roles = await JsonSerializer.DeserializeAsync<List<RoleDto>>(stream) ?? new List<RoleDto>();
-            PluginServices.Instance!.Framework.RunOnTick(() =>
+            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _roles.Clear();
                 _roles.AddRange(roles);
@@ -295,7 +295,7 @@ public class EventCreateWindow
             {
                 var stream = await response.Content.ReadAsStreamAsync();
                 var schedules = await JsonSerializer.DeserializeAsync<List<RepeatSchedule>>(stream) ?? new();
-                PluginServices.Instance!.Framework.RunOnTick(() =>
+                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
                 {
                     _schedules.Clear();
                     _schedules.AddRange(schedules);

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -70,7 +70,7 @@ public class SettingsWindow : IDisposable
                 {
                     _syncStatus = "Validating API key...";
                     _syncInProgress = true;
-                    Task.Run(async () =>
+                    _ = Task.Run(async () =>
                     {
                         try
                         {


### PR DESCRIPTION
## Summary
- prefix background sync invocation with `_ =`
- mark scheduled updates in event creation with `_ =` to note fire-and-forget

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4cea8797c83288f5738822567bafa