### PR TITLE
Use encoder for icon caching

### DIFF
--- a/DemiCatPlugin/GameDataCache.cs
+++ b/DemiCatPlugin/GameDataCache.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net.Http;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Dalamud.Plugin.Services;
 using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.TextureWraps;
@@ -141,7 +136,9 @@ internal sealed class GameDataCache : IDisposable
             {
                 var texture = _textureProvider.GetFromGameIcon(iconId);
                 using var icon = await texture.RentAsync();
-                await File.WriteAllBytesAsync(filePath, icon.GetRgbaImageData());
+                await using var s = icon.EncodeToStream(Dalamud.ImageFormat.Png);
+                await using var f = File.Create(filePath);
+                await s.CopyToAsync(f);
             }
             catch
             {


### PR DESCRIPTION
## Summary
- encode game icons to PNG via Dalamud's built-in encoder
- trim unused `using` directives in `GameDataCache`

## Testing
- `dotnet build` *(fails: A compatible .NET SDK was not found. Install the [9.0.100] .NET SDK)*
- `pytest` *(fails: Interrupted: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aef5904f248328814593b0cc99a1c3