### PR TITLE
Use BIGINT for fc-user relations

### DIFF
--- a/demibot/demibot/db/migrations/versions/0013_add_fc_and_asset_tables.py
+++ b/demibot/demibot/db/migrations/versions/0013_add_fc_and_asset_tables.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = "0013_add_fc_and_asset_tables"
@@ -44,7 +45,7 @@ def upgrade() -> None:
         ),
         sa.Column(
             "user_id",
-            sa.Integer(),
+            mysql.BIGINT(unsigned=True),
             sa.ForeignKey("users.id", ondelete="CASCADE"),
             primary_key=True,
         ),
@@ -125,7 +126,7 @@ def upgrade() -> None:
         sa.Column("id", sa.Integer(), primary_key=True),
         sa.Column(
             "user_id",
-            sa.Integer(),
+            mysql.BIGINT(unsigned=True),
             sa.ForeignKey("users.id", ondelete="CASCADE"),
             nullable=False,
         ),


### PR DESCRIPTION
## Summary
- use BIGINT unsigned for user_id fields in fc_user and user_installation migrations

## Testing
- `alembic -c alembic.ini upgrade head`
- `mysql -u demibot -pAdmin -e "USE demibot; SHOW TABLES LIKE 'fc_user'; SHOW TABLES LIKE 'user_installation';"`
- `mysql -u demibot -pAdmin demibot -e "SHOW CREATE TABLE fc_user\G"`
- `mysql -u demibot -pAdmin demibot -e "SHOW CREATE TABLE user_installation\G"`


------
https://chatgpt.com/codex/tasks/task_e_68b10dad1dac8328b8bc19345ae0c290