### PR TITLE
Add SyncShell server endpoints and plugin scaffold

### DIFF
--- a/SyncShellClient/SyncShellClient.cs
+++ b/SyncShellClient/SyncShellClient.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.IoC;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Services;
+
+namespace SyncShellClient;
+
+public class SyncShellClient : IDalamudPlugin
+{
+    public string Name => "SyncShellClient";
+
+    [PluginService] private IDalamudPluginInterface PluginInterface { get; set; } = null!;
+    [PluginService] private ClientState ClientState { get; set; } = null!;
+
+    private readonly HttpClient _http = new();
+    private readonly ClientWebSocket _ws = new();
+    private IpcSubscriber<string[]>? _enabledMods;
+
+    public SyncShellClient()
+    {
+        _enabledMods = PluginInterface.GetIpcSubscriber<string[]>("Penumbra.GetEnabledMods");
+        ClientState.Login += OnLogin;
+    }
+
+    private async void OnLogin()
+    {
+        await RefreshPresenceAsync();
+        await SendManifestAsync();
+    }
+
+    private async Task RefreshPresenceAsync()
+    {
+        try
+        {
+            await _http.GetAsync("http://localhost:5050/api/presences");
+        }
+        catch
+        {
+            // ignore network errors
+        }
+    }
+
+    private async Task SendManifestAsync()
+    {
+        if (!ClientState.IsLoggedIn || _enabledMods is null)
+            return;
+        string[] mods;
+        try
+        {
+            mods = _enabledMods.InvokeFunc();
+        }
+        catch
+        {
+            return;
+        }
+        var payload = JsonSerializer.Serialize(new { mods });
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        try
+        {
+            if (_ws.State != WebSocketState.Open)
+            {
+                await _ws.ConnectAsync(new Uri("ws://localhost:5050/ws/syncshell"), CancellationToken.None);
+            }
+            await _ws.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None);
+        }
+        catch
+        {
+            // ignore socket errors
+        }
+    }
+
+    public void Dispose()
+    {
+        ClientState.Login -= OnLogin;
+        _ws.Dispose();
+        _http.Dispose();
+    }
+}

--- a/SyncShellClient/SyncShellClient.csproj
+++ b/SyncShellClient/SyncShellClient.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Dalamud.NET.Sdk/13.0.0">
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DalamudApiLevel>13</DalamudApiLevel>
+    <AssemblyName>SyncShellClient</AssemblyName>
+    <RootNamespace>SyncShellClient</RootNamespace>
+    <Version>0.0.1</Version>
+    <AssemblyVersion>0.0.1.0</AssemblyVersion>
+    <FileVersion>0.0.1.0</FileVersion>
+  </PropertyGroup>
+</Project>

--- a/SyncShellClient/packages.lock.json
+++ b/SyncShellClient/packages.lock.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net9.0-windows7.0": {
+      "DalamudPackager": {
+        "type": "Direct",
+        "requested": "[13.0.0, )",
+        "resolved": "13.0.0",
+        "contentHash": "Mb3cUDSK/vDPQ8gQIeuCw03EMYrej1B4J44a1AvIJ9C759p9XeqdU9Hg4WgOmlnlPe0G7ILTD32PKSUpkQNa8w=="
+      },
+      "DotNet.ReproducibleBuilds": {
+        "type": "Direct",
+        "requested": "[1.2.25, )",
+        "resolved": "1.2.25",
+        "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
+      }
+    }
+  }
+}

--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import time
+from uuid import uuid4
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..deps import RequestContext, api_key_auth
+
+
+router = APIRouter(prefix="/api/syncshell", tags=["syncshell"])
+
+# Simple in-memory stores for demonstration purposes only.
+_pair_tokens: dict[int, str] = {}
+_rate_limiter: dict[int, list[float]] = {}
+
+RATE_LIMIT = 30  # max requests per minute per user
+MAX_MANIFEST_BYTES = 1024 * 1024  # 1 MiB manifest payload cap
+
+
+def _check_rate_limit(user_id: int) -> None:
+    """Very small in-memory rate limiter."""
+    now = time.time()
+    bucket = _rate_limiter.setdefault(user_id, [])
+    bucket[:] = [t for t in bucket if now - t < 60]
+    if len(bucket) >= RATE_LIMIT:
+        raise HTTPException(status_code=429, detail="rate limit exceeded")
+    bucket.append(now)
+
+
+@router.post("/pair")
+async def pair(ctx: RequestContext = Depends(api_key_auth)) -> dict[str, Any]:
+    """Issue a short-lived pairing token for a client."""
+    _check_rate_limit(ctx.user.id)
+    token = uuid4().hex
+    _pair_tokens[ctx.user.id] = token
+    return {"token": token}
+
+
+@router.post("/manifest")
+async def upload_manifest(
+    manifest: list[dict[str, Any]],
+    ctx: RequestContext = Depends(api_key_auth),
+) -> dict[str, Any]:
+    """Receive a hashed file manifest from a client.
+
+    The manifest is capped in size to prevent excessive memory usage and
+    naive clients from overwhelming the API.
+    """
+    _check_rate_limit(ctx.user.id)
+    payload_size = len(str(manifest).encode())
+    if payload_size > MAX_MANIFEST_BYTES:
+        raise HTTPException(status_code=413, detail="manifest too large")
+    # In a real implementation, the manifest would be persisted and compared
+    # against server-side data to determine missing assets.
+    return {"status": "ok"}
+
+
+@router.post("/asset/upload")
+async def request_asset_upload(ctx: RequestContext = Depends(api_key_auth)) -> dict[str, str]:
+    """Return a pre-signed URL for chunked asset upload.
+
+    This is a stub; integration with the Vault service should generate and
+    return a short-lived URL that the client can PUT to.
+    """
+    _check_rate_limit(ctx.user.id)
+    return {"url": "https://vault.example/upload"}
+
+
+@router.get("/asset/download/{asset_id}")
+async def request_asset_download(asset_id: str, ctx: RequestContext = Depends(api_key_auth)) -> dict[str, str]:
+    """Return a pre-signed URL for asset download."""
+    _check_rate_limit(ctx.user.id)
+    return {"url": f"https://vault.example/{asset_id}"}


### PR DESCRIPTION
## Summary
- add `/api/syncshell` route group for pairing, manifest exchange and asset URLs
- introduce basic SyncShellClient Dalamud plugin scaffold with Penumbra IPC and presence/manifest handling

## Testing
- `pytest` *(fails: sqlite3.IntegrityError)*
- `~/dotnet/dotnet build SyncShellClient/SyncShellClient.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e5c223848328b30619c900e3f528