### PR TITLE
Handle deleted requests in watcher

### DIFF
--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -40,6 +40,14 @@ internal static class RequestStateService
         }
     }
 
+    public static void Remove(string id)
+    {
+        lock (LockObj)
+        {
+            RequestsMap.Remove(id);
+        }
+    }
+
     public static bool TryGet(string id, out RequestState state)
     {
         lock (LockObj)

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -79,6 +79,13 @@ public class RequestWatcher : IDisposable
                 return;
 
             var id = payload.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+            var deleted = payload.TryGetProperty("deleted", out var delEl) && delEl.GetBoolean();
+            if (deleted)
+            {
+                if (id != null) RequestStateService.Remove(id);
+                return;
+            }
+
             var title = payload.TryGetProperty("title", out var titleEl) ? titleEl.GetString() ?? "Request" : "Request";
             var statusString = payload.TryGetProperty("status", out var statusEl) ? statusEl.GetString() : null;
             var version = payload.TryGetProperty("version", out var verEl) ? verEl.GetInt32() : 0;


### PR DESCRIPTION
## Summary
- detect `deleted:true` in request websocket notifications and remove from state
- add helper `Remove` method on `RequestStateService`

## Testing
- `/usr/share/dotnet9/dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest tests/test_channel_name_retry.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68afb8c39bbc83288c220c104aa0f479