### PR TITLE
Filter invalid channel names before populating dropdowns

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -192,7 +192,7 @@ public class ChatWindow : IDisposable
     public void SetChannels(List<ChannelDto> channels)
     {
         ResolveChannelNames(channels);
-        channels.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name));
+        channels.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit));
         _channels.Clear();
         _channels.AddRange(channels);
         if (!string.IsNullOrEmpty(_channelId))
@@ -211,9 +211,10 @@ public class ChatWindow : IDisposable
     {
         foreach (var c in channels)
         {
-            if (string.IsNullOrWhiteSpace(c.Name))
+            if (string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit))
             {
-                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
+                PluginServices.Instance!.Log.Warning($"Channel name missing or invalid for {c.Id}.");
+                continue;
             }
         }
     }

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -580,7 +580,7 @@ public class EventCreateWindow
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             ResolveChannelNames(dto.Event);
-            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name));
+            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit));
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();
@@ -615,9 +615,10 @@ public class EventCreateWindow
     {
         foreach (var c in channels)
         {
-            if (string.IsNullOrWhiteSpace(c.Name))
+            if (string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit))
             {
-                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
+                PluginServices.Instance!.Log.Warning($"Channel name missing or invalid for {c.Id}.");
+                continue;
             }
         }
     }

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -150,7 +150,7 @@ public class TemplatesWindow
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             ResolveChannelNames(dto.Event);
-            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name));
+            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit));
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();
@@ -185,9 +185,10 @@ public class TemplatesWindow
     {
         foreach (var c in channels)
         {
-            if (string.IsNullOrWhiteSpace(c.Name))
+            if (string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit))
             {
-                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
+                PluginServices.Instance!.Log.Warning($"Channel name missing or invalid for {c.Id}.");
+                continue;
             }
         }
     }

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -402,7 +402,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
             ResolveChannelNames(dto.Event);
-            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name));
+            dto.Event.RemoveAll(c => string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit));
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();
@@ -437,9 +437,10 @@ public class UiRenderer : IAsyncDisposable, IDisposable
     {
         foreach (var c in channels)
         {
-            if (string.IsNullOrWhiteSpace(c.Name))
+            if (string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit))
             {
-                PluginServices.Instance!.Log.Warning($"Channel name missing for {c.Id}.");
+                PluginServices.Instance!.Log.Warning($"Channel name missing or invalid for {c.Id}.");
+                continue;
             }
         }
     }


### PR DESCRIPTION
## Summary
- warn and skip channels with missing or placeholder names
- ensure channel dropdowns only show valid Discord names

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: .NET SDK 9.0 not installed)*
- `pytest` *(fails: tests/test_channels_endpoint.py::test_get_channels_returns_placeholder_and_flags_retry - IndexError: list index out of range)*

------
https://chatgpt.com/codex/tasks/task_e_68a684ee6d388328801d7a16e60c864a