### PR TITLE
Allow channel filter and limit when retrieving embeds

### DIFF
--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -118,7 +118,12 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/embeds");
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/embeds";
+            if (!string.IsNullOrEmpty(_channelId))
+            {
+                url += $"?channel_id={_channelId}";
+            }
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
             if (!string.IsNullOrEmpty(_config.AuthToken))
             {
                 request.Headers.Add("X-Api-Key", _config.AuthToken);
@@ -311,7 +316,12 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/embeds");
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/embeds";
+            if (!string.IsNullOrEmpty(_channelId))
+            {
+                url += $"?channel_id={_channelId}";
+            }
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
             if (!string.IsNullOrEmpty(_config.AuthToken))
             {
                 request.Headers.Add("X-Api-Key", _config.AuthToken);

--- a/demibot/demibot/README.md
+++ b/demibot/demibot/README.md
@@ -24,7 +24,7 @@ Endpoints implemented:
 - GET/POST /api/messages, /api/messages/{channelId}
 - GET/POST /api/officer-messages, /api/officer-messages/{channelId}
 - GET /api/users
-- GET /api/embeds
+- GET /api/embeds (optional query: `channel_id`, `limit`)
 - POST /api/events
 - POST /api/interactions
 - WebSocket at /ws/embeds

--- a/tests/test_embeds_filters.py
+++ b/tests/test_embeds_filters.py
@@ -1,0 +1,48 @@
+import sys
+import json
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+import types
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+from demibot.db.models import Embed, Guild, GuildChannel
+from demibot.db.session import init_db, get_session
+from demibot.http.routes.embeds import get_embeds
+
+async def _run_test() -> None:
+    db_path = Path("test_embeds_filters.db")
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    async for db in get_session():
+        guild = Guild(id=1, discord_guild_id=1, name="Test")
+        db.add(guild)
+        db.add(GuildChannel(guild_id=guild.id, channel_id=10, kind="event"))
+        db.add(GuildChannel(guild_id=guild.id, channel_id=20, kind="event"))
+        db.add(Embed(discord_message_id=1, channel_id=10, guild_id=1, payload_json=json.dumps({"id": "1"}), buttons_json=None, source="test"))
+        db.add(Embed(discord_message_id=2, channel_id=10, guild_id=1, payload_json=json.dumps({"id": "2"}), buttons_json=None, source="test"))
+        db.add(Embed(discord_message_id=3, channel_id=20, guild_id=1, payload_json=json.dumps({"id": "3"}), buttons_json=None, source="test"))
+        await db.commit()
+        break
+
+    ctx = SimpleNamespace(guild=SimpleNamespace(id=1), roles=["officer"])
+    async for db in get_session():
+        res = await get_embeds(ctx=ctx, db=db, channel_id=10)
+        assert len(res) == 2
+        assert all(e["channelId"] == 10 for e in res)
+        res2 = await get_embeds(ctx=ctx, db=db, limit=1)
+        assert len(res2) == 1
+        res3 = await get_embeds(ctx=ctx, db=db, channel_id=10, limit=1)
+        assert len(res3) == 1 and res3[0]["channelId"] == 10
+        break
+
+def test_embeds_filters() -> None:
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- add optional `channel_id` and `limit` filters to `/api/embeds`
- pass selected channel in plugin `UiRenderer` requests
- document embed filters and test filtering behavior

## Testing
- `pytest`
- `dotnet test` *(fails: .NET SDK 9.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac586c096483288eaeedb6de5ec545