### PR TITLE
Run migrations at startup and import models for Alembic

### DIFF
--- a/demibot/demibot/db/__init__.py
+++ b/demibot/demibot/db/__init__.py
@@ -1,3 +1,16 @@
+"""Database package exports and side effect imports.
+
+This module exposes the declarative ``Base`` for other modules to use and
+imports the models package for its side effects.  Importing ``models`` ensures
+that all ORM model classes are registered on ``Base.metadata`` so that tools
+like Alembic can discover them during autogeneration and migrations.
+"""
+
 from .base import Base
+
+# Import models so Alembic autogeneration can pick them up.  The imported names
+# are not re-exported but the import has the desired side effect of registering
+# all models with ``Base.metadata``.
+from . import models  # noqa: F401
 
 __all__ = ["Base"]

--- a/demibot/demibot/db/session.py
+++ b/demibot/demibot/db/session.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from typing import AsyncGenerator
 
-import logging
-from sqlalchemy import inspect, text
+import asyncio
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -13,42 +17,57 @@ from sqlalchemy.ext.asyncio import (
 
 from .base import Base
 
+
 _engine: AsyncEngine | None = None
 _Session: async_sessionmaker[AsyncSession] | None = None
 
 
+def _sync_url(url: str) -> str:
+    """Convert an async SQLAlchemy URL to its sync counterpart.
+
+    Alembic's migration runner uses synchronous SQLAlchemy engines.  This helper
+    swaps out async drivers for their synchronous equivalents so the same DSN
+    can be used for both async runtime access and migration execution.
+    """
+
+    sa_url = make_url(url)
+    driver = sa_url.drivername
+    if driver.endswith("+aiosqlite"):
+        driver = driver.replace("+aiosqlite", "")
+    elif driver.endswith("+asyncpg"):
+        driver = driver.replace("+asyncpg", "+psycopg2")
+    elif driver.endswith("+asyncmy"):
+        driver = driver.replace("+asyncmy", "+pymysql")
+    return str(sa_url.set(drivername=driver))
+
+
 async def init_db(url: str) -> AsyncEngine:
-    """Create the database engine and ensure all tables and columns exist."""
+    """Create the database engine and run migrations for the given URL."""
 
     global _engine, _Session
+
+    sa_url = make_url(url)
+    sync_url = _sync_url(url)
+
+    if sa_url.get_backend_name() == "sqlite":
+        # SQLite lacks many ALTER TABLE capabilities used in migrations.
+        # For test environments we create tables directly from metadata.
+        _engine = create_async_engine(url, echo=False, future=True)
+        _Session = async_sessionmaker(_engine, expire_on_commit=False)
+        async with _engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        return _engine
+
+    # Run migrations using Alembic so the schema matches the latest models.
+    config = Config()
+    config.set_main_option(
+        "script_location", str(Path(__file__).resolve().parent / "migrations")
+    )
+    config.set_main_option("sqlalchemy.url", sync_url)
+    await asyncio.to_thread(command.upgrade, config, "head")
+
     _engine = create_async_engine(url, echo=False, future=True)
     _Session = async_sessionmaker(_engine, expire_on_commit=False)
-
-    async with _engine.begin() as conn:
-        def _init(sync_conn):
-            inspector = inspect(sync_conn)
-            existing_tables = set(inspector.get_table_names())
-
-            Base.metadata.create_all(sync_conn)
-            inspector = inspect(sync_conn)
-
-            for table in Base.metadata.sorted_tables:
-                if table.name not in existing_tables:
-                    logging.info("Created table %s", table.name)
-                existing = {c["name"] for c in inspector.get_columns(table.name)}
-                for column in table.columns:
-                    if column.name not in existing:
-                        ddl = text(
-                            f"ALTER TABLE {table.name} ADD COLUMN "
-                            f"{column.compile(dialect=sync_conn.dialect)}"
-                        )
-                        sync_conn.execute(ddl)
-                        logging.info(
-                            "Added column %s to table %s", column.name, table.name
-                        )
-
-        await conn.run_sync(_init)
-
     return _engine
 
 


### PR DESCRIPTION
## Summary
- ensure all ORM models are imported when demibot.db is loaded so Alembic can autogenerate migrations
- update init_db to run Alembic migrations (with SQLite fallback) before creating the async engine

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1319b3348328bcbef2695ce14563