### PR TITLE
Skip invalid channels without names

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -188,6 +188,7 @@ public class ChatWindow : IDisposable
     public void SetChannels(List<ChannelDto> channels)
     {
         ResolveChannelNames(channels);
+        channels.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id);
         _channels.Clear();
         _channels.AddRange(channels);
         if (!string.IsNullOrEmpty(_channelId))

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -550,6 +550,7 @@ public class EventCreateWindow
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             ResolveChannelNames(dto.Event);
+            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -141,6 +141,7 @@ public class TemplatesWindow
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             ResolveChannelNames(dto.Event);
+            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -398,6 +398,7 @@ public class UiRenderer : IDisposable
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             ResolveChannelNames(dto.Event);
+            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();


### PR DESCRIPTION
## Summary
- ignore event channels whose name is missing or matches their ID
- ensure channel selection lists only display valid entries

## Testing
- `/root/.dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj`
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68a526d5ec688328a9a9fe81daf86586