### PR TITLE
Await prior channel watcher task and log errors

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -24,9 +24,13 @@ public class ChannelWatcher : IDisposable
         _officerChatWindow = officerChatWindow;
     }
 
-    public void Start()
+    public async Task Start()
     {
         _cts?.Cancel();
+        if (_task != null)
+        {
+            try { await _task; } catch { }
+        }
         _ws?.Dispose();
         _cts = new CancellationTokenSource();
         _task = Run(_cts.Token);
@@ -69,9 +73,9 @@ public class ChannelWatcher : IDisposable
                     });
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // ignore errors and retry
+                PluginServices.Instance!.Log.Error(ex, "Channel watcher loop failed");
             }
             finally
             {

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -403,7 +403,10 @@ public class SettingsWindow : IDisposable
 
                     try
                     {
-                        ChannelWatcher?.Start();
+                        if (ChannelWatcher != null)
+                        {
+                            await ChannelWatcher.Start();
+                        }
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
## Summary
- Await existing ChannelWatcher task after cancelling before starting a new one
- Log exceptions thrown in ChannelWatcher run loop
- Update SettingsWindow to await ChannelWatcher start

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68afb50ac60c8328846e3a4cc0247e7a