### PR TITLE
Use ImGuiHandle for textures

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -40,7 +40,7 @@ public class RequestBoardWindow
                     if (tex != null)
                     {
                         var wrap = tex.GetWrapOrDefault();
-                        ImGui.Image(wrap?.ImGuiBinding.Handle ?? IntPtr.Zero, new Vector2(32));
+                        ImGui.Image(wrap?.ImGuiHandle ?? IntPtr.Zero, new Vector2(32));
                         ImGui.SameLine();
                     }
                     var text = item.Name;
@@ -67,7 +67,7 @@ public class RequestBoardWindow
                     if (tex != null)
                     {
                         var wrap = tex.GetWrapOrDefault();
-                        ImGui.Image(wrap?.ImGuiBinding.Handle ?? IntPtr.Zero, new Vector2(32));
+                        ImGui.Image(wrap?.ImGuiHandle ?? IntPtr.Zero, new Vector2(32));
                         ImGui.SameLine();
                     }
                     ImGui.TextUnformatted($"{duty.Name} [{req.Status}]");


### PR DESCRIPTION
## Summary
- fix request board icons to use ImGuiHandle

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aefd0e8774832888331e57b22ec518