### PR TITLE
Resolve textures before display on request board

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -37,7 +37,7 @@ public class RequestBoardWindow
                 {
                     var item = req.ItemData;
                     var tex = PluginServices.Instance!.TextureProvider.GetFromFile(item.IconPath);
-                    if (tex != null)
+                    if (tex != null && tex.TryGetWrap(out _, out _))
                     {
                         var wrap = tex.GetWrapOrDefault();
                         ImGui.Image(wrap?.ImGuiHandle ?? IntPtr.Zero, new Vector2(32));
@@ -64,7 +64,7 @@ public class RequestBoardWindow
                 {
                     var duty = req.DutyData;
                     var tex = PluginServices.Instance!.TextureProvider.GetFromFile(duty.IconPath);
-                    if (tex != null)
+                    if (tex != null && tex.TryGetWrap(out _, out _))
                     {
                         var wrap = tex.GetWrapOrDefault();
                         ImGui.Image(wrap?.ImGuiHandle ?? IntPtr.Zero, new Vector2(32));


### PR DESCRIPTION
## Summary
- Resolve texture wraps before rendering request board icons

## Testing
- `dotnet build` *(fails: 9.0.100 SDK not installed)*
- `pytest` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68afa7c9c3a48328a1cbee372cee926d