### PR TITLE
Drop and recreate FKs for unsigned user id migration

### DIFF
--- a/demibot/demibot/db/migrations/versions/0003_unsigned_user_ids.py
+++ b/demibot/demibot/db/migrations/versions/0003_unsigned_user_ids.py
@@ -12,6 +12,11 @@ depends_on = None
 
 
 def upgrade() -> None:
+    op.drop_constraint("user_keys_ibfk_1", "user_keys", type_="foreignkey")
+    op.drop_constraint("memberships_ibfk_2", "memberships", type_="foreignkey")
+    op.drop_constraint("messages_ibfk_2", "messages", type_="foreignkey")
+    op.drop_constraint("attendance_ibfk_1", "attendance", type_="foreignkey")
+
     op.alter_column(
         "users",
         "id",
@@ -51,10 +56,28 @@ def upgrade() -> None:
         type_=mysql.BIGINT(unsigned=True),
         existing_nullable=False,
         nullable=False,
+    )
+
+    op.create_foreign_key(
+        "user_keys_ibfk_1", "user_keys", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "memberships_ibfk_2", "memberships", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "messages_ibfk_2", "messages", "users", ["author_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "attendance_ibfk_1", "attendance", "users", ["user_id"], ["id"]
     )
 
 
 def downgrade() -> None:
+    op.drop_constraint("user_keys_ibfk_1", "user_keys", type_="foreignkey")
+    op.drop_constraint("memberships_ibfk_2", "memberships", type_="foreignkey")
+    op.drop_constraint("messages_ibfk_2", "messages", type_="foreignkey")
+    op.drop_constraint("attendance_ibfk_1", "attendance", type_="foreignkey")
+
     op.alter_column(
         "users",
         "id",
@@ -94,4 +117,17 @@ def downgrade() -> None:
         type_=sa.BigInteger(),
         existing_nullable=False,
         nullable=False,
+    )
+
+    op.create_foreign_key(
+        "user_keys_ibfk_1", "user_keys", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "memberships_ibfk_2", "memberships", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "messages_ibfk_2", "messages", "users", ["author_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "attendance_ibfk_1", "attendance", "users", ["user_id"], ["id"]
     )


### PR DESCRIPTION
## Summary
- handle foreign keys when converting user id columns to unsigned bigints

## Testing
- `PYTHONPATH=demibot DEMIBOT_DATABASE_URL=mysql+pymysql://user:pass@127.0.0.1/db alembic -c /tmp/alembic.ini upgrade head` *(fails: Can't connect to MySQL server)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b109c085848328902711841fffeed4