### PR TITLE
Retry resolving missing channel names

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -112,6 +112,7 @@ public class OfficerChatWindow : ChatWindow
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<OfficerChannelListDto>(stream) ?? new OfficerChannelListDto();
+            var invalid = ResolveChannelNames(dto.Officer);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Officer);
@@ -119,6 +120,12 @@ public class OfficerChatWindow : ChatWindow
                 _channelFetchFailed = false;
                 _channelErrorMessage = string.Empty;
             });
+            if (invalid && !_channelRefreshAttempted)
+            {
+                _channelRefreshAttempted = true;
+                await RequestChannelRefresh();
+                await FetchChannels();
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- display channel IDs when names are missing and retry fetching after asking backend to refresh
- support channel name refresh for chat and officer chat windows

## Testing
- `dotnet test` *(fails: .NET 9.0 SDK missing)*
- `pytest` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adba673978832886cd4dba0b9e14a5