### PR TITLE
feat: persist syncshell tokens and vault integration

### DIFF
--- a/demibot/demibot/db/migrations/versions/0029_add_syncshell_tables.py
+++ b/demibot/demibot/db/migrations/versions/0029_add_syncshell_tables.py
@@ -1,0 +1,44 @@
+"""add syncshell pairing and manifest tables
+
+Revision ID: 0029_add_syncshell_tables
+Revises: 0028_add_guild_channel_unique
+Create Date: 2025-01-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.mysql import BIGINT
+
+# revision identifiers, used by Alembic.
+revision = "0029_add_syncshell_tables"
+down_revision = "0028_add_guild_channel_unique"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "syncshell_pairings",
+        sa.Column("user_id", BIGINT(unsigned=True), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column("token", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_syncshell_pairings_token",
+        "syncshell_pairings",
+        ["token"],
+        unique=True,
+    )
+    op.create_table(
+        "syncshell_manifests",
+        sa.Column("user_id", BIGINT(unsigned=True), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column("manifest_json", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("syncshell_manifests")
+    op.drop_index("ix_syncshell_pairings_token", table_name="syncshell_pairings")
+    op.drop_table("syncshell_pairings")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -168,6 +168,29 @@ class MembershipRole(Base):
     role_id: Mapped[int] = mapped_column(ForeignKey("roles.id"), primary_key=True)
 
 
+class SyncshellPairing(Base):
+    __tablename__ = "syncshell_pairings"
+
+    user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True
+    )
+    token: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class SyncshellManifest(Base):
+    __tablename__ = "syncshell_manifests"
+
+    user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True
+    )
+    manifest_json: Mapped[str] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+
 class Message(Base):
     __tablename__ = "messages"
     __table_args__ = (

--- a/demibot/demibot/http/vault.py
+++ b/demibot/demibot/http/vault.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+import json
+import asyncio
+from urllib.request import Request, urlopen
+
+VAULT_SERVICE_URL = os.getenv("VAULT_SERVICE_URL", "http://vault")
+
+async def presign_upload() -> str:
+    loop = asyncio.get_running_loop()
+
+    def _request() -> str:
+        req = Request(f"{VAULT_SERVICE_URL}/presign/upload", method="POST")
+        with urlopen(req, timeout=10) as resp:
+            data = json.load(resp)
+            return data["url"]
+
+    return await loop.run_in_executor(None, _request)
+
+async def presign_download(asset_id: str) -> str:
+    loop = asyncio.get_running_loop()
+
+    def _request() -> str:
+        with urlopen(f"{VAULT_SERVICE_URL}/presign/download/{asset_id}", timeout=10) as resp:
+            data = json.load(resp)
+            return data["url"]
+
+    return await loop.run_in_executor(None, _request)


### PR DESCRIPTION
## Summary
- store syncshell pairing tokens and manifests in database
- add vault client and use it for presigned asset URLs
- add migration for new syncshell tables

## Testing
- `pytest` *(fails: UNIQUE constraint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ebc861488328b641c83fa4e9a00b