### PR TITLE
Run .NET tests during environment setup

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -144,6 +144,11 @@ fi
 "$DOTNET_CMD" restore DemiCatPlugin/DemiCatPlugin.csproj
 "$DOTNET_CMD" build DemiCatPlugin/DemiCatPlugin.csproj -c Release
 
+# Run .NET tests
+find tests -name '*Tests.csproj' -print0 | while IFS= read -r -d '' testproj; do
+    "$DOTNET_CMD" test "$testproj" --configuration Release --no-build
+done
+
 # -----------------------------
 # Optional tests
 # -----------------------------


### PR DESCRIPTION
## Summary
- Automatically run .NET test projects during environment setup

## Testing
- `shellcheck scripts/setup_env.sh`
- `bash scripts/setup_env.sh` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5365b848c8328a5703858731325ca