### PR TITLE
Use ImGuiBinding handle for textures

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -40,7 +40,7 @@ public class RequestBoardWindow
                     if (tex != null)
                     {
                         var wrap = tex.GetWrapOrDefault();
-                        ImGui.Image(wrap?.ImGuiHandle ?? IntPtr.Zero, new Vector2(32));
+                        ImGui.Image(wrap?.ImGuiBinding.Handle ?? IntPtr.Zero, new Vector2(32));
                         ImGui.SameLine();
                     }
                     var text = item.Name;
@@ -67,7 +67,7 @@ public class RequestBoardWindow
                     if (tex != null)
                     {
                         var wrap = tex.GetWrapOrDefault();
-                        ImGui.Image(wrap?.ImGuiHandle ?? IntPtr.Zero, new Vector2(32));
+                        ImGui.Image(wrap?.ImGuiBinding.Handle ?? IntPtr.Zero, new Vector2(32));
                         ImGui.SameLine();
                     }
                     ImGui.TextUnformatted($"{duty.Name} [{req.Status}]");


### PR DESCRIPTION
## Summary
- Use `ImGuiBinding.Handle` when rendering textures in `RequestBoardWindow`

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', fastapi, sqlalchemy, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aef6d1a9748328babca01d57a79ae2