### PR TITLE
build: reference Lumina Excel generated sheets

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -21,6 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="Lumina.Excel.GeneratedSheets">
+      <HintPath>$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="icon.png" />
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- add reference to Lumina Excel generated sheets to enable generated Excel sheet access

## Testing
- `DOTNET_ROLL_FORWARD=latestMajor dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release` *(fails: Dalamud installation not found)*
- `pytest` *(fails: missing python packages such as discord, fastapi, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68aeee0ed9a48328bee1bb547a7c0367