### PR TITLE
Ensure migrations keep NOT NULL constraints

### DIFF
--- a/demibot/demibot/db/migrations/versions/0002_user_id_bigint.py
+++ b/demibot/demibot/db/migrations/versions/0002_user_id_bigint.py
@@ -11,57 +11,86 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.alter_column("users", "id", existing_type=sa.Integer(), type_=sa.BigInteger())
+    op.alter_column(
+        "users",
+        "id",
+        existing_type=sa.Integer(),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        nullable=False,
+    )
     op.alter_column(
         "user_keys",
         "user_id",
         existing_type=sa.Integer(),
         type_=sa.BigInteger(),
+        existing_nullable=False,
+        nullable=False,
     )
     op.alter_column(
         "memberships",
         "user_id",
         existing_type=sa.Integer(),
         type_=sa.BigInteger(),
+        existing_nullable=False,
+        nullable=False,
     )
     op.alter_column(
         "messages",
         "author_id",
         existing_type=sa.Integer(),
         type_=sa.BigInteger(),
+        existing_nullable=False,
+        nullable=False,
     )
     op.alter_column(
         "attendance",
         "user_id",
         existing_type=sa.Integer(),
         type_=sa.BigInteger(),
+        existing_nullable=False,
+        nullable=False,
     )
 
 
 def downgrade() -> None:
-    op.alter_column("users", "id", existing_type=sa.BigInteger(), type_=sa.Integer())
+    op.alter_column(
+        "users",
+        "id",
+        existing_type=sa.BigInteger(),
+        type_=sa.Integer(),
+        existing_nullable=False,
+        nullable=False,
+    )
     op.alter_column(
         "user_keys",
         "user_id",
         existing_type=sa.BigInteger(),
         type_=sa.Integer(),
+        existing_nullable=False,
+        nullable=False,
     )
     op.alter_column(
         "memberships",
         "user_id",
         existing_type=sa.BigInteger(),
         type_=sa.Integer(),
+        existing_nullable=False,
+        nullable=False,
     )
     op.alter_column(
         "messages",
         "author_id",
         existing_type=sa.BigInteger(),
         type_=sa.Integer(),
+        existing_nullable=False,
+        nullable=False,
     )
     op.alter_column(
         "attendance",
         "user_id",
         existing_type=sa.BigInteger(),
         type_=sa.Integer(),
+        existing_nullable=False,
+        nullable=False,
     )
-


### PR DESCRIPTION
## Summary
- preserve NOT NULL when altering user ID columns

## Testing
- `alembic -c /tmp/alembic.ini upgrade head` *(fails: Cannot change column 'id': used in a foreign key constraint 'attendance_ibfk_1')*
- `pytest` *(fails: ProgrammingError: (sqlite3.OperationalError) no such table: guilds; RuntimeError: There is no current event loop in thread 'MainThread')*

------
https://chatgpt.com/codex/tasks/task_e_68b0ed6600148328b88a17aef0e14c01