### PR TITLE
Expand Alembic version ID length

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -1,0 +1,17 @@
+# Migration Guidelines
+
+The Python service uses Alembic for database migrations. Revision identifiers
+are stored in the `alembic_version` table. To accommodate descriptive names,
+`alembic_version.version_num` is configured for up to 128 characters (see
+migration `0018_expand_version_num_to_128_chars` and
+`demibot/demibot/db/migrations/env.py`).
+
+When creating a new migration:
+
+- Start the filename and `revision` string with the next sequential number
+  (e.g. `0019_descriptive_change`).
+- Keep the full revision identifier under 128 characters so it fits in the
+  version table.
+
+Following these guidelines prevents future migrations from exceeding the
+`version_num` column's length limit.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ source .venv/bin/activate
 pip install -e .
 alembic -c demibot/db/migrations/env.py upgrade head
 ```
-Re-run the migration command after pulling updates to apply any schema changes.
+Re-run the migration command after pulling updates to apply any schema changes. See MIGRATIONS.md for naming guidelines.
 
 ### 2. Configure and start the bot
 ```bash

--- a/demibot/demibot/db/migrations/env.py
+++ b/demibot/demibot/db/migrations/env.py
@@ -9,6 +9,9 @@ from alembic import context
 from demibot.db.base import Base  # noqa: F401
 from demibot.db import models  # noqa: F401
 
+# Alembic version table expanded to 128 characters
+# to allow descriptive revision identifiers.
+
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/demibot/demibot/db/migrations/versions/0018_expand_version_num_to_128_chars.py
+++ b/demibot/demibot/db/migrations/versions/0018_expand_version_num_to_128_chars.py
@@ -1,0 +1,32 @@
+"""expand version_num to 128 chars
+
+Revision ID: 0018_expand_version_num_to_128_chars
+Revises: 0017_add_user_character_and_world
+Create Date: 2025-10-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0018_expand_version_num_to_128_chars"
+down_revision = "0017_add_user_character_and_world"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "alembic_version",
+        "version_num",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=128),
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "alembic_version",
+        "version_num",
+        existing_type=sa.String(length=128),
+        type_=sa.String(length=64),
+    )


### PR DESCRIPTION
## Summary
- Expand `alembic_version.version_num` to 128 characters
- Document the 128-char limit in migration `env.py` and new MIGRATIONS.md
- Reference migration guidelines from README

## Testing
- `pytest` *(fails: sqlalchemy.exc.ProgrammingError and RuntimeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b1173064448328871be3376cb63a95