### PR TITLE
prefetch request items and runs

### DIFF
--- a/demibot/demibot/http/routes/requests.py
+++ b/demibot/demibot/http/routes/requests.py
@@ -150,7 +150,9 @@ async def list_requests(
     db: AsyncSession = Depends(get_db),
 ) -> list[dict[str, Any]]:
     result = await db.execute(
-        select(DbRequest).where(DbRequest.guild_id == ctx.guild.id)
+        select(DbRequest)
+        .where(DbRequest.guild_id == ctx.guild.id)
+        .options(selectinload(DbRequest.items), selectinload(DbRequest.runs))
     )
     return [_dto(r) for r in result.scalars()]
 


### PR DESCRIPTION
## Summary
- prefetch request items and runs when listing requests to cut down on additional DB queries

## Testing
- `pytest tests/test_request_status_permissions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afd334e76c8328a6b64e5be36021c6