### PR TITLE
fix officer message websocket path

### DIFF
--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -109,7 +109,7 @@ async def post_officer_message(
         json.dumps(dto.model_dump()),
         ctx.guild.id,
         officer_only=True,
-        path="/ws/messages",
+        path="/ws/officer-messages",
     )
 
     return {"ok": True, "id": str(discord_msg_id)}


### PR DESCRIPTION
## Summary
- fix officer message broadcast path to `/ws/officer-messages`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a51dc886b883289e651086cbcdf26f