### PR TITLE
Add reaction and editing endpoints with basic UI

### DIFF
--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, UploadFile, File, Form, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
+import json
+import discord
 
 from ..deps import RequestContext, api_key_auth, get_db
 from ..schemas import ChatMessage
-from ._messages_common import PostBody, fetch_messages, save_message
+from ._messages_common import (
+    PostBody,
+    fetch_messages,
+    save_message,
+    edit_message as edit_message_common,
+    delete_message as delete_message_common,
+)
+from ..discord_client import discord_client
 
 router = APIRouter(prefix="/api")
 
@@ -31,3 +40,107 @@ async def post_message(
     db: AsyncSession = Depends(get_db),
 ):
     return await save_message(body, ctx, db, is_officer=False)
+
+
+@router.post("/channels/{channel_id}/messages")
+async def post_message_with_attachments(
+    channel_id: str,
+    content: str = Form(...),
+    useCharacterName: bool | None = Form(False),
+    message_reference: str | None = Form(None),
+    files: list[UploadFile] | None = File(None),
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    body = PostBody(
+        channelId=channel_id,
+        content=content,
+        useCharacterName=useCharacterName,
+        messageReference=json.loads(message_reference) if message_reference else None,
+    )
+    return await save_message(body, ctx, db, is_officer=False, files=files)
+
+
+@router.put("/channels/{channel_id}/messages/{message_id}/reactions/{emoji}")
+async def add_reaction(
+    channel_id: str,
+    message_id: str,
+    emoji: str,
+    ctx: RequestContext = Depends(api_key_auth),
+):
+    if not discord_client:
+        raise HTTPException(status_code=503, detail="Discord client unavailable")
+    channel = discord_client.get_channel(int(channel_id))
+    if not channel or not isinstance(channel, discord.abc.Messageable):
+        raise HTTPException(status_code=404)
+    try:
+        msg = await channel.fetch_message(int(message_id))
+        await msg.add_reaction(emoji)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {"ok": True}
+
+
+@router.delete("/channels/{channel_id}/messages/{message_id}/reactions/{emoji}")
+async def remove_reaction(
+    channel_id: str,
+    message_id: str,
+    emoji: str,
+    ctx: RequestContext = Depends(api_key_auth),
+):
+    if not discord_client:
+        raise HTTPException(status_code=503, detail="Discord client unavailable")
+    channel = discord_client.get_channel(int(channel_id))
+    if not channel or not isinstance(channel, discord.abc.Messageable):
+        raise HTTPException(status_code=404)
+    try:
+        msg = await channel.fetch_message(int(message_id))
+        await msg.remove_reaction(emoji, discord_client.user)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {"ok": True}
+
+
+@router.patch("/channels/{channel_id}/messages/{message_id}")
+async def patch_message(
+    channel_id: str,
+    message_id: str,
+    body: dict,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    content = body.get("content")
+    if content is None:
+        raise HTTPException(status_code=400, detail="content required")
+    return await edit_message_common(channel_id, message_id, content, ctx, db, is_officer=False)
+
+
+@router.delete("/channels/{channel_id}/messages/{message_id}")
+async def delete_message(
+    channel_id: str,
+    message_id: str,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    return await delete_message_common(channel_id, message_id, ctx, db, is_officer=False)
+
+
+@router.post("/channels/{channel_id}/commands")
+async def execute_command(
+    channel_id: str,
+    body: dict,
+    ctx: RequestContext = Depends(api_key_auth),
+):
+    if not discord_client:
+        raise HTTPException(status_code=503, detail="Discord client unavailable")
+    command = body.get("command")
+    if not command:
+        raise HTTPException(status_code=400, detail="command required")
+    channel = discord_client.get_channel(int(channel_id))
+    if not channel or not isinstance(channel, discord.abc.Messageable):
+        raise HTTPException(status_code=404)
+    try:
+        sent = await channel.send(command)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return {"ok": True, "id": str(sent.id)}

--- a/ui/components/Message.vue
+++ b/ui/components/Message.vue
@@ -1,8 +1,31 @@
 <template>
   <div class="message">
-    <div v-if="message.content" class="content">{{ message.content }}</div>
-    <!-- Webhook messages (type 20) use the same renderer -->
-    <EmbedRenderer v-for="(embed, i) in message.embeds" :key="i" :embed="embed" />
+    <div v-if="isEditing">
+      <textarea v-model="editContent" class="edit-box"></textarea>
+      <button @click="saveEdit">Save</button>
+      <button @click="cancelEdit">Cancel</button>
+    </div>
+    <div v-else>
+      <div v-if="message.content" class="content">{{ message.content }}</div>
+      <div class="reference" v-if="message.reference">
+        Replying to {{ message.reference.messageId || message.reference.id }}
+      </div>
+      <div class="attachments" v-if="message.attachments">
+        <div v-for="(att, i) in message.attachments" :key="i">
+          <img v-if="att.contentType && att.contentType.startsWith('image/')" :src="att.url" :alt="att.filename" />
+          <a v-else :href="att.url" target="_blank">{{ att.filename }}</a>
+        </div>
+      </div>
+      <!-- Webhook messages (type 20) use the same renderer -->
+      <EmbedRenderer v-for="(embed, i) in message.embeds" :key="i" :embed="embed" />
+      <div class="controls" v-if="isAuthor">
+        <button @click="startEdit">Edit</button>
+        <button @click="deleteMessage">Delete</button>
+      </div>
+      <div class="reactions">
+        <button v-for="e in emojis" :key="e" @click="react(e)">{{ e }}</button>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -13,14 +36,51 @@ export default {
   name: 'Message',
   components: { EmbedRenderer },
   props: {
-    message: {
-      type: Object,
-      required: true
-    }
+    message: { type: Object, required: true },
+    currentUserId: { type: String, required: false }
+  },
+  data() {
+    return {
+      isEditing: false,
+      editContent: this.message.content,
+      emojis: ['👍', '👎', '❤️']
+    };
   },
   computed: {
-    isWebhook() {
-      return this.message.type === 20;
+    isAuthor() {
+      return (
+        this.currentUserId &&
+        this.message.author &&
+        this.message.author.id === this.currentUserId
+      );
+    }
+  },
+  methods: {
+    react(emoji) {
+      fetch(
+        `/api/channels/${this.message.channelId}/messages/${this.message.id}/reactions/${encodeURIComponent(emoji)}`,
+        { method: 'PUT' }
+      );
+    },
+    startEdit() {
+      this.isEditing = true;
+      this.editContent = this.message.content;
+    },
+    cancelEdit() {
+      this.isEditing = false;
+    },
+    saveEdit() {
+      fetch(`/api/channels/${this.message.channelId}/messages/${this.message.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: this.editContent })
+      });
+      this.isEditing = false;
+    },
+    deleteMessage() {
+      fetch(`/api/channels/${this.message.channelId}/messages/${this.message.id}`, {
+        method: 'DELETE'
+      });
     }
   }
 };
@@ -32,6 +92,13 @@ export default {
 }
 .content {
   margin-bottom: 0.5rem;
+}
+.attachments img {
+  max-width: 200px;
+  display: block;
+}
+.reactions button {
+  margin-right: 0.25rem;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- add FastAPI routes for message reactions, editing, deletion, attachments, and slash command proxy
- support attachments and reply references in message persistence
- expose reactions and edit/delete controls in Vue message component

## Testing
- `pytest` *(fails: 29 errors during collection)*
- `dotnet test` *(fails: compatible .NET SDK 9.0.100 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b25a6a7a048328a9f0a98b27170ae8