### PR TITLE
fix: mark nullable rows

### DIFF
--- a/DemiCatPlugin/GameDataCache.cs
+++ b/DemiCatPlugin/GameDataCache.cs
@@ -72,7 +72,7 @@ internal sealed class GameDataCache : IDisposable
             }
             #else
             var sheet = _dataManager.GetExcelSheet<Lumina.Excel.ExcelRow>(name: "Item");
-            dynamic row = sheet?.GetRow(id);
+            dynamic? row = sheet?.GetRow(id);
             if (row != null)
             {
                 string name = row.Name?.ToString() ?? $"Item {id}";
@@ -119,7 +119,7 @@ internal sealed class GameDataCache : IDisposable
             }
             #else
             var sheet = _dataManager.GetExcelSheet<Lumina.Excel.ExcelRow>(name: "ContentFinderCondition");
-            dynamic row = sheet?.GetRow(id);
+            dynamic? row = sheet?.GetRow(id);
             if (row != null)
             {
                 string name = row.Name?.ToString() ?? $"Duty {id}";


### PR DESCRIPTION
## Summary
- mark Excel sheet row references as nullable when resolving items and duties

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aefd11d2e08328b960e42e9c66f736