### PR TITLE
Add request notifications and commands

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -25,6 +25,7 @@ public class Plugin : IDalamudPlugin
     private readonly PresenceSidebar _presenceSidebar;
     private readonly MainWindow _mainWindow;
     private readonly ChannelWatcher _channelWatcher;
+    private readonly RequestWatcher _requestWatcher;
     private Config _config;
     private readonly HttpClient _httpClient = new();
     private readonly Action _openMainUi;
@@ -54,6 +55,7 @@ public class Plugin : IDalamudPlugin
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceSidebar);
         _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);
         _channelWatcher = new ChannelWatcher(_config, _ui, _chatWindow, _officerChatWindow);
+        _requestWatcher = new RequestWatcher(_config);
         _settings.MainWindow = _mainWindow;
         _settings.ChatWindow = _chatWindow;
         _settings.OfficerChatWindow = _officerChatWindow;
@@ -69,6 +71,7 @@ public class Plugin : IDalamudPlugin
         _openConfigUi = () => _settings.IsOpen = true;
         _services.PluginInterface.UiBuilder.OpenConfigUi += _openConfigUi;
 
+        _requestWatcher.Start();
         _services.Log.Info("DemiCat loaded.");
     }
 
@@ -90,6 +93,7 @@ public class Plugin : IDalamudPlugin
         _mainWindow.Dispose();
         _ui.DisposeAsync().GetAwaiter().GetResult();
         _channelWatcher.Dispose();
+        _requestWatcher.Dispose();
         _settings.Dispose();
     }
 

--- a/DemiCatPlugin/PluginServices.cs
+++ b/DemiCatPlugin/PluginServices.cs
@@ -1,4 +1,5 @@
 using Dalamud.Game.ClientState;
+using Dalamud.Game.Gui.Toast;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
@@ -26,6 +27,9 @@ internal class PluginServices
 
     [PluginService]
     internal IDataManager DataManager { get; private set; } = null!;
+
+    [PluginService]
+    internal IToastGui ToastGui { get; private set; } = null!;
 
     public PluginServices()
     {

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DemiCatPlugin;
+
+public class RequestWatcher : IDisposable
+{
+    private readonly Config _config;
+    private ClientWebSocket? _ws;
+    private Task? _task;
+    private CancellationTokenSource? _cts;
+
+    public RequestWatcher(Config config)
+    {
+        _config = config;
+    }
+
+    public void Start()
+    {
+        _cts?.Cancel();
+        _ws?.Dispose();
+        _cts = new CancellationTokenSource();
+        _task = Run(_cts.Token);
+    }
+
+    private async Task Run(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrEmpty(_config.AuthToken) || !_config.Enabled)
+            {
+                try { await Task.Delay(TimeSpan.FromSeconds(5), token); } catch { }
+                continue;
+            }
+            try
+            {
+                _ws?.Dispose();
+                _ws = new ClientWebSocket();
+                _ws.Options.SetRequestHeader("X-Api-Key", _config.AuthToken);
+                var uri = BuildWebSocketUri();
+                await _ws.ConnectAsync(uri, token);
+                var buffer = new byte[1024];
+                while (_ws.State == WebSocketState.Open && !token.IsCancellationRequested)
+                {
+                    var (message, type) = await ChannelWatcher.ReceiveMessageAsync(_ws, buffer, token);
+                    if (type == WebSocketMessageType.Close)
+                        break;
+                    if (message == "ping")
+                    {
+                        await _ws.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("pong")), WebSocketMessageType.Text, true, token);
+                        continue;
+                    }
+                    HandleMessage(message);
+                }
+            }
+            catch
+            {
+                // ignore errors and retry
+            }
+            finally
+            {
+                _ws?.Dispose();
+                _ws = null;
+            }
+            try { await Task.Delay(TimeSpan.FromSeconds(5), token); } catch { }
+        }
+    }
+
+    private void HandleMessage(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("payload", out var payload))
+                return;
+            if (payload.TryGetProperty("title", out var titleEl))
+            {
+                var title = titleEl.GetString() ?? "Request";
+                PluginServices.Instance?.ToastGui.ShowNormal($"Request created: {title}");
+            }
+            else if (payload.TryGetProperty("status", out var statusEl))
+            {
+                var status = statusEl.GetString();
+                if (status == "accepted")
+                {
+                    PluginServices.Instance?.ToastGui.ShowNormal("Request accepted");
+                }
+                else if (status == "completed")
+                {
+                    PluginServices.Instance?.ToastGui.ShowNormal("Request completed");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "Failed to handle request notification");
+        }
+    }
+
+    private Uri BuildWebSocketUri()
+    {
+        var baseUri = _config.ApiBaseUrl.TrimEnd('/') + "/ws/requests";
+        var builder = new UriBuilder(baseUri);
+        if (builder.Scheme == "https") builder.Scheme = "wss";
+        else if (builder.Scheme == "http") builder.Scheme = "ws";
+        return builder.Uri;
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _ws?.Dispose();
+    }
+}

--- a/demibot/demibot/discordbot/cogs/requests.py
+++ b/demibot/demibot/discordbot/cogs/requests.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import aiohttp
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from .setup_wizard import demi
+from ...db.models import RequestType, Urgency
+
+class Requests(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+async def _create_request(
+    interaction: discord.Interaction,
+    title: str,
+    description: str | None,
+    rtype: RequestType,
+    urgency: Urgency,
+) -> None:
+    host = interaction.client.cfg.server.host
+    if host == "0.0.0.0":
+        host = "localhost"
+    base_url = f"http://{host}:{interaction.client.cfg.server.port}"
+    body = {
+        "title": title,
+        "description": description,
+        "type": rtype,
+        "urgency": urgency,
+    }
+    headers = {"X-Api-Key": interaction.client.cfg.security.api_key}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{base_url}/api/requests", json=body, headers=headers) as resp:
+            if resp.status != 200:
+                text = await resp.text()
+                await interaction.response.send_message(
+                    f"Failed to create request: {resp.status} {text}", ephemeral=True
+                )
+                return
+    await interaction.response.send_message("Request submitted", ephemeral=True)
+
+request_group = app_commands.Group(name="request", description="Create requests")
+
+@request_group.command(name="craft", description="Request a crafted item")
+@app_commands.describe(title="Item name", description="Details", urgency="Urgency")
+async def request_craft(
+    interaction: discord.Interaction,
+    title: str,
+    description: str | None = None,
+    urgency: Urgency = Urgency.MEDIUM,
+) -> None:
+    await _create_request(interaction, title, description, RequestType.ITEM, urgency)
+
+@request_group.command(name="dungeon", description="Request dungeon run")
+@app_commands.describe(title="Dungeon name", description="Details", urgency="Urgency")
+async def request_dungeon(
+    interaction: discord.Interaction,
+    title: str,
+    description: str | None = None,
+    urgency: Urgency = Urgency.MEDIUM,
+) -> None:
+    await _create_request(interaction, title, description, RequestType.RUN, urgency)
+
+@demi.command(name="request", description="Create a request (legacy)")
+@app_commands.describe(title="Title", description="Details", rtype="Type", urgency="Urgency")
+async def legacy_request(
+    interaction: discord.Interaction,
+    title: str,
+    description: str,
+    rtype: RequestType,
+    urgency: Urgency = Urgency.MEDIUM,
+) -> None:
+    await _create_request(interaction, title, description, rtype, urgency)
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Requests(bot))
+    bot.tree.add_command(request_group)


### PR DESCRIPTION
## Summary
- notify #requests channel and users when requests are created, accepted, or completed
- display toast notifications in plugin via WebSocket watcher
- add slash commands for crafting and dungeon requests

## Testing
- `pytest`
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: .NET SDK 9.0.100 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68addacc2c408328835b771f42ded6e6