### PR TITLE
Expand alembic version column length

### DIFF
--- a/demibot/demibot/db/migrations/versions/0017_add_user_character_and_world.py
+++ b/demibot/demibot/db/migrations/versions/0017_add_user_character_and_world.py
@@ -15,6 +15,12 @@ depends_on = None
 
 
 def upgrade() -> None:
+    op.alter_column(
+        "alembic_version",
+        "version_num",
+        existing_type=sa.String(length=32),
+        type_=sa.String(length=64),
+    )
     op.add_column("users", sa.Column("character_name", sa.String(length=255), nullable=True))
     op.add_column("users", sa.Column("world", sa.String(length=32), nullable=True))
 
@@ -22,3 +28,9 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_column("users", "character_name")
     op.drop_column("users", "world")
+    op.alter_column(
+        "alembic_version",
+        "version_num",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=32),
+    )


### PR DESCRIPTION
## Summary
- Expand `alembic_version.version_num` to 64 characters before adding new user fields
- Ensure downgrade restores original column length

## Testing
- `PYTHONPATH=demibot DEMIBOT_DATABASE_URL=mysql+pymysql://root@127.0.0.1:3306/demibot alembic -c alembic.ini upgrade head`
- `mysql -uroot demibot -e "select * from alembic_version"`
- `PYTHONPATH=demibot DEMIBOT_DATABASE_URL=sqlite:///test.db pytest -q` *(fails: sqlite3.ProgrammingError, RuntimeError: no current event loop, ModuleNotFoundError: aiomysql)*

------
https://chatgpt.com/codex/tasks/task_e_68b11246dac08328b708851b99eeaae8