### PR TITLE
Replace non-generated data sheet calls with ExcelRow-based sheets

### DIFF
--- a/DemiCatPlugin/GameDataCache.cs
+++ b/DemiCatPlugin/GameDataCache.cs
@@ -71,7 +71,7 @@ internal sealed class GameDataCache : IDisposable
                 return new CachedEntry(name, iconFile, DateTime.UtcNow);
             }
             #else
-            var sheet = _dataManager.GetExcelSheet("Item");
+            var sheet = _dataManager.GetExcelSheet<Lumina.Excel.ExcelRow>(name: "Item");
             dynamic row = sheet?.GetRow(id);
             if (row != null)
             {
@@ -118,7 +118,7 @@ internal sealed class GameDataCache : IDisposable
                 return new CachedEntry(name, iconFile, DateTime.UtcNow);
             }
             #else
-            var sheet = _dataManager.GetExcelSheet("ContentFinderCondition");
+            var sheet = _dataManager.GetExcelSheet<Lumina.Excel.ExcelRow>(name: "ContentFinderCondition");
             dynamic row = sheet?.GetRow(id);
             if (row != null)
             {


### PR DESCRIPTION
## Summary
- use generic ExcelRow retrieval for Item sheet
- use generic ExcelRow retrieval for ContentFinderCondition sheet

## Testing
- `/root/.dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj` (fails: Dalamud installation not found)
- `pytest` (fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy')

------
https://chatgpt.com/codex/tasks/task_e_68aefbd8d9188328afacf9517e383d17