### PR TITLE
Ensure sync status updates are marshalled

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -119,7 +119,7 @@ public class SettingsWindow : IDisposable
         if (framework == null)
         {
             _log.Error("Cannot sync: framework is not available.");
-            _syncStatus = "Network error";
+            PluginServices.Instance?.Framework?.RunOnTick(() => _syncStatus = "Network error");
             return;
         }
 


### PR DESCRIPTION
## Summary
- Marshal network error status through RunOnTick when framework is null
- Remove direct background thread updates of _syncStatus

## Testing
- ⚠️ `dotnet build` (dotnet command not found)
- ⚠️ `pytest -q` (missing aiosqlite, aiomysql, trio dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68a4e1ccae708328a5eb93eb51d40ced