### PR TITLE
Validate API base URL before WebSocket connect

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -410,6 +410,21 @@ public class ChatWindow : IDisposable
     {
         while (!token.IsCancellationRequested)
         {
+            if (!ApiHelpers.ValidateApiBaseUrl(_config))
+            {
+                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                    _statusMessage = "Invalid API base URL");
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5), token);
+                }
+                catch
+                {
+                    // ignore cancellation
+                }
+                continue;
+            }
+
             try
             {
                 _ws?.Dispose();


### PR DESCRIPTION
## Summary
- Validate API base URL before opening chat WebSocket and delay when missing or invalid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a50d01a3108328a291d5a695a87764