### PR TITLE
Return full request from status endpoints

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -110,8 +110,17 @@ public class RequestBoardWindow
     {
         try
         {
-            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/requests/{req.Id}/status";
-            var json = JsonSerializer.Serialize(new { status = StatusToString(newStatus), version = req.Version });
+            var action = newStatus switch
+            {
+                RequestStatus.Claimed => "accept",
+                RequestStatus.InProgress => "start",
+                RequestStatus.AwaitingConfirm => "complete",
+                RequestStatus.Completed => "confirm",
+                _ => null
+            };
+            if (action == null) return;
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/requests/{req.Id}/{action}";
+            var json = JsonSerializer.Serialize(new { version = req.Version });
             var msg = new HttpRequestMessage(HttpMethod.Post, url);
             msg.Headers.Add("X-Api-Key", _config.AuthToken);
             msg.Content = new StringContent(json, Encoding.UTF8, "application/json");


### PR DESCRIPTION
## Summary
- Return full request object from accept/start/complete/confirm endpoints and broadcast updates
- Switch RequestBoardWindow to call new status endpoints and handle full DTO responses

## Testing
- `pytest`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade4552a248328824fb99c414b8005