### PR TITLE
Handle existing events and ensure unique guild channels

### DIFF
--- a/demibot/demibot/db/migrations/versions/0028_add_guild_channel_unique.py
+++ b/demibot/demibot/db/migrations/versions/0028_add_guild_channel_unique.py
@@ -1,0 +1,31 @@
+"""add unique constraint to guild channels
+
+Revision ID: 0028_add_guild_channel_unique
+Revises: 0027_add_message_metadata_fields
+Create Date: 2025-01-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0028_add_guild_channel_unique'
+down_revision = '0027_add_message_metadata_fields'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        'uq_guild_channels_guild_channel',
+        'guild_channels',
+        ['guild_id', 'channel_id'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        'uq_guild_channels_guild_channel',
+        'guild_channels',
+        type_='unique',
+    )

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     String,
     Text,
     Index,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.mysql import BIGINT
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -90,6 +91,9 @@ class GuildConfig(Base):
 
 class GuildChannel(Base):
     __tablename__ = "guild_channels"
+    __table_args__ = (
+        UniqueConstraint("guild_id", "channel_id", name="uq_guild_channels_guild_channel"),
+    )
 
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"), primary_key=True)
     channel_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Any
 import discord
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
-from sqlalchemy import select
+from sqlalchemy import select, delete
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -147,18 +147,35 @@ async def create_event(
         channelId=int(body.channelId) if body.channelId.isdigit() else None,
         mentions=mention_ids or None,
     )
-    db.add(
-        Embed(
-            discord_message_id=int(eid),
-            channel_id=channel_id,
-            guild_id=ctx.guild.id,
-            payload_json=json.dumps(dto.model_dump(mode="json")),
-            buttons_json=json.dumps([b.model_dump(mode="json") for b in buttons])
+    existing = await db.get(Embed, int(eid))
+    if existing:
+        existing.channel_id = channel_id
+        existing.guild_id = ctx.guild.id
+        existing.payload_json = json.dumps(dto.model_dump(mode="json"))
+        existing.buttons_json = (
+            json.dumps([b.model_dump(mode="json") for b in buttons])
             if buttons
-            else None,
-            source="demibot",
+            else None
         )
-    )
+        await db.execute(
+            delete(EventButton).where(EventButton.message_id == int(eid))
+        )
+        await db.execute(
+            delete(RecurringEvent).where(RecurringEvent.id == int(eid))
+        )
+    else:
+        db.add(
+            Embed(
+                discord_message_id=int(eid),
+                channel_id=channel_id,
+                guild_id=ctx.guild.id,
+                payload_json=json.dumps(dto.model_dump(mode="json")),
+                buttons_json=json.dumps([b.model_dump(mode="json") for b in buttons])
+                if buttons
+                else None,
+                source="demibot",
+            )
+        )
     for b in buttons:
         cid = b.customId
         if cid and cid.startswith("rsvp:"):
@@ -194,6 +211,7 @@ async def create_event(
             select(GuildChannel.kind).where(
                 GuildChannel.guild_id == ctx.guild.id,
                 GuildChannel.channel_id == channel_id,
+                GuildChannel.kind == "officer_chat",
             )
         )
     ).scalar_one_or_none()

--- a/tests/test_event_update.py
+++ b/tests/test_event_update.py
@@ -1,0 +1,90 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+import json
+from types import SimpleNamespace
+from datetime import datetime
+from unittest.mock import patch
+from sqlalchemy import select
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.db.models import Embed, Guild, GuildChannel
+from demibot.db.session import init_db, get_session
+from demibot.http.routes.events import create_event, CreateEventBody
+
+
+async def _run_test() -> None:
+    db_path = Path("test_event_update.db")
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+
+    constant = datetime(2024, 1, 1)
+    eid = str(int(constant.timestamp() * 1000))
+
+    async for db in get_session():
+        guild = Guild(id=1, discord_guild_id=1, name="Test")
+        db.add(guild)
+        db.add(GuildChannel(guild_id=1, channel_id=123, kind="event"))
+        await db.commit()
+        break
+
+    ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
+    body = CreateEventBody(
+        channelId="123",
+        title="First",
+        time="2024-01-01T00:00:00Z",
+        description="desc",
+    )
+
+    async for db in get_session():
+        original_dumps = json.dumps
+        with patch(
+            "demibot.http.routes.events.json.dumps",
+            lambda obj, *a, **k: original_dumps(obj, default=str, *a, **k),
+        ), patch("demibot.http.routes.events.datetime") as dt:
+            dt.utcnow.return_value = constant
+            dt.fromisoformat.side_effect = datetime.fromisoformat
+            await create_event(body=body, ctx=ctx, db=db)
+        await db.commit()
+        break
+
+    body2 = CreateEventBody(
+        channelId="123",
+        title="Second",
+        time="2024-01-01T00:00:00Z",
+        description="desc",
+    )
+    async for db in get_session():
+        original_dumps = json.dumps
+        with patch(
+            "demibot.http.routes.events.json.dumps",
+            lambda obj, *a, **k: original_dumps(obj, default=str, *a, **k),
+        ), patch("demibot.http.routes.events.datetime") as dt:
+            dt.utcnow.return_value = constant
+            dt.fromisoformat.side_effect = datetime.fromisoformat
+            await create_event(body=body2, ctx=ctx, db=db)
+        row = await db.get(Embed, int(eid))
+        payload = json.loads(row.payload_json)
+        assert payload["title"] == "Second"
+        res = await db.execute(select(Embed))
+        embeds = res.scalars().all()
+        assert len(embeds) == 1
+        break
+
+
+def test_event_update_existing() -> None:
+    asyncio.run(_run_test())
+


### PR DESCRIPTION
## Summary
- Update `create_event` to upsert existing events and clean up buttons and recurrence entries
- Limit officer chat lookup to its specific kind to avoid multi-row queries
- Enforce unique `(guild_id, channel_id)` pairs for guild channels
- Cover duplicate-event behavior with a new test

## Testing
- `pytest tests/test_event_update.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2e05f8f508328a48b3153c38dc3fb