### PR TITLE
Add Dalamud NuGet source to setup script

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -131,6 +131,14 @@ else
     install_dotnet
 fi
 
+if ! "$DOTNET_CMD" nuget list source | grep -q Dalamud; then
+    if [[ -n "${GITHUB_USERNAME:-}" && -n "${GITHUB_TOKEN:-}" ]]; then
+        "$DOTNET_CMD" nuget add source https://nuget.pkg.github.com/goatcorp/index.json --name Dalamud --username "$GITHUB_USERNAME" --password "$GITHUB_TOKEN" --store-password-in-clear-text
+    else
+        "$DOTNET_CMD" nuget add source https://nuget.pkg.github.com/goatcorp/index.json --name Dalamud
+    fi
+fi
+
 "$DOTNET_CMD" restore DemiCatPlugin/DemiCatPlugin.csproj
 "$DOTNET_CMD" build DemiCatPlugin/DemiCatPlugin.csproj -c Release
 


### PR DESCRIPTION
## Summary
- ensure Dalamud NuGet feed is configured before restoring the plugin

## Testing
- `bash -n scripts/setup_env.sh`
- `shellcheck scripts/setup_env.sh`
- `scripts/setup_env.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_68a535dcaed48328af63e69e00253a20