### PR TITLE
Use SavePngAsync for icon cache

### DIFF
--- a/DemiCatPlugin/GameDataCache.cs
+++ b/DemiCatPlugin/GameDataCache.cs
@@ -160,9 +160,8 @@ internal sealed class GameDataCache : IDisposable
             {
                 var texture = _textureProvider.GetFromGameIcon(iconId);
                 using var icon = await texture.RentAsync();
-                await using var s = icon.EncodeToStream(Dalamud.ImageFormat.Png);
                 await using var f = File.Create(filePath);
-                await s.CopyToAsync(f);
+                await icon.SavePngAsync(f);
             }
             catch
             {


### PR DESCRIPTION
## Summary
- switch icon caching to SavePngAsync instead of EncodeToStream

## Testing
- `dotnet test` *(fails: Requested SDK version 9.0.100 not found)*
- `pytest` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aefbe07be883289c11f51eba2e76e0