### PR TITLE
Specify WebSocket paths for broadcasts

### DIFF
--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -86,6 +86,7 @@ class Mirror(commands.Cog):
                         json.dumps(dto.model_dump()),
                         guild_id,
                         officer_only=is_officer,
+                        path="/ws/embeds",
                     )
                     stored = True
                 if stored:
@@ -169,7 +170,10 @@ class Mirror(commands.Cog):
                 mentions=mentions or None,
             )
             await manager.broadcast_text(
-                json.dumps(dto.model_dump()), guild_id, officer_only=is_officer
+                json.dumps(dto.model_dump()),
+                guild_id,
+                officer_only=is_officer,
+                path="/ws/messages",
             )
             break
 

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -195,7 +195,10 @@ async def create_event(
         )
     ).scalar_one_or_none()
     await manager.broadcast_text(
-        json.dumps(dto.model_dump(mode="json")), ctx.guild.id, kind == "officer_chat"
+        json.dumps(dto.model_dump(mode="json")),
+        ctx.guild.id,
+        officer_only=kind == "officer_chat",
+        path="/ws/embeds",
     )
     return {"ok": True, "id": eid}
 

--- a/demibot/demibot/http/routes/interactions.py
+++ b/demibot/demibot/http/routes/interactions.py
@@ -126,7 +126,10 @@ async def post_interaction(
             )
         ).scalar_one_or_none()
         await manager.broadcast_text(
-            json.dumps(payload), embed.guild_id, kind == "officer_chat"
+            json.dumps(payload),
+            embed.guild_id,
+            officer_only=kind == "officer_chat",
+            path="/ws/embeds",
         )
 
     return {"ok": True}

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -102,7 +102,10 @@ async def post_message(
         content=msg.content_display,
     )
     await manager.broadcast_text(
-        json.dumps(dto.model_dump()), ctx.guild.id, officer_only=False
+        json.dumps(dto.model_dump()),
+        ctx.guild.id,
+        officer_only=False,
+        path="/ws/messages",
     )
 
     return {"ok": True, "id": str(discord_msg_id)}

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -106,7 +106,10 @@ async def post_officer_message(
         content=msg.content_display,
     )
     await manager.broadcast_text(
-        json.dumps(dto.model_dump()), ctx.guild.id, officer_only=True
+        json.dumps(dto.model_dump()),
+        ctx.guild.id,
+        officer_only=True,
+        path="/ws/messages",
     )
 
     return {"ok": True, "id": str(discord_msg_id)}


### PR DESCRIPTION
## Summary
- route chat messages and embeds to dedicated WebSocket endpoints
- broadcast event/interaction updates on the embeds socket
- ensure message endpoints, including officer chat, specify the messages socket

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5129e79308328a489c70bb7ce54e4