### PR TITLE
Skip unresolved channels without placeholders

### DIFF
--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -56,9 +56,7 @@ async def get_channels(
                 kind,
                 ctx.guild.id,
             )
-            by_kind.setdefault(kind, []).append(
-                {"id": str(channel_id), "name": str(channel_id)}
-            )
+            by_kind.setdefault(kind, [])
             if name is not None:
                 await db.execute(
                     update(GuildChannel)
@@ -110,6 +108,17 @@ async def refresh_channels(
                 kind,
                 ctx.guild.id,
             )
+            if name is not None:
+                await db.execute(
+                    update(GuildChannel)
+                    .where(
+                        GuildChannel.guild_id == ctx.guild.id,
+                        GuildChannel.channel_id == channel_id,
+                        GuildChannel.kind == kind,
+                    )
+                    .values(name=None)
+                )
+                updated = True
             continue
         if new_name != name:
             await db.execute(


### PR DESCRIPTION
## Summary
- omit unresolved channels instead of returning numeric placeholders
- clear unresolved names during refresh to avoid persisting placeholders

## Testing
- `python -m py_compile demibot/demibot/http/routes/channels.py`
- `pytest` *(fails: No module named 'sqlalchemy', 'discord', 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68a6836ab2d88328b908121123aea398