### PR TITLE
Store Discord event embeds and attachments

### DIFF
--- a/demibot/models/event.py
+++ b/demibot/models/event.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, JSON
+from sqlalchemy.orm import Mapped, mapped_column
+
+from demibot.db.base import Base
+
+
+class Event(Base):
+    """Database model for stored Discord events.
+
+    The table keeps track of the originating message along with any embeds or
+    attachments captured from the original Discord post. The ``embeds`` and
+    ``attachments`` columns use SQLAlchemy's ``JSON`` type so they can store
+    arbitrary structured data without requiring a schema migration each time
+    Discord tweaks its payload format.
+    """
+
+    __tablename__ = "events"
+
+    discord_message_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    channel_id: Mapped[int] = mapped_column(BigInteger, index=True)
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
+
+    # New JSON columns capturing the full embed and attachment payloads
+    embeds: Mapped[Optional[List[Dict]]] = mapped_column(JSON, nullable=True)
+    attachments: Mapped[Optional[List[Dict]]] = mapped_column(JSON, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/ui/pages/Events.vue
+++ b/ui/pages/Events.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="events">
+    <div v-for="event in events" :key="event.id" class="event">
+      <div class="attachments" v-if="event.attachments">
+        <div v-for="(att, i) in event.attachments" :key="i">
+          <img
+            v-if="att.contentType && att.contentType.startsWith('image/')"
+            :src="att.url"
+            :alt="att.filename"
+          />
+          <a v-else :href="att.url" target="_blank">{{ att.filename }}</a>
+        </div>
+      </div>
+      <div v-if="event.embeds">
+        <EmbedRenderer v-for="(emb, i) in event.embeds" :key="i" :embed="emb" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import EmbedRenderer from '../components/EmbedRenderer.vue';
+
+export default {
+  name: 'EventsPage',
+  components: { EmbedRenderer },
+  data() {
+    return {
+      events: []
+    };
+  },
+  async created() {
+    try {
+      const res = await fetch('/api/events');
+      if (res.ok) {
+        this.events = await res.json();
+      }
+    } catch (e) {
+      console.error('Failed to load events', e);
+    }
+  }
+};
+</script>
+
+<style scoped>
+.events {
+  padding: 1rem;
+}
+.event {
+  margin-bottom: 1.5rem;
+}
+.attachments img {
+  max-width: 200px;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- persist embeds and attachments from Discord messages when creating events
- expose stored event data via new `/api/events` endpoint
- render event attachments and embeds in new `Events` page

## Testing
- `pytest tests/test_create_event_source.py tests/test_rsvp_max_signups.py tests/test_recurring_events.py tests/test_recurring_event_management.py` *(fails: UNIQUE constraint failed: guilds.id)*


------
https://chatgpt.com/codex/tasks/task_e_68b2e23698148328bb3a43bf846bcfe3