### PR TITLE
Treat numeric channel names as missing

### DIFF
--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -20,12 +20,12 @@ async def ensure_channel_name(
 ) -> str | None:
     """Ensure the channel's name is stored in the database.
 
-    If ``current_name`` is falsy, the Discord API is queried for the channel's
-    name and the database is updated.  The resolved name is returned (or
-    ``None`` if it could not be resolved).
+    If ``current_name`` is falsy or composed solely of digits, the Discord API
+    is queried for the channel's name and the database is updated.  The
+    resolved name is returned (or ``None`` if it could not be resolved).
     """
 
-    if current_name or not discord_client:
+    if (current_name and not current_name.isdigit()) or not discord_client:
         return current_name
     channel = discord_client.get_channel(channel_id)
     if channel is None:

--- a/demibot/scripts/refresh_channels.py
+++ b/demibot/scripts/refresh_channels.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import select, update
+
+from demibot.config import ensure_config
+from demibot.db.models import GuildChannel
+from demibot.db.session import get_session, init_db
+
+
+async def _refresh() -> None:
+    cfg = ensure_config()
+    await init_db(cfg.database.url)
+    async for db in get_session():
+        result = await db.execute(
+            select(
+                GuildChannel.guild_id,
+                GuildChannel.channel_id,
+                GuildChannel.kind,
+                GuildChannel.name,
+            )
+        )
+        updated = False
+        for guild_id, channel_id, kind, name in result.all():
+            if name and name.isdigit():
+                await db.execute(
+                    update(GuildChannel)
+                    .where(
+                        GuildChannel.guild_id == guild_id,
+                        GuildChannel.channel_id == channel_id,
+                        GuildChannel.kind == kind,
+                    )
+                    .values(name=None)
+                )
+                updated = True
+        if updated:
+            await db.commit()
+        break
+
+
+if __name__ == "__main__":
+    asyncio.run(_refresh())


### PR DESCRIPTION
## Summary
- treat numeric channel names as missing and fetch from Discord
- add script to clear numeric channel names in the database

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -e demibot` *(fails: configuration error: `project.dependencies` must be array)*

------
https://chatgpt.com/codex/tasks/task_e_68a54683ed308328b26bd2151e0cc883