### PR TITLE
Use texture provider for game icon caching

### DIFF
--- a/DemiCatPlugin/GameDataCache.cs
+++ b/DemiCatPlugin/GameDataCache.cs
@@ -5,6 +5,8 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dalamud.Plugin.Services;
+using Dalamud.Interface.Textures;
+using Dalamud.Interface.Textures.TextureWraps;
 
 namespace DemiCatPlugin;
 
@@ -137,7 +139,8 @@ internal sealed class GameDataCache : IDisposable
         {
             try
             {
-                using var icon = _dataManager.GetIcon(iconId);
+                var texture = _textureProvider.GetFromGameIcon(iconId);
+                using var icon = await texture.RentAsync();
                 await File.WriteAllBytesAsync(filePath, icon.GetRgbaImageData());
             }
             catch


### PR DESCRIPTION
## Summary
- use texture provider to resolve game icons and save them as cached png files

## Testing
- `pytest`
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud.NET.Sdk: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68aeef50c12c8328a695c8119245e071