### PR TITLE
Handle foreign keys during user id BigInteger migration

### DIFF
--- a/demibot/demibot/db/migrations/versions/0002_user_id_bigint.py
+++ b/demibot/demibot/db/migrations/versions/0002_user_id_bigint.py
@@ -11,6 +11,11 @@ depends_on = None
 
 
 def upgrade() -> None:
+    op.drop_constraint("user_keys_ibfk_1", "user_keys", type_="foreignkey")
+    op.drop_constraint("memberships_ibfk_2", "memberships", type_="foreignkey")
+    op.drop_constraint("messages_ibfk_2", "messages", type_="foreignkey")
+    op.drop_constraint("attendance_ibfk_1", "attendance", type_="foreignkey")
+
     op.alter_column(
         "users",
         "id",
@@ -50,10 +55,28 @@ def upgrade() -> None:
         type_=sa.BigInteger(),
         existing_nullable=False,
         nullable=False,
+    )
+
+    op.create_foreign_key(
+        "user_keys_ibfk_1", "user_keys", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "memberships_ibfk_2", "memberships", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "messages_ibfk_2", "messages", "users", ["author_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "attendance_ibfk_1", "attendance", "users", ["user_id"], ["id"]
     )
 
 
 def downgrade() -> None:
+    op.drop_constraint("user_keys_ibfk_1", "user_keys", type_="foreignkey")
+    op.drop_constraint("memberships_ibfk_2", "memberships", type_="foreignkey")
+    op.drop_constraint("messages_ibfk_2", "messages", type_="foreignkey")
+    op.drop_constraint("attendance_ibfk_1", "attendance", type_="foreignkey")
+
     op.alter_column(
         "users",
         "id",
@@ -93,4 +116,17 @@ def downgrade() -> None:
         type_=sa.Integer(),
         existing_nullable=False,
         nullable=False,
+    )
+
+    op.create_foreign_key(
+        "user_keys_ibfk_1", "user_keys", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "memberships_ibfk_2", "memberships", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "messages_ibfk_2", "messages", "users", ["author_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "attendance_ibfk_1", "attendance", "users", ["user_id"], ["id"]
     )


### PR DESCRIPTION
## Summary
- drop foreign keys referencing `users.id`
- alter all user id columns to `BigInteger`
- recreate the dropped foreign keys

## Testing
- `PYTHONPATH=demibot alembic -c /tmp/alembic.ini upgrade head` *(fails: Can't connect to MySQL server on '127.0.0.1')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b0f76e766c8328b91dba35cef8cd5f