### PR TITLE
Start channel watcher and restart watchers on config changes

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -60,6 +60,7 @@ public class Plugin : IDalamudPlugin
         _settings.ChatWindow = _chatWindow;
         _settings.OfficerChatWindow = _officerChatWindow;
         _settings.ChannelWatcher = _channelWatcher;
+        _settings.RequestWatcher = _requestWatcher;
 
         _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
 
@@ -72,6 +73,7 @@ public class Plugin : IDalamudPlugin
         _services.PluginInterface.UiBuilder.OpenConfigUi += _openConfigUi;
 
         _requestWatcher.Start();
+        _ = _channelWatcher.Start();
         _services.Log.Info("DemiCat loaded.");
     }
 

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -35,6 +35,7 @@ public class SettingsWindow : IDisposable
     public ChatWindow? ChatWindow { get; set; }
     public OfficerChatWindow? OfficerChatWindow { get; set; }
     public ChannelWatcher? ChannelWatcher { get; set; }
+    public RequestWatcher? RequestWatcher { get; set; }
 
     public SettingsWindow(Config config, HttpClient httpClient, Func<Task<bool>> refreshRoles, Func<Task> startNetworking, IPluginLog log, IDalamudPluginInterface pluginInterface)
     {
@@ -407,6 +408,7 @@ public class SettingsWindow : IDisposable
                         {
                             await ChannelWatcher.Start();
                         }
+                        RequestWatcher?.Start();
                     }
                     catch (Exception ex)
                     {
@@ -517,6 +519,11 @@ public class SettingsWindow : IDisposable
         }
 
         _ = services.Framework.RunOnTick(() => services.PluginInterface.SavePluginConfig(_config));
+        if (ChannelWatcher != null)
+        {
+            _ = ChannelWatcher.Start();
+        }
+        RequestWatcher?.Start();
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- start channel watcher when plugin loads
- expose RequestWatcher to settings and restart watchers after config saves or API key updates

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alembic')*

------
https://chatgpt.com/codex/tasks/task_e_68b23de3652c83288667f782b3971d3c