### PR TITLE
Use unsigned BIGINT for Discord IDs

### DIFF
--- a/demibot/demibot/db/migrations/versions/0021_unsigned_discord_ids.py
+++ b/demibot/demibot/db/migrations/versions/0021_unsigned_discord_ids.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import mysql
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision = "0021_unsigned_discord_ids"
+down_revision = "0020_align_install_status_enum"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_guilds_discord_guild_id", table_name="guilds")
+    op.drop_index("ix_users_discord_user_id", table_name="users")
+    op.drop_index("ix_messages_channel_id_created_at", table_name="messages")
+    op.drop_index("ix_embeds_channel_id", table_name="embeds")
+    op.drop_index(op.f("ix_roles_discord_role_id"), table_name="roles")
+
+    op.alter_column(
+        "guilds",
+        "discord_guild_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "guild_config",
+        "officer_visible_channel_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "guild_config",
+        "officer_role_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "guild_channels",
+        "channel_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "users",
+        "discord_user_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "roles",
+        "discord_role_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "messages",
+        "discord_message_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "messages",
+        "channel_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "embeds",
+        "discord_message_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "embeds",
+        "channel_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "attendance",
+        "discord_message_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "event_buttons",
+        "message_id",
+        existing_type=sa.BigInteger(),
+        type_=mysql.BIGINT(unsigned=True),
+        existing_nullable=False,
+    )
+
+    bind = op.get_bind()
+    insp = inspect(bind)
+    if "recurring_events" in insp.get_table_names():
+        op.alter_column(
+            "recurring_events",
+            "id",
+            existing_type=sa.BigInteger(),
+            type_=mysql.BIGINT(unsigned=True),
+            existing_nullable=False,
+        )
+        op.alter_column(
+            "recurring_events",
+            "channel_id",
+            existing_type=sa.BigInteger(),
+            type_=mysql.BIGINT(unsigned=True),
+            existing_nullable=False,
+        )
+
+    op.create_index(
+        "ix_guilds_discord_guild_id", "guilds", ["discord_guild_id"], unique=True
+    )
+    op.create_index(
+        "ix_users_discord_user_id", "users", ["discord_user_id"], unique=True
+    )
+    op.create_index(
+        "ix_messages_channel_id_created_at",
+        "messages",
+        ["channel_id", "created_at"],
+    )
+    op.create_index("ix_embeds_channel_id", "embeds", ["channel_id"])
+    op.create_index(
+        op.f("ix_roles_discord_role_id"),
+        "roles",
+        ["discord_role_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_roles_discord_role_id"), table_name="roles")
+    op.drop_index("ix_embeds_channel_id", table_name="embeds")
+    op.drop_index("ix_messages_channel_id_created_at", table_name="messages")
+    op.drop_index("ix_users_discord_user_id", table_name="users")
+    op.drop_index("ix_guilds_discord_guild_id", table_name="guilds")
+
+    bind = op.get_bind()
+    insp = inspect(bind)
+    if "recurring_events" in insp.get_table_names():
+        op.alter_column(
+            "recurring_events",
+            "channel_id",
+            existing_type=mysql.BIGINT(unsigned=True),
+            type_=sa.BigInteger(),
+            existing_nullable=False,
+        )
+        op.alter_column(
+            "recurring_events",
+            "id",
+            existing_type=mysql.BIGINT(unsigned=True),
+            type_=sa.BigInteger(),
+            existing_nullable=False,
+        )
+
+    op.alter_column(
+        "event_buttons",
+        "message_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "attendance",
+        "discord_message_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "embeds",
+        "channel_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "embeds",
+        "discord_message_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "messages",
+        "channel_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "messages",
+        "discord_message_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "roles",
+        "discord_role_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "users",
+        "discord_user_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "guild_channels",
+        "channel_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "guild_config",
+        "officer_role_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "guild_config",
+        "officer_visible_channel_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "guilds",
+        "discord_guild_id",
+        existing_type=mysql.BIGINT(unsigned=True),
+        type_=sa.BigInteger(),
+        existing_nullable=False,
+    )
+
+    op.create_index(
+        op.f("ix_roles_discord_role_id"),
+        "roles",
+        ["discord_role_id"],
+        unique=True,
+    )
+    op.create_index("ix_embeds_channel_id", "embeds", ["channel_id"])
+    op.create_index(
+        "ix_messages_channel_id_created_at",
+        "messages",
+        ["channel_id", "created_at"],
+    )
+    op.create_index(
+        "ix_users_discord_user_id", "users", ["discord_user_id"], unique=True
+    )
+    op.create_index(
+        "ix_guilds_discord_guild_id", "guilds", ["discord_guild_id"], unique=True
+    )

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -63,7 +63,9 @@ class Guild(Base):
     __tablename__ = "guilds"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    discord_guild_id: Mapped[int] = mapped_column(BigInteger, unique=True, index=True)
+    discord_guild_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), unique=True, index=True
+    )
     name: Mapped[str] = mapped_column(String(255))
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(
@@ -78,8 +80,10 @@ class GuildConfig(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
-    officer_visible_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger)
-    officer_role_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    officer_visible_channel_id: Mapped[Optional[int]] = mapped_column(
+        BIGINT(unsigned=True)
+    )
+    officer_role_id: Mapped[Optional[int]] = mapped_column(BIGINT(unsigned=True))
 
     guild: Mapped[Guild] = relationship(back_populates="config")
 
@@ -88,7 +92,7 @@ class GuildChannel(Base):
     __tablename__ = "guild_channels"
 
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"), primary_key=True)
-    channel_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    channel_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
     kind: Mapped[str] = mapped_column(String(24), primary_key=True)
     name: Mapped[Optional[str]] = mapped_column(String(255))
 
@@ -97,7 +101,9 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
-    discord_user_id: Mapped[int] = mapped_column(BigInteger, unique=True, index=True)
+    discord_user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), unique=True, index=True
+    )
     global_name: Mapped[Optional[str]] = mapped_column(String(255))
     discriminator: Mapped[Optional[str]] = mapped_column(String(10))
     character_name: Mapped[Optional[str]] = mapped_column(String(255))
@@ -141,7 +147,7 @@ class Role(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
-    discord_role_id: Mapped[int] = mapped_column(BigInteger, unique=True)
+    discord_role_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), unique=True)
     name: Mapped[str] = mapped_column(String(255))
     is_officer: Mapped[bool] = mapped_column(Boolean, default=False)
     is_chat: Mapped[bool] = mapped_column(Boolean, default=False)
@@ -162,8 +168,10 @@ class Message(Base):
         Index("ix_messages_channel_id_created_at", "channel_id", "created_at"),
     )
 
-    discord_message_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
-    channel_id: Mapped[int] = mapped_column(BigInteger, index=True)
+    discord_message_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), primary_key=True
+    )
+    channel_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), index=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
     author_id: Mapped[int] = mapped_column(
         BIGINT(unsigned=True), ForeignKey("users.id")
@@ -181,9 +189,9 @@ class Embed(Base):
     __tablename__ = "embeds"
 
     discord_message_id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, index=True
+        BIGINT(unsigned=True), primary_key=True, index=True
     )
-    channel_id: Mapped[int] = mapped_column(BigInteger, index=True)
+    channel_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), index=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
     payload_json: Mapped[str] = mapped_column(Text)
     buttons_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -197,7 +205,7 @@ class Embed(Base):
 class Attendance(Base):
     __tablename__ = "attendance"
 
-    discord_message_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    discord_message_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
     user_id: Mapped[int] = mapped_column(
         BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True
     )
@@ -210,8 +218,8 @@ class Presence(Base):
         Index("ix_presences_guild_id_status", "guild_id", "status"),
     )
 
-    guild_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
-    user_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    guild_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
+    user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
     status: Mapped[str] = mapped_column(String(16))
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
@@ -221,9 +229,9 @@ class Presence(Base):
 class RecurringEvent(Base):
     __tablename__ = "recurring_events"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
-    channel_id: Mapped[int] = mapped_column(BigInteger)
+    channel_id: Mapped[int] = mapped_column(BIGINT(unsigned=True))
     repeat: Mapped[str] = mapped_column(String(16))
     next_post_at: Mapped[datetime] = mapped_column(DateTime)
     payload_json: Mapped[str] = mapped_column(Text)
@@ -241,7 +249,7 @@ class SignupPreset(Base):
 class EventButton(Base):
     __tablename__ = "event_buttons"
 
-    message_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    message_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
     tag: Mapped[str] = mapped_column(String(50), primary_key=True)
     label: Mapped[str] = mapped_column(String(255))
     emoji: Mapped[Optional[str]] = mapped_column(String(64))


### PR DESCRIPTION
## Summary
- Store Discord snowflake identifiers as unsigned BIGINT across models
- Provide migration to convert existing Discord ID columns to unsigned BIGINT

## Testing
- `alembic -c demibot/demibot/db/migrations/alembic.ini upgrade head` *(fails: Column 'status' has duplicated value 'installed' in ENUM)*
- `pytest` *(fails: 4 failed, 39 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b19453506c8328ab2741ecacd4e6f9