### PR TITLE
Refactor message handling into shared helper

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from datetime import datetime
+import json
+
+import discord
+from fastapi import HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext
+from ..schemas import ChatMessage, AttachmentDto
+from ..ws import manager
+from ...db.models import Message
+from ..discord_client import discord_client
+
+
+class PostBody(BaseModel):
+    channelId: str
+    content: str
+    useCharacterName: bool | None = False
+
+
+async def fetch_messages(
+    channel_id: str,
+    ctx: RequestContext,
+    db: AsyncSession,
+    *,
+    is_officer: bool,
+) -> list[dict]:
+    if is_officer and "officer" not in ctx.roles:
+        raise HTTPException(status_code=403)
+    stmt = (
+        select(Message)
+        .where(
+            Message.channel_id == int(channel_id),
+            Message.is_officer.is_(is_officer),
+        )
+        .order_by(Message.created_at)
+    )
+    result = await db.execute(stmt)
+    out: list[ChatMessage] = []
+    for m in result.scalars():
+        attachments = None
+        if m.attachments_json:
+            try:
+                data = json.loads(m.attachments_json)
+                attachments = [AttachmentDto(**a) for a in data]
+            except Exception:
+                attachments = None
+        out.append(
+            ChatMessage(
+                id=str(m.discord_message_id),
+                channelId=str(m.channel_id),
+                authorName=m.author_name,
+                authorAvatarUrl=m.author_avatar_url,
+                timestamp=m.created_at,
+                content=m.content_display,
+                attachments=attachments,
+            )
+        )
+    return [o.model_dump() for o in out]
+
+
+async def save_message(
+    body: PostBody,
+    ctx: RequestContext,
+    db: AsyncSession,
+    *,
+    is_officer: bool,
+) -> dict:
+    if is_officer and "officer" not in ctx.roles:
+        raise HTTPException(status_code=403)
+    channel_id = int(body.channelId)
+    discord_msg_id: int | None = None
+    if discord_client:
+        channel = discord_client.get_channel(channel_id)
+        if isinstance(channel, discord.abc.Messageable):
+            sent = await channel.send(body.content)
+            discord_msg_id = sent.id
+    if discord_msg_id is None:
+        discord_msg_id = int(datetime.utcnow().timestamp() * 1000)
+    msg = Message(
+        discord_message_id=discord_msg_id,
+        channel_id=channel_id,
+        guild_id=ctx.guild.id,
+        author_id=ctx.user.id,
+        author_name=ctx.user.global_name or ("Officer" if is_officer else "Player"),
+        content_raw=body.content,
+        content_display=body.content,
+        is_officer=is_officer,
+    )
+    db.add(msg)
+    await db.commit()
+    await db.refresh(msg)
+    dto = ChatMessage(
+        id=str(discord_msg_id),
+        channelId=str(channel_id),
+        authorName=msg.author_name,
+        authorAvatarUrl=msg.author_avatar_url,
+        timestamp=msg.created_at,
+        content=msg.content_display,
+    )
+    await manager.broadcast_text(
+        dto.model_dump_json(),
+        ctx.guild.id,
+        officer_only=is_officer,
+        path="/ws/officer-messages" if is_officer else "/ws/messages",
+    )
+    return {"ok": True, "id": str(discord_msg_id)}

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -1,27 +1,12 @@
 from __future__ import annotations
 
-from datetime import datetime
-import json
-
-import discord
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ..schemas import ChatMessage, AttachmentDto
-from ..ws import manager
-from ...db.models import Message
-from ..discord_client import discord_client
+from ._messages_common import PostBody, fetch_messages, save_message
 
 router = APIRouter(prefix="/api")
-
-
-class PostBody(BaseModel):
-    channelId: str
-    content: str
-    useCharacterName: bool | None = False
 
 
 @router.get("/messages/{channel_id}")
@@ -30,36 +15,7 @@ async def get_messages(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    stmt = (
-        select(Message)
-        .where(
-            Message.channel_id == int(channel_id),
-            Message.is_officer.is_(False),
-        )
-        .order_by(Message.created_at)
-    )
-    result = await db.execute(stmt)
-    out: list[ChatMessage] = []
-    for m in result.scalars():
-        attachments = None
-        if m.attachments_json:
-            try:
-                data = json.loads(m.attachments_json)
-                attachments = [AttachmentDto(**a) for a in data]
-            except Exception:
-                attachments = None
-        out.append(
-            ChatMessage(
-                id=str(m.discord_message_id),
-                channelId=str(m.channel_id),
-                authorName=m.author_name,
-                authorAvatarUrl=m.author_avatar_url,
-                timestamp=m.created_at,
-                content=m.content_display,
-                attachments=attachments,
-            )
-        )
-    return [o.model_dump() for o in out]
+    return await fetch_messages(channel_id, ctx, db, is_officer=False)
 
 
 @router.post("/messages")
@@ -68,44 +24,4 @@ async def post_message(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    channel_id = int(body.channelId)
-    discord_msg_id: int | None = None
-    if discord_client:
-        channel = discord_client.get_channel(channel_id)
-        if isinstance(channel, discord.abc.Messageable):
-            sent = await channel.send(body.content)
-            discord_msg_id = sent.id
-
-    if discord_msg_id is None:
-        discord_msg_id = int(datetime.utcnow().timestamp() * 1000)
-
-    msg = Message(
-        discord_message_id=discord_msg_id,
-        channel_id=channel_id,
-        guild_id=ctx.guild.id,
-        author_id=ctx.user.id,
-        author_name=ctx.user.global_name or "Player",
-        content_raw=body.content,
-        content_display=body.content,
-        is_officer=False,
-    )
-    db.add(msg)
-    await db.commit()
-    await db.refresh(msg)
-
-    dto = ChatMessage(
-        id=str(discord_msg_id),
-        channelId=str(channel_id),
-        authorName=msg.author_name,
-        authorAvatarUrl=msg.author_avatar_url,
-        timestamp=msg.created_at,
-        content=msg.content_display,
-    )
-    await manager.broadcast_text(
-        json.dumps(dto.model_dump()),
-        ctx.guild.id,
-        officer_only=False,
-        path="/ws/messages",
-    )
-
-    return {"ok": True, "id": str(discord_msg_id)}
+    return await save_message(body, ctx, db, is_officer=False)

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -1,27 +1,12 @@
 from __future__ import annotations
 
-from datetime import datetime
-import json
-
-import discord
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
-from sqlalchemy import select
+from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ..schemas import ChatMessage, AttachmentDto
-from ..ws import manager
-from ...db.models import Message
-from ..discord_client import discord_client
+from ._messages_common import PostBody, fetch_messages, save_message
 
 router = APIRouter(prefix="/api")
-
-
-class PostBody(BaseModel):
-    channelId: str
-    content: str
-    useCharacterName: bool | None = False
 
 
 @router.get("/officer-messages/{channel_id}")
@@ -30,38 +15,7 @@ async def get_officer_messages(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    if "officer" not in ctx.roles:
-        raise HTTPException(status_code=403)
-    stmt = (
-        select(Message)
-        .where(
-            Message.channel_id == int(channel_id),
-            Message.is_officer.is_(True),
-        )
-        .order_by(Message.created_at)
-    )
-    result = await db.execute(stmt)
-    out: list[ChatMessage] = []
-    for m in result.scalars():
-        attachments = None
-        if m.attachments_json:
-            try:
-                data = json.loads(m.attachments_json)
-                attachments = [AttachmentDto(**a) for a in data]
-            except Exception:
-                attachments = None
-        out.append(
-            ChatMessage(
-                id=str(m.discord_message_id),
-                channelId=str(m.channel_id),
-                authorName=m.author_name,
-                authorAvatarUrl=m.author_avatar_url,
-                timestamp=m.created_at,
-                content=m.content_display,
-                attachments=attachments,
-            )
-        )
-    return [o.model_dump() for o in out]
+    return await fetch_messages(channel_id, ctx, db, is_officer=True)
 
 
 @router.post("/officer-messages")
@@ -70,46 +24,4 @@ async def post_officer_message(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    if "officer" not in ctx.roles:
-        raise HTTPException(status_code=403)
-    channel_id = int(body.channelId)
-    discord_msg_id: int | None = None
-    if discord_client:
-        channel = discord_client.get_channel(channel_id)
-        if isinstance(channel, discord.abc.Messageable):
-            sent = await channel.send(body.content)
-            discord_msg_id = sent.id
-
-    if discord_msg_id is None:
-        discord_msg_id = int(datetime.utcnow().timestamp() * 1000)
-
-    msg = Message(
-        discord_message_id=discord_msg_id,
-        channel_id=channel_id,
-        guild_id=ctx.guild.id,
-        author_id=ctx.user.id,
-        author_name=ctx.user.global_name or "Officer",
-        content_raw=body.content,
-        content_display=body.content,
-        is_officer=True,
-    )
-    db.add(msg)
-    await db.commit()
-    await db.refresh(msg)
-
-    dto = ChatMessage(
-        id=str(discord_msg_id),
-        channelId=str(channel_id),
-        authorName=msg.author_name,
-        authorAvatarUrl=msg.author_avatar_url,
-        timestamp=msg.created_at,
-        content=msg.content_display,
-    )
-    await manager.broadcast_text(
-        dto.model_dump_json(),
-        ctx.guild.id,
-        officer_only=True,
-        path="/ws/officer-messages",
-    )
-
-    return {"ok": True, "id": str(discord_msg_id)}
+    return await save_message(body, ctx, db, is_officer=True)

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -1,0 +1,104 @@
+import asyncio
+from typing import List, Tuple
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from demibot.db.models import Guild, User, Message
+from demibot.db.session import init_db, get_session
+from demibot.http.deps import RequestContext
+from demibot.http.routes import _messages_common as mc
+
+
+class DummyKey:
+    pass
+
+
+def test_save_and_fetch_messages(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
+            db.add(User(id=1, discord_user_id=10, global_name="Alice"))
+            await db.commit()
+            guild = await db.get(Guild, 1)
+            user = await db.get(User, 1)
+            ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=[])
+
+            calls: List[Tuple[str, int, bool, str | None]] = []
+
+            async def dummy_broadcast(message: str, guild_id: int, officer_only: bool = False, path: str | None = None):
+                calls.append((message, guild_id, officer_only, path))
+
+            monkeypatch.setattr(mc.manager, "broadcast_text", dummy_broadcast)
+
+            body = mc.PostBody(channelId="123", content="hello")
+            res = await mc.save_message(body, ctx, db, is_officer=False)
+            assert res["ok"] is True
+
+            msg = (await db.execute(select(Message))).scalar_one()
+            assert msg.is_officer is False
+
+            assert calls and calls[0][2] is False and calls[0][3] == "/ws/messages"
+
+            data = await mc.fetch_messages("123", ctx, db, is_officer=False)
+            assert len(data) == 1 and data[0]["content"] == "hello"
+            break
+
+    asyncio.run(_run())
+
+
+def test_officer_flow(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
+            db.add(User(id=1, discord_user_id=10, global_name="Alice"))
+            await db.commit()
+            guild = await db.get(Guild, 1)
+            user = await db.get(User, 1)
+            ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=["officer"])
+
+            calls: List[Tuple[str, int, bool, str | None]] = []
+
+            async def dummy_broadcast(message: str, guild_id: int, officer_only: bool = False, path: str | None = None):
+                calls.append((message, guild_id, officer_only, path))
+
+            monkeypatch.setattr(mc.manager, "broadcast_text", dummy_broadcast)
+
+            body = mc.PostBody(channelId="123", content="secret")
+            res = await mc.save_message(body, ctx, db, is_officer=True)
+            assert res["ok"] is True
+
+            msg = (await db.execute(select(Message))).scalar_one()
+            assert msg.is_officer is True
+
+            assert calls and calls[0][2] is True and calls[0][3] == "/ws/officer-messages"
+
+            data = await mc.fetch_messages("123", ctx, db, is_officer=True)
+            assert len(data) == 1 and data[0]["content"] == "secret"
+            break
+
+    asyncio.run(_run())
+
+
+def test_officer_requires_role(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
+            db.add(User(id=1, discord_user_id=10, global_name="Alice"))
+            await db.commit()
+            guild = await db.get(Guild, 1)
+            user = await db.get(User, 1)
+            ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=[])
+
+            body = mc.PostBody(channelId="123", content="secret")
+            with pytest.raises(HTTPException):
+                await mc.save_message(body, ctx, db, is_officer=True)
+            with pytest.raises(HTTPException):
+                await mc.fetch_messages("123", ctx, db, is_officer=True)
+            break
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- extract shared `fetch_messages` and `save_message` logic into `_messages_common.py`
- refactor general and officer message routes to use shared helper
- add unit tests for officer and regular message flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac5620ad1083288b15bd837a1f6d06