### PR TITLE
Use unsigned BIGINT for presence identifiers

### DIFF
--- a/demibot/demibot/db/migrations/versions/0007_add_presence_table.py
+++ b/demibot/demibot/db/migrations/versions/0007_add_presence_table.py
@@ -1,5 +1,6 @@
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = "0007_add_presence_table"
@@ -11,8 +12,8 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "presences",
-        sa.Column("guild_id", sa.BigInteger(), nullable=False),
-        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("guild_id", mysql.BIGINT(unsigned=True), nullable=False),
+        sa.Column("user_id", mysql.BIGINT(unsigned=True), nullable=False),
         sa.Column("status", sa.String(length=16), nullable=False),
         sa.Column("updated_at", sa.DateTime(), nullable=False),
         sa.PrimaryKeyConstraint("guild_id", "user_id"),


### PR DESCRIPTION
## Summary
- Ensure `guild_id` and `user_id` in presences migration use `mysql.BIGINT(unsigned=True)`
- Searched migrations for `user_id` definitions to confirm consistency

## Testing
- `pytest -q` *(fails: sqlalchemy ProgrammingError: Error binding parameter 1: type 'Header' is not supported; RuntimeError: There is no current event loop in thread 'MainThread')*

------
https://chatgpt.com/codex/tasks/task_e_68b10f6f0b448328bb63b341c71fe88c