### PR TITLE
Add WebSocket heartbeat to maintain connections

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -488,6 +488,11 @@ public class ChatWindow : IDisposable
                         count += result.Count;
                     }
                     var json = Encoding.UTF8.GetString(buffer, 0, count);
+                    if (json == "ping")
+                    {
+                        await _ws.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("pong")), WebSocketMessageType.Text, true, token);
+                        continue;
+                    }
                     try
                     {
                         using var document = JsonDocument.Parse(json);


### PR DESCRIPTION
## Summary
- send periodic WebSocket pings and drop inactive connections
- teach ChatWindow and ChannelWatcher to respond to ping messages

## Testing
- `PYTHONPATH=demibot pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac5bd3e93483288afe20316fb8414d