### PR TITLE
Handle user id autoincrement with FK recreation

### DIFF
--- a/demibot/demibot/db/migrations/versions/0024_autoincrement_user_id.py
+++ b/demibot/demibot/db/migrations/versions/0024_autoincrement_user_id.py
@@ -10,8 +10,124 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("ALTER TABLE users MODIFY id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT")
+    # drop FKs referencing users.id
+    op.drop_constraint("user_keys_ibfk_1", "user_keys", type_="foreignkey")
+    op.drop_constraint("memberships_ibfk_2", "memberships", type_="foreignkey")
+    op.drop_constraint("messages_ibfk_2", "messages", type_="foreignkey")
+    op.drop_constraint("attendance_ibfk_1", "attendance", type_="foreignkey")
+    op.drop_constraint("requests_ibfk_2", "requests", type_="foreignkey")
+    op.drop_constraint("requests_ibfk_3", "requests", type_="foreignkey")
+    op.drop_constraint("fc_user_ibfk_2", "fc_user", type_="foreignkey")
+    op.drop_constraint("asset_ibfk_2", "asset", type_="foreignkey")
+    op.drop_constraint(
+        "user_installation_ibfk_1", "user_installation", type_="foreignkey"
+    )
+
+    op.execute(
+        "ALTER TABLE users MODIFY id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT"
+    )
+
+    # recreate FKs
+    op.create_foreign_key(
+        "user_keys_ibfk_1", "user_keys", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "memberships_ibfk_2", "memberships", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "messages_ibfk_2", "messages", "users", ["author_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "attendance_ibfk_1", "attendance", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "requests_ibfk_2", "requests", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "requests_ibfk_3", "requests", "users", ["assignee_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "fc_user_ibfk_2",
+        "fc_user",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "asset_ibfk_2",
+        "asset",
+        "users",
+        ["uploader_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "user_installation_ibfk_1",
+        "user_installation",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
 
 
 def downgrade() -> None:
+    # drop FKs referencing users.id
+    op.drop_constraint("user_keys_ibfk_1", "user_keys", type_="foreignkey")
+    op.drop_constraint("memberships_ibfk_2", "memberships", type_="foreignkey")
+    op.drop_constraint("messages_ibfk_2", "messages", type_="foreignkey")
+    op.drop_constraint("attendance_ibfk_1", "attendance", type_="foreignkey")
+    op.drop_constraint("requests_ibfk_2", "requests", type_="foreignkey")
+    op.drop_constraint("requests_ibfk_3", "requests", type_="foreignkey")
+    op.drop_constraint("fc_user_ibfk_2", "fc_user", type_="foreignkey")
+    op.drop_constraint("asset_ibfk_2", "asset", type_="foreignkey")
+    op.drop_constraint(
+        "user_installation_ibfk_1", "user_installation", type_="foreignkey"
+    )
+
     op.execute("ALTER TABLE users MODIFY id BIGINT UNSIGNED NOT NULL")
+
+    # recreate FKs
+    op.create_foreign_key(
+        "user_keys_ibfk_1", "user_keys", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "memberships_ibfk_2", "memberships", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "messages_ibfk_2", "messages", "users", ["author_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "attendance_ibfk_1", "attendance", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "requests_ibfk_2", "requests", "users", ["user_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "requests_ibfk_3", "requests", "users", ["assignee_id"], ["id"]
+    )
+    op.create_foreign_key(
+        "fc_user_ibfk_2",
+        "fc_user",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "asset_ibfk_2",
+        "asset",
+        "users",
+        ["uploader_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "user_installation_ibfk_1",
+        "user_installation",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )


### PR DESCRIPTION
## Summary
- drop foreign keys referencing `users.id`
- alter `users.id` to auto increment and restore foreign keys

## Testing
- `alembic -c /tmp/alembic.ini upgrade head` *(fails: Can't connect to MySQL server on '127.0.0.1')*
- `PYTHONPATH=demibot pytest` *(fails: 29 failed, 11 passed, 103 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b23185bed483289f52ac00957bfdf9