### PR TITLE
Deduplicate roles in API auth

### DIFF
--- a/demibot/demibot/http/deps.py
+++ b/demibot/demibot/http/deps.py
@@ -56,12 +56,12 @@ async def api_key_auth(
         .where(Membership.guild_id == guild.id, Membership.user_id == user.id)
     )
     roles_result = await db.execute(roles_stmt)
-    roles: list[str] = []
+    roles: set[str] = set()
     for r in roles_result.scalars():
         if r.is_officer:
-            roles.append("officer")
+            roles.add("officer")
         if r.is_chat:
-            roles.append("chat")
+            roles.add("chat")
     logging.info(
         "API %s %s guild=%s user=%s",
         request.method if request else "?",
@@ -69,4 +69,4 @@ async def api_key_auth(
         guild.discord_guild_id,
         user.discord_user_id,
     )
-    return RequestContext(user=user, guild=guild, key=key, roles=roles)
+    return RequestContext(user=user, guild=guild, key=key, roles=list(roles))


### PR DESCRIPTION
## Summary
- prevent duplicate officer/chat roles in API authentication

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*
- `pip install -r demibot/requirements-dev.txt`
- `pip install ./demibot` *(fails: invalid pyproject.toml configuration)*


------
https://chatgpt.com/codex/tasks/task_e_68afb183992083288e743b13c981aa36