### PR TITLE
Add setup for Vault cog

### DIFF
--- a/demibot/demibot/discordbot/cogs/vault.py
+++ b/demibot/demibot/discordbot/cogs/vault.py
@@ -200,3 +200,7 @@ class Vault(commands.Cog):
         else:
             cp.last_id = asset_id
             cp.last_generated_at = now
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Vault(bot))


### PR DESCRIPTION
## Summary
- add async setup hook to register Vault cog

## Testing
- `pytest` *(fails: sqlalchemy ProgrammingError, RuntimeError)*

------
https://chatgpt.com/codex/tasks/task_e_68b19df3d8bc8328bce401e4f8eba2d9