### PR TITLE
Handle missing Discord ID in WebSocket authentication

### DIFF
--- a/demibot/demibot/http/ws.py
+++ b/demibot/demibot/http/ws.py
@@ -125,7 +125,11 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     ctx: RequestContext | None = None
     async for db in get_session():
         try:
-            ctx = await api_key_auth(x_api_key=token, db=db)
+            ctx = await api_key_auth(
+                x_api_key=token,
+                x_discord_id=None,
+                db=db,
+            )
         except HTTPException as exc:
             logging.warning(
                 "WS %s auth failed (%s): %s",

--- a/tests/test_officer_ws.py
+++ b/tests/test_officer_ws.py
@@ -83,7 +83,8 @@ def test_officer_path_requires_role(monkeypatch):
         async def fake_get_session():
             yield None
 
-        async def fake_api_key_auth(x_api_key, db):
+        async def fake_api_key_auth(x_api_key, x_discord_id, db):
+            assert x_discord_id is None
             return ctx
 
         connected = False

--- a/tests/test_ws_api_key.py
+++ b/tests/test_ws_api_key.py
@@ -1,0 +1,71 @@
+import types
+import asyncio
+import pytest
+from fastapi import HTTPException, WebSocketDisconnect
+
+from demibot.http import ws as ws_module
+from demibot.http.deps import RequestContext
+
+class StubWebSocket:
+    def __init__(self):
+        self.scope = {"path": "/ws/messages"}
+        self.headers = {"X-Api-Key": "token"}
+        self.query_params = {}
+        self.close_code = None
+        self.close_reason = None
+
+    async def accept(self):
+        pass
+
+    async def close(self, code: int, reason: str):
+        self.close_code = code
+        self.close_reason = reason
+
+    async def receive_text(self):
+        raise WebSocketDisconnect()
+
+def test_websocket_auth_success(monkeypatch):
+    ws = StubWebSocket()
+    guild = types.SimpleNamespace(id=1, discord_guild_id=1)
+    user = types.SimpleNamespace(id=1, discord_user_id=1)
+    ctx = RequestContext(user=user, guild=guild, key=None, roles=[])
+
+    async def fake_get_session():
+        yield None
+
+    async def fake_api_key_auth(x_api_key, x_discord_id, db):
+        assert x_discord_id is None
+        return ctx
+
+    connected = False
+
+    async def fake_connect(*args, **kwargs):
+        nonlocal connected
+        connected = True
+
+    monkeypatch.setattr(ws_module, "get_session", fake_get_session)
+    monkeypatch.setattr(ws_module, "api_key_auth", fake_api_key_auth)
+    monkeypatch.setattr(ws_module.manager, "connect", fake_connect)
+    monkeypatch.setattr(ws_module.manager, "disconnect", lambda *a, **k: None)
+
+    asyncio.run(ws_module.websocket_endpoint(ws))
+    assert connected is True
+    assert ws.close_code is None
+
+
+def test_websocket_auth_failure(monkeypatch):
+    ws = StubWebSocket()
+
+    async def fake_get_session():
+        yield None
+
+    async def fake_api_key_auth(x_api_key, x_discord_id, db):
+        assert x_discord_id is None
+        raise HTTPException(status_code=401, detail="bad token")
+
+    monkeypatch.setattr(ws_module, "get_session", fake_get_session)
+    monkeypatch.setattr(ws_module, "api_key_auth", fake_api_key_auth)
+
+    asyncio.run(ws_module.websocket_endpoint(ws))
+    assert ws.close_code == 1008
+    assert ws.close_reason == "auth failed"


### PR DESCRIPTION
## Summary
- Pass `x_discord_id=None` when authenticating WebSocket connections to avoid accidental privilege checks
- Add unit tests covering WebSocket auth success and failure
- Adjust existing test stubs for new auth signature

## Testing
- `PYTHONPATH=demibot pytest tests/test_ws_api_key.py tests/test_officer_ws.py -q`
- `PYTHONPATH=demibot pytest -q` *(fails: UNIQUE constraint failed: guilds.id and other existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b24733b31883289e03d2d89476affd