### PR TITLE
Track asset uploader and dependencies

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -207,15 +207,15 @@ public class SyncshellWindow : IDisposable
                 return;
 
             var json = await resp.Content.ReadAsStringAsync();
-            var assets = JsonSerializer.Deserialize<List<Asset>>(json, new JsonSerializerOptions
+            var assetsResp = JsonSerializer.Deserialize<AssetResponse>(json, new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             });
-            if (assets != null)
+            if (assetsResp?.Items != null)
             {
-                MergeAssets(assets);
+                MergeAssets(assetsResp.Items);
                 _etag = resp.Headers.ETag?.Tag;
-                foreach (var a in assets)
+                foreach (var a in assetsResp.Items)
                     _ = TryAutoApply(a);
             }
 
@@ -731,47 +731,75 @@ public class SyncshellWindow : IDisposable
 
     private class Asset
     {
+        [JsonPropertyName("id")]
         public string Id { get; set; } = string.Empty;
+        [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("kind")]
         public string Kind { get; set; } = string.Empty;
+        [JsonPropertyName("size")]
         public long Size { get; set; }
+        [JsonPropertyName("uploader")]
         public string Uploader { get; set; } = string.Empty;
+        [JsonPropertyName("created_at")]
         public DateTimeOffset CreatedAt { get; set; }
+        [JsonPropertyName("updated_at")]
         public DateTimeOffset UpdatedAt { get; set; }
+        [JsonPropertyName("download_url")]
         public string DownloadUrl { get; set; } = string.Empty;
+        [JsonPropertyName("dependencies")]
         public List<string> Dependencies { get; set; } = new();
+        [JsonPropertyName("items")]
         public List<Asset>? Items { get; set; }
+    }
+
+    private class AssetResponse
+    {
+        [JsonPropertyName("items")]
+        public List<Asset> Items { get; set; } = new();
     }
 
     private class AssetsCache
     {
+        [JsonPropertyName("etag")]
         public string? Etag { get; set; }
+        [JsonPropertyName("assets")]
         public List<Asset> Assets { get; set; } = new();
     }
 
     private class Installation
     {
+        [JsonPropertyName("asset_id")]
         public string AssetId { get; set; } = string.Empty;
+        [JsonPropertyName("status")]
         public string Status { get; set; } = string.Empty;
+        [JsonPropertyName("updated_at")]
         public DateTimeOffset UpdatedAt { get; set; }
     }
 
     private class InstallationsCache
     {
+        [JsonPropertyName("installations")]
         public List<Installation> Installations { get; set; } = new();
     }
 
     private class BundleResponse
     {
+        [JsonPropertyName("items")]
         public List<Bundle> Items { get; set; } = new();
     }
 
     private class Bundle
     {
+        [JsonPropertyName("id")]
         public string Id { get; set; } = string.Empty;
+        [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("description")]
         public string? Description { get; set; }
+        [JsonPropertyName("updated_at")]
         public DateTimeOffset? UpdatedAt { get; set; }
+        [JsonPropertyName("assets")]
         public List<Asset> Assets { get; set; } = new();
     }
 }

--- a/demibot/demibot/db/migrations/versions/0022_add_asset_uploader.py
+++ b/demibot/demibot/db/migrations/versions/0022_add_asset_uploader.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import BIGINT
+
+# revision identifiers, used by Alembic.
+revision = "0022_add_asset_uploader"
+down_revision = "0021_unsigned_discord_ids"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "asset",
+        sa.Column(
+            "uploader_id",
+            BIGINT(unsigned=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_asset_uploader_id", "asset", ["uploader_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_asset_uploader_id", table_name="asset")
+    op.drop_column("asset", "uploader_id")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -432,6 +432,9 @@ class Asset(Base):
     )
     deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+    uploader_id: Mapped[Optional[int]] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
 
     __mapper_args__ = {"version_id_col": version}
 
@@ -441,6 +444,14 @@ class Asset(Base):
     )
     installations: Mapped[list["UserInstallation"]] = relationship(
         back_populates="asset", cascade="all, delete-orphan"
+    )
+    uploader: Mapped[Optional[User]] = relationship()
+    dependencies: Mapped[list["Asset"]] = relationship(
+        "Asset",
+        secondary=lambda: AssetDependency.__table__,
+        primaryjoin=lambda: Asset.id == AssetDependency.asset_id,
+        secondaryjoin=lambda: Asset.id == AssetDependency.dependency_id,
+        backref="dependents",
     )
 
 

--- a/tests/test_vault_fc_id.py
+++ b/tests/test_vault_fc_id.py
@@ -6,9 +6,10 @@ from sqlalchemy import select
 import io
 import json
 import zipfile
+from datetime import datetime
 
 from demibot.discordbot.cogs.vault import Vault
-from demibot.db.models import AppearanceBundle, AssetKind, Fc, Guild
+from demibot.db.models import AppearanceBundle, AssetKind, Fc, Guild, User
 from demibot.db.session import get_session, init_db
 
 
@@ -18,7 +19,8 @@ def test_vault_assigns_fc_id():
         async for db in get_session():
             guild = Guild(id=1, discord_guild_id=1, name="Guild")
             fc = Fc(id=1, name="FC", world="World")
-            db.add_all([guild, fc])
+            user = User(id=1, discord_user_id=1)
+            db.add_all([guild, fc, user])
             await db.commit()
             bot = SimpleNamespace(
                 cfg=SimpleNamespace(database=SimpleNamespace(url="sqlite+aiosqlite://"))
@@ -27,7 +29,15 @@ def test_vault_assigns_fc_id():
             fc_id = await vault._get_fc_id(db, SimpleNamespace(id=1))
             assert fc_id == 1
             asset = await vault._upsert_asset(
-                db, fc_id, AssetKind.APPEARANCE, "bundle", "hash", 1
+                db,
+                fc_id,
+                AssetKind.APPEARANCE,
+                "bundle",
+                "hash",
+                1,
+                1,
+                datetime.utcnow(),
+                [],
             )
             assert asset.fc_id == 1
             buf = io.BytesIO()


### PR DESCRIPTION
## Summary
- capture uploader and dependencies during Vault ingestion
- expose uploader, creation time, and dependencies via assets API
- align SyncshellWindow JSON parsing with new API fields

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b19f8f6cf88328ad62a5a8f6698bb7