### PR TITLE
Batch channel name DB commits

### DIFF
--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -89,7 +89,6 @@ async def ensure_channel_name(
         )
         .values(name=name)
     )
-    await db.commit()
     return name
 
 

--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -73,15 +73,6 @@ async def get_channels(
             continue
         if new_name != name:
             name = new_name
-            await db.execute(
-                update(GuildChannel)
-                .where(
-                    GuildChannel.guild_id == ctx.guild.id,
-                    GuildChannel.channel_id == channel_id,
-                    GuildChannel.kind == kind,
-                )
-                .values(name=name)
-            )
             updated = True
         by_kind.setdefault(kind, []).append({"id": str(channel_id), "name": name})
     if updated:
@@ -123,15 +114,6 @@ async def refresh_channels(
                 updated = True
             continue
         if new_name != name:
-            await db.execute(
-                update(GuildChannel)
-                .where(
-                    GuildChannel.guild_id == ctx.guild.id,
-                    GuildChannel.channel_id == channel_id,
-                    GuildChannel.kind == kind,
-                )
-                .values(name=new_name)
-            )
             updated = True
     if updated:
         await db.commit()


### PR DESCRIPTION
## Summary
- stop committing inside `ensure_channel_name`
- batch channel name updates in `/channels` endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a70890e38883289d321d27d680056f