### PR TITLE
Ensure non-nullable user columns in unsigned ID migration

### DIFF
--- a/demibot/demibot/db/migrations/versions/0003_unsigned_user_ids.py
+++ b/demibot/demibot/db/migrations/versions/0003_unsigned_user_ids.py
@@ -10,16 +10,88 @@ down_revision = "0002_user_id_bigint"
 branch_labels = None
 depends_on = None
 
+
 def upgrade() -> None:
-    op.alter_column("users", "id", existing_type=sa.BigInteger(), type_=mysql.BIGINT(unsigned=True))
-    op.alter_column("user_keys", "user_id", existing_type=sa.BigInteger(), type_=mysql.BIGINT(unsigned=True))
-    op.alter_column("memberships", "user_id", existing_type=sa.BigInteger(), type_=mysql.BIGINT(unsigned=True))
-    op.alter_column("messages", "author_id", existing_type=sa.BigInteger(), type_=mysql.BIGINT(unsigned=True))
-    op.alter_column("attendance", "user_id", existing_type=sa.BigInteger(), type_=mysql.BIGINT(unsigned=True))
+    op.alter_column(
+        "users",
+        "id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+        nullable=False,
+    )
+    op.alter_column(
+        "user_keys",
+        "user_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+        nullable=False,
+    )
+    op.alter_column(
+        "memberships",
+        "user_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+        nullable=False,
+    )
+    op.alter_column(
+        "messages",
+        "author_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+        nullable=False,
+    )
+    op.alter_column(
+        "attendance",
+        "user_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+        nullable=False,
+    )
+
 
 def downgrade() -> None:
-    op.alter_column("users", "id", existing_type=mysql.BIGINT(unsigned=True), type_=sa.BigInteger())
-    op.alter_column("user_keys", "user_id", existing_type=mysql.BIGINT(unsigned=True), type_=sa.BigInteger())
-    op.alter_column("memberships", "user_id", existing_type=mysql.BIGINT(unsigned=True), type_=sa.BigInteger())
-    op.alter_column("messages", "author_id", existing_type=mysql.BIGINT(unsigned=True), type_=sa.BigInteger())
-    op.alter_column("attendance", "user_id", existing_type=mysql.BIGINT(unsigned=True), type_=sa.BigInteger())
+    op.alter_column(
+        "users",
+        "id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        nullable=False,
+    )
+    op.alter_column(
+        "user_keys",
+        "user_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        nullable=False,
+    )
+    op.alter_column(
+        "memberships",
+        "user_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        nullable=False,
+    )
+    op.alter_column(
+        "messages",
+        "author_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        nullable=False,
+    )
+    op.alter_column(
+        "attendance",
+        "user_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+        nullable=False,
+    )


### PR DESCRIPTION
## Summary
- ensure `op.alter_column` calls in `0003_unsigned_user_ids` maintain non-null constraints

## Testing
- `PYTHONPATH=demibot ALEMBIC_CONFIG=/tmp/alembic.ini alembic upgrade head` *(fails: sqlite3.OperationalError: near "ALTER": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f29acaec8328b80eb8f9352585b3