### PR TITLE
Remove stray terminator from dotnet workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,4 +30,3 @@ jobs:
               dotnet test "$proj" --no-build --configuration Release
             done
           fi
-        fi


### PR DESCRIPTION
## Summary
- fix dotnet workflow syntax by removing unneeded trailing `fi`

## Testing
- `dotnet --version` *(fails: command not found)*
- `pytest` *(fails: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68a51e02efe08328bf9441c8a89fa83a