### PR TITLE
Add sync pause and cache clearing

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -118,10 +118,9 @@ public class SettingsWindow : IDisposable
                     }
                 }
 
-                if (ImGui.Button("Clear cache"))
+                if (ImGui.Button("Clear my cached data"))
                 {
-                    _config.Categories.Clear();
-                    SaveConfig();
+                    ClearCachedData();
                 }
 
                 ImGui.SameLine();
@@ -258,6 +257,13 @@ public class SettingsWindow : IDisposable
         }
     }
 
+    private void ClearCachedData()
+    {
+        _config.Categories.Clear();
+        SaveConfig();
+        SyncshellWindow.Instance?.ClearCaches();
+    }
+
     private async Task ForgetMe()
     {
         var framework = PluginServices.Instance?.Framework;
@@ -274,7 +280,7 @@ public class SettingsWindow : IDisposable
             {
                 _config.AuthToken = null;
                 _apiKey = string.Empty;
-                SaveConfig();
+                ClearCachedData();
                 if (framework != null)
                     _ = framework.RunOnTick(() => _syncStatus = "User forgotten");
             }


### PR DESCRIPTION
## Summary
- honor sync pause setting by skipping refresh loops and IPC traffic
- add a button to clear cached assets and installation data
- forget-me request now also wipes local caches

## Testing
- `~/.dotnet/dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: missing modules such as discord, fastapi, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68ae392185548328985b6abc852942ea