### PR TITLE
Fix ImGui checkbox and text input handling

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -140,7 +140,9 @@ public class EventCreateWindow
         {
             var button = _buttons[i];
             ImGui.PushID(i);
-            ImGui.Checkbox("Include", ref button.Include);
+            var include = button.Include;
+            if (ImGui.Checkbox("Include", ref include))
+                button.Include = include;
             ImGui.SameLine();
             ImGui.TextUnformatted($"{button.Label} ({button.Tag})");
             ImGui.SameLine();

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -33,9 +33,15 @@ public class SignupOptionEditor
         var open = _open;
         if (ImGui.BeginPopupModal("Signup Option", ref open, ImGuiWindowFlags.AlwaysAutoResize))
         {
-            ImGui.InputText("Tag", ref _working.Tag, 32);
-            ImGui.InputText("Label", ref _working.Label, 64);
-            ImGui.InputText("Emoji", ref _working.Emoji, 16);
+            var tag = _working.Tag;
+            if (ImGui.InputText("Tag", ref tag, 32))
+                _working.Tag = tag;
+            var label = _working.Label;
+            if (ImGui.InputText("Label", ref label, 64))
+                _working.Label = label;
+            var emoji = _working.Emoji;
+            if (ImGui.InputText("Emoji", ref emoji, 16))
+                _working.Emoji = emoji;
             var max = _working.MaxSignups ?? 0;
             if (ImGui.InputInt("Max Signups", ref max))
             {


### PR DESCRIPTION
## Summary
- Fix Include checkbox to avoid modifying a local copy
- Copy signup option strings to local variables before InputText

## Testing
- `dotnet --version` *(fails: required SDK 9.0.100 not installed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a5420874e48328a8d0c0b862c032b6