### PR TITLE
Handle empty API key during sync

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -156,6 +156,12 @@ public class SettingsWindow : IDisposable
         try
         {
             _apiKey = _apiKey.Trim();
+            if (string.IsNullOrWhiteSpace(_apiKey))
+            {
+                _ = framework.RunOnTick(() => _syncStatus = "API key required");
+                return;
+            }
+
             var key = _apiKey;
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/validate";
             var request = new HttpRequestMessage(HttpMethod.Post, url)


### PR DESCRIPTION
## Summary
- Prevent `Sync` from running when API key is missing

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found, requested 9.0.100)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a53e84642c832881566c654fc2b30a