### PR TITLE
feat(ui): add embed renderer for messages

### DIFF
--- a/ui/components/EmbedRenderer.vue
+++ b/ui/components/EmbedRenderer.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="embed" :style="colorStyle">
+    <div class="embed-content">
+      <div v-if="embed.title" class="embed-title">
+        <a v-if="embed.url" :href="embed.url" target="_blank" rel="noopener">{{ embed.title }}</a>
+        <span v-else>{{ embed.title }}</span>
+      </div>
+      <div v-if="embed.description" class="embed-description" v-html="embed.description" />
+      <div v-if="embed.fields && embed.fields.length" class="embed-fields">
+        <div v-for="(field, i) in embed.fields" :key="i" class="embed-field" :class="{ inline: field.inline }">
+          <div class="field-name" v-if="field.name">{{ field.name }}</div>
+          <div class="field-value" v-if="field.value" v-html="field.value" />
+        </div>
+      </div>
+      <div v-if="embed.image" class="embed-image">
+        <img :src="embed.image.url" alt="" />
+      </div>
+      <div v-if="embed.thumbnail" class="embed-thumbnail">
+        <img :src="embed.thumbnail.url" alt="" />
+      </div>
+      <div v-if="embed.footer" class="embed-footer">
+        <span v-if="embed.footer.icon_url" class="footer-icon">
+          <img :src="embed.footer.icon_url" alt="" />
+        </span>
+        <span class="footer-text">{{ embed.footer.text }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'EmbedRenderer',
+  props: {
+    embed: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+    colorStyle() {
+      if (!this.embed.color) return {};
+      const color = `#${this.embed.color.toString(16).padStart(6, '0')}`;
+      return { borderColor: color };
+    }
+  }
+};
+</script>
+
+<style scoped>
+.embed {
+  display: flex;
+  border-left: 4px solid #ccc;
+  background-color: #2f3136;
+  padding: 10px;
+  border-radius: 4px;
+  color: #dcddde;
+  max-width: 500px;
+}
+.embed-content {
+  flex: 1;
+}
+.embed-title a,
+.embed-title span {
+  font-weight: 600;
+  color: #00aff4;
+  text-decoration: none;
+}
+.embed-description {
+  margin-top: 4px;
+  white-space: pre-line;
+}
+.embed-fields {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.embed-field {
+  flex: 1 1 100%;
+  margin-bottom: 8px;
+}
+.embed-field.inline {
+  flex: 1 1 45%;
+  margin-right: 5%;
+}
+.embed-field.inline:nth-child(2n) {
+  margin-right: 0;
+}
+.field-name {
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+.embed-image img {
+  width: 100%;
+  margin-top: 8px;
+  border-radius: 4px;
+}
+.embed-thumbnail img {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  margin-left: 10px;
+}
+.embed-footer {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #b9bbbe;
+  display: flex;
+  align-items: center;
+}
+.footer-icon img {
+  width: 20px;
+  height: 20px;
+  margin-right: 6px;
+  border-radius: 50%;
+}
+</style>
+

--- a/ui/components/Message.vue
+++ b/ui/components/Message.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="message">
+    <div v-if="message.content" class="content">{{ message.content }}</div>
+    <!-- Webhook messages (type 20) use the same renderer -->
+    <EmbedRenderer v-for="(embed, i) in message.embeds" :key="i" :embed="embed" />
+  </div>
+</template>
+
+<script>
+import EmbedRenderer from './EmbedRenderer.vue';
+
+export default {
+  name: 'Message',
+  components: { EmbedRenderer },
+  props: {
+    message: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+    isWebhook() {
+      return this.message.type === 20;
+    }
+  }
+};
+</script>
+
+<style scoped>
+.message {
+  margin-bottom: 1rem;
+}
+.content {
+  margin-bottom: 0.5rem;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add `EmbedRenderer` component to render Discord-style embeds
- render embeds in `Message` component, including webhook messages
- add CSS for color bars, inline fields, thumbnails, and other embed layouts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68b2566c24308328be49546748dcc5ef