### PR TITLE
Add sync settings and category tracking to Config

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -1,4 +1,5 @@
 using Dalamud.Configuration;
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -26,8 +27,29 @@ public class Config : IPluginConfiguration
     public List<Template> Templates { get; set; } = new();
     public List<SignupPreset> SignupPresets { get; set; } = new();
 
+    [JsonPropertyName("syncEnabled")]
+    public bool SyncEnabled { get; set; } = true;
+
+    [JsonPropertyName("autoApply")]
+    public Dictionary<string, bool> AutoApply { get; set; } = new();
+
+    [JsonPropertyName("categories")]
+    public Dictionary<string, CategoryState> Categories { get; set; } = new();
+
     [JsonExtensionData]
     public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+
+    public class CategoryState
+    {
+        [JsonPropertyName("lastPullAt")]
+        public DateTimeOffset? LastPullAt { get; set; }
+
+        [JsonPropertyName("seenAssets")]
+        public HashSet<string> SeenAssets { get; set; } = new();
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement>? ExtensionData { get; set; }
+    }
 
     public void Migrate()
     {


### PR DESCRIPTION
## Summary
- add `syncEnabled` toggle to plugin config
- track per-category settings and auto-apply flags
- record category sync metadata (last pull time, seen assets)

## Testing
- `dotnet test` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: discord, fastapi, sqlalchemy, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2b8ee41083289a752918e47e92b3