### PR TITLE
Improve WebSocket auth logging and watcher resilience

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -55,7 +55,7 @@ public class Plugin : IDalamudPlugin
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceSidebar);
         _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);
         _channelWatcher = new ChannelWatcher(_config, _ui, _chatWindow, _officerChatWindow);
-        _requestWatcher = new RequestWatcher(_config);
+        _requestWatcher = new RequestWatcher(_config, _httpClient);
         _settings.MainWindow = _mainWindow;
         _settings.ChatWindow = _chatWindow;
         _settings.OfficerChatWindow = _officerChatWindow;


### PR DESCRIPTION
## Summary
- add detailed logging around WebSocket auth checks and X-Api-Key header
- surface auth failures in ChannelWatcher/RequestWatcher with exponential backoff and HTTP fallback refresh

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b23b3951b88328a9bd2a086fb481c6