### PR TITLE
Save icons via stream

### DIFF
--- a/DemiCatPlugin/GameDataCache.cs
+++ b/DemiCatPlugin/GameDataCache.cs
@@ -160,8 +160,9 @@ internal sealed class GameDataCache : IDisposable
             {
                 var texture = _textureProvider.GetFromGameIcon(iconId);
                 using var icon = await texture.RentAsync();
-                await using var f = File.Create(filePath);
-                await icon.SavePngAsync(f);
+                await using var stream = icon.EncodeToStream(Dalamud.ImageFormat.Png);
+                await using var file = File.Create(filePath);
+                await stream.CopyToAsync(file);
             }
             catch
             {


### PR DESCRIPTION
## Summary
- write rented icons to disk by encoding to PNG stream
- remove invalid `SavePngAsync` call

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj -c Release` *(fails: Dalamud installation not found)*
- `pytest tests/test_asset_download.py` *(fails: No module named 'demibot')*


------
https://chatgpt.com/codex/tasks/task_e_68afa22f7f5c8328a421593fedb07668