### PR TITLE
Improve channel lookup logging

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -209,7 +209,7 @@ public class ChatWindow : IDisposable
         {
             if (string.IsNullOrWhiteSpace(c.Name))
             {
-                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}; using ID as fallback.");
+                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
                 c.Name = c.Id;
             }
         }

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -599,7 +599,7 @@ public class EventCreateWindow
         {
             if (string.IsNullOrWhiteSpace(c.Name))
             {
-                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}; using ID as fallback.");
+                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
                 c.Name = c.Id;
             }
         }

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -173,7 +173,7 @@ public class TemplatesWindow
         {
             if (string.IsNullOrWhiteSpace(c.Name))
             {
-                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}; using ID as fallback.");
+                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
                 c.Name = c.Id;
             }
         }

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -430,7 +430,7 @@ public class UiRenderer : IDisposable
         {
             if (string.IsNullOrWhiteSpace(c.Name))
             {
-                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}; using ID as fallback.");
+                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
                 c.Name = c.Id;
             }
         }

--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -31,11 +31,16 @@ async def ensure_channel_name(
     if channel is None:
         try:
             channel = await discord_client.fetch_channel(channel_id)  # type: ignore[attr-defined]
-        except Exception:  # pragma: no cover - network errors
-            logging.warning("Failed to fetch channel %s", channel_id)
+        except Exception as exc:  # pragma: no cover - network errors
+            logging.warning(
+                "Failed to fetch channel %s in guild %s: %s",
+                channel_id,
+                guild_id,
+                exc,
+            )
             return None
     if channel is None:
-        logging.warning("Channel %s not found", channel_id)
+        logging.warning("Channel %s not found in guild %s", channel_id, guild_id)
         return None
     name = channel.name
     await db.execute(


### PR DESCRIPTION
## Summary
- log guild ID, channel ID, and error when channel lookup fails
- record channel IDs for blank names before exclusion/placeholder in plugin helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5abdf074c8328b77e77dfcdb66902