### PR TITLE
Add explicit presence reload and defer loaded flag

### DIFF
--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -27,6 +27,12 @@ public class PresenceSidebar : IDisposable
         _httpClient = httpClient;
     }
 
+    public void Reload()
+    {
+        _loaded = false;
+        _presences.Clear();
+    }
+
     public void Reset()
     {
         _loaded = false;
@@ -74,7 +80,6 @@ public class PresenceSidebar : IDisposable
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
-            _loaded = true;
             return;
         }
         try
@@ -87,7 +92,6 @@ public class PresenceSidebar : IDisposable
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
-                _loaded = true;
                 return;
             }
             var stream = await response.Content.ReadAsStreamAsync();
@@ -97,14 +101,11 @@ public class PresenceSidebar : IDisposable
                 _presences.Clear();
                 _presences.AddRange(list);
             });
+            _loaded = true;
         }
         catch
         {
             // ignore
-        }
-        finally
-        {
-            _loaded = true;
         }
     }
 

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -203,7 +203,9 @@ public class SettingsWindow : IDisposable
 
                 await _startNetworking();
                 MainWindow?.Ui.ResetChannels();
-                (ChatWindow?.Presence ?? OfficerChatWindow?.Presence)?.Reset();
+                var presence = ChatWindow?.Presence ?? OfficerChatWindow?.Presence;
+                presence?.Reset();
+                presence?.Reload();
                 if (ChatWindow != null) ChatWindow.ChannelsLoaded = false;
                 if (OfficerChatWindow != null) OfficerChatWindow.ChannelsLoaded = false;
                 _ = framework.RunOnTick(() => _syncStatus = rolesRefreshed ? "API key validated" : "Roles sync failed");


### PR DESCRIPTION
## Summary
- Add `Reload()` to `PresenceSidebar` to clear presence list and reset loaded state
- Only mark presence as loaded when HTTP fetch succeeds
- Invoke presence reset and reload after successful sync to refresh data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a508e55c8083289ee747782166f6b3