### PR TITLE
Use texture wrap handle for request board images

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
@@ -38,7 +39,8 @@ public class RequestBoardWindow
                     var tex = PluginServices.Instance!.TextureProvider.GetFromFile(item.IconPath);
                     if (tex != null)
                     {
-                        ImGui.Image(tex.ImGuiHandle, new Vector2(32));
+                        var wrap = tex.GetWrapOrDefault();
+                        ImGui.Image(wrap?.ImGuiHandle ?? IntPtr.Zero, new Vector2(32));
                         ImGui.SameLine();
                     }
                     var text = item.Name;
@@ -64,7 +66,8 @@ public class RequestBoardWindow
                     var tex = PluginServices.Instance!.TextureProvider.GetFromFile(duty.IconPath);
                     if (tex != null)
                     {
-                        ImGui.Image(tex.ImGuiHandle, new Vector2(32));
+                        var wrap = tex.GetWrapOrDefault();
+                        ImGui.Image(wrap?.ImGuiHandle ?? IntPtr.Zero, new Vector2(32));
                         ImGui.SameLine();
                     }
                     ImGui.TextUnformatted($"{duty.Name} [{req.Status}]");


### PR DESCRIPTION
## Summary
- get texture wrap and use its handle when drawing item and duty icons

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68aef1d4d64c832887ad9456e796a0d3