### PR TITLE
refactor: drop unused config arg from HTTP app factory

### DIFF
--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -17,13 +17,7 @@ from fastapi import FastAPI
 
 from .ws import websocket_endpoint
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
-    from ..config import AppConfig
-
-
-def create_app(cfg: "AppConfig | None") -> FastAPI:
+def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
 
     app = FastAPI()

--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -50,7 +50,7 @@ async def main_async() -> None:
         cfg.server.port,
     )
     try:
-        app = create_app(cfg)
+        app = create_app()
         bot = create_bot(cfg)
         set_discord_client(bot)
         config = uvicorn.Config(


### PR DESCRIPTION
## Summary
- remove unused `cfg` parameter from `create_app`
- update call site in `main.py`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68afb0f28818832898442b5be5437781