### PR TITLE
Reload signup presets after sync

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -14,6 +14,7 @@ public class MainWindow : IDisposable
     private readonly SettingsWindow _settings;
     private readonly EventCreateWindow _create;
     private readonly TemplatesWindow _templates;
+    private readonly HttpClient _httpClient;
 
     public bool IsOpen;
     public bool HasOfficerRole { get; set; }
@@ -26,6 +27,7 @@ public class MainWindow : IDisposable
         _chat = chat;
         _officer = officer;
         _settings = settings;
+        _httpClient = httpClient;
         _create = new EventCreateWindow(config, httpClient);
         _templates = new TemplatesWindow(config, httpClient);
     }
@@ -103,6 +105,12 @@ public class MainWindow : IDisposable
     public void ResetEventCreateRoles()
     {
         _create.ResetRoles();
+    }
+
+    public void ReloadSignupPresets()
+    {
+        SignupPresetService.Reset();
+        _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
     }
 
     private void SaveConfig()

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -185,9 +185,11 @@ public class SettingsWindow : IDisposable
                 if (response.IsSuccessStatusCode)
                 {
                     _log.Info("API key validated successfully.");
-                    _config.AuthToken = key;
-                    _apiKey = key;
+                    var newKey = key;
+                    _config.AuthToken = newKey;
+                    _apiKey = newKey;
                     SaveConfig();
+                    MainWindow?.ReloadSignupPresets();
 
                     if (_refreshRoles != null)
                     {

--- a/DemiCatPlugin/SignupPresetService.cs
+++ b/DemiCatPlugin/SignupPresetService.cs
@@ -13,6 +13,12 @@ internal static class SignupPresetService
 
     internal static IReadOnlyList<SignupPreset> Presets => _presets;
 
+    internal static void Reset()
+    {
+        _presets = new();
+        _loaded = false;
+    }
+
     internal static async Task EnsureLoaded(HttpClient httpClient, Config config)
     {
         if (!_loaded)


### PR DESCRIPTION
## Summary
- update auth token and reload signup presets after successful sync
- add cache reset for signup presets service

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5b784a2088328bea75464fc5abddb