### PR TITLE
Allow privileged API calls to specify Discord user

### DIFF
--- a/demibot/demibot/discordbot/cogs/events.py
+++ b/demibot/demibot/discordbot/cogs/events.py
@@ -32,7 +32,10 @@ async def create_event(
         "time": time,
         "description": description,
     }
-    headers = {"X-Api-Key": interaction.client.cfg.security.api_key}
+    headers = {
+        "X-Api-Key": interaction.client.cfg.security.api_key,
+        "X-Discord-Id": str(interaction.user.id),
+    }
     async with aiohttp.ClientSession() as session:
         async with session.post(
             f"{base_url}/api/events", json=body, headers=headers

--- a/demibot/demibot/discordbot/cogs/requests.py
+++ b/demibot/demibot/discordbot/cogs/requests.py
@@ -29,7 +29,10 @@ async def _create_request(
         "type": rtype,
         "urgency": urgency,
     }
-    headers = {"X-Api-Key": interaction.client.cfg.security.api_key}
+    headers = {
+        "X-Api-Key": interaction.client.cfg.security.api_key,
+        "X-Discord-Id": str(interaction.user.id),
+    }
     async with aiohttp.ClientSession() as session:
         async with session.post(f"{base_url}/api/requests", json=body, headers=headers) as resp:
             if resp.status != 200:

--- a/tests/test_discord_id_header.py
+++ b/tests/test_discord_id_header.py
@@ -1,0 +1,39 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+from demibot.db.models import Guild, User, UserKey
+from demibot.db.session import init_db, get_session
+from demibot.http.deps import api_key_auth
+
+
+def test_x_discord_id_overrides_user(tmp_path):
+    db_path = tmp_path / "auth.db"
+    asyncio.run(init_db(f"sqlite+aiosqlite:///{db_path}"))
+
+    async def populate():
+        async for db in get_session():
+            guild = Guild(id=1, discord_guild_id=1, name="Test")
+            svc = User(id=1, discord_user_id=10)
+            user = User(id=2, discord_user_id=20)
+            key = UserKey(user_id=svc.id, guild_id=guild.id, token="svc")
+            db.add_all([guild, svc, user, key])
+            await db.commit()
+            break
+
+    asyncio.run(populate())
+
+    async def run():
+        async for db in get_session():
+            ctx = await api_key_auth(x_api_key="svc", x_discord_id=20, db=db)
+            return ctx.user.id
+
+    uid = asyncio.run(run())
+    assert uid == 2


### PR DESCRIPTION
## Summary
- allow API key auth to override the acting user via `X-Discord-Id`
- forward Discord interaction user IDs from bot requests
- test impersonation via new header

## Testing
- `pytest tests/test_discord_id_header.py -q`
- `pytest -q` *(fails: No module named 'alembic', starlette.testclient requires httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68afd17c74b08328b89d255cda0fc8e1