### PR TITLE
Fix Penumbra IPC reload/redraw calls

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -445,7 +445,7 @@ public class SyncshellWindow : IDisposable
                 {
                     Directory.CreateDirectory(dest);
                     ZipFile.ExtractToDirectory(path, dest, true);
-                    pi.GetIpcSubscriber<object?>("Penumbra.Reload").InvokeAction(null);
+                    pi.GetIpcSubscriber("Penumbra.Reload").InvokeAction();
                     success = true;
                 }
                 catch
@@ -462,7 +462,7 @@ public class SyncshellWindow : IDisposable
             {
                 try
                 {
-                    pi?.GetIpcSubscriber<object?>("Penumbra.RedrawAll").InvokeAction(null);
+                    pi?.GetIpcSubscriber("Penumbra.RedrawAll").InvokeAction();
                 }
                 catch
                 {


### PR DESCRIPTION
## Summary
- use no-payload Penumbra reload/redraw IPC

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aef2bb72c48328abc81df9bf6cec05