### PR TITLE
feat: add delta token endpoint and asset downloads

### DIFF
--- a/demibot/demibot/db/migrations/versions/0015_add_fc_user_last_pull_at.py
+++ b/demibot/demibot/db/migrations/versions/0015_add_fc_user_last_pull_at.py
@@ -1,0 +1,23 @@
+"""add fc_user last_pull_at
+
+Revision ID: 0015_add_fc_user_last_pull_at
+Revises: 0014_add_fc_user_settings
+Create Date: 2025-09-21
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0015_add_fc_user_last_pull_at"
+down_revision = "0014_add_fc_user_settings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("fc_user", sa.Column("last_pull_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("fc_user", "last_pull_at")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -378,6 +378,7 @@ class FcUser(Base):
         primary_key=True,
     )
     joined_at: Mapped[datetime] = mapped_column(DateTime)
+    last_pull_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     settings: Mapped[Optional[str]] = mapped_column(Text)
     consent_sync: Mapped[bool] = mapped_column(Boolean, default=False)
 

--- a/demibot/demibot/http/routes/assets.py
+++ b/demibot/demibot/http/routes/assets.py
@@ -5,15 +5,17 @@ import hmac
 import os
 from datetime import datetime
 from typing import List
+from pathlib import Path
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Response, HTTPException
+from fastapi.responses import FileResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import get_db
 from ...db.models import Asset, AssetKind
 
-router = APIRouter(prefix="/api")
+router = APIRouter()
 
 _SECRET = os.environ.get("ASSET_SIGNING_SECRET", "devsecret").encode()
 
@@ -21,10 +23,10 @@ _SECRET = os.environ.get("ASSET_SIGNING_SECRET", "devsecret").encode()
 def _sign_download(asset_id: int, asset_hash: str) -> str:
     """Generate a signed download URL for an asset."""
     sig = hmac.new(_SECRET, f"{asset_id}:{asset_hash}".encode(), hashlib.sha256).hexdigest()
-    return f"/assets/{asset_id}/download?sig={sig}"
+    return f"/assets/{asset_hash}?asset_id={asset_id}&sig={sig}"
 
 
-@router.get("/fc/{fc_id}/assets")
+@router.get("/api/fc/{fc_id}/assets")
 async def list_assets(
     fc_id: int,
     response: Response,
@@ -85,3 +87,34 @@ async def list_assets(
         etag_src = ",".join(str(i["id"]) for i in items)
         response.headers["ETag"] = hashlib.sha256(etag_src.encode()).hexdigest()
     return {"items": items}
+
+
+@router.get("/assets/{object_key:path}")
+async def download_asset(
+    object_key: str,
+    hash: str | None = None,
+    sig: str | None = None,
+    asset_id: int | None = None,
+):
+    base = Path(os.environ.get("ASSET_STORAGE_PATH", "assets")).resolve()
+    file_path = (base / object_key).resolve()
+    if not str(file_path).startswith(str(base)) or not file_path.is_file():
+        raise HTTPException(status_code=404)
+    if sig:
+        if asset_id is None:
+            raise HTTPException(status_code=400)
+        expected = hmac.new(
+            _SECRET, f"{asset_id}:{object_key}".encode(), hashlib.sha256
+        ).hexdigest()
+        if not hmac.compare_digest(expected, sig):
+            raise HTTPException(status_code=403)
+    elif hash:
+        sha = hashlib.sha256()
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                sha.update(chunk)
+        if sha.hexdigest() != hash:
+            raise HTTPException(status_code=400)
+    else:
+        raise HTTPException(status_code=403)
+    return FileResponse(file_path)

--- a/demibot/demibot/http/routes/bundles.py
+++ b/demibot/demibot/http/routes/bundles.py
@@ -20,7 +20,7 @@ _SECRET = os.environ.get("ASSET_SIGNING_SECRET", "devsecret").encode()
 
 def _sign_download(asset_id: int, asset_hash: str) -> str:
     sig = hmac.new(_SECRET, f"{asset_id}:{asset_hash}".encode(), hashlib.sha256).hexdigest()
-    return f"/assets/{asset_id}/download?sig={sig}"
+    return f"/assets/{asset_hash}?asset_id={asset_id}&sig={sig}"
 
 
 @router.get("/fc/{fc_id}/bundles")

--- a/demibot/demibot/http/routes/delta_token.py
+++ b/demibot/demibot/http/routes/delta_token.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ...db.models import FcUser
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/delta-token")
+async def get_delta_token(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    now = datetime.utcnow()
+    await db.execute(
+        update(FcUser).where(FcUser.user_id == ctx.user.id).values(last_pull_at=now)
+    )
+    await db.commit()
+    return {"since": now.isoformat()}

--- a/tests/test_asset_download.py
+++ b/tests/test_asset_download.py
@@ -1,0 +1,35 @@
+import hashlib
+import os
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from demibot.http.routes.assets import router as assets_router
+
+
+def _make_app():
+    app = FastAPI()
+    app.include_router(assets_router)
+    return app
+
+
+def test_download_asset_validates_hash(tmp_path, monkeypatch):
+    content = b"hello world"
+    file_path = tmp_path / "test.bin"
+    file_path.write_bytes(content)
+    monkeypatch.setenv("ASSET_STORAGE_PATH", str(tmp_path))
+    expected = hashlib.sha256(content).hexdigest()
+    client = TestClient(_make_app())
+    resp = client.get(f"/assets/test.bin?hash={expected}")
+    assert resp.status_code == 200
+    assert resp.content == content
+
+
+def test_download_asset_rejects_bad_hash(tmp_path, monkeypatch):
+    content = b"bad"
+    file_path = tmp_path / "bad.bin"
+    file_path.write_bytes(content)
+    monkeypatch.setenv("ASSET_STORAGE_PATH", str(tmp_path))
+    client = TestClient(_make_app())
+    resp = client.get("/assets/bad.bin?hash=deadbeef")
+    assert resp.status_code == 400

--- a/tests/test_delta_token.py
+++ b/tests/test_delta_token.py
@@ -1,0 +1,30 @@
+import asyncio
+from datetime import datetime, timedelta
+
+from demibot.db.models import Guild, User, Fc, FcUser
+from demibot.db.session import init_db, get_session
+from demibot.http.deps import RequestContext
+from demibot.http.routes.delta_token import get_delta_token
+from sqlalchemy import select
+
+
+def test_delta_token_updates_last_pull():
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            user = User(id=1, discord_user_id=1, global_name="Test")
+            guild = Guild(id=1, discord_guild_id=1, name="Guild")
+            fc = Fc(id=1, name="FC", world="World")
+            fcu = FcUser(fc_id=1, user_id=1, joined_at=datetime.utcnow())
+            db.add_all([user, guild, fc, fcu])
+            await db.commit()
+            ctx = RequestContext(user=user, guild=guild, key=object(), roles=[])
+            res = await get_delta_token(ctx=ctx, db=db)
+            row = (
+                await db.execute(select(FcUser).where(FcUser.user_id == user.id))
+            ).scalar_one()
+            since_dt = datetime.fromisoformat(res["since"])
+            assert row.last_pull_at is not None
+            assert abs(row.last_pull_at - since_dt) < timedelta(seconds=1)
+            break
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add `/api/delta-token` endpoint returning current timestamp and persisting it to `fc_user.last_pull_at`
- stream assets from storage with `/assets/{object_key}` and signed hash validation
- add database migration and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae22d317248328aed85e9780b3ed96