### PR TITLE
Add vault asset ingestion to Discord bot

### DIFF
--- a/demibot/demibot/db/migrations/versions/0013_add_fc_and_asset_tables.py
+++ b/demibot/demibot/db/migrations/versions/0013_add_fc_and_asset_tables.py
@@ -149,7 +149,7 @@ def upgrade() -> None:
         sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column("kind", asset_kind, nullable=False),
         sa.Column("last_id", sa.Integer(), nullable=False),
-        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("last_generated_at", sa.DateTime(), nullable=False),
     )
     op.create_index(
         "ix_index_checkpoint_kind", "index_checkpoint", ["kind"], unique=True

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -509,4 +509,6 @@ class IndexCheckpoint(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     kind: Mapped[AssetKind] = mapped_column(SAEnum(AssetKind), nullable=False)
     last_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    last_generated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )

--- a/demibot/demibot/discordbot/cogs/vault.py
+++ b/demibot/demibot/discordbot/cogs/vault.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from zipfile import ZipFile, BadZipFile
+
+import discord
+from discord.ext import commands
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ...db.models import (
+    AppearanceBundle,
+    AppearanceBundleItem,
+    Asset,
+    AssetKind,
+    IndexCheckpoint,
+)
+from ...db.session import get_session, init_db
+
+WHITELIST = {
+    ".zip",
+    ".json",
+    ".txt",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".py",
+}
+
+INSTRUCTIONS = (
+    "Upload asset bundles or files here. Allowed extensions: "
+    + ", ".join(sorted(WHITELIST))
+)
+
+
+class Vault(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        asyncio.create_task(init_db(bot.cfg.database.url))
+        self.storage_path = Path(
+            os.environ.get("ASSET_STORAGE_PATH", "assets")
+        ).resolve()
+        self.storage_path.mkdir(parents=True, exist_ok=True)
+        self.vault_channels: dict[int, int] = {}
+
+    async def cog_load(self) -> None:  # pragma: no cover - startup behaviour
+        self.bot.loop.create_task(self._ensure_vault_channels())
+
+    async def _ensure_vault_channels(self) -> None:  # pragma: no cover - startup
+        if hasattr(self.bot, "wait_until_ready"):
+            await self.bot.wait_until_ready()
+        for guild in self.bot.guilds:
+            await self._ensure_vault_channel(guild)
+
+    async def _ensure_vault_channel(self, guild: discord.Guild) -> None:
+        channel = discord.utils.get(guild.text_channels, name="vault")
+        if channel is None:
+            overwrites = {
+                guild.default_role: discord.PermissionOverwrite(view_channel=False),
+                guild.me: discord.PermissionOverwrite(view_channel=True),
+            }
+            try:
+                channel = await guild.create_text_channel(
+                    "vault", overwrites=overwrites, reason="Create vault channel"
+                )
+            except Exception:  # pragma: no cover - network failure
+                return
+        self.vault_channels[guild.id] = channel.id
+        try:
+            pins = await channel.pins()
+        except Exception:  # pragma: no cover - network failure
+            return
+        if not any(INSTRUCTIONS in p.content for p in pins):
+            try:
+                msg = await channel.send(INSTRUCTIONS)
+                await msg.pin()
+            except Exception:  # pragma: no cover - network failure
+                return
+
+    @commands.Cog.listener()
+    async def on_guild_join(self, guild: discord.Guild) -> None:
+        await self._ensure_vault_channel(guild)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        if message.guild is None or message.author.bot:
+            return
+        channel_id = self.vault_channels.get(message.guild.id)
+        if channel_id is None or message.channel.id != channel_id:
+            return
+        if not message.attachments:
+            return
+
+        errors: list[str] = []
+        for attachment in message.attachments:
+            ext = Path(attachment.filename).suffix.lower()
+            if ext not in WHITELIST:
+                errors.append(f"{attachment.filename}: extension not allowed")
+                continue
+            try:
+                data = await attachment.read()
+            except Exception:
+                errors.append(f"{attachment.filename}: download failed")
+                continue
+            sha = hashlib.sha256(data).hexdigest()
+            size = len(data)
+            kind = self._determine_kind(ext, data)
+            try:
+                (self.storage_path / sha).write_bytes(data)
+            except Exception:
+                errors.append(f"{attachment.filename}: failed to store file")
+                continue
+            async for db in get_session():
+                asset = await self._upsert_asset(
+                    db, kind, attachment.filename, sha, size
+                )
+                if kind is AssetKind.APPEARANCE:
+                    await self._ensure_bundle(db, asset, data)
+                await self._update_checkpoint(db, kind, asset.id)
+                await db.commit()
+                break
+        if errors:
+            await message.add_reaction("❌")
+            await message.reply("; ".join(errors), mention_author=False)
+        else:
+            await message.add_reaction("✅")
+
+    def _determine_kind(self, ext: str, data: bytes) -> AssetKind:
+        if ext == ".py":
+            return AssetKind.SCRIPT
+        if ext == ".zip":
+            try:
+                with ZipFile(io.BytesIO(data)) as zf:
+                    names = zf.namelist()
+                for name in names:
+                    if name.endswith(".json"):
+                        return AssetKind.APPEARANCE
+            except BadZipFile:
+                pass
+        return AssetKind.FILE
+
+    async def _upsert_asset(
+        self, db: AsyncSession, kind: AssetKind, name: str, sha: str, size: int
+    ) -> Asset:
+        result = await db.execute(select(Asset).where(Asset.hash == sha))
+        asset = result.scalar_one_or_none()
+        if asset is None:
+            asset = Asset(kind=kind, name=name, hash=sha, size=size)
+            db.add(asset)
+            await db.flush()
+        else:
+            asset.name = name
+            asset.size = size
+        return asset
+
+    async def _ensure_bundle(
+        self, db: AsyncSession, asset: Asset, data: bytes
+    ) -> None:
+        info = self._parse_bundle_manifest(data)
+        name = info.get("name") if isinstance(info, dict) else asset.name
+        bundle = AppearanceBundle(name=name)
+        db.add(bundle)
+        await db.flush()
+        db.add(
+            AppearanceBundleItem(bundle_id=bundle.id, asset_id=asset.id, quantity=1)
+        )
+
+    def _parse_bundle_manifest(self, data: bytes) -> dict:
+        try:
+            with ZipFile(io.BytesIO(data)) as zf:
+                for name in zf.namelist():
+                    if name.endswith("manifest.json") or name.endswith("bundle.json"):
+                        with zf.open(name) as f:
+                            return json.load(f)
+        except Exception:
+            return {}
+        return {}
+
+    async def _update_checkpoint(
+        self, db: AsyncSession, kind: AssetKind, asset_id: int
+    ) -> None:
+        result = await db.execute(
+            select(IndexCheckpoint).where(IndexCheckpoint.kind == kind)
+        )
+        cp = result.scalar_one_or_none()
+        now = datetime.utcnow()
+        if cp is None:
+            db.add(
+                IndexCheckpoint(
+                    kind=kind, last_id=asset_id, last_generated_at=now
+                )
+            )
+        else:
+            cp.last_id = asset_id
+            cp.last_generated_at = now


### PR DESCRIPTION
## Summary
- ensure a private `vault` channel exists with pinned upload instructions
- process vault attachments into asset and appearance bundle tables while updating checkpoints
- add `last_generated_at` field to `index_checkpoint`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae281c5ed0832888f12b6fc47301a3