### PR TITLE
Expand request status enum to support full workflow

### DIFF
--- a/demibot/demibot/db/migrations/versions/0019_expand_request_status.py
+++ b/demibot/demibot/db/migrations/versions/0019_expand_request_status.py
@@ -1,0 +1,55 @@
+"""expand request status to include full workflow
+
+Revision ID: 0019_expand_request_status
+Revises: 0018_expand_version_num_to_128_chars
+Create Date: 2025-10-29
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+revision = "0019_expand_request_status"
+down_revision = "0018_expand_version_num_to_128_chars"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "requests",
+        "status",
+        existing_type=mysql.ENUM("open", "approved", "denied", name="request_status"),
+        type_=mysql.ENUM(
+            "open",
+            "claimed",
+            "in_progress",
+            "awaiting_confirm",
+            "completed",
+            "cancelled",
+            "approved",
+            "denied",
+            name="request_status",
+        ),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "requests",
+        "status",
+        existing_type=mysql.ENUM(
+            "open",
+            "claimed",
+            "in_progress",
+            "awaiting_confirm",
+            "completed",
+            "cancelled",
+            "approved",
+            "denied",
+            name="request_status",
+        ),
+        type_=mysql.ENUM("open", "approved", "denied", name="request_status"),
+        nullable=False,
+    )


### PR DESCRIPTION
## Summary
- add migration altering `requests.status` to include claimed, in_progress, awaiting_confirm, completed, and cancelled states alongside legacy values

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite'; sqlalchemy.exc.ProgrammingError: Error binding parameter 1: type 'Header' is not supported; RuntimeError: There is no current event loop in thread 'MainThread')*

------
https://chatgpt.com/codex/tasks/task_e_68b191b482bc8328813795ff9419cce0