### PR TITLE
Use synchronous disposal for HTTP response

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -364,12 +364,10 @@ public class SyncshellWindow : IDisposable
                 : $"{baseUrl}{asset.DownloadUrl}";
 
             var tmp = Path.GetTempFileName();
-            await using (var resp = await _httpClient.GetAsync(url))
-            {
-                resp.EnsureSuccessStatusCode();
-                await using var fs = File.Create(tmp);
-                await resp.Content.CopyToAsync(fs);
-            }
+            using var resp = await _httpClient.GetAsync(url);
+            resp.EnsureSuccessStatusCode();
+            await using var fs = File.Create(tmp);
+            await resp.Content.CopyToAsync(fs);
 
             await UpdateInstallationStatus(asset.Id, "DOWNLOADED");
 


### PR DESCRIPTION
## Summary
- Replace `await using` with `using var` for HTTP response in `InstallAsset`

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: A compatible .NET SDK was not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aef1059b1483289c59872d96b15321