### PR TITLE
Retry channel name resolution

### DIFF
--- a/tests/test_channel_name_retry.py
+++ b/tests/test_channel_name_retry.py
@@ -1,0 +1,93 @@
+import asyncio
+from pathlib import Path
+import logging
+
+from sqlalchemy import select
+
+from demibot import channel_names as cn
+from demibot.db.models import Guild, GuildChannel
+from demibot.db.session import init_db, get_session
+
+
+def _setup_db(path: str) -> None:
+    db_path = Path(path)
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    asyncio.run(init_db(url))
+
+    async def populate() -> None:
+        async for db in get_session():
+            guild = Guild(id=1, discord_guild_id=1, name="Test")
+            db.add(guild)
+            db.add(GuildChannel(guild_id=guild.id, channel_id=100, kind="event", name=None))
+            await db.commit()
+            break
+
+    asyncio.run(populate())
+
+
+def test_fetch_channel_updates_name():
+    _setup_db("test1.db")
+
+    class DummyChannel:
+        name = "resolved"
+
+    class DummyClient:
+        def get_channel(self, _):
+            return None
+
+        async def fetch_channel(self, _):
+            return DummyChannel()
+
+    cn.discord_client = DummyClient()
+
+    async def run() -> str | None:
+        async for db in get_session():
+            await cn.ensure_channel_name(db, 1, 100, "event", None)
+            row = (
+                await db.execute(
+                    select(GuildChannel).where(
+                        GuildChannel.guild_id == 1,
+                        GuildChannel.channel_id == 100,
+                        GuildChannel.kind == "event",
+                    )
+                )
+            ).scalar_one()
+            return row.name
+
+    name = asyncio.run(run())
+    assert name == "resolved"
+
+
+def test_retry_null_channel_names_logs_failure(caplog):
+    _setup_db("test2.db")
+
+    class DummyClient:
+        def get_channel(self, _):
+            return None
+
+        async def fetch_channel(self, _):
+            raise RuntimeError("boom")
+
+    cn.discord_client = DummyClient()
+    caplog.set_level(logging.WARNING)
+
+    asyncio.run(cn.retry_null_channel_names(max_attempts=2))
+
+    async def get_name() -> str | None:
+        async for db in get_session():
+            row = (
+                await db.execute(
+                    select(GuildChannel.name).where(
+                        GuildChannel.guild_id == 1,
+                        GuildChannel.channel_id == 100,
+                        GuildChannel.kind == "event",
+                    )
+                )
+            ).scalar_one()
+            return row
+
+    name = asyncio.run(get_name())
+    assert name is None
+    assert any("Channel name missing" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- commit channel names to the DB after fetching from Discord
- add retry loop for channels with missing names and log failures
- invoke retry after periodic channel name resync

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5babc639c83288ebc8d9108c269c0