### PR TITLE
Use async disposal for UiRenderer

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -88,7 +88,7 @@ public class Plugin : IDalamudPlugin
         _chatWindow.Dispose();
         _officerChatWindow.Dispose();
         _mainWindow.Dispose();
-        _ui.Dispose();
+        _ui.DisposeAsync().GetAwaiter().GetResult();
         _channelWatcher.Dispose();
         _settings.Dispose();
     }

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -15,7 +15,7 @@ using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
 
-public class UiRenderer : IDisposable
+public class UiRenderer : IAsyncDisposable, IDisposable
 {
     private readonly HttpClient _httpClient;
     private readonly Config _config;
@@ -440,7 +440,7 @@ public class UiRenderer : IDisposable
         [JsonPropertyName("event")] public List<ChannelDto> Event { get; set; } = new();
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         StopPolling();
         if (_webSocket != null)
@@ -449,7 +449,7 @@ public class UiRenderer : IDisposable
             {
                 if (_webSocket.State == WebSocketState.Open)
                 {
-                    _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).Wait();
+                    await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
                 }
             }
             catch
@@ -471,6 +471,11 @@ public class UiRenderer : IDisposable
         {
             view.Dispose();
         }
+    }
+
+    public void Dispose()
+    {
+        DisposeAsync().GetAwaiter().GetResult();
     }
 }
 


### PR DESCRIPTION
## Summary
- implement `IAsyncDisposable` for `UiRenderer` and await websocket closure
- call `DisposeAsync` from plugin shutdown path

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a5c1c500488328b3031a8be7066276