### PR TITLE
Skip unnamed channels and warn on missing channel data

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -191,7 +191,7 @@ public class ChatWindow : IDisposable
     public void SetChannels(List<ChannelDto> channels)
     {
         ResolveChannelNames(channels);
-        channels.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id);
+        channels.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name));
         _channels.Clear();
         _channels.AddRange(channels);
         if (!string.IsNullOrEmpty(_channelId))
@@ -213,7 +213,6 @@ public class ChatWindow : IDisposable
             if (string.IsNullOrWhiteSpace(c.Name))
             {
                 PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
-                c.Name = c.Id;
             }
         }
     }
@@ -407,7 +406,6 @@ public class ChatWindow : IDisposable
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
-            ResolveChannelNames(dto.Chat);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Chat);

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -567,7 +567,7 @@ public class EventCreateWindow
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             ResolveChannelNames(dto.Event);
-            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id);
+            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name));
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();
@@ -600,7 +600,6 @@ public class EventCreateWindow
             if (string.IsNullOrWhiteSpace(c.Name))
             {
                 PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
-                c.Name = c.Id;
             }
         }
     }

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -96,7 +96,6 @@ public class OfficerChatWindow : ChatWindow
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<OfficerChannelListDto>(stream) ?? new OfficerChannelListDto();
-            ResolveChannelNames(dto.Officer);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Officer);

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -141,7 +141,7 @@ public class TemplatesWindow
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             ResolveChannelNames(dto.Event);
-            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id);
+            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name));
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();
@@ -174,7 +174,6 @@ public class TemplatesWindow
             if (string.IsNullOrWhiteSpace(c.Name))
             {
                 PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
-                c.Name = c.Id;
             }
         }
     }

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -393,7 +393,7 @@ public class UiRenderer : IDisposable
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             ResolveChannelNames(dto.Event);
-            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id);
+            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name));
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();
@@ -426,7 +426,6 @@ public class UiRenderer : IDisposable
             if (string.IsNullOrWhiteSpace(c.Name))
             {
                 PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
-                c.Name = c.Id;
             }
         }
     }


### PR DESCRIPTION
## Summary
- skip channels without names and warn when a name lookup fails
- stop substituting channel ids for missing names across plugin windows

## Testing
- `pytest`
- `dotnet test tests/DemiCatPlugin.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a5b21c22e48328ad25e295eb8c5fdc