### PR TITLE
Add signup option editor

### DIFF
--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -1,0 +1,80 @@
+using System;
+using Dalamud.Bindings.ImGui;
+using DiscordHelper;
+using System.Numerics;
+
+namespace DemiCatPlugin;
+
+public class SignupOptionEditor
+{
+    private bool _open;
+    private Template.TemplateButton _working = new();
+    private Action<Template.TemplateButton>? _onSave;
+
+    public void Open(Template.TemplateButton button, Action<Template.TemplateButton> onSave)
+    {
+        _working = new Template.TemplateButton
+        {
+            Tag = button.Tag,
+            Include = button.Include,
+            Label = button.Label,
+            Emoji = button.Emoji,
+            Style = button.Style,
+            MaxSignups = button.MaxSignups
+        };
+        _onSave = onSave;
+        _open = true;
+    }
+
+    public void Draw()
+    {
+        if (!_open) return;
+        ImGui.OpenPopup("Signup Option");
+        var open = _open;
+        if (ImGui.BeginPopupModal("Signup Option", ref open, ImGuiWindowFlags.AlwaysAutoResize))
+        {
+            ImGui.InputText("Tag", ref _working.Tag, 32);
+            ImGui.InputText("Label", ref _working.Label, 64);
+            ImGui.InputText("Emoji", ref _working.Emoji, 16);
+            var max = _working.MaxSignups ?? 0;
+            if (ImGui.InputInt("Max Signups", ref max))
+            {
+                _working.MaxSignups = max > 0 ? max : null;
+            }
+            var style = _working.Style.ToString();
+            if (ImGui.BeginCombo("Style", style))
+            {
+                foreach (ButtonStyle bs in Enum.GetValues<ButtonStyle>())
+                {
+                    if (bs == ButtonStyle.Link) continue;
+                    var sel = bs == _working.Style;
+                    if (ImGui.Selectable(bs.ToString(), sel)) _working.Style = bs;
+                    if (sel) ImGui.SetItemDefaultFocus();
+                }
+                ImGui.EndCombo();
+            }
+            if (ImGui.Button("Save"))
+            {
+                _onSave?.Invoke(new Template.TemplateButton
+                {
+                    Tag = _working.Tag,
+                    Include = _working.Include,
+                    Label = _working.Label,
+                    Emoji = _working.Emoji,
+                    Style = _working.Style,
+                    MaxSignups = _working.MaxSignups
+                });
+                _open = false;
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Cancel"))
+            {
+                _open = false;
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.EndPopup();
+        }
+        if (!open) _open = false;
+    }
+}

--- a/tests/test_signup_presets.py
+++ b/tests/test_signup_presets.py
@@ -36,11 +36,28 @@ async def _run_test() -> None:
         db.add(guild)
         await db.commit()
         ctx = SimpleNamespace(guild=guild)
-        body = SignupPresetBody(name="Raid", buttons=[{"tag": "yes", "label": "Yes"}])
+        body = SignupPresetBody(
+            name="Raid",
+            buttons=[{"tag": "yes", "label": "Yes", "emoji": "✅", "style": 3, "maxSignups": 5}],
+        )
         res = await create_signup_preset(body=body, ctx=ctx, db=db)
         pid = res["id"]
         presets = await list_signup_presets(ctx=ctx, db=db)
-        assert presets == [{"id": pid, "name": "Raid", "buttons": [{"tag": "yes", "label": "Yes"}]}]
+        assert presets == [
+            {
+                "id": pid,
+                "name": "Raid",
+                "buttons": [
+                    {
+                        "tag": "yes",
+                        "label": "Yes",
+                        "emoji": "✅",
+                        "style": 3,
+                        "maxSignups": 5,
+                    }
+                ],
+            }
+        ]
         await delete_signup_preset(preset_id=pid, ctx=ctx, db=db)
         presets = await list_signup_presets(ctx=ctx, db=db)
         assert presets == []


### PR DESCRIPTION
## Summary
- add SignupOptionEditor modal for customizing RSVP buttons
- integrate editor into EventCreateWindow to manage signup options
- verify backend saves complete signup option data

## Testing
- `dotnet --version` *(fails: SDK 9.0.100 not found)*
- `pytest tests/test_signup_presets.py`

------
https://chatgpt.com/codex/tasks/task_e_68a530d2c494832880b18ee455b111b8