### PR TITLE
Use generic overload for IPC action

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -508,7 +508,7 @@ public class SyncshellWindow : IDisposable
         try
         {
             var pi = PluginServices.Instance?.PluginInterface;
-            pi?.GetIpcSubscriber<string>(channel).InvokeAction(payload);
+            pi?.GetIpcSubscriber<string, object?>(channel).InvokeAction(payload);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- ensure IPC actions with payload choose the action-with-argument overload

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: A compatible .NET SDK was not found)*
- `pytest` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aef7e61740832886c6e44ac2b5f386