### PR TITLE
Mirror Apollo buttons and persist

### DIFF
--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -183,7 +183,7 @@ public class EventView : IDisposable
             {
                 var id = button.CustomId ?? button.Label;
                 var text = string.IsNullOrEmpty(button.Emoji) ? button.Label : $"{button.Emoji} {button.Label}";
-                var styled = button.Style.HasValue;
+                var styled = button.Style.HasValue && button.Style.Value != ButtonStyle.Link;
                 if (styled)
                 {
                     var color = GetStyleColor(button.Style!.Value);
@@ -193,7 +193,14 @@ public class EventView : IDisposable
                 }
                 if (ImGui.Button($"{text}##{id}{_dto.Id}", new Vector2(-1, 0)))
                 {
-                    _ = SendInteraction(id);
+                    if (!string.IsNullOrEmpty(button.Url))
+                    {
+                        try { Process.Start(new ProcessStartInfo(button.Url) { UseShellExecute = true }); } catch { }
+                    }
+                    else if (!string.IsNullOrEmpty(button.CustomId))
+                    {
+                        _ = SendInteraction(button.CustomId);
+                    }
                 }
                 if (styled)
                 {

--- a/demibot/demibot/db/migrations/versions/0010_add_buttons_json_to_embeds.py
+++ b/demibot/demibot/db/migrations/versions/0010_add_buttons_json_to_embeds.py
@@ -1,0 +1,34 @@
+import json
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0010_add_buttons_json_to_embeds"
+down_revision = "0009_add_event_buttons"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("embeds", sa.Column("buttons_json", sa.Text(), nullable=True))
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text("SELECT discord_message_id, payload_json FROM embeds")
+    ).fetchall()
+    for message_id, payload_json in rows:
+        try:
+            payload = json.loads(payload_json)
+        except Exception:
+            continue
+        buttons = payload.get("buttons")
+        if buttons:
+            conn.execute(
+                sa.text(
+                    "UPDATE embeds SET buttons_json = :bj WHERE discord_message_id = :mid"
+                ),
+                {"bj": json.dumps(buttons), "mid": message_id},
+            )
+
+
+def downgrade() -> None:
+    op.drop_column("embeds", "buttons_json")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -140,6 +140,7 @@ class Embed(Base):
     channel_id: Mapped[int] = mapped_column(BigInteger, index=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
     payload_json: Mapped[str] = mapped_column(Text)
+    buttons_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     source: Mapped[str] = mapped_column(String(16))
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(

--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -56,7 +56,9 @@ async def get_channels(
                 kind,
                 ctx.guild.id,
             )
-            by_kind.setdefault(kind, [])
+            by_kind.setdefault(kind, []).append(
+                {"id": str(channel_id), "name": str(channel_id)}
+            )
             if name is not None:
                 await db.execute(
                     update(GuildChannel)

--- a/demibot/demibot/http/routes/embeds.py
+++ b/demibot/demibot/http/routes/embeds.py
@@ -29,6 +29,11 @@ async def get_embeds(
         payload = json.loads(e.payload_json)
         if not payload.get("channelId"):
             payload["channelId"] = e.channel_id
+        if e.buttons_json and not payload.get("buttons"):
+            try:
+                payload["buttons"] = json.loads(e.buttons_json)
+            except Exception:
+                pass
         payload["guildId"] = e.guild_id
         embeds.append(payload)
     return embeds

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -153,6 +153,9 @@ async def create_event(
             channel_id=channel_id,
             guild_id=ctx.guild.id,
             payload_json=json.dumps(dto.model_dump(mode="json")),
+            buttons_json=json.dumps([b.model_dump(mode="json") for b in buttons])
+            if buttons
+            else None,
             source="demibot",
         )
     )

--- a/tests/test_apollo_embed.py
+++ b/tests/test_apollo_embed.py
@@ -1,4 +1,3 @@
-import json
 from types import SimpleNamespace
 
 import sys
@@ -56,6 +55,15 @@ class DummyMessage:
         self.content = ""
         self.mentions = []
         self.embeds = [embed]
+        btn = SimpleNamespace(
+            type=2,
+            custom_id="rsvp:yes",
+            label="Yes",
+            style=1,
+            emoji=None,
+        )
+        row = SimpleNamespace(children=[btn])
+        self.components = [row]
 async def _run_test() -> None:
     db_path = Path("test.db")
     if db_path.exists():
@@ -86,11 +94,13 @@ async def _run_test() -> None:
             )
         ).scalar_one()
         assert row.source == "apollo"
+        assert row.buttons_json is not None
         ctx = SimpleNamespace(guild=SimpleNamespace(id=1), roles=["officer"])
         result = await get_embeds(ctx=ctx, db=db)
         assert result and result[0]["id"] == str(msg.id)
         assert result[0]["guildId"] == 1
         assert result[0]["channelId"] == 123
+        assert result[0]["buttons"][0]["customId"] == "rsvp:yes"
         break
 
 


### PR DESCRIPTION
## Summary
- capture buttons from Apollo embeds
- persist and expose serialized embed buttons
- open links and handle styling for embed buttons

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6892da1c08328a4cd4318032e232c