### PR TITLE
Handle unresolved Discord channel names

### DIFF
--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -33,10 +33,10 @@ async def ensure_channel_name(
             channel = await discord_client.fetch_channel(channel_id)  # type: ignore[attr-defined]
         except Exception:  # pragma: no cover - network errors
             logging.warning("Failed to fetch channel %s", channel_id)
-            return str(channel_id)
+            return None
     if channel is None:
         logging.warning("Channel %s not found", channel_id)
-        return str(channel_id)
+        return None
     name = channel.name
     await db.execute(
         update(GuildChannel)
@@ -65,7 +65,7 @@ async def resync_channel_names_once() -> None:
         updated = False
         for guild_id, channel_id, kind, name in result.all():
             new_name = await ensure_channel_name(db, guild_id, channel_id, kind, name)
-            if new_name and new_name != name:
+            if new_name is not None and new_name != name:
                 updated = True
         if updated:
             await db.commit()

--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -31,7 +31,7 @@ async def get_channels(
     updated = False
     for kind, channel_id, name in result.all():
         new_name = await ensure_channel_name(db, ctx.guild.id, channel_id, kind, name)
-        if new_name and new_name != name:
+        if new_name is not None and new_name != name:
             name = new_name
             await db.execute(
                 update(GuildChannel)
@@ -63,7 +63,7 @@ async def refresh_channels(
     updated = False
     for kind, channel_id, name in result.all():
         new_name = await ensure_channel_name(db, ctx.guild.id, channel_id, kind, name)
-        if new_name and new_name != name:
+        if new_name is not None and new_name != name:
             await db.execute(
                 update(GuildChannel)
                 .where(


### PR DESCRIPTION
## Summary
- Return `None` from `ensure_channel_name` when Discord lookups fail
- Skip DB updates when channel names can't be resolved

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a52b16f87c83289125968ef12adb3b