### PR TITLE
Prefix plugin API routes with /api

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -183,7 +183,7 @@ public class SettingsWindow : IDisposable
             if (_httpClient == null || string.IsNullOrEmpty(_config.AuthToken) || !ApiHelpers.ValidateApiBaseUrl(_config))
                 return;
 
-            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/users/me/settings";
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/settings";
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Add("X-Api-Key", _config.AuthToken);
             var response = await _httpClient.SendAsync(request);
@@ -233,7 +233,7 @@ public class SettingsWindow : IDisposable
             if (_httpClient == null || string.IsNullOrEmpty(_config.AuthToken) || !ApiHelpers.ValidateApiBaseUrl(_config))
                 return;
 
-            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/users/me/settings";
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/settings";
             var payload = new
             {
                 settings = new
@@ -272,7 +272,7 @@ public class SettingsWindow : IDisposable
             if (_httpClient == null || string.IsNullOrEmpty(_config.AuthToken) || !ApiHelpers.ValidateApiBaseUrl(_config))
                 return;
 
-            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/users/me/forget";
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/forget";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
             request.Headers.Add("X-Api-Key", _config.AuthToken);
             var response = await _httpClient.SendAsync(request);

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -183,7 +183,7 @@ public class SyncshellWindow : IDisposable
             }
 
             var baseUrl = _config.ApiBaseUrl.TrimEnd('/');
-            var url = $"{baseUrl}/fc/{_config.FcChannelId}/assets";
+            var url = $"{baseUrl}/api/fc/{_config.FcChannelId}/assets";
             if (state.LastPullAt.HasValue)
                 url += $"?since={Uri.EscapeDataString(state.LastPullAt.Value.ToString("O"))}";
 
@@ -254,7 +254,7 @@ public class SyncshellWindow : IDisposable
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
             return null;
 
-        var url = $"{baseUrl}/fc/{_config.FcChannelId}/bundles";
+        var url = $"{baseUrl}/api/fc/{_config.FcChannelId}/bundles";
         if (since.HasValue)
             url += $"?since={Uri.EscapeDataString(since.Value.ToString("O"))}";
 
@@ -523,7 +523,7 @@ public class SyncshellWindow : IDisposable
             if (string.IsNullOrEmpty(_config.AuthToken) || !ApiHelpers.ValidateApiBaseUrl(_config))
                 return;
 
-            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/users/me/installations";
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/installations";
             var payload = new { assetId, status };
             var request = new HttpRequestMessage(HttpMethod.Post, url)
             {
@@ -639,7 +639,7 @@ public class SyncshellWindow : IDisposable
             if (string.IsNullOrEmpty(_config.AuthToken) || !ApiHelpers.ValidateApiBaseUrl(_config))
                 return;
 
-            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/users/me/installations";
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/installations";
             var req = new HttpRequestMessage(HttpMethod.Get, url);
             req.Headers.Add("X-Api-Key", _config.AuthToken);
             var resp = await _httpClient.SendAsync(req);


### PR DESCRIPTION
## Summary
- route settings calls through `/api/users/me/*`
- adjust syncshell fetch/update paths to use `/api` prefixes

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: A compatible .NET SDK was not found; global.json requests 9.0.100)*
- `pytest` *(fails: missing dependencies such as alembic, httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68afd503345883289c97d8083fd1d40d