### PR TITLE
Reset event and presence panes after syncing settings

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -58,6 +58,8 @@ public class ChatWindow : IDisposable
         set => _channelsLoaded = value;
     }
 
+    public PresenceSidebar Presence => _presence;
+
     public ChatWindow(Config config, HttpClient httpClient, PresenceSidebar presence)
     {
         _config = config;

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -17,6 +17,7 @@ public class MainWindow : IDisposable
 
     public bool IsOpen;
     public bool HasOfficerRole { get; set; }
+    public UiRenderer Ui => _ui;
 
     public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient)
     {

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -27,6 +27,16 @@ public class PresenceSidebar : IDisposable
         _httpClient = httpClient;
     }
 
+    public void Reset()
+    {
+        _loaded = false;
+        _wsCts?.Cancel();
+        _ws?.Dispose();
+        _ws = null;
+        _wsCts = new CancellationTokenSource();
+        _wsTask = RunWebSocket(_wsCts.Token);
+    }
+
     public void Draw()
     {
         if (_wsTask == null)

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -202,6 +202,8 @@ public class SettingsWindow : IDisposable
                 }
 
                 await _startNetworking();
+                MainWindow?.Ui.ResetChannels();
+                (ChatWindow?.Presence ?? OfficerChatWindow?.Presence)?.Reset();
                 if (ChatWindow != null) ChatWindow.ChannelsLoaded = false;
                 if (OfficerChatWindow != null) OfficerChatWindow.ChannelsLoaded = false;
                 _ = framework.RunOnTick(() => _syncStatus = rolesRefreshed ? "API key validated" : "Roles sync failed");

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -352,6 +352,12 @@ public class UiRenderer : IDisposable
         ImGui.EndChild();
     }
 
+    public void ResetChannels()
+    {
+        _channelsLoaded = false;
+        _channels.Clear();
+    }
+
     private void SaveConfig()
     {
         PluginServices.Instance!.PluginInterface.SavePluginConfig(_config);


### PR DESCRIPTION
## Summary
- add `ResetChannels` to `UiRenderer` to clear channel cache
- add `Reset` to `PresenceSidebar` to restart its WebSocket loop
- refresh event and presence panes during settings sync

## Testing
- `pytest`
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: A compatible .NET SDK version 9.0.100 was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5066c0e888328ac82bbca7a461654