### PR TITLE
Log channel fetch failures and add channel refresh endpoint

### DIFF
--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -32,9 +32,11 @@ async def ensure_channel_name(
         try:
             channel = await discord_client.fetch_channel(channel_id)  # type: ignore[attr-defined]
         except Exception:  # pragma: no cover - network errors
-            return None
+            logging.warning("Failed to fetch channel %s", channel_id)
+            return str(channel_id)
     if channel is None:
-        return None
+        logging.warning("Channel %s not found", channel_id)
+        return str(channel_id)
     name = channel.name
     await db.execute(
         update(GuildChannel)

--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
@@ -33,9 +33,48 @@ async def get_channels(
         new_name = await ensure_channel_name(db, ctx.guild.id, channel_id, kind, name)
         if new_name and new_name != name:
             name = new_name
+            await db.execute(
+                update(GuildChannel)
+                .where(
+                    GuildChannel.guild_id == ctx.guild.id,
+                    GuildChannel.channel_id == channel_id,
+                    GuildChannel.kind == kind,
+                )
+                .values(name=name)
+            )
             updated = True
         by_kind.setdefault(kind, []).append({"id": str(channel_id), "name": name or ""})
     if updated:
         await db.commit()
         await manager.broadcast_text("update", ctx.guild.id, path="/ws/channels")
     return by_kind
+
+
+@router.post("/channels/refresh")
+async def refresh_channels(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(GuildChannel.kind, GuildChannel.channel_id, GuildChannel.name).where(
+            GuildChannel.guild_id == ctx.guild.id
+        )
+    )
+    updated = False
+    for kind, channel_id, name in result.all():
+        new_name = await ensure_channel_name(db, ctx.guild.id, channel_id, kind, name)
+        if new_name and new_name != name:
+            await db.execute(
+                update(GuildChannel)
+                .where(
+                    GuildChannel.guild_id == ctx.guild.id,
+                    GuildChannel.channel_id == channel_id,
+                    GuildChannel.kind == kind,
+                )
+                .values(name=new_name)
+            )
+            updated = True
+    if updated:
+        await db.commit()
+        await manager.broadcast_text("update", ctx.guild.id, path="/ws/channels")
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- warn and fall back to channel ID when Discord channel lookups fail
- persist fallback names and expose a manual `/api/channels/refresh` endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a51cd4419483289e247175a6610eb5