### PR TITLE
refactor: use pydantic v2 model_config for installations route

### DIFF
--- a/demibot/demibot/http/routes/installations.py
+++ b/demibot/demibot/http/routes/installations.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,8 +19,7 @@ class InstallationPayload(BaseModel):
     asset_id: int = Field(alias="assetId")
     status: InstallStatus
 
-    class Config:
-        allow_population_by_field_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 @router.get("/users/me/installations")


### PR DESCRIPTION
## Summary
- switch installations payload to Pydantic v2 `model_config`
- import `ConfigDict`

## Testing
- `PYTHONPATH=demibot python -W error -W ignore::DeprecationWarning -c "import demibot.http.routes.installations"`
- `PYTHONPATH=demibot pytest` *(fails: ProgrammingError: (sqlite3.OperationalError) no such table: ...)

------
https://chatgpt.com/codex/tasks/task_e_68afdb41575483289b0013e3e8b93bf8