### PR TITLE
Make configuration setup async

### DIFF
--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -33,7 +33,7 @@ async def main_async() -> None:
 
     logging.basicConfig(level=logging.DEBUG)
     log_config.setup_logging()
-    cfg = ensure_config(force_reconfigure=args.reconfigure)
+    cfg = await ensure_config(force_reconfigure=args.reconfigure)
 
     db_url = cfg.database.url
     masked_url = re.sub(r":[^:@/]+@", ":***@", db_url)

--- a/demibot/scripts/refresh_channels.py
+++ b/demibot/scripts/refresh_channels.py
@@ -10,7 +10,7 @@ from demibot.db.session import get_session, init_db
 
 
 async def _refresh() -> None:
-    cfg = ensure_config()
+    cfg = await ensure_config()
     await init_db(cfg.database.url)
     async for db in get_session():
         result = await db.execute(


### PR DESCRIPTION
## Summary
- refactor ensure_config and its database check to async SQLAlchemy
- await configuration initialization in main entrypoint and refresh script

## Testing
- `python -m demibot.main --reconfigure`
- `pytest` *(fails: sqlalchemy.exc.ProgrammingError, RuntimeError: There is no current event loop in thread)*

------
https://chatgpt.com/codex/tasks/task_e_68b0496f9c448328b23d38b932820a38