### PR TITLE
Ensure alembic version_num remains non-nullable

### DIFF
--- a/demibot/demibot/db/migrations/versions/0018_expand_version_num_to_128_chars.py
+++ b/demibot/demibot/db/migrations/versions/0018_expand_version_num_to_128_chars.py
@@ -20,6 +20,8 @@ def upgrade() -> None:
         "version_num",
         existing_type=sa.String(length=64),
         type_=sa.String(length=128),
+        existing_nullable=False,
+        nullable=False,
     )
 
 
@@ -29,4 +31,6 @@ def downgrade() -> None:
         "version_num",
         existing_type=sa.String(length=128),
         type_=sa.String(length=64),
+        existing_nullable=False,
+        nullable=False,
     )


### PR DESCRIPTION
## Summary
- Preserve non-nullable constraint when expanding `alembic_version.version_num`

## Testing
- `python - <<'PY' from alembic import command ... command.upgrade(config, 'head') PY` *(fails: NotImplementedError: No support for ALTER of constraints in SQLite dialect)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b198bbb9cc832894f53d27c5f4a99f