### PR TITLE
Handle aiomysql URLs in sync URL helper

### DIFF
--- a/demibot/demibot/db/session.py
+++ b/demibot/demibot/db/session.py
@@ -38,6 +38,8 @@ def _sync_url(url: str) -> str:
         driver = driver.replace("+asyncpg", "+psycopg2")
     elif driver.endswith("+asyncmy"):
         driver = driver.replace("+asyncmy", "+pymysql")
+    elif driver.endswith("+aiomysql"):
+        driver = driver.replace("+aiomysql", "+pymysql")
     return str(sa_url.set(drivername=driver))
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -14,3 +14,21 @@ def test_password_with_special_chars() -> None:
     assert engine.url.password == password
     # Engine was never connected, but dispose to satisfy SQLAlchemy
     engine.sync_engine.dispose()
+
+
+def test_sync_url_converts_aiomysql() -> None:
+    """_sync_url converts aiomysql driver to a synchronous equivalent."""
+    import sys
+    import types
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1] / "demibot"
+    sys.path.append(str(root))
+    demibot_pkg = types.ModuleType("demibot")
+    demibot_pkg.__path__ = [str(root / "demibot")]
+    sys.modules.setdefault("demibot", demibot_pkg)
+
+    from demibot.db.session import _sync_url
+
+    url = "mysql+aiomysql://user:pass@localhost/test"
+    assert _sync_url(url) == "mysql+pymysql://user:***@localhost/test"


### PR DESCRIPTION
## Summary
- handle `mysql+aiomysql` URLs by converting to `mysql+pymysql`
- test that `_sync_url` converts aiomysql driver

## Testing
- `pytest tests/test_session.py -q`
- `pytest -q` *(fails: Error binding parameter 1: type 'Header' is not supported in key_generation_roles tests; no event loop in officer_ws test)*

------
https://chatgpt.com/codex/tasks/task_e_68afd9f1b088832889c210f1147010d7