### PR TITLE
Handle long websocket messages

### DIFF
--- a/DemiCatPlugin/InternalsVisibleTo.cs
+++ b/DemiCatPlugin/InternalsVisibleTo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("DemiCatPlugin.Tests")]

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ dotnet build
 ```
 The build output `DemiCatPlugin.dll` can be found under `bin/Debug/net9.0/`. Copy it into your Dalamud plugins folder and enable it.
 
+WebSocket communication now streams data in 1 KB chunks and continues reading until the end of each message, allowing the plugin to handle payloads larger than the previous 16-byte limit.
+
 Alternatively, add this repository to Dalamud so it can install and update the plugin automatically:
 
 1. In-game, open **Dalamud Settings → Experimental → Custom Repositories**.

--- a/tests/ChannelWatcherTests.cs
+++ b/tests/ChannelWatcherTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using DemiCatPlugin;
+using Xunit;
+
+public class ChannelWatcherTests
+{
+    private class StubWebSocket : WebSocket
+    {
+        private readonly Queue<ArraySegment<byte>> _segments;
+
+        public StubWebSocket(string message, int chunkSize)
+        {
+            var bytes = Encoding.UTF8.GetBytes(message);
+            _segments = new Queue<ArraySegment<byte>>();
+            for (int i = 0; i < bytes.Length; i += chunkSize)
+            {
+                var len = Math.Min(chunkSize, bytes.Length - i);
+                var chunk = new byte[len];
+                Array.Copy(bytes, i, chunk, 0, len);
+                _segments.Enqueue(new ArraySegment<byte>(chunk));
+            }
+        }
+
+        public override WebSocketCloseStatus? CloseStatus => null;
+        public override string? CloseStatusDescription => null;
+        public override WebSocketState State => WebSocketState.Open;
+        public override string? SubProtocol => null;
+
+        public override void Abort() { }
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken) => Task.CompletedTask;
+        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken) => Task.CompletedTask;
+        public override void Dispose() { }
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+        {
+            if (_segments.Count == 0)
+            {
+                return Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true));
+            }
+            var segment = _segments.Dequeue();
+            Array.Copy(segment.Array!, segment.Offset, buffer.Array!, buffer.Offset, segment.Count);
+            bool end = _segments.Count == 0;
+            return Task.FromResult(new WebSocketReceiveResult(segment.Count, WebSocketMessageType.Text, end));
+        }
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ReceiveMessageAsync_ReadsLargeMessages()
+    {
+        var message = new string('a', 5000);
+        var ws = new StubWebSocket(message, 1000);
+        var buffer = new byte[1024];
+        var (received, type) = await ChannelWatcher.ReceiveMessageAsync(ws, buffer, CancellationToken.None);
+        Assert.Equal(WebSocketMessageType.Text, type);
+        Assert.Equal(message, received);
+    }
+}

--- a/tests/DemiCatPlugin.Tests.csproj
+++ b/tests/DemiCatPlugin.Tests.csproj
@@ -13,4 +13,7 @@
   <ItemGroup>
     <Compile Include="../DemiCatPlugin/MarkdownFormatter.cs" Link="MarkdownFormatter.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../DemiCatPlugin/DemiCatPlugin.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- expand websocket buffer to 1KB and loop until EndOfMessage so long messages are handled
- add helper to assemble websocket fragments and expose it for tests
- document streaming websocket handling and add unit test

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68adc09950e483289146e792d7e05f06