### PR TITLE
Scrub user details and purge expired assets

### DIFF
--- a/demibot/demibot/asset_cleanup.py
+++ b/demibot/demibot/asset_cleanup.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+from sqlalchemy import delete
+
+from .db.session import get_session
+from .db.models import Asset
+
+PURGE_INTERVAL = 3600
+
+
+async def purge_deleted_assets_once(retention_days: int = 30) -> None:
+    async for db in get_session():
+        cutoff = datetime.utcnow() - timedelta(days=retention_days)
+        await db.execute(delete(Asset).where(Asset.deleted_at < cutoff))
+        await db.commit()
+        break
+
+
+async def purge_deleted_assets() -> None:
+    while True:
+        try:
+            await purge_deleted_assets_once()
+        except Exception:  # pragma: no cover - best effort
+            logging.exception("Asset purge failed")
+        await asyncio.sleep(PURGE_INTERVAL)

--- a/demibot/demibot/db/migrations/versions/0017_add_user_character_and_world.py
+++ b/demibot/demibot/db/migrations/versions/0017_add_user_character_and_world.py
@@ -1,0 +1,24 @@
+"""add user character_name and world
+
+Revision ID: 0017_add_user_character_and_world
+Revises: 0016_add_asset_deleted_at
+Create Date: 2025-09-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0017_add_user_character_and_world"
+down_revision = "0016_add_asset_deleted_at"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("character_name", sa.String(length=255), nullable=True))
+    op.add_column("users", sa.Column("world", sa.String(length=32), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "character_name")
+    op.drop_column("users", "world")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -97,6 +97,8 @@ class User(Base):
     discord_user_id: Mapped[int] = mapped_column(BigInteger, unique=True, index=True)
     global_name: Mapped[Optional[str]] = mapped_column(String(255))
     discriminator: Mapped[Optional[str]] = mapped_column(String(10))
+    character_name: Mapped[Optional[str]] = mapped_column(String(255))
+    world: Mapped[Optional[str]] = mapped_column(String(32))
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow

--- a/demibot/demibot/http/routes/user_settings.py
+++ b/demibot/demibot/http/routes/user_settings.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ...db.models import FcUser, Message, User, UserInstallation
+from ...db.models import Asset, FcUser, Message, User, UserInstallation
 
 router = APIRouter(prefix="/api")
 
@@ -55,13 +57,33 @@ async def forget_me(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
+    result = await db.execute(
+        select(UserInstallation.asset_id)
+        .join(Asset, UserInstallation.asset_id == Asset.id)
+        .where(UserInstallation.user_id == ctx.user.id, Asset.fc_id.is_(None))
+    )
+    asset_ids = [row[0] for row in result.all()]
+
     await db.execute(
         delete(UserInstallation).where(UserInstallation.user_id == ctx.user.id)
     )
+
+    if asset_ids:
+        await db.execute(
+            update(Asset)
+            .where(Asset.id.in_(asset_ids))
+            .values(deleted_at=datetime.utcnow())
+        )
+
     await db.execute(
         update(User)
         .where(User.id == ctx.user.id)
-        .values(global_name=None, discriminator=None)
+        .values(
+            global_name=None,
+            discriminator=None,
+            character_name=None,
+            world=None,
+        )
     )
     await db.execute(
         update(Message)

--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -19,6 +19,7 @@ from .http.api import create_app
 from .http.discord_client import set_discord_client
 from .repeat_events import recurring_event_poster
 from .channel_names import channel_name_resync
+from .asset_cleanup import purge_deleted_assets
 
 
 async def main_async() -> None:
@@ -62,6 +63,7 @@ async def main_async() -> None:
             bot.start(cfg.discord_token),
             recurring_event_poster(),
             channel_name_resync(),
+            purge_deleted_assets(),
         )
     except Exception:
         logging.exception("Failed to start services")

--- a/tests/test_asset_purge.py
+++ b/tests/test_asset_purge.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timedelta
+import asyncio
+
+from sqlalchemy import select
+
+from demibot.db.models import Asset, AssetKind
+from demibot.db.session import init_db, get_session
+from demibot.asset_cleanup import purge_deleted_assets_once
+
+
+def test_purge_deleted_assets_once():
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            old = Asset(
+                id=1,
+                kind=AssetKind.FILE,
+                name="old",
+                hash="h1",
+                size=1,
+                deleted_at=datetime.utcnow() - timedelta(days=31),
+            )
+            recent = Asset(
+                id=2,
+                kind=AssetKind.FILE,
+                name="new",
+                hash="h2",
+                size=1,
+                deleted_at=datetime.utcnow(),
+            )
+            db.add_all([old, recent])
+            await db.commit()
+            await purge_deleted_assets_once(retention_days=30)
+            assets = (await db.execute(select(Asset).order_by(Asset.id))).scalars().all()
+            assert len(assets) == 1
+            assert assets[0].id == 2
+            break
+    asyncio.run(_run())

--- a/tests/test_forget_me.py
+++ b/tests/test_forget_me.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+import asyncio
+
+from sqlalchemy import select
+
+from demibot.db.models import (
+    Guild,
+    User,
+    Fc,
+    FcUser,
+    Asset,
+    AssetKind,
+    UserInstallation,
+    InstallStatus,
+)
+from demibot.db.session import init_db, get_session
+from demibot.http.deps import RequestContext
+from demibot.http.routes.user_settings import forget_me
+
+
+def test_forget_me_scrubs_user_and_assets():
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            user = User(
+                id=1,
+                discord_user_id=1,
+                global_name="Test",
+                discriminator="1234",
+                character_name="Char",
+                world="World",
+            )
+            guild = Guild(id=1, discord_guild_id=1, name="Guild")
+            fc = Fc(id=1, name="FC", world="World")
+            fcu = FcUser(fc_id=1, user_id=1, joined_at=datetime.utcnow())
+            asset = Asset(
+                id=1,
+                kind=AssetKind.FILE,
+                name="A",
+                hash="h",
+                size=1,
+            )
+            inst = UserInstallation(
+                id=1,
+                user_id=1,
+                asset_id=1,
+                status=InstallStatus.INSTALLED,
+            )
+            db.add_all([user, guild, fc, fcu, asset, inst])
+            await db.commit()
+            ctx = RequestContext(user=user, guild=guild, key=object(), roles=[])
+            await forget_me(ctx=ctx, db=db)
+            user_row = await db.get(User, 1)
+            assert user_row.global_name is None
+            assert user_row.character_name is None
+            assert user_row.world is None
+            inst_rows = (await db.execute(select(UserInstallation))).all()
+            assert not inst_rows
+            asset_row = (
+                await db.execute(select(Asset).where(Asset.id == 1))
+            ).scalar_one()
+            assert asset_row.deleted_at is not None
+            break
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- remove personal character_name and world data on `/users/me/forget`
- soft-delete user-uploaded assets and purge old deleted assets periodically
- add tests for forget endpoint and asset purging

## Testing
- `PYTHONPATH=demibot pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae3b1f25bc8328972252a86a2fa5df