### PR TITLE
Add .NET 9 CI workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,20 +13,11 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
-      - name: Restore .NET tools
-        if: ${{ hashFiles('**/dotnet-tools.json') != '' }}
-        run: dotnet tool restore
-      - name: Restore dependencies
+      - name: Restore
         run: dotnet restore DemiCatPlugin/DemiCatPlugin.csproj
       - name: Build
-        run: dotnet build DemiCatPlugin/DemiCatPlugin.csproj --configuration Release --no-restore
+        run: dotnet build DemiCatPlugin/DemiCatPlugin.csproj --configuration Release
       - name: Test
-        run: |
-          test_projects=$(find . -name '*Tests.csproj')
-          if [ -z "$test_projects" ]; then
-            echo 'No test projects found.'
-          else
-            for proj in $test_projects; do
-              dotnet test "$proj" --no-build --configuration Release
-            done
-          fi
+        if: ${{ hashFiles('**/*Tests.csproj') != '' }}
+        run: dotnet test tests --configuration Release
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow using .NET 9 to restore, build, and test the plugin

## Testing
- `dotnet restore DemiCatPlugin/DemiCatPlugin.csproj`
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj --configuration Release` (fails: Dalamud installation not found)
- `dotnet test tests --configuration Release`


------
https://chatgpt.com/codex/tasks/task_e_68a5b7b93d9883289e464fe74077cd98