### PR TITLE
Enforce permissions on request status changes

### DIFF
--- a/demibot/demibot/http/routes/requests.py
+++ b/demibot/demibot/http/routes/requests.py
@@ -269,6 +269,9 @@ async def accept_request(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
+    req = await db.get(DbRequest, request_id)
+    if not req or req.guild_id != ctx.guild.id:
+        raise HTTPException(status_code=404)
     req = await _update_status(
         db,
         ctx.guild.id,
@@ -291,6 +294,11 @@ async def start_request(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
+    req = await db.get(DbRequest, request_id)
+    if not req or req.guild_id != ctx.guild.id:
+        raise HTTPException(status_code=404)
+    if req.assignee_id != ctx.user.id:
+        raise HTTPException(status_code=403)
     req = await _update_status(
         db,
         ctx.guild.id,
@@ -311,6 +319,11 @@ async def complete_request(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
+    req = await db.get(DbRequest, request_id)
+    if not req or req.guild_id != ctx.guild.id:
+        raise HTTPException(status_code=404)
+    if req.assignee_id != ctx.user.id:
+        raise HTTPException(status_code=403)
     req = await _update_status(
         db,
         ctx.guild.id,
@@ -332,6 +345,11 @@ async def confirm_request(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
+    req = await db.get(DbRequest, request_id)
+    if not req or req.guild_id != ctx.guild.id:
+        raise HTTPException(status_code=404)
+    if req.user_id != ctx.user.id and "officer" not in ctx.roles:
+        raise HTTPException(status_code=403)
     req = await _update_status(
         db,
         ctx.guild.id,
@@ -351,6 +369,11 @@ async def cancel_request(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, bool]:
+    req = await db.get(DbRequest, request_id)
+    if not req or req.guild_id != ctx.guild.id:
+        raise HTTPException(status_code=404)
+    if req.user_id != ctx.user.id and "officer" not in ctx.roles:
+        raise HTTPException(status_code=403)
     result = await db.execute(
         update(DbRequest)
         .where(

--- a/tests/test_request_status_permissions.py
+++ b/tests/test_request_status_permissions.py
@@ -1,0 +1,184 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import sys
+import types
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+routes_pkg = types.ModuleType("demibot.http.routes")
+routes_pkg.__path__ = [str(root / "demibot/http/routes")]
+sys.modules.setdefault("demibot.http.routes", routes_pkg)
+
+discord_mod = types.ModuleType("discord")
+abc_mod = types.ModuleType("discord.abc")
+abc_mod.Messageable = type("Messageable", (), {})
+discord_mod.abc = abc_mod
+sys.modules.setdefault("discord", discord_mod)
+sys.modules.setdefault("discord.abc", abc_mod)
+ext_mod = types.ModuleType("discord.ext")
+commands_mod = types.ModuleType("discord.ext.commands")
+ext_mod.commands = commands_mod
+discord_mod.ext = ext_mod
+sys.modules.setdefault("discord.ext", ext_mod)
+sys.modules.setdefault("discord.ext.commands", commands_mod)
+from demibot.db.models import (
+    Guild,
+    User,
+    Request as DbRequest,
+    RequestStatus,
+    RequestType,
+    Urgency,
+)
+from demibot.db.session import init_db, get_session
+from demibot.http.deps import RequestContext
+import demibot.http.routes.requests as request_routes
+
+
+async def _setup_db(db_path: str) -> None:
+    await init_db(f"sqlite+aiosqlite:///{db_path}")
+    async for db in get_session():
+        guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
+        requester = User(id=1, discord_user_id=1)
+        assignee = User(id=2, discord_user_id=2)
+        other = User(id=3, discord_user_id=3)
+        db.add_all([guild, requester, assignee, other])
+        await db.commit()
+        break
+
+
+@pytest.fixture()
+def db_setup(tmp_path):
+    path = tmp_path / "requests.db"
+    asyncio.run(_setup_db(str(path)))
+    return path
+
+
+async def _noop(*args, **kwargs):
+    return None
+
+
+@pytest.fixture(autouse=True)
+def patch_broadcast(monkeypatch):
+    monkeypatch.setattr(request_routes, "_broadcast", _noop)
+    monkeypatch.setattr(request_routes, "_notify", _noop)
+
+
+def test_start_requires_assignee(db_setup):
+    async def run():
+        async for db in get_session():
+            guild = await db.get(Guild, 1)
+            requester = await db.get(User, 1)
+            assignee = await db.get(User, 2)
+            other = await db.get(User, 3)
+            req = DbRequest(
+                id=1,
+                guild_id=guild.id,
+                user_id=requester.id,
+                assignee_id=assignee.id,
+                title="Test",
+                type=RequestType.ITEM,
+                status=RequestStatus.CLAIMED,
+                urgency=Urgency.LOW,
+            )
+            db.add(req)
+            await db.commit()
+            ctx = RequestContext(user=other, guild=guild, key=SimpleNamespace(), roles=[])
+            body = request_routes.StatusBody(version=req.version)
+            with pytest.raises(HTTPException) as exc:
+                await request_routes.start_request(req.id, body, ctx=ctx, db=db)
+            return exc.value.status_code
+    code = asyncio.run(run())
+    assert code == 403
+
+
+def test_complete_requires_assignee(db_setup):
+    async def run():
+        async for db in get_session():
+            guild = await db.get(Guild, 1)
+            requester = await db.get(User, 1)
+            assignee = await db.get(User, 2)
+            other = await db.get(User, 3)
+            req = DbRequest(
+                id=2,
+                guild_id=guild.id,
+                user_id=requester.id,
+                assignee_id=assignee.id,
+                title="Test",
+                type=RequestType.ITEM,
+                status=RequestStatus.IN_PROGRESS,
+                urgency=Urgency.LOW,
+            )
+            db.add(req)
+            await db.commit()
+            ctx = RequestContext(user=other, guild=guild, key=SimpleNamespace(), roles=[])
+            body = request_routes.StatusBody(version=req.version)
+            with pytest.raises(HTTPException) as exc:
+                await request_routes.complete_request(req.id, body, ctx=ctx, db=db)
+            return exc.value.status_code
+    code = asyncio.run(run())
+    assert code == 403
+
+
+def test_confirm_requires_requester(db_setup):
+    async def run():
+        async for db in get_session():
+            guild = await db.get(Guild, 1)
+            requester = await db.get(User, 1)
+            assignee = await db.get(User, 2)
+            other = await db.get(User, 3)
+            req = DbRequest(
+                id=3,
+                guild_id=guild.id,
+                user_id=requester.id,
+                assignee_id=assignee.id,
+                title="Test",
+                type=RequestType.ITEM,
+                status=RequestStatus.AWAITING_CONFIRM,
+                urgency=Urgency.LOW,
+            )
+            db.add(req)
+            await db.commit()
+            ctx = RequestContext(user=other, guild=guild, key=SimpleNamespace(), roles=[])
+            body = request_routes.StatusBody(version=req.version)
+            with pytest.raises(HTTPException) as exc:
+                await request_routes.confirm_request(req.id, body, ctx=ctx, db=db)
+            return exc.value.status_code
+    code = asyncio.run(run())
+    assert code == 403
+
+
+def test_cancel_requires_requester(db_setup):
+    async def run():
+        async for db in get_session():
+            guild = await db.get(Guild, 1)
+            requester = await db.get(User, 1)
+            assignee = await db.get(User, 2)
+            other = await db.get(User, 3)
+            req = DbRequest(
+                id=4,
+                guild_id=guild.id,
+                user_id=requester.id,
+                assignee_id=assignee.id,
+                title="Test",
+                type=RequestType.ITEM,
+                status=RequestStatus.OPEN,
+                urgency=Urgency.LOW,
+            )
+            db.add(req)
+            await db.commit()
+            ctx = RequestContext(user=other, guild=guild, key=SimpleNamespace(), roles=[])
+            with pytest.raises(HTTPException) as exc:
+                await request_routes.cancel_request(req.id, ctx=ctx, db=db)
+            return exc.value.status_code
+    code = asyncio.run(run())
+    assert code == 403


### PR DESCRIPTION
## Summary
- Validate request ownership before changing status
- Restrict start/complete to assignee and confirm/cancel to requester or officer
- Add tests for request status permission checks

## Testing
- `pytest tests/test_request_status_permissions.py -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68afcfb96afc8328ab5dae121e0c60f0