### PR TITLE
Add attachments_json column to messages

### DIFF
--- a/demibot/demibot/db/migrations/versions/0026_add_attachments_json_to_messages.py
+++ b/demibot/demibot/db/migrations/versions/0026_add_attachments_json_to_messages.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0026_add_attachments_json_to_messages"
+down_revision = "0025_add_author_avatar_url"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("messages", sa.Column("attachments_json", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("messages", "attachments_json")


### PR DESCRIPTION
## Summary
- add Alembic migration adding optional attachments_json to messages

## Testing
- `python - <<'PYTHON'
from sqlalchemy import create_engine, text
engine = create_engine('sqlite:///demibot_test.db')
with engine.begin() as conn:
    conn.execute(text('DROP TABLE IF EXISTS messages'))
    conn.execute(text('DROP TABLE IF EXISTS alembic_version'))
    conn.execute(text('CREATE TABLE messages (discord_message_id INTEGER PRIMARY KEY, author_avatar_url VARCHAR(255))'))
    conn.execute(text('CREATE TABLE alembic_version (version_num VARCHAR(128) NOT NULL)'))
    conn.execute(text("INSERT INTO alembic_version (version_num) VALUES ('0025_add_author_avatar_url')"))

from alembic.config import Config
from alembic import command
import sys
sys.path.insert(0, 'demibot')
cfg = Config()
cfg.set_main_option('script_location', 'demibot/demibot/db/migrations')
cfg.set_main_option('sqlalchemy.url', 'sqlite:///demibot_test.db')
command.upgrade(cfg, 'head')
print('Migration succeeded')
PYTHON`
- `sqlite3 demibot_test.db 'PRAGMA table_info(messages);'`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b24636c60083289a797fb366eaf5e0