### PR TITLE
Ensure only latest API key remains valid

### DIFF
--- a/demibot/demibot/discordbot/cogs/keygen.py
+++ b/demibot/demibot/discordbot/cogs/keygen.py
@@ -104,6 +104,12 @@ async def key_command(interaction: discord.Interaction) -> None:
             for r in member_roles:
                 role_id, _ = role_map[r.id]
                 db.add(MembershipRole(membership_id=membership.id, role_id=role_id))
+            await db.execute(
+                delete(UserKey).where(
+                    UserKey.user_id == user.id,
+                    UserKey.guild_id == guild.id,
+                )
+            )
 
             db.add(
                 UserKey(


### PR DESCRIPTION
## Summary
- purge existing API keys for the requesting user and guild
- commit transaction after inserting new key so previous tokens are invalidated

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a67734121c8328abbb5bd2baebed64