### PR TITLE
Use null-conditional operator for Penumbra conflict

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -85,20 +85,20 @@ public class SyncshellWindow : IDisposable
             ImGui.TextUnformatted($"Mod {_penumbraConflict.ModName} already exists. Use vault version or keep mine?");
             if (ImGui.Button("Use vault version"))
             {
-                _penumbraConflict.Tcs.TrySetResult(true);
+                _penumbraConflict?.Tcs.TrySetResult(true);
                 _penumbraConflict = null;
             }
             ImGui.SameLine();
             if (ImGui.Button("Keep mine"))
             {
-                _penumbraConflict.Tcs.TrySetResult(false);
+                _penumbraConflict?.Tcs.TrySetResult(false);
                 _penumbraConflict = null;
             }
             ImGui.EndPopup();
         }
         else if (_penumbraConflict != null && !openConflict)
         {
-            _penumbraConflict.Tcs.TrySetResult(false);
+            _penumbraConflict?.Tcs.TrySetResult(false);
             _penumbraConflict = null;
         }
 


### PR DESCRIPTION
## Summary
- guard Penumbra conflict task completion source with null-conditional operator

## Testing
- `/root/dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aef38d1ac0832888f1c7dc089099f0