### PR TITLE
Ensure User id auto-increments

### DIFF
--- a/demibot/demibot/db/migrations/versions/0024_autoincrement_user_id.py
+++ b/demibot/demibot/db/migrations/versions/0024_autoincrement_user_id.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0024_autoincrement_user_id"
+down_revision = "0023_add_recurring_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE users MODIFY id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE users MODIFY id BIGINT UNSIGNED NOT NULL")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -100,7 +100,9 @@ class GuildChannel(Base):
 class User(Base):
     __tablename__ = "users"
 
-    id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
+    id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), primary_key=True, autoincrement=True
+    )
     discord_user_id: Mapped[int] = mapped_column(
         BIGINT(unsigned=True), unique=True, index=True
     )


### PR DESCRIPTION
## Summary
- make User.id an autoincrementing BIGINT
- add migration to enforce auto-increment on users.id

## Testing
- `pytest`
- `alembic -c alembic.ini upgrade head` *(fails: No support for ALTER of constraints in SQLite dialect)*
- `PYTHONPATH=demibot python -m demibot.main` *(fails: prompts for interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_68b22d62bd748328b0ae9cc8d0b9fe2e