### PR TITLE
feat: add etag and last pull tracking

### DIFF
--- a/demibot/demibot/http/routes/bundles.py
+++ b/demibot/demibot/http/routes/bundles.py
@@ -5,13 +5,19 @@ import hmac
 import os
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, Response, Request
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from ..deps import get_db
-from ...db.models import AppearanceBundle, AppearanceBundleItem, Asset
+from ..deps import get_db, api_key_auth, RequestContext
+from ...db.models import (
+    AppearanceBundle,
+    AppearanceBundleItem,
+    Asset,
+    FcUser,
+    IndexCheckpoint,
+)
 
 router = APIRouter(prefix="/api")
 
@@ -23,13 +29,35 @@ def _sign_download(asset_id: int, asset_hash: str) -> str:
     return f"/assets/{asset_hash}?asset_id={asset_id}&sig={sig}"
 
 
+async def _update_last_pull(db: AsyncSession, fc_id: int, user_id: int) -> None:
+    res = await db.execute(
+        select(FcUser).where(FcUser.fc_id == fc_id, FcUser.user_id == user_id)
+    )
+    fcu = res.scalar_one_or_none()
+    if fcu is not None:
+        fcu.last_pull_at = datetime.utcnow()
+
+
 @router.get("/fc/{fc_id}/bundles")
 async def list_bundles(
     fc_id: int,
+    response: Response,
+    request: Request,
     since: datetime | None = None,
+    ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
     """List appearance bundles for a free company."""
+
+    cp_res = await db.execute(select(func.max(IndexCheckpoint.last_generated_at)))
+    last_generated = cp_res.scalar_one_or_none()
+    if last_generated is not None:
+        etag = last_generated.isoformat()
+        if request.headers.get("if-none-match") == etag:
+            await _update_last_pull(db, fc_id, ctx.user.id)
+            await db.commit()
+            return Response(status_code=304, headers={"ETag": etag})
+        response.headers["ETag"] = etag
 
     stmt = (
         select(AppearanceBundle)
@@ -67,4 +95,7 @@ async def list_bundles(
                 "assets": assets,
             }
         )
+
+    await _update_last_pull(db, fc_id, ctx.user.id)
+    await db.commit()
     return {"items": payload}

--- a/tests/test_assets_bundles_etag.py
+++ b/tests/test_assets_bundles_etag.py
@@ -1,0 +1,132 @@
+import time
+import asyncio
+from datetime import datetime
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from demibot.http.routes.assets import router as assets_router
+from demibot.http.routes.bundles import router as bundles_router
+from demibot.http.deps import RequestContext, api_key_auth
+from demibot.db.session import init_db, get_session
+from demibot.db.models import (
+    User,
+    Fc,
+    FcUser,
+    Asset,
+    AssetKind,
+    IndexCheckpoint,
+    AppearanceBundle,
+    AppearanceBundleItem,
+)
+
+
+def _override_auth(user):
+    def _auth_override():
+        return RequestContext(user=user, guild=None, key=None, roles=[])
+
+    return _auth_override
+
+
+def _get_last_pull(user_id=1, fc_id=1):
+    async def _run():
+        async for db in get_session():
+            res = await db.execute(
+                select(FcUser.last_pull_at).where(
+                    FcUser.fc_id == fc_id, FcUser.user_id == user_id
+                )
+            )
+            return res.scalar_one()
+
+    return asyncio.run(_run())
+
+
+def test_assets_etag_and_last_pull():
+    user = User(id=1, discord_user_id=1)
+    fc = Fc(id=1, name="FC", world="World")
+    fcu = FcUser(fc_id=1, user_id=1, joined_at=datetime.utcnow())
+    asset = Asset(
+        id=1,
+        fc_id=1,
+        kind=AssetKind.FILE,
+        name="file",
+        hash="h1",
+        size=1,
+    )
+    cp_time = datetime(2024, 1, 1)
+    cp = IndexCheckpoint(
+        id=1, kind=AssetKind.FILE, last_id=1, last_generated_at=cp_time
+    )
+
+    async def _setup():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            db.add_all([user, fc, fcu, asset, cp])
+            await db.commit()
+            break
+
+    asyncio.run(_setup())
+
+    app = FastAPI()
+    app.include_router(assets_router)
+    app.dependency_overrides[api_key_auth] = _override_auth(user)
+    client = TestClient(app)
+
+    resp = client.get("/api/fc/1/assets")
+    assert resp.status_code == 200
+    etag = resp.headers["ETag"]
+    assert etag == cp_time.isoformat()
+    lp1 = _get_last_pull()
+    assert lp1 is not None
+    time.sleep(0.01)
+    resp2 = client.get("/api/fc/1/assets", headers={"If-None-Match": etag})
+    assert resp2.status_code == 304
+    lp2 = _get_last_pull()
+    assert lp2 > lp1
+
+
+def test_bundles_etag_and_last_pull():
+    user = User(id=1, discord_user_id=1)
+    fc = Fc(id=1, name="FC", world="World")
+    fcu = FcUser(fc_id=1, user_id=1, joined_at=datetime.utcnow())
+    asset = Asset(
+        id=1,
+        fc_id=1,
+        kind=AssetKind.APPEARANCE,
+        name="a",
+        hash="h1",
+        size=1,
+    )
+    bundle = AppearanceBundle(id=1, fc_id=1, name="b")
+    item = AppearanceBundleItem(bundle_id=1, asset_id=1, quantity=1)
+    cp_time = datetime(2024, 1, 1)
+    cp = IndexCheckpoint(
+        id=1, kind=AssetKind.APPEARANCE, last_id=1, last_generated_at=cp_time
+    )
+
+    async def _setup():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            db.add_all([user, fc, fcu, asset, bundle, item, cp])
+            await db.commit()
+            break
+
+    asyncio.run(_setup())
+
+    app = FastAPI()
+    app.include_router(bundles_router)
+    app.dependency_overrides[api_key_auth] = _override_auth(user)
+    client = TestClient(app)
+
+    resp = client.get("/api/fc/1/bundles")
+    assert resp.status_code == 200
+    etag = resp.headers["ETag"]
+    assert etag == cp_time.isoformat()
+    lp1 = _get_last_pull()
+    assert lp1 is not None
+    time.sleep(0.01)
+    resp2 = client.get("/api/fc/1/bundles", headers={"If-None-Match": etag})
+    assert resp2.status_code == 304
+    lp2 = _get_last_pull()
+    assert lp2 > lp1


### PR DESCRIPTION
## Summary
- compute ETag for asset and bundle listings using index checkpoint timestamps
- return 304 when If-None-Match matches current ETag
- record last_pull_at for free company users after fetch

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae3d6621a483288ec2dfd724913900