### PR TITLE
Ensure database initialisation is idempotent

### DIFF
--- a/demibot/demibot/db/session.py
+++ b/demibot/demibot/db/session.py
@@ -20,6 +20,7 @@ from .base import Base
 
 _engine: AsyncEngine | None = None
 _Session: async_sessionmaker[AsyncSession] | None = None
+_init_lock = asyncio.Lock()
 
 
 def _sync_url(url: str) -> str:
@@ -47,30 +48,36 @@ async def init_db(url: str) -> AsyncEngine:
     """Create the database engine and run migrations for the given URL."""
 
     global _engine, _Session
-
-    sa_url = make_url(url)
-    sync_url = _sync_url(url)
-
-    if sa_url.get_backend_name() == "sqlite":
-        # SQLite lacks many ALTER TABLE capabilities used in migrations.
-        # For test environments we create tables directly from metadata.
-        _engine = create_async_engine(url, echo=False, future=True)
-        _Session = async_sessionmaker(_engine, expire_on_commit=False)
-        async with _engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
+    if _engine is not None:
         return _engine
 
-    # Run migrations using Alembic so the schema matches the latest models.
-    config = Config()
-    config.set_main_option(
-        "script_location", str(Path(__file__).resolve().parent / "migrations")
-    )
-    config.set_main_option("sqlalchemy.url", sync_url)
-    await asyncio.to_thread(command.upgrade, config, "head")
+    async with _init_lock:
+        if _engine is not None:
+            return _engine
 
-    _engine = create_async_engine(url, echo=False, future=True)
-    _Session = async_sessionmaker(_engine, expire_on_commit=False)
-    return _engine
+        sa_url = make_url(url)
+        sync_url = _sync_url(url)
+
+        if sa_url.get_backend_name() == "sqlite":
+            # SQLite lacks many ALTER TABLE capabilities used in migrations.
+            # For test environments we create tables directly from metadata.
+            _engine = create_async_engine(url, echo=False, future=True)
+            _Session = async_sessionmaker(_engine, expire_on_commit=False)
+            async with _engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
+            return _engine
+
+        # Run migrations using Alembic so the schema matches the latest models.
+        config = Config()
+        config.set_main_option(
+            "script_location", str(Path(__file__).resolve().parent / "migrations")
+        )
+        config.set_main_option("sqlalchemy.url", sync_url)
+        await asyncio.to_thread(command.upgrade, config, "head")
+
+        _engine = create_async_engine(url, echo=False, future=True)
+        _Session = async_sessionmaker(_engine, expire_on_commit=False)
+        return _engine
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:

--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -28,12 +28,11 @@ CHANNEL_SYNC_INTERVAL = 3600
 class Mirror(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        # Ensure the database engine is available for this cog
-        asyncio.create_task(init_db(bot.cfg.database.url))
         self._sync_task: asyncio.Task | None = None
         self._reconcile_lock = asyncio.Lock()
 
     async def cog_load(self) -> None:
+        await init_db(self.bot.cfg.database.url)
         self.bot.loop.create_task(self._sync_guild_channels_once())
         self._sync_task = asyncio.create_task(self._channel_sync_loop())
 

--- a/demibot/demibot/discordbot/cogs/vault.py
+++ b/demibot/demibot/discordbot/cogs/vault.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import io
 import json
@@ -46,7 +45,6 @@ INSTRUCTIONS = (
 class Vault(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        asyncio.create_task(init_db(bot.cfg.database.url))
         self.storage_path = Path(
             os.environ.get("ASSET_STORAGE_PATH", "assets")
         ).resolve()
@@ -54,6 +52,7 @@ class Vault(commands.Cog):
         self.vault_channels: dict[int, int] = {}
 
     async def cog_load(self) -> None:  # pragma: no cover - startup behaviour
+        await init_db(self.bot.cfg.database.url)
         self.bot.loop.create_task(self._ensure_vault_channels())
 
     async def _ensure_vault_channels(self) -> None:  # pragma: no cover - startup


### PR DESCRIPTION
## Summary
- Make `init_db` concurrency-safe and idempotent with a shared lock
- Await database initialisation in Mirror and Vault cogs instead of background tasks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b21875c33c832888ba08f1c68f0c8f