### PR TITLE
Specify generic type for Penumbra IPC calls

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -445,7 +445,7 @@ public class SyncshellWindow : IDisposable
                 {
                     Directory.CreateDirectory(dest);
                     ZipFile.ExtractToDirectory(path, dest, true);
-                    pi.GetIpcSubscriber("Penumbra.Reload").InvokeAction();
+                    pi.GetIpcSubscriber<object>("Penumbra.Reload").InvokeAction();
                     success = true;
                 }
                 catch
@@ -462,7 +462,7 @@ public class SyncshellWindow : IDisposable
             {
                 try
                 {
-                    pi?.GetIpcSubscriber("Penumbra.RedrawAll").InvokeAction();
+                    pi?.GetIpcSubscriber<object>("Penumbra.RedrawAll").InvokeAction();
                 }
                 catch
                 {


### PR DESCRIPTION
## Summary
- pass object type when invoking Penumbra.Reload
- pass object type when invoking Penumbra.RedrawAll

## Testing
- `~/.dotnet/dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aef6d6364083288a5ae51a1413fd95