### PR TITLE
Sync Discord channel names and improve plugin fallbacks

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -175,6 +175,7 @@ public class ChatWindow : IDisposable
 
     public void SetChannels(List<ChannelDto> channels)
     {
+        ResolveChannelNames(channels);
         _channels.Clear();
         _channels.AddRange(channels);
         if (!string.IsNullOrEmpty(_channelId))
@@ -186,6 +187,18 @@ public class ChatWindow : IDisposable
         {
             _channelId = _channels[_selectedIndex].Id;
             _ = RefreshMessages();
+        }
+    }
+
+    protected void ResolveChannelNames(List<ChannelDto> channels)
+    {
+        foreach (var c in channels)
+        {
+            if (string.IsNullOrWhiteSpace(c.Name))
+            {
+                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}; using ID as fallback.");
+                c.Name = c.Id;
+            }
         }
     }
 
@@ -365,6 +378,7 @@ public class ChatWindow : IDisposable
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
+            ResolveChannelNames(dto.Chat);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Chat);

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -198,6 +198,10 @@ public class MainWindow : IDisposable
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
+            ResolveChannelNames(dto.Event);
+            ResolveChannelNames(dto.FcChat);
+            ResolveChannelNames(dto.OfficerChat);
+            ResolveChannelNames(dto.OfficerVisible);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();
@@ -232,6 +236,18 @@ public class MainWindow : IDisposable
             PluginServices.Instance!.Log.Error(ex, "Error fetching channels");
             _channelFetchFailed = true;
             _channelsLoaded = true;
+        }
+    }
+
+    private static void ResolveChannelNames(List<ChannelDto> channels)
+    {
+        foreach (var c in channels)
+        {
+            if (string.IsNullOrWhiteSpace(c.Name))
+            {
+                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}; using ID as fallback.");
+                c.Name = c.Id;
+            }
         }
     }
 

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -96,6 +96,7 @@ public class OfficerChatWindow : ChatWindow
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<OfficerChannelListDto>(stream) ?? new OfficerChannelListDto();
+            ResolveChannelNames(dto.Officer);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Officer);

--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .db.models import GuildChannel
+from .db.session import get_session
+from .http.discord_client import discord_client
+
+
+async def ensure_channel_name(
+    db: AsyncSession,
+    guild_id: int,
+    channel_id: int,
+    kind: str,
+    current_name: str | None = None,
+) -> str | None:
+    """Ensure the channel's name is stored in the database.
+
+    If ``current_name`` is falsy, the Discord API is queried for the channel's
+    name and the database is updated.  The resolved name is returned (or
+    ``None`` if it could not be resolved).
+    """
+
+    if current_name or not discord_client:
+        return current_name
+    channel = discord_client.get_channel(channel_id)
+    if channel is None:
+        try:
+            channel = await discord_client.fetch_channel(channel_id)  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - network errors
+            return None
+    if channel is None:
+        return None
+    name = channel.name
+    await db.execute(
+        update(GuildChannel)
+        .where(
+            GuildChannel.guild_id == guild_id,
+            GuildChannel.channel_id == channel_id,
+            GuildChannel.kind == kind,
+        )
+        .values(name=name)
+    )
+    return name
+
+
+async def resync_channel_names_once() -> None:
+    """Refresh channel names for all guilds once."""
+
+    async for db in get_session():
+        result = await db.execute(
+            select(
+                GuildChannel.guild_id,
+                GuildChannel.channel_id,
+                GuildChannel.kind,
+                GuildChannel.name,
+            )
+        )
+        updated = False
+        for guild_id, channel_id, kind, name in result.all():
+            new_name = await ensure_channel_name(db, guild_id, channel_id, kind, name)
+            if new_name and new_name != name:
+                updated = True
+        if updated:
+            await db.commit()
+        break
+
+
+SYNC_INTERVAL = 3600
+
+
+async def channel_name_resync() -> None:
+    """Background task to periodically resync channel names."""
+
+    while True:
+        try:
+            await resync_channel_names_once()
+        except Exception:  # pragma: no cover - best effort
+            logging.exception("Channel name resync failed")
+        await asyncio.sleep(SYNC_INTERVAL)

--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -16,7 +16,9 @@ from .config import ensure_config
 from .db.session import init_db
 from .discordbot.bot import create_bot
 from .http.api import create_app
+from .http.discord_client import set_discord_client
 from .repeat_events import recurring_event_poster
+from .channel_names import channel_name_resync
 
 
 async def main_async() -> None:
@@ -49,6 +51,7 @@ async def main_async() -> None:
     try:
         app = create_app(cfg)
         bot = create_bot(cfg)
+        set_discord_client(bot)
         config = uvicorn.Config(
             app, host=cfg.server.host, port=cfg.server.port, log_level="info"
         )
@@ -58,6 +61,7 @@ async def main_async() -> None:
             server.serve(),
             bot.start(cfg.discord_token),
             recurring_event_poster(),
+            channel_name_resync(),
         )
     except Exception:
         logging.exception("Failed to start services")


### PR DESCRIPTION
## Summary
- Resolve missing channel names via Discord API when `/api/channels` is requested
- Periodically resync channel names across guilds in background
- Warn and fall back to channel ID when name is empty in plugin windows

## Testing
- `pytest`
- ⚠️ `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4f8a9febc8328a175b692bc3de595