### PR TITLE
Sync guild channels on startup

### DIFF
--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import discord
 from discord.ext import commands
 from sqlalchemy import select
 
-from ...db.models import Embed, GuildChannel, Message
+from ...db.models import Embed, Guild, GuildChannel, Message
 from ...db.session import get_session, init_db
 from ...http.schemas import (
     ChatMessage,
@@ -20,11 +21,83 @@ from ...http.schemas import (
 from ...http.ws import manager
 
 
+CHANNEL_SYNC_INTERVAL = 3600
+
+
 class Mirror(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         # Ensure the database engine is available for this cog
         asyncio.create_task(init_db(bot.cfg.database.url))
+        asyncio.create_task(self._sync_guild_channels_once())
+        self._sync_task = asyncio.create_task(self._channel_sync_loop())
+
+    async def _sync_guild_channels_once(self) -> None:
+        if hasattr(self.bot, "wait_until_ready"):
+            await self.bot.wait_until_ready()
+        await self._reconcile_channels()
+
+    async def _channel_sync_loop(self) -> None:
+        if hasattr(self.bot, "wait_until_ready"):
+            await self.bot.wait_until_ready()
+        while True:
+            try:
+                await self._reconcile_channels()
+            except Exception:
+                logging.exception("Guild channel sync failed")
+            await asyncio.sleep(CHANNEL_SYNC_INTERVAL)
+
+    async def _reconcile_channels(self) -> None:
+        async for db in get_session():
+            for guild in self.bot.guilds:
+                result = await db.execute(
+                    select(Guild).where(Guild.discord_guild_id == guild.id)
+                )
+                db_guild = result.scalar_one_or_none()
+                if db_guild is None:
+                    db_guild = Guild(discord_guild_id=guild.id, name=guild.name)
+                    db.add(db_guild)
+                    await db.flush()
+                elif db_guild.name != guild.name:
+                    db_guild.name = guild.name
+
+                existing = {
+                    row.channel_id: row
+                    for row in (
+                        await db.execute(
+                            select(GuildChannel).where(
+                                GuildChannel.guild_id == db_guild.id
+                            )
+                        )
+                    ).scalars()
+                }
+
+                try:
+                    channels = await guild.fetch_channels()
+                except Exception:
+                    logging.exception("Failed to fetch channels for guild %s", guild.id)
+                    continue
+
+                for ch in channels:
+                    if not hasattr(ch, "name"):
+                        continue
+                    existing_row = existing.get(ch.id)
+                    if existing_row is None:
+                        db.add(
+                            GuildChannel(
+                                guild_id=db_guild.id,
+                                channel_id=ch.id,
+                                kind="chat",
+                                name=ch.name,
+                            )
+                        )
+                    elif existing_row.name != ch.name:
+                        existing_row.name = ch.name
+            await db.commit()
+            break
+
+    def cog_unload(self) -> None:
+        self._sync_task.cancel()
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:


### PR DESCRIPTION
## Summary
- Fetch guild channel list on cog startup, adding new channels and updating names
- Periodically resync guild channel mappings to stay current with Discord changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a701f978208328bd28f98264d3825d