### PR TITLE
Reset event create roles after settings sync

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -613,6 +613,13 @@ public class EventCreateWindow
         _presetName = string.Empty;
     }
 
+    public void ResetRoles()
+    {
+        _roles.Clear();
+        _rolesLoaded = false;
+        _roleFetchFailed = false;
+    }
+
     private void ResetDefaultButtons()
     {
         _buttons.Clear();

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -100,6 +100,11 @@ public class MainWindow : IDisposable
         ImGui.PopStyleColor(5);
     }
 
+    public void ResetEventCreateRoles()
+    {
+        _create.ResetRoles();
+    }
+
     private void SaveConfig()
     {
         PluginServices.Instance!.PluginInterface.SavePluginConfig(_config);

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -203,6 +203,7 @@ public class SettingsWindow : IDisposable
 
                 await _startNetworking();
                 MainWindow?.Ui.ResetChannels();
+                MainWindow?.ResetEventCreateRoles();
                 var presence = ChatWindow?.Presence ?? OfficerChatWindow?.Presence;
                 presence?.Reset();
                 presence?.Reload();


### PR DESCRIPTION
## Summary
- add ResetRoles() to EventCreateWindow to clear cached roles
- expose role reset via MainWindow and call it after successful settings sync

## Testing
- `pytest`
- `dotnet test` *(fails: A compatible .NET SDK was not found; requested 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_68a52cd7a1ec8328a64dd4b0dab8153d