### PR TITLE
Run backend tests in CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,4 +20,14 @@ jobs:
       - name: Test
         if: ${{ hashFiles('**/*Tests.csproj') != '' }}
         run: dotnet test tests --configuration Release
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run backend tests
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r demibot/requirements-dev.txt
+          pytest
 


### PR DESCRIPTION
## Summary
- run Python backend tests after .NET tests in CI
- set up Python 3.11 for backend tests

## Testing
- `~/dotnet/dotnet build DemiCatPlugin/DemiCatPlugin.csproj --configuration Release` *(fails: Dalamud installation not found)*
- `pytest` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a5cab1193883288ceab888c8403377