### PR TITLE
Seed RequestStateService from API

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -22,6 +22,7 @@ public class RequestBoardWindow
         _config = config;
         _httpClient = httpClient;
         _gameData = new GameDataCache(httpClient);
+        _ = RequestStateService.RefreshAll(httpClient, config);
     }
 
     public void Draw()


### PR DESCRIPTION
## Summary
- populate RequestStateService with existing requests on RequestBoardWindow creation
- fetch all requests from `/api/requests` via new RefreshAll helper

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: .NET SDK 9.0.100 not installed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aded73cadc832887c0da49b8a51ecc