### PR TITLE
feat(http): track user installations

### DIFF
--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -51,9 +51,12 @@ class AssetKind(str, Enum):
 
 
 class InstallStatus(str, Enum):
-    PENDING = "pending"
-    INSTALLED = "installed"
-    FAILED = "failed"
+    """Status of an asset installation on a user's client."""
+
+    DOWNLOADED = "DOWNLOADED"
+    INSTALLED = "INSTALLED"
+    APPLIED = "APPLIED"
+    FAILED = "FAILED"
 
 
 class Guild(Base):

--- a/demibot/demibot/http/routes/__init__.py
+++ b/demibot/demibot/http/routes/__init__.py
@@ -10,6 +10,7 @@ from . import (
     guild_roles,
     requests,
     user_settings,
+    installations,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "guild_roles",
     "requests",
     "user_settings",
+    "installations",
 ]

--- a/demibot/demibot/http/routes/installations.py
+++ b/demibot/demibot/http/routes/installations.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ...db.models import InstallStatus, UserInstallation
+
+router = APIRouter(prefix="/api")
+
+
+class InstallationPayload(BaseModel):
+    """Payload for creating or updating a user installation."""
+
+    asset_id: int = Field(alias="assetId")
+    status: InstallStatus
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+@router.get("/users/me/installations")
+async def get_my_installations(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """List installation records for the authenticated user."""
+
+    stmt = select(UserInstallation).where(UserInstallation.user_id == ctx.user.id)
+    result = await db.execute(stmt)
+    rows = result.scalars().all()
+    items = [
+        {
+            "assetId": str(row.asset_id),
+            "status": row.status.value,
+            "updatedAt": row.updated_at.isoformat() if row.updated_at else None,
+        }
+        for row in rows
+    ]
+    return items
+
+
+@router.post("/users/me/installations")
+async def post_my_installations(
+    payload: InstallationPayload,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create or update an installation record for the authenticated user."""
+
+    stmt = select(UserInstallation).where(
+        UserInstallation.user_id == ctx.user.id,
+        UserInstallation.asset_id == payload.asset_id,
+    )
+    result = await db.execute(stmt)
+    inst = result.scalar_one_or_none()
+    now = datetime.utcnow()
+    if inst is None:
+        inst = UserInstallation(
+            user_id=ctx.user.id,
+            asset_id=payload.asset_id,
+            status=payload.status,
+            updated_at=now,
+        )
+        db.add(inst)
+    else:
+        inst.status = payload.status
+        inst.updated_at = now
+    await db.commit()
+    await db.refresh(inst)
+    return {
+        "assetId": str(inst.asset_id),
+        "status": inst.status.value,
+        "updatedAt": inst.updated_at.isoformat() if inst.updated_at else None,
+    }

--- a/tests/test_installations.py
+++ b/tests/test_installations.py
@@ -1,0 +1,61 @@
+import asyncio
+from datetime import datetime
+
+from sqlalchemy import select
+
+from demibot.db.models import (
+    Guild,
+    User,
+    Asset,
+    AssetKind,
+    InstallStatus,
+    UserInstallation,
+)
+from demibot.db.session import init_db, get_session
+from demibot.http.deps import RequestContext
+from demibot.http.routes.installations import (
+    get_my_installations,
+    post_my_installations,
+    InstallationPayload,
+)
+
+
+def test_installations_flow():
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            user = User(id=1, discord_user_id=1, global_name="Test")
+            guild = Guild(id=1, discord_guild_id=1, name="Guild")
+            asset = Asset(id=1, kind=AssetKind.FILE, name="A", hash="h", size=1)
+            db.add_all([user, guild, asset])
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=guild, key=object(), roles=[])
+
+            # initial list empty
+            items = await get_my_installations(ctx=ctx, db=db)
+            assert items == []
+
+            # download
+            payload = InstallationPayload(assetId=1, status=InstallStatus.DOWNLOADED)
+            await post_my_installations(payload, ctx=ctx, db=db)
+            items = await get_my_installations(ctx=ctx, db=db)
+            assert items[0]["status"] == "DOWNLOADED"
+
+            # install
+            payload = InstallationPayload(assetId=1, status=InstallStatus.INSTALLED)
+            await post_my_installations(payload, ctx=ctx, db=db)
+            items = await get_my_installations(ctx=ctx, db=db)
+            assert items[0]["status"] == "INSTALLED"
+
+            # apply
+            payload = InstallationPayload(assetId=1, status=InstallStatus.APPLIED)
+            await post_my_installations(payload, ctx=ctx, db=db)
+            items = await get_my_installations(ctx=ctx, db=db)
+            assert items[0]["status"] == "APPLIED"
+
+            # only one row exists
+            rows = (await db.execute(select(UserInstallation))).scalars().all()
+            assert len(rows) == 1
+            break
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add new InstallStatus values for tracking client installs
- add /api/users/me/installations endpoints for listing/updating installations
- cover installation status flow in tests

## Testing
- `PYTHONPATH=demibot pytest tests/test_installations.py tests/test_forget_me.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae94b8ede48328a34f7940851b7379