### PR TITLE
feat: add request workflow API

### DIFF
--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -29,8 +29,13 @@ class RequestType(str, Enum):
 
 class RequestStatus(str, Enum):
     OPEN = "open"
-    APPROVED = "approved"
-    DENIED = "denied"
+    ACCEPTED = "accepted"
+    STARTED = "started"
+    COMPLETED = "completed"
+    CONFIRMED = "confirmed"
+    CANCELLED = "cancelled"
+    APPROVED = "approved"  # legacy
+    DENIED = "denied"  # legacy
 
 
 class Urgency(str, Enum):

--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -32,6 +32,7 @@ def create_app(cfg: "AppConfig | None") -> FastAPI:
     app.add_api_websocket_route("/ws/officer-messages", websocket_endpoint)
     app.add_api_websocket_route("/ws/presences", websocket_endpoint)
     app.add_api_websocket_route("/ws/channels", websocket_endpoint)
+    app.add_api_websocket_route("/ws/requests", websocket_endpoint)
 
     @app.get("/health")
     async def health() -> dict[str, str]:

--- a/demibot/demibot/http/routes/__init__.py
+++ b/demibot/demibot/http/routes/__init__.py
@@ -8,6 +8,7 @@ from . import (
     interactions,
     validate_roles,
     guild_roles,
+    requests,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "interactions",
     "validate_roles",
     "guild_roles",
+    "requests",
 ]

--- a/demibot/demibot/http/routes/requests.py
+++ b/demibot/demibot/http/routes/requests.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ..ws import manager
+from ...db.models import Request as DbRequest, RequestStatus, RequestType, Urgency
+
+router = APIRouter(prefix="/api")
+
+
+class RequestCreateBody(BaseModel):
+    title: str
+    description: str | None = None
+    type: RequestType
+    urgency: Urgency
+
+
+class RequestPatchBody(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    urgency: Urgency | None = None
+
+
+class CommentBody(BaseModel):
+    text: str
+
+
+class RequestDto(BaseModel):
+    id: str
+    title: str
+    description: str | None
+    type: RequestType
+    status: RequestStatus
+    urgency: Urgency
+
+    class Config:
+        from_attributes = True
+
+
+def _dto(req: DbRequest) -> dict[str, Any]:
+    return RequestDto.model_validate(req).model_dump(mode="json")
+
+
+async def _broadcast(guild_id: int, request_id: int, delta: dict[str, Any]) -> None:
+    payload = json.dumps({"topic": "requests.stream", "payload": delta})
+    await manager.broadcast_text(payload, guild_id, path="/ws/requests")
+    payload = json.dumps({"topic": f"request.{request_id}", "payload": delta})
+    await manager.broadcast_text(payload, guild_id, path="/ws/requests")
+
+
+@router.get("/requests")
+async def list_requests(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> list[dict[str, Any]]:
+    result = await db.execute(select(DbRequest).where(DbRequest.guild_id == ctx.guild.id))
+    return [_dto(r) for r in result.scalars()]
+
+
+@router.post("/requests")
+async def create_request(
+    body: RequestCreateBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    req = DbRequest(
+        guild_id=ctx.guild.id,
+        user_id=ctx.user.id,
+        title=body.title,
+        description=body.description,
+        type=body.type,
+        status=RequestStatus.OPEN,
+        urgency=body.urgency,
+    )
+    db.add(req)
+    await db.commit()
+    await db.refresh(req)
+    await _broadcast(ctx.guild.id, req.id, _dto(req))
+    return {"id": str(req.id)}
+
+
+@router.get("/requests/{request_id}")
+async def get_request(
+    request_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    req = await db.get(DbRequest, request_id)
+    if not req or req.guild_id != ctx.guild.id:
+        raise HTTPException(status_code=404)
+    return _dto(req)
+
+
+@router.patch("/requests/{request_id}")
+async def update_request(
+    request_id: int,
+    body: RequestPatchBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, bool]:
+    req = await db.get(DbRequest, request_id)
+    if not req or req.guild_id != ctx.guild.id:
+        raise HTTPException(status_code=404)
+    if body.title is not None:
+        req.title = body.title
+    if body.description is not None:
+        req.description = body.description
+    if body.urgency is not None:
+        req.urgency = body.urgency
+    await db.commit()
+    await db.refresh(req)
+    await _broadcast(ctx.guild.id, req.id, _dto(req))
+    return {"ok": True}
+
+
+@router.delete("/requests/{request_id}")
+async def delete_request(
+    request_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, bool]:
+    req = await db.get(DbRequest, request_id)
+    if not req or req.guild_id != ctx.guild.id:
+        raise HTTPException(status_code=404)
+    await db.delete(req)
+    await db.commit()
+    delta = {"id": str(request_id), "deleted": True}
+    await _broadcast(ctx.guild.id, request_id, delta)
+    return {"ok": True}
+
+
+async def _update_status(
+    db: AsyncSession,
+    guild_id: int,
+    request_id: int,
+    from_status: RequestStatus,
+    to_status: RequestStatus,
+) -> DbRequest:
+    result = await db.execute(
+        update(DbRequest)
+        .where(
+            DbRequest.id == request_id,
+            DbRequest.guild_id == guild_id,
+            DbRequest.status == from_status,
+        )
+        .values(status=to_status)
+    )
+    if result.rowcount == 0:
+        raise HTTPException(status_code=409)
+    await db.commit()
+    req = await db.get(DbRequest, request_id)
+    return req
+
+
+@router.post("/requests/{request_id}/accept")
+async def accept_request(
+    request_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, bool]:
+    req = await _update_status(
+        db, ctx.guild.id, request_id, RequestStatus.OPEN, RequestStatus.ACCEPTED
+    )
+    await _broadcast(ctx.guild.id, req.id, {"id": str(req.id), "status": req.status})
+    return {"ok": True}
+
+
+@router.post("/requests/{request_id}/start")
+async def start_request(
+    request_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, bool]:
+    req = await _update_status(
+        db, ctx.guild.id, request_id, RequestStatus.ACCEPTED, RequestStatus.STARTED
+    )
+    await _broadcast(ctx.guild.id, req.id, {"id": str(req.id), "status": req.status})
+    return {"ok": True}
+
+
+@router.post("/requests/{request_id}/complete")
+async def complete_request(
+    request_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, bool]:
+    req = await _update_status(
+        db, ctx.guild.id, request_id, RequestStatus.STARTED, RequestStatus.COMPLETED
+    )
+    await _broadcast(ctx.guild.id, req.id, {"id": str(req.id), "status": req.status})
+    return {"ok": True}
+
+
+@router.post("/requests/{request_id}/confirm")
+async def confirm_request(
+    request_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, bool]:
+    req = await _update_status(
+        db, ctx.guild.id, request_id, RequestStatus.COMPLETED, RequestStatus.CONFIRMED
+    )
+    await _broadcast(ctx.guild.id, req.id, {"id": str(req.id), "status": req.status})
+    return {"ok": True}
+
+
+@router.post("/requests/{request_id}/cancel")
+async def cancel_request(
+    request_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, bool]:
+    result = await db.execute(
+        update(DbRequest)
+        .where(
+            DbRequest.id == request_id,
+            DbRequest.guild_id == ctx.guild.id,
+            DbRequest.status != RequestStatus.CONFIRMED,
+            DbRequest.status != RequestStatus.CANCELLED,
+        )
+        .values(status=RequestStatus.CANCELLED)
+    )
+    if result.rowcount == 0:
+        raise HTTPException(status_code=409)
+    await db.commit()
+    req = await db.get(DbRequest, request_id)
+    await _broadcast(ctx.guild.id, req.id, {"id": str(req.id), "status": req.status})
+    return {"ok": True}
+
+
+@router.post("/requests/{request_id}/comment")
+async def comment_request(
+    request_id: int,
+    body: CommentBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, bool]:
+    req = await db.get(DbRequest, request_id)
+    if not req or req.guild_id != ctx.guild.id:
+        raise HTTPException(status_code=404)
+    delta = {"id": str(req.id), "comment": body.text}
+    await _broadcast(ctx.guild.id, req.id, delta)
+    return {"ok": True}
+


### PR DESCRIPTION
## Summary
- add request management endpoints with CRUD and workflow transitions
- expose `/ws/requests` WebSocket channel and broadcast request deltas
- expand request status model for workflow states

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adcd1e424c8328b19bbede37671521