### PR TITLE
Add Markdown formatting support and tests

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -225,6 +225,8 @@ public class ChatWindow : IDisposable
             }
         }
         text = Regex.Replace(text, "<a?:([a-zA-Z0-9_]+):\\d+>", ":$1:");
+
+        text = MarkdownFormatter.Format(text);
         return text;
     }
 

--- a/DemiCatPlugin/MarkdownFormatter.cs
+++ b/DemiCatPlugin/MarkdownFormatter.cs
@@ -1,0 +1,15 @@
+using System.Text.RegularExpressions;
+
+namespace DemiCatPlugin;
+
+public static class MarkdownFormatter
+{
+    public static string Format(string text)
+    {
+        text = Regex.Replace(text, "\\[(.+?)\\]\\((.+?)\\)", m => $"[LINK={m.Groups[2].Value}]{m.Groups[1].Value}[/LINK]");
+        text = Regex.Replace(text, "\\*\\*(.+?)\\*\\*", m => $"[B]{m.Groups[1].Value}[/B]");
+        text = Regex.Replace(text, "\\*(.+?)\\*", m => $"[I]{m.Groups[1].Value}[/I]");
+        text = Regex.Replace(text, "__(.+?)__", m => $"[U]{m.Groups[1].Value}[/U]");
+        return text;
+    }
+}

--- a/tests/ChatWindowTests.cs
+++ b/tests/ChatWindowTests.cs
@@ -1,0 +1,16 @@
+using DemiCatPlugin;
+using Xunit;
+
+public class ChatWindowTests
+{
+    [Fact]
+    public void FormatContent_ConvertsMarkdownToImGuiTags()
+    {
+        var input = "Here is **bold**, *italic*, __underline__, and [link](https://example.com).";
+        var expected = "Here is [B]bold[/B], [I]italic[/I], [U]underline[/U], and [LINK=https://example.com]link[/LINK].";
+
+        var result = MarkdownFormatter.Format(input);
+
+        Assert.Equal(expected, result);
+    }
+}

--- a/tests/DemiCatPlugin.Tests.csproj
+++ b/tests/DemiCatPlugin.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../DemiCatPlugin/MarkdownFormatter.cs" Link="MarkdownFormatter.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- support bold, italic, underline, and link markdown in chat messages
- add MarkdownFormatter helper and unit tests

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a510065204832882c6d337bd9f3dce