### PR TITLE
Schedule mirror cog initial sync asynchronously

### DIFF
--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -34,7 +34,7 @@ class Mirror(commands.Cog):
         self._reconcile_lock = asyncio.Lock()
 
     async def cog_load(self) -> None:
-        await self._sync_guild_channels_once()  # wait for initial insert/commit
+        self.bot.loop.create_task(self._sync_guild_channels_once())
         self._sync_task = asyncio.create_task(self._channel_sync_loop())
 
     async def _sync_guild_channels_once(self) -> None:


### PR DESCRIPTION
## Summary
- schedule `_sync_guild_channels_once()` on the loop instead of awaiting in `cog_load`
- keep periodic channel sync task

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a78329dfd88328915ae67d2579ad25