### PR TITLE
Unify request status values

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -207,6 +207,7 @@ public class RequestBoardWindow
         RequestStatus.InProgress => "in_progress",
         RequestStatus.AwaitingConfirm => "awaiting_confirm",
         RequestStatus.Completed => "completed",
+        RequestStatus.Cancelled => "cancelled",
         _ => "open"
     };
 
@@ -217,6 +218,7 @@ public class RequestBoardWindow
         "in_progress" => RequestStatus.InProgress,
         "awaiting_confirm" => RequestStatus.AwaitingConfirm,
         "completed" => RequestStatus.Completed,
+        "cancelled" => RequestStatus.Cancelled,
         _ => RequestStatus.Open
     };
 }

--- a/DemiCatPlugin/RequestState.cs
+++ b/DemiCatPlugin/RequestState.cs
@@ -8,7 +8,8 @@ public enum RequestStatus
     Claimed,
     InProgress,
     AwaitingConfirm,
-    Completed
+    Completed,
+    Cancelled
 }
 
 public class RequestState

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -97,6 +97,7 @@ public class RequestWatcher : IDisposable
                 "in_progress" => RequestStatus.InProgress,
                 "awaiting_confirm" => RequestStatus.AwaitingConfirm,
                 "completed" => RequestStatus.Completed,
+                "cancelled" => RequestStatus.Cancelled,
                 _ => RequestStatus.Open
             };
 
@@ -114,11 +115,15 @@ public class RequestWatcher : IDisposable
 
             if (status == RequestStatus.Claimed)
             {
-                PluginServices.Instance?.ToastGui.ShowNormal("Request accepted");
+                PluginServices.Instance?.ToastGui.ShowNormal("Request claimed");
             }
             else if (status == RequestStatus.Completed)
             {
                 PluginServices.Instance?.ToastGui.ShowNormal("Request completed");
+            }
+            else if (status == RequestStatus.Cancelled)
+            {
+                PluginServices.Instance?.ToastGui.ShowNormal("Request cancelled");
             }
         }
         catch (Exception ex)

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -29,10 +29,10 @@ class RequestType(str, Enum):
 
 class RequestStatus(str, Enum):
     OPEN = "open"
-    ACCEPTED = "accepted"
-    STARTED = "started"
+    CLAIMED = "claimed"
+    IN_PROGRESS = "in_progress"
+    AWAITING_CONFIRM = "awaiting_confirm"
     COMPLETED = "completed"
-    CONFIRMED = "confirmed"
     CANCELLED = "cancelled"
     APPROVED = "approved"  # legacy
     DENIED = "denied"  # legacy


### PR DESCRIPTION
## Summary
- align Python and C# code to shared request status enum
- send unified status strings through API and websocket payloads
- handle cancelled state in plugin and watcher

## Testing
- `pytest`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade5e7da348328a36a3e09256e594b