### PR TITLE
Avoid clipped ImGui content regions

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -94,7 +94,7 @@ public class ChatWindow : IDisposable
         ImGui.EndChild();
         ImGui.SameLine();
 
-        ImGui.BeginChild("##chatArea", new Vector2(0, 0), false);
+        ImGui.BeginChild("##chatArea", ImGui.GetContentRegionAvail(), false);
 
         if (_channels.Count > 0)
         {
@@ -118,7 +118,7 @@ public class ChatWindow : IDisposable
             SaveConfig();
         }
 
-        ImGui.BeginChild("##chatScroll", new Vector2(0, -30), true);
+        ImGui.BeginChild("##chatScroll", new Vector2(-1, -30), true);
         foreach (var msg in _messages)
         {
             ImGui.BeginGroup();

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -111,7 +111,7 @@ public class SyncshellWindow : IDisposable
             var childHeight = 70f;
             if (asset.Kind == "BUNDLE" && asset.Items != null)
                 childHeight += ImGui.GetTextLineHeightWithSpacing() * asset.Items.Count;
-            ImGui.BeginChild("card", new Vector2(0, childHeight), true);
+            ImGui.BeginChild("card", new Vector2(-1, childHeight), true);
             ImGui.TextUnformatted(asset.Name);
             if (!_seenAssetIds.Contains(asset.Id))
             {

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -71,7 +71,7 @@ public class TemplatesWindow
 
         ImGui.SameLine();
 
-        ImGui.BeginChild("TemplateContent", new Vector2(0, 0), false);
+        ImGui.BeginChild("TemplateContent", ImGui.GetContentRegionAvail(), false);
         if (_selectedIndex >= 0 && _selectedIndex < filteredTemplates.Count)
         {
             var tmpl = filteredTemplates[_selectedIndex];

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -395,7 +395,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 .ToList();
         }
 
-        ImGui.BeginChild("##eventScroll", new Vector2(0, 0), true);
+        ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), true);
         foreach (var view in embeds)
         {
             view.Draw();


### PR DESCRIPTION
## Summary
- Use `ImGui.GetContentRegionAvail()` for chat and event child regions to consume available space
- Replace zero-width child panes with `-1` width to stretch to available area

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pytest` *(fails: multiple integrity errors after installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b23b3e43748328b5c1a4dda3d4caf0