### PR TITLE
Use string IDs for roles

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -123,7 +123,7 @@ public class EventCreateWindow
                 ImGui.Text("Mention Roles");
                 foreach (var role in _roles)
                 {
-                    var roleId = role.Id.ToString();
+                    var roleId = role.Id;
                     var sel = _mentions.Contains(roleId);
                     if (ImGui.Checkbox($"{role.Name}##role{role.Id}", ref sel))
                     {

--- a/DemiCatPlugin/RoleDto.cs
+++ b/DemiCatPlugin/RoleDto.cs
@@ -4,7 +4,7 @@ namespace DemiCatPlugin;
 
 public class RoleDto
 {
-    [JsonPropertyName("id")] public ulong Id { get; set; }
+    [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
 }
 


### PR DESCRIPTION
## Summary
- store role identifiers as strings in RoleDto
- track role mentions using string IDs in event creation UI

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a539d98f5c8328ac2bd415ff1c3315