### PR TITLE
Add migration for author avatar URL

### DIFF
--- a/demibot/README.md
+++ b/demibot/README.md
@@ -37,6 +37,7 @@ Run database migrations:
 ```bash
 alembic -c demibot/db/migrations/env.py upgrade head
 ```
+Re-run the migration command after pulling updates to apply any schema changes.
 
 Run the API server (and Discord bot if configured) with:
 

--- a/demibot/demibot/db/migrations/versions/0025_add_author_avatar_url.py
+++ b/demibot/demibot/db/migrations/versions/0025_add_author_avatar_url.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0025_add_author_avatar_url"
+down_revision = "0024_autoincrement_user_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "messages",
+        sa.Column("author_avatar_url", sa.String(255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("messages", "author_avatar_url")


### PR DESCRIPTION
## Summary
- add migration to store message author's avatar URL
- document rerunning migrations after updates

## Testing
- `PYTHONPATH=demibot python - <<'PY'
from alembic.config import Config
from alembic import command

cfg = Config()
cfg.set_main_option('script_location', 'demibot/demibot/db/migrations')
cfg.set_main_option('sqlalchemy.url', 'sqlite:////tmp/demibot.db')
command.upgrade(cfg, 'head')
PY` *(fails: No support for ALTER of constraints in SQLite dialect)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b239053a54832892857117cbb4c728