### PR TITLE
Add optional Lumina sheet reference with string-based fallbacks

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -21,10 +21,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="Lumina.Excel.GeneratedSheets">
+    <Reference Include="Lumina.Excel.GeneratedSheets" Condition="Exists('$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll')">
       <HintPath>$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll</HintPath>
     </Reference>
   </ItemGroup>
+
+  <PropertyGroup Condition="Exists('$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll')">
+    <DefineConstants>$(DefineConstants);LUMINA_GENERATED_SHEETS</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="icon.png" />

--- a/DemiCatPlugin/GameDataCache.cs
+++ b/DemiCatPlugin/GameDataCache.cs
@@ -66,6 +66,7 @@ internal sealed class GameDataCache : IDisposable
     {
         try
         {
+            #if LUMINA_GENERATED_SHEETS
             var sheet = _dataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets.Item>();
             var row = sheet?.GetRow(id);
             if (row != null)
@@ -74,6 +75,17 @@ internal sealed class GameDataCache : IDisposable
                 var iconFile = await GetIconFile(row.Icon, id);
                 return new CachedEntry(name, iconFile, DateTime.UtcNow);
             }
+            #else
+            var sheet = _dataManager.GetExcelSheet("Item");
+            dynamic row = sheet?.GetRow(id);
+            if (row != null)
+            {
+                string name = row.Name?.ToString() ?? $"Item {id}";
+                uint icon = row.Icon;
+                var iconFile = await GetIconFile(icon, id);
+                return new CachedEntry(name, iconFile, DateTime.UtcNow);
+            }
+            #endif
         }
         catch
         {
@@ -101,6 +113,7 @@ internal sealed class GameDataCache : IDisposable
     {
         try
         {
+            #if LUMINA_GENERATED_SHEETS
             var sheet = _dataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets.ContentFinderCondition>();
             var row = sheet?.GetRow(id);
             if (row != null)
@@ -109,6 +122,17 @@ internal sealed class GameDataCache : IDisposable
                 var iconFile = await GetIconFile(row.Icon, id, "duty");
                 return new CachedEntry(name, iconFile, DateTime.UtcNow);
             }
+            #else
+            var sheet = _dataManager.GetExcelSheet("ContentFinderCondition");
+            dynamic row = sheet?.GetRow(id);
+            if (row != null)
+            {
+                string name = row.Name?.ToString() ?? $"Duty {id}";
+                uint icon = row.Icon;
+                var iconFile = await GetIconFile(icon, id, "duty");
+                return new CachedEntry(name, iconFile, DateTime.UtcNow);
+            }
+            #endif
         }
         catch
         {


### PR DESCRIPTION
## Summary
- Make `Lumina.Excel.GeneratedSheets` reference conditional
- Add `LUMINA_GENERATED_SHEETS` constant when the DLL exists
- Use string-based Excel lookups when generated sheets are missing

## Testing
- `~/.dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aef581c524832893145b26e1a5333e