### PR TITLE
Show dependency warnings and handle Penumbra mod conflicts

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -33,6 +33,9 @@ public class Config : IPluginConfiguration
     [JsonPropertyName("autoApply")]
     public Dictionary<string, bool> AutoApply { get; set; } = new();
 
+    [JsonPropertyName("penumbraChoices")]
+    public Dictionary<string, bool> PenumbraChoices { get; set; } = new();
+
     [JsonPropertyName("categories")]
     public Dictionary<string, CategoryState> Categories { get; set; } = new();
 


### PR DESCRIPTION
## Summary
- Display missing asset dependencies with a button to install them all
- Prompt before replacing existing Penumbra mods and remember the user's choice

## Testing
- `dotnet build DemiCatPlugin` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 20 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ae37b583d0832888b0e5b0db7f6133