### PR TITLE
Persist full message metadata

### DIFF
--- a/demibot/demibot/db/migrations/versions/0027_add_message_metadata_fields.py
+++ b/demibot/demibot/db/migrations/versions/0027_add_message_metadata_fields.py
@@ -1,0 +1,34 @@
+"""add message metadata fields
+
+Revision ID: 0027_add_message_metadata_fields
+Revises: 0026_add_attachments_json_to_messages
+Create Date: 2024-09-20 00:00:00.000000"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0027_add_message_metadata_fields'
+down_revision = '0026_add_attachments_json_to_messages'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('messages', sa.Column('content', sa.Text(), nullable=True))
+    op.add_column('messages', sa.Column('author_json', sa.Text(), nullable=True))
+    op.add_column('messages', sa.Column('embeds_json', sa.Text(), nullable=True))
+    op.add_column('messages', sa.Column('mentions_json', sa.Text(), nullable=True))
+    op.add_column('messages', sa.Column('reference_json', sa.Text(), nullable=True))
+    op.add_column('messages', sa.Column('components_json', sa.Text(), nullable=True))
+    op.add_column('messages', sa.Column('edited_timestamp', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('messages', 'edited_timestamp')
+    op.drop_column('messages', 'components_json')
+    op.drop_column('messages', 'reference_json')
+    op.drop_column('messages', 'mentions_json')
+    op.drop_column('messages', 'embeds_json')
+    op.drop_column('messages', 'author_json')
+    op.drop_column('messages', 'content')

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -183,6 +183,13 @@ class Message(Base):
     content_raw: Mapped[str] = mapped_column(Text)
     content_display: Mapped[str] = mapped_column(Text)
     attachments_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    content: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    author_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    embeds_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    mentions_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    reference_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    components_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    edited_timestamp: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     is_officer: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 

--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext
-from ..schemas import ChatMessage, AttachmentDto
+from ..schemas import ChatMessage, AttachmentDto, MessageAuthor, Mention
 from ..ws import manager
 from ...db.models import Message
 from ..discord_client import discord_client
@@ -57,6 +57,43 @@ async def fetch_messages(
                 attachments = [AttachmentDto(**a) for a in data]
             except Exception:
                 attachments = None
+
+        mentions = None
+        if m.mentions_json:
+            try:
+                data = json.loads(m.mentions_json)
+                mentions = [Mention(**a) for a in data]
+            except Exception:
+                mentions = None
+
+        author = None
+        if m.author_json:
+            try:
+                author = MessageAuthor(**json.loads(m.author_json))
+            except Exception:
+                author = None
+
+        embeds = None
+        if m.embeds_json:
+            try:
+                embeds = json.loads(m.embeds_json)
+            except Exception:
+                embeds = None
+
+        reference = None
+        if m.reference_json:
+            try:
+                reference = json.loads(m.reference_json)
+            except Exception:
+                reference = None
+
+        components = None
+        if m.components_json:
+            try:
+                components = json.loads(m.components_json)
+            except Exception:
+                components = None
+
         out.append(
             ChatMessage(
                 id=str(m.discord_message_id),
@@ -64,8 +101,14 @@ async def fetch_messages(
                 authorName=m.author_name,
                 authorAvatarUrl=m.author_avatar_url,
                 timestamp=m.created_at,
-                content=m.content_display,
+                content=m.content or m.content_display or m.content_raw,
                 attachments=attachments,
+                mentions=mentions,
+                author=author,
+                embeds=embeds,
+                reference=reference,
+                components=components,
+                editedTimestamp=m.edited_timestamp,
             )
         )
     return [o.model_dump() for o in out]
@@ -89,14 +132,22 @@ async def save_message(
             discord_msg_id = sent.id
     if discord_msg_id is None:
         discord_msg_id = int(datetime.utcnow().timestamp() * 1000)
+    author = MessageAuthor(
+        id=str(ctx.user.id),
+        name=ctx.user.global_name or ("Officer" if is_officer else "Player"),
+        avatarUrl=None,
+    )
     msg = Message(
         discord_message_id=discord_msg_id,
         channel_id=channel_id,
         guild_id=ctx.guild.id,
         author_id=ctx.user.id,
-        author_name=ctx.user.global_name or ("Officer" if is_officer else "Player"),
+        author_name=author.name,
+        author_avatar_url=author.avatarUrl,
         content_raw=body.content,
         content_display=body.content,
+        content=body.content,
+        author_json=author.model_dump_json(),
         is_officer=is_officer,
     )
     db.add(msg)
@@ -108,7 +159,9 @@ async def save_message(
         authorName=msg.author_name,
         authorAvatarUrl=msg.author_avatar_url,
         timestamp=msg.created_at,
-        content=msg.content_display,
+        content=msg.content or msg.content_display,
+        author=author,
+        editedTimestamp=msg.edited_timestamp,
     )
     await manager.broadcast_text(
         dto.model_dump_json(),

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -4,12 +4,13 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
+from ..schemas import ChatMessage
 from ._messages_common import PostBody, fetch_messages, save_message
 
 router = APIRouter(prefix="/api")
 
 
-@router.get("/messages/{channel_id}")
+@router.get("/messages/{channel_id}", response_model=list[ChatMessage])
 async def get_messages(
     channel_id: str,
     limit: int | None = None,

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -72,6 +72,12 @@ class AttachmentDto(BaseModel):
     contentType: Optional[str] = None
 
 
+class MessageAuthor(BaseModel):
+    id: str
+    name: str
+    avatarUrl: Optional[str] = None
+
+
 class ChatMessage(BaseModel):
     id: str
     channelId: str
@@ -81,6 +87,11 @@ class ChatMessage(BaseModel):
     content: str
     attachments: List[AttachmentDto] | None = None
     mentions: List[Mention] | None = None
+    author: MessageAuthor | None = None
+    embeds: List[dict] | None = None
+    reference: dict | None = None
+    components: List[dict] | None = None
+    editedTimestamp: Optional[datetime] = None
 
 # ---- Presence ----
 


### PR DESCRIPTION
## Summary
- expand message model with content, author, embeds, mentions, reference, components, and edited timestamp
- expose new message metadata through API and websocket handlers
- add migration for new message metadata columns

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_save_and_fetch_messages`
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_officer_flow`
- `PYTHONPATH=demibot pytest tests/test_messages_common.py` *(fails: UNIQUE constraint failed: guilds.id)*

------
https://chatgpt.com/codex/tasks/task_e_68b25307dee48328bbe0666b45980277