### PR TITLE
Embed presence sidebar in chat windows

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -32,6 +32,7 @@ public class ChatWindow : IDisposable
     protected string _input = string.Empty;
     protected bool _useCharacterName;
     protected string _statusMessage = string.Empty;
+    protected readonly PresenceSidebar _presence;
     private ClientWebSocket? _ws;
     private Task? _wsTask;
     private CancellationTokenSource? _wsCts;
@@ -57,10 +58,11 @@ public class ChatWindow : IDisposable
         set => _channelsLoaded = value;
     }
 
-    public ChatWindow(Config config, HttpClient httpClient)
+    public ChatWindow(Config config, HttpClient httpClient, PresenceSidebar presence)
     {
         _config = config;
         _httpClient = httpClient;
+        _presence = presence;
         _channelId = config.ChatChannelId;
         _useCharacterName = config.UseCharacterName;
     }
@@ -77,6 +79,13 @@ public class ChatWindow : IDisposable
         {
             _ = FetchChannels();
         }
+
+        ImGui.BeginChild("##presence", new Vector2(150, 0), true);
+        _presence.Draw();
+        ImGui.EndChild();
+        ImGui.SameLine();
+
+        ImGui.BeginChild("##chatArea", new Vector2(0, 0), false);
 
         if (_channels.Count > 0)
         {
@@ -171,6 +180,7 @@ public class ChatWindow : IDisposable
             ImGui.TextUnformatted(_statusMessage);
         }
 
+        ImGui.EndChild();
     }
 
     public void SetChannels(List<ChannelDto> channels)

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -14,7 +14,7 @@ public class FcChatWindow : ChatWindow
     private readonly List<UserDto> _users = new();
     private DateTime _lastUserFetch = DateTime.MinValue;
 
-    public FcChatWindow(Config config, HttpClient httpClient) : base(config, httpClient)
+    public FcChatWindow(Config config, HttpClient httpClient, PresenceSidebar presence) : base(config, httpClient, presence)
     {
         _channelId = config.FcChannelId;
     }

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -10,7 +10,7 @@ namespace DemiCatPlugin;
 
 public class OfficerChatWindow : ChatWindow
 {
-    public OfficerChatWindow(Config config, HttpClient httpClient) : base(config, httpClient)
+    public OfficerChatWindow(Config config, HttpClient httpClient, PresenceSidebar presence) : base(config, httpClient, presence)
     {
         _channelId = config.OfficerChannelId;
     }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -22,6 +22,7 @@ public class Plugin : IDalamudPlugin
     private readonly SettingsWindow _settings;
     private readonly ChatWindow _chatWindow;
     private readonly OfficerChatWindow _officerChatWindow;
+    private readonly PresenceSidebar _presenceSidebar;
     private readonly MainWindow _mainWindow;
     private Config _config;
     private readonly HttpClient _httpClient = new();
@@ -47,8 +48,9 @@ public class Plugin : IDalamudPlugin
 
         _ui = new UiRenderer(_config, _httpClient);
         _settings = new SettingsWindow(_config, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
-        _chatWindow = new FcChatWindow(_config, _httpClient);
-        _officerChatWindow = new OfficerChatWindow(_config, _httpClient);
+        _presenceSidebar = new PresenceSidebar(_config, _httpClient);
+        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceSidebar);
+        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceSidebar);
         _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);
         _settings.MainWindow = _mainWindow;
         _settings.ChatWindow = _chatWindow;
@@ -83,6 +85,7 @@ public class Plugin : IDalamudPlugin
         _services.PluginInterface.UiBuilder.OpenConfigUi -= _openConfigUi;
 
         _httpClient.Dispose();
+        _presenceSidebar.Dispose();
         _chatWindow.Dispose();
         _officerChatWindow.Dispose();
         _mainWindow.Dispose();

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -7,12 +7,11 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Numerics;
 using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
 
-public class PresencePane : IDisposable
+public class PresenceSidebar : IDisposable
 {
     private readonly Config _config;
     private readonly HttpClient _httpClient;
@@ -22,7 +21,7 @@ public class PresencePane : IDisposable
     private CancellationTokenSource? _wsCts;
     private bool _loaded;
 
-    public PresencePane(Config config, HttpClient httpClient)
+    public PresenceSidebar(Config config, HttpClient httpClient)
     {
         _config = config;
         _httpClient = httpClient;
@@ -40,7 +39,6 @@ public class PresencePane : IDisposable
             _ = Refresh();
         }
 
-        ImGui.BeginChild("PresenceList", new Vector2(150, 0), true);
         var online = _presences.Where(p => p.Status != "offline").OrderBy(p => p.Name).ToList();
         var offline = _presences.Where(p => p.Status == "offline").OrderBy(p => p.Name).ToList();
         ImGui.TextUnformatted($"Online - {online.Count}");
@@ -54,7 +52,6 @@ public class PresencePane : IDisposable
         {
             ImGui.TextUnformatted(p.Name);
         }
-        ImGui.EndChild();
     }
 
     public void Dispose()
@@ -179,3 +176,4 @@ public class PresencePane : IDisposable
         return builder.Uri;
     }
 }
+


### PR DESCRIPTION
## Summary
- Replace unused PresencePane with reusable PresenceSidebar
- Show presence list alongside chat and officer messages
- Wire plugin to share one PresenceSidebar instance

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -v minimal` *(fails: A compatible .NET SDK 9.0.100 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5012534888328bdbeda316256535a