### PR TITLE
Add message pagination support

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -28,6 +28,8 @@ public class OfficerChatWindow : ChatWindow
         }
     }
 
+    protected override string MessagesPath => "/api/officer-messages";
+
     protected override async Task SendMessage()
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config))

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -12,10 +12,15 @@ router = APIRouter(prefix="/api")
 @router.get("/messages/{channel_id}")
 async def get_messages(
     channel_id: str,
+    limit: int | None = None,
+    before: str | None = None,
+    after: str | None = None,
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    return await fetch_messages(channel_id, ctx, db, is_officer=False)
+    return await fetch_messages(
+        channel_id, ctx, db, is_officer=False, limit=limit, before=before, after=after
+    )
 
 
 @router.post("/messages")

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -12,10 +12,15 @@ router = APIRouter(prefix="/api")
 @router.get("/officer-messages/{channel_id}")
 async def get_officer_messages(
     channel_id: str,
+    limit: int | None = None,
+    before: str | None = None,
+    after: str | None = None,
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    return await fetch_messages(channel_id, ctx, db, is_officer=True)
+    return await fetch_messages(
+        channel_id, ctx, db, is_officer=True, limit=limit, before=before, after=after
+    )
 
 
 @router.post("/officer-messages")

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from demibot.db.models import Guild, User, Message
 from demibot.db.session import init_db, get_session
 from demibot.http.deps import RequestContext
-from demibot.http.routes import _messages_common as mc
+from demibot.http.routes import _messages_common as mc, messages as routes
 
 
 class DummyKey:
@@ -99,6 +99,60 @@ def test_officer_requires_role(monkeypatch):
                 await mc.save_message(body, ctx, db, is_officer=True)
             with pytest.raises(HTTPException):
                 await mc.fetch_messages("123", ctx, db, is_officer=True)
+            break
+
+    asyncio.run(_run())
+
+
+def test_fetch_messages_pagination():
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
+            db.add(User(id=1, discord_user_id=10, global_name="Alice"))
+            await db.commit()
+            guild = await db.get(Guild, 1)
+            user = await db.get(User, 1)
+            ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=[])
+            for i in range(1, 11):
+                db.add(
+                    Message(
+                        discord_message_id=i,
+                        channel_id=123,
+                        guild_id=guild.id,
+                        author_id=user.id,
+                        author_name="Alice",
+                        content_raw=str(i),
+                        content_display=str(i),
+                    )
+                )
+            await db.commit()
+
+            msgs = await mc.fetch_messages("123", ctx, db, is_officer=False, limit=5)
+            assert [int(m["id"]) for m in msgs] == [6, 7, 8, 9, 10]
+
+            msgs = await mc.fetch_messages(
+                "123", ctx, db, is_officer=False, limit=3, before="8"
+            )
+            assert [int(m["id"]) for m in msgs] == [5, 6, 7]
+
+            msgs = await mc.fetch_messages("123", ctx, db, is_officer=False, after="8")
+            assert [int(m["id"]) for m in msgs] == [9, 10]
+
+            msgs = await mc.fetch_messages(
+                "123", ctx, db, is_officer=False, before="10", after="3"
+            )
+            assert [int(m["id"]) for m in msgs] == [4, 5, 6, 7, 8, 9]
+
+            msgs = await mc.fetch_messages(
+                "123", ctx, db, is_officer=False, after="10"
+            )
+            assert msgs == []
+
+            data = await routes.get_messages(
+                "123", limit=2, ctx=ctx, db=db
+            )
+            assert [int(m["id"]) for m in data] == [9, 10]
             break
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add limit/before/after query params for message routes
- fetch messages with SQL filtering and pagination
- load chat messages in paginated chunks on client
- test message pagination boundaries

## Testing
- `PYTHONPATH=demibot pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd1f767848328beb9958c7fb38804