### PR TITLE
Use Pydantic JSON serializer for officer messages

### DIFF
--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -106,7 +106,7 @@ async def post_officer_message(
         content=msg.content_display,
     )
     await manager.broadcast_text(
-        json.dumps(dto.model_dump()),
+        dto.model_dump_json(),
         ctx.guild.id,
         officer_only=True,
         path="/ws/officer-messages",


### PR DESCRIPTION
## Summary
- replace `json.dumps(dto.model_dump())` with `dto.model_dump_json()` in officer message broadcast

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a51e97dfd483288470d5ca40f2ac92