### PR TITLE
Rename 0017 migration and remove version table update

### DIFF
--- a/demibot/demibot/db/migrations/versions/0017_user_character_world.py
+++ b/demibot/demibot/db/migrations/versions/0017_user_character_world.py
@@ -1,6 +1,6 @@
 """add user character_name and world
 
-Revision ID: 0017_add_user_character_and_world
+Revision ID: 0017_user_character_world
 Revises: 0016_add_asset_deleted_at
 Create Date: 2025-09-21
 """
@@ -8,19 +8,13 @@ Create Date: 2025-09-21
 from alembic import op
 import sqlalchemy as sa
 
-revision = "0017_add_user_character_and_world"
+revision = "0017_user_character_world"
 down_revision = "0016_add_asset_deleted_at"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    op.alter_column(
-        "alembic_version",
-        "version_num",
-        existing_type=sa.String(length=32),
-        type_=sa.String(length=64),
-    )
     op.add_column("users", sa.Column("character_name", sa.String(length=255), nullable=True))
     op.add_column("users", sa.Column("world", sa.String(length=32), nullable=True))
 
@@ -28,9 +22,3 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_column("users", "character_name")
     op.drop_column("users", "world")
-    op.alter_column(
-        "alembic_version",
-        "version_num",
-        existing_type=sa.String(length=64),
-        type_=sa.String(length=32),
-    )

--- a/demibot/demibot/db/migrations/versions/0018_expand_version_num_to_128_chars.py
+++ b/demibot/demibot/db/migrations/versions/0018_expand_version_num_to_128_chars.py
@@ -1,7 +1,7 @@
 """expand version_num to 128 chars
 
 Revision ID: 0018_expand_version_num_to_128_chars
-Revises: 0017_add_user_character_and_world
+Revises: 0017_user_character_world
 Create Date: 2025-10-28
 """
 
@@ -9,7 +9,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "0018_expand_version_num_to_128_chars"
-down_revision = "0017_add_user_character_and_world"
+down_revision = "0017_user_character_world"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- shorten 0017 migration identifier and remove version table alteration
- point later migrations to the new revision

## Testing
- `PYTHONPATH=demibot DATABASE_URL=sqlite:///./alembic_test.db alembic -c /tmp/alembic.ini upgrade head` *(fails: No support for ALTER of constraints in SQLite dialect)*

------
https://chatgpt.com/codex/tasks/task_e_68b193068bcc8328a78380db0139f357