### PR TITLE
Enable required Discord intents

### DIFF
--- a/demibot/demibot/discordbot/bot.py
+++ b/demibot/demibot/discordbot/bot.py
@@ -13,8 +13,15 @@ logger = logging.getLogger(__name__)
 
 
 class DemiBot(commands.Bot):
-    def __init__(self, cfg: AppConfig) -> None:
-        intents = discord.Intents.all()
+    def __init__(
+        self, cfg: AppConfig, intents: discord.Intents | None = None
+    ) -> None:
+        if intents is None:
+            intents = discord.Intents.default()
+            intents.message_content = True
+            intents.reactions = True
+            intents.members = True
+            intents.presences = True
         super().__init__(command_prefix="!", intents=intents)
         self.cfg = cfg
 
@@ -53,5 +60,5 @@ class DemiBot(commands.Bot):
         except Exception:
             logger.exception("Failed to sync application commands")
 
-def create_bot(cfg: AppConfig) -> DemiBot:
-    return DemiBot(cfg)
+def create_bot(cfg: AppConfig, intents: discord.Intents | None = None) -> DemiBot:
+    return DemiBot(cfg, intents=intents)

--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -9,6 +9,7 @@ import re
 import sys
 
 import uvicorn
+import discord
 
 from demibot import log_config
 
@@ -51,7 +52,12 @@ async def main_async() -> None:
     )
     try:
         app = create_app()
-        bot = create_bot(cfg)
+        intents = discord.Intents.default()
+        intents.message_content = True
+        intents.reactions = True
+        intents.members = True
+        intents.presences = True
+        bot = create_bot(cfg, intents=intents)
         set_discord_client(bot)
         config = uvicorn.Config(
             app, host=cfg.server.host, port=cfg.server.port, log_level="info"


### PR DESCRIPTION
## Summary
- configure DemiBot to request message content, reaction, member, and presence intents
- pass configured intents from main entry point

## Testing
- `pytest -q` *(fails: UNIQUE constraint failed: guilds.id)*

------
https://chatgpt.com/codex/tasks/task_e_68b251cdf37c8328abb8c09e160a6066