### PR TITLE
Validate API URL before network calls

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -44,6 +44,7 @@ public class EventCreateWindow
     private readonly List<ChannelDto> _channels = new();
     private bool _channelsLoaded;
     private bool _channelFetchFailed;
+    private string _channelErrorMessage = string.Empty;
     private int _selectedIndex;
     private string _channelId = string.Empty;
 
@@ -74,7 +75,7 @@ public class EventCreateWindow
         }
         else
         {
-            ImGui.TextUnformatted(_channelFetchFailed ? "Failed to load channels" : "No channels available");
+            ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
         }
 
         ImGui.InputText("Title", ref _title, 256);
@@ -267,7 +268,7 @@ public class EventCreateWindow
             PluginServices.Instance!.Log.Warning("Cannot fetch roles: API base URL is not configured.");
             _rolesLoaded = true;
             _roleFetchFailed = true;
-            _roleErrorMessage = "Failed to load roles";
+            _roleErrorMessage = "Invalid API URL";
             return;
         }
         try
@@ -313,7 +314,9 @@ public class EventCreateWindow
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
+            PluginServices.Instance!.Log.Warning("Cannot fetch schedules: API base URL is not configured.");
             _schedulesLoaded = true;
+            _lastResult = "Invalid API URL";
             return;
         }
         try
@@ -338,11 +341,13 @@ public class EventCreateWindow
             else
             {
                 _schedulesLoaded = true;
+                _lastResult = "Failed to load schedules";
             }
         }
         catch
         {
             _schedulesLoaded = true;
+            _lastResult = "Failed to load schedules";
         }
     }
 
@@ -544,6 +549,7 @@ public class EventCreateWindow
         {
             PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
             _channelFetchFailed = true;
+            _channelErrorMessage = "Invalid API URL";
             _channelsLoaded = true;
             return;
         }
@@ -561,6 +567,7 @@ public class EventCreateWindow
                 var responseBody = await response.Content.ReadAsStringAsync();
                 PluginServices.Instance!.Log.Warning($"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}");
                 _channelFetchFailed = true;
+                _channelErrorMessage = "Failed to load channels";
                 _channelsLoaded = true;
                 return;
             }
@@ -583,12 +590,14 @@ public class EventCreateWindow
                 }
                 _channelsLoaded = true;
                 _channelFetchFailed = false;
+                _channelErrorMessage = string.Empty;
             });
         }
         catch (Exception ex)
         {
             PluginServices.Instance!.Log.Error(ex, "Error fetching channels");
             _channelFetchFailed = true;
+            _channelErrorMessage = "Failed to load channels";
             _channelsLoaded = true;
         }
     }

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -261,7 +261,8 @@ public class EventView : IDisposable
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
-            _lastResult = "Signup failed";
+            PluginServices.Instance!.Log.Warning("Cannot send interaction: API base URL is not configured.");
+            _lastResult = "Invalid API URL";
             return;
         }
 

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -57,7 +57,13 @@ public class FcChatWindow : ChatWindow
 
     protected override async Task SendMessage()
     {
-        if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            PluginServices.Instance!.Log.Warning("Cannot send message: API base URL is not configured.");
+            _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = "Invalid API URL");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
         {
             return;
         }

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -30,7 +30,13 @@ public class OfficerChatWindow : ChatWindow
 
     protected override async Task SendMessage()
     {
-        if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            PluginServices.Instance!.Log.Warning("Cannot send message: API base URL is not configured.");
+            _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = "Invalid API URL");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(_channelId) || string.IsNullOrWhiteSpace(_input))
         {
             return;
         }
@@ -74,6 +80,7 @@ public class OfficerChatWindow : ChatWindow
         {
             PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
             _channelFetchFailed = true;
+            _channelErrorMessage = "Invalid API URL";
             _channelsLoaded = true;
             return;
         }
@@ -91,6 +98,7 @@ public class OfficerChatWindow : ChatWindow
                 var responseBody = await response.Content.ReadAsStringAsync();
                 PluginServices.Instance!.Log.Warning($"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}");
                 _channelFetchFailed = true;
+                _channelErrorMessage = "Failed to load channels";
                 _channelsLoaded = true;
                 return;
             }
@@ -101,12 +109,14 @@ public class OfficerChatWindow : ChatWindow
                 SetChannels(dto.Officer);
                 _channelsLoaded = true;
                 _channelFetchFailed = false;
+                _channelErrorMessage = string.Empty;
             });
         }
         catch (Exception ex)
         {
             PluginServices.Instance!.Log.Error(ex, "Error fetching channels");
             _channelFetchFailed = true;
+            _channelErrorMessage = "Failed to load channels";
             _channelsLoaded = true;
         }
     }

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -87,6 +87,8 @@ public class PresenceSidebar : IDisposable
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
+            PluginServices.Instance!.Log.Warning("Cannot refresh presences: API base URL is not configured.");
+            _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = "Invalid API URL");
             return;
         }
         try
@@ -123,7 +125,7 @@ public class PresenceSidebar : IDisposable
             if (!ApiHelpers.ValidateApiBaseUrl(_config))
             {
                 _ = PluginServices.Instance!.Framework.RunOnTick(() =>
-                    _statusMessage = "Invalid API base URL");
+                    _statusMessage = "Invalid API URL");
                 try
                 {
                     await Task.Delay(TimeSpan.FromSeconds(5), token);

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -23,6 +23,7 @@ public class TemplatesWindow
     private readonly List<ChannelDto> _channels = new();
     private bool _channelsLoaded;
     private bool _channelFetchFailed;
+    private string _channelErrorMessage = string.Empty;
     private int _channelIndex;
     private string _channelId = string.Empty;
 
@@ -51,7 +52,7 @@ public class TemplatesWindow
         }
         else
         {
-            ImGui.TextUnformatted(_channelFetchFailed ? "Failed to load channels" : "No channels available");
+            ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
         }
 
         _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
@@ -118,6 +119,7 @@ public class TemplatesWindow
         {
             PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
             _channelFetchFailed = true;
+            _channelErrorMessage = "Invalid API URL";
             _channelsLoaded = true;
             return;
         }
@@ -135,6 +137,7 @@ public class TemplatesWindow
                 var responseBody = await response.Content.ReadAsStringAsync();
                 PluginServices.Instance!.Log.Warning($"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}");
                 _channelFetchFailed = true;
+                _channelErrorMessage = "Failed to load channels";
                 _channelsLoaded = true;
                 return;
             }
@@ -157,12 +160,14 @@ public class TemplatesWindow
                 }
                 _channelsLoaded = true;
                 _channelFetchFailed = false;
+                _channelErrorMessage = string.Empty;
             });
         }
         catch (Exception ex)
         {
             PluginServices.Instance!.Log.Error(ex, "Error fetching channels");
             _channelFetchFailed = true;
+            _channelErrorMessage = "Failed to load channels";
             _channelsLoaded = true;
         }
     }

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -28,6 +28,7 @@ public class UiRenderer : IDisposable
     private readonly List<ChannelDto> _channels = new();
     private bool _channelsLoaded;
     private bool _channelFetchFailed;
+    private string _channelErrorMessage = string.Empty;
     private int _selectedIndex;
     private readonly SemaphoreSlim _connectGate = new(1, 1);
 
@@ -327,7 +328,7 @@ public class UiRenderer : IDisposable
         }
         else
         {
-            ImGui.TextUnformatted(_channelFetchFailed ? "Failed to load channels" : "No channels available");
+            ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
         }
 
         List<EventView> embeds;
@@ -370,6 +371,7 @@ public class UiRenderer : IDisposable
         {
             PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
             _channelFetchFailed = true;
+            _channelErrorMessage = "Invalid API URL";
             _channelsLoaded = true;
             return;
         }
@@ -387,6 +389,7 @@ public class UiRenderer : IDisposable
                 var responseBody = await response.Content.ReadAsStringAsync();
                 PluginServices.Instance!.Log.Warning($"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}");
                 _channelFetchFailed = true;
+                _channelErrorMessage = "Failed to load channels";
                 _channelsLoaded = true;
                 return;
             }
@@ -409,12 +412,14 @@ public class UiRenderer : IDisposable
                 }
                 _channelsLoaded = true;
                 _channelFetchFailed = false;
+                _channelErrorMessage = string.Empty;
             });
         }
         catch (Exception ex)
         {
             PluginServices.Instance!.Log.Error(ex, "Error fetching channels");
             _channelFetchFailed = true;
+            _channelErrorMessage = "Failed to load channels";
             _channelsLoaded = true;
         }
     }


### PR DESCRIPTION
## Summary
- abort message sending when API URL invalid and warn user
- propagate API URL validation to channel and role fetches with error hints
- surface "Invalid API URL" status in sidebar and windows

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found: Requested SDK version: 9.0.100)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'sqlalchemy', 'fastapi', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a5be76a91083288a5157929ba4b196