### PR TITLE
Add user settings API and consent tracking

### DIFF
--- a/demibot/demibot/db/migrations/versions/0014_add_fc_user_settings.py
+++ b/demibot/demibot/db/migrations/versions/0014_add_fc_user_settings.py
@@ -1,0 +1,33 @@
+"""add fc_user settings and consent flag
+
+Revision ID: 0014_add_fc_user_settings
+Revises: 0013_add_fc_and_asset_tables
+Create Date: 2025-09-01
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0014_add_fc_user_settings"
+down_revision = "0013_add_fc_and_asset_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("fc_user", sa.Column("settings", sa.Text(), nullable=True))
+    op.add_column(
+        "fc_user",
+        sa.Column(
+            "consent_sync",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("fc_user", "consent_sync")
+    op.drop_column("fc_user", "settings")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -378,6 +378,8 @@ class FcUser(Base):
         primary_key=True,
     )
     joined_at: Mapped[datetime] = mapped_column(DateTime)
+    settings: Mapped[Optional[str]] = mapped_column(Text)
+    consent_sync: Mapped[bool] = mapped_column(Boolean, default=False)
 
     fc: Mapped[Fc] = relationship(back_populates="users")
     user: Mapped[User] = relationship()

--- a/demibot/demibot/http/routes/__init__.py
+++ b/demibot/demibot/http/routes/__init__.py
@@ -9,6 +9,7 @@ from . import (
     validate_roles,
     guild_roles,
     requests,
+    user_settings,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "validate_roles",
     "guild_roles",
     "requests",
+    "user_settings",
 ]

--- a/demibot/demibot/http/routes/user_settings.py
+++ b/demibot/demibot/http/routes/user_settings.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ...db.models import FcUser, Message, User, UserInstallation
+
+router = APIRouter(prefix="/api")
+
+
+class SettingsPayload(BaseModel):
+    settings: dict[str, Any] | None = None
+    consent_sync: bool
+
+
+@router.get("/users/me/settings")
+async def get_my_settings(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(FcUser).where(FcUser.user_id == ctx.user.id)
+    result = await db.execute(stmt)
+    row = result.scalar_one_or_none()
+    if not row:
+        raise HTTPException(status_code=404)
+    data = json.loads(row.settings) if row.settings else {}
+    return {"settings": data, "consent_sync": row.consent_sync}
+
+
+@router.put("/users/me/settings")
+async def put_my_settings(
+    payload: SettingsPayload,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    stmt = select(FcUser).where(FcUser.user_id == ctx.user.id)
+    result = await db.execute(stmt)
+    row = result.scalar_one_or_none()
+    if not row:
+        raise HTTPException(status_code=404)
+    row.settings = json.dumps(payload.settings or {})
+    row.consent_sync = payload.consent_sync
+    await db.commit()
+    return {"settings": payload.settings or {}, "consent_sync": row.consent_sync}
+
+
+@router.post("/users/me/forget")
+async def forget_me(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    await db.execute(
+        delete(UserInstallation).where(UserInstallation.user_id == ctx.user.id)
+    )
+    await db.execute(
+        update(User)
+        .where(User.id == ctx.user.id)
+        .values(global_name=None, discriminator=None)
+    )
+    await db.execute(
+        update(Message)
+        .where(Message.author_id == ctx.user.id)
+        .values(author_name="[deleted]", author_avatar_url=None)
+    )
+    await db.execute(
+        update(FcUser)
+        .where(FcUser.user_id == ctx.user.id)
+        .values(consent_sync=False, settings=None)
+    )
+    await db.commit()
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add endpoints for managing user settings and forgetting user data
- persist per-user settings and sync consent in `fc_user`
- include new routes in HTTP router registry

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1aea91b48328ae3237cdabaec6cc