### PR TITLE
Add HQ flag and assignee to requests

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -138,6 +138,7 @@ public class RequestBoardWindow
                 var dutyId = payload.TryGetProperty("duty_id", out var dEl) ? dEl.GetUInt32() : (uint?)req.DutyId;
                 var hq = payload.TryGetProperty("hq", out var hEl) ? hEl.GetBoolean() : req.Hq;
                 var quantity = payload.TryGetProperty("quantity", out var qEl) ? qEl.GetInt32() : req.Quantity;
+                var assigneeId = payload.TryGetProperty("assignee_id", out var aEl) ? aEl.GetUInt32() : (uint?)req.AssigneeId;
                 RequestStateService.Upsert(new RequestState
                 {
                     Id = id,
@@ -147,7 +148,8 @@ public class RequestBoardWindow
                     ItemId = itemId,
                     DutyId = dutyId,
                     Hq = hq,
-                    Quantity = quantity
+                    Quantity = quantity,
+                    AssigneeId = assigneeId
                 });
             }
             else if ((int)resp.StatusCode == 409)
@@ -181,6 +183,7 @@ public class RequestBoardWindow
                 var dutyId = payload.TryGetProperty("duty_id", out var dEl) ? dEl.GetUInt32() : (uint?)null;
                 var hq = payload.TryGetProperty("hq", out var hEl) && hEl.GetBoolean();
                 var quantity = payload.TryGetProperty("quantity", out var qEl) ? qEl.GetInt32() : 0;
+                var assigneeId = payload.TryGetProperty("assignee_id", out var aEl) ? aEl.GetUInt32() : (uint?)null;
                 RequestStateService.Upsert(new RequestState
                 {
                     Id = id,
@@ -190,7 +193,8 @@ public class RequestBoardWindow
                     ItemId = itemId,
                     DutyId = dutyId,
                     Hq = hq,
-                    Quantity = quantity
+                    Quantity = quantity,
+                    AssigneeId = assigneeId
                 });
             }
         }

--- a/DemiCatPlugin/RequestState.cs
+++ b/DemiCatPlugin/RequestState.cs
@@ -28,4 +28,6 @@ public class RequestState
         = false;
     public int Quantity { get; set; }
         = 0;
+    public uint? AssigneeId { get; set; }
+        = null;
 }

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -86,6 +86,7 @@ public class RequestWatcher : IDisposable
             var dutyId = payload.TryGetProperty("duty_id", out var dutyEl) ? dutyEl.GetUInt32() : (uint?)null;
             var hq = payload.TryGetProperty("hq", out var hqEl) && hqEl.GetBoolean();
             var quantity = payload.TryGetProperty("quantity", out var qtyEl) ? qtyEl.GetInt32() : 0;
+            var assigneeId = payload.TryGetProperty("assignee_id", out var aEl) ? aEl.GetUInt32() : (uint?)null;
 
             if (id == null || statusString == null)
                 return;
@@ -110,7 +111,8 @@ public class RequestWatcher : IDisposable
                 ItemId = itemId,
                 DutyId = dutyId,
                 Hq = hq,
-                Quantity = quantity
+                Quantity = quantity,
+                AssigneeId = assigneeId
             });
 
             if (status == RequestStatus.Claimed)

--- a/demibot/demibot/db/migrations/versions/0012_add_request_assignee_and_hq.py
+++ b/demibot/demibot/db/migrations/versions/0012_add_request_assignee_and_hq.py
@@ -1,0 +1,36 @@
+"""add assignee and hq fields to requests tables
+
+Revision ID: 0012_add_request_assignee_and_hq
+Revises: 0011_add_requests_tables
+Create Date: 2024-06-01
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import BIGINT
+
+# revision identifiers, used by Alembic.
+revision = "0012_add_request_assignee_and_hq"
+down_revision = "0011_add_requests_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "requests",
+        sa.Column("assignee_id", BIGINT(unsigned=True), sa.ForeignKey("users.id"), nullable=True),
+    )
+    op.create_index("ix_requests_assignee_id", "requests", ["assignee_id"])
+    op.add_column(
+        "request_items",
+        sa.Column("hq", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("request_items", "hq")
+    op.drop_index("ix_requests_assignee_id", table_name="requests")
+    op.drop_column("requests", "assignee_id")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -242,6 +242,9 @@ class Request(Base):
     user_id: Mapped[int] = mapped_column(
         BIGINT(unsigned=True), ForeignKey("users.id"), index=True
     )
+    assignee_id: Mapped[Optional[int]] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), nullable=True, index=True
+    )
     title: Mapped[str] = mapped_column(String(255))
     description: Mapped[Optional[str]] = mapped_column(Text)
     type: Mapped[RequestType] = mapped_column(SAEnum(RequestType))
@@ -275,6 +278,7 @@ class RequestItem(Base):
     )
     item_id: Mapped[int] = mapped_column(BigInteger)
     quantity: Mapped[int] = mapped_column(Integer, default=1)
+    hq: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow


### PR DESCRIPTION
## Summary
- Track assignees on requests and HQ status on request items
- Expose item/duty IDs, HQ flag, quantity, and assignee in request DTOs and broadcasts
- Populate extended request fields in plugin state from HTTP and WebSocket updates

## Testing
- `python -m pytest`
- `dotnet build DemiCatPlugin` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade76142108328860b78268829c166