### PR TITLE
Remove redundant init_db calls from cogs

### DIFF
--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from ...db.models import Embed, Guild, GuildChannel, Message
-from ...db.session import get_session, init_db
+from ...db.session import get_session
 from ...http.schemas import (
     ChatMessage,
     EmbedDto,
@@ -32,7 +32,6 @@ class Mirror(commands.Cog):
         self._reconcile_lock = asyncio.Lock()
 
     async def cog_load(self) -> None:
-        await init_db(self.bot.cfg.database.url)
         self.bot.loop.create_task(self._sync_guild_channels_once())
         self._sync_task = asyncio.create_task(self._channel_sync_loop())
 

--- a/demibot/demibot/discordbot/cogs/vault.py
+++ b/demibot/demibot/discordbot/cogs/vault.py
@@ -24,7 +24,7 @@ from ...db.models import (
     User,
     IndexCheckpoint,
 )
-from ...db.session import get_session, init_db
+from ...db.session import get_session
 
 WHITELIST = {
     ".zip",
@@ -52,7 +52,6 @@ class Vault(commands.Cog):
         self.vault_channels: dict[int, int] = {}
 
     async def cog_load(self) -> None:  # pragma: no cover - startup behaviour
-        await init_db(self.bot.cfg.database.url)
         self.bot.loop.create_task(self._ensure_vault_channels())
 
     async def _ensure_vault_channels(self) -> None:  # pragma: no cover - startup


### PR DESCRIPTION
## Summary
- stop mirror and vault cogs from reinitialising the database
- rely on main startup to initialise the database once

## Testing
- `pytest -q` *(fails: sqlite3.IntegrityError UNIQUE constraint, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b2219ad4b48328852350d1b833f0e1