### PR TITLE
Add development requirements and setup installation

### DIFF
--- a/demibot/requirements-dev.txt
+++ b/demibot/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-anyio
+pytest-asyncio
+trio

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -112,6 +112,9 @@ if deps:
     subprocess.check_call(['pip', 'install', *deps])
 PY
 
+# Install development/test dependencies
+pip install -r demibot/requirements-dev.txt
+
 # -----------------------------
 # .NET SDK and plugin build
 # -----------------------------


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` with pytest and async plugins
- install dev requirements in `setup_env.sh`

## Testing
- `PYTHONPATH=demibot pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5373892448328b544cc56c2063b18