### PR TITLE
Add TerraFX Windows interop dependency

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StbImageSharp" Version="2.30.15" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add TerraFX.Interop.Windows reference so GameDataCache can resolve GUID constants

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: A compatible .NET SDK was not found; requires 9.0.100)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68afaf4fcd448328924891131229d83c