### PR TITLE
Ensure RunOnTick errors are properly handled

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -130,7 +130,8 @@ public class SettingsWindow : IDisposable
             if (framework == null)
             {
                 _log.Error("Cannot sync: framework is not available.");
-                framework?.RunOnTick(() => _syncStatus = "Network error");
+                if (framework != null)
+                    _ = framework.RunOnTick(() => _syncStatus = "Network error");
                 return;
             }
 


### PR DESCRIPTION
## Summary
- explicitly discard RunOnTick task when framework is available to avoid compiler warnings

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: could not resolve Dalamud assemblies)*
- `dotnet test tests/DemiCatPlugin.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a706ade9848328a4d6297bc276d788