### PR TITLE
feat(ui): add tab pages and routing

### DIFF
--- a/ui/App.vue
+++ b/ui/App.vue
@@ -1,0 +1,32 @@
+<template>
+  <div id="app">
+    <nav class="nav">
+      <router-link to="/events">Events</router-link>
+      <router-link to="/create">Create</router-link>
+      <router-link to="/templates">Templates</router-link>
+      <router-link to="/requests">Requests</router-link>
+      <router-link to="/chat">Chat</router-link>
+      <router-link to="/syncshell">SyncShell</router-link>
+      <router-link to="/officer">Officer</router-link>
+    </nav>
+    <router-view />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'App'
+};
+</script>
+
+<style scoped>
+.nav {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+}
+.nav a {
+  text-decoration: none;
+}
+</style>
+

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>DemiCat UI</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/ui/main.js
+++ b/ui/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import router from './router';
+
+createApp(App).use(router).mount('#app');

--- a/ui/pages/Chat.vue
+++ b/ui/pages/Chat.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="chat">
+    <h2>Chat</h2>
+    <div class="controls">
+      <input v-model="apiKey" placeholder="API Key" />
+      <input v-model="channelId" placeholder="Channel ID" />
+      <button @click="setup">Connect</button>
+    </div>
+    <div class="messages">
+      <Message v-for="m in messages" :key="m.id" :message="m" />
+    </div>
+  </div>
+</template>
+
+<script>
+import Message from '../components/Message.vue';
+
+export default {
+  name: 'ChatPage',
+  components: { Message },
+  data() {
+    return { apiKey: '', channelId: '', messages: [], ws: null };
+  },
+  beforeUnmount() {
+    if (this.ws) this.ws.close();
+  },
+  methods: {
+    async setup() {
+      if (!this.channelId) return;
+      await this.load();
+      this.connect();
+    },
+    async load() {
+      try {
+        const res = await fetch(`/api/messages/${this.channelId}`);
+        if (res.ok) {
+          this.messages = await res.json();
+        }
+      } catch (e) {
+        console.error('Failed to load messages', e);
+      }
+    },
+    connect() {
+      if (this.ws) {
+        this.ws.close();
+        this.ws = null;
+      }
+      const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      let url = `${proto}://${window.location.host}/ws/messages`;
+      if (this.apiKey) {
+        url += `?token=${encodeURIComponent(this.apiKey)}`;
+      }
+      this.ws = new WebSocket(url);
+      this.ws.onmessage = (ev) => {
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.channelId === this.channelId) {
+            this.messages.push(msg);
+          }
+        } catch (e) {
+          console.error('Bad message payload', e);
+        }
+      };
+    }
+  }
+};
+</script>
+
+<style scoped>
+.chat {
+  padding: 1rem;
+}
+.controls input {
+  margin-right: 0.5rem;
+}
+.messages {
+  margin-top: 1rem;
+}
+</style>
+

--- a/ui/pages/Create.vue
+++ b/ui/pages/Create.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="create">
+    <h2>Create Event</h2>
+    <form @submit.prevent="submit">
+      <div>
+        <label>Channel ID: <input v-model="form.channelId" required /></label>
+      </div>
+      <div>
+        <label>Title: <input v-model="form.title" required /></label>
+      </div>
+      <div>
+        <label>Description:</label>
+        <textarea v-model="form.description"></textarea>
+      </div>
+      <button type="submit">Create</button>
+    </form>
+    <div v-if="created">
+      <h3>Preview</h3>
+      <EmbedRenderer :embed="created" />
+    </div>
+  </div>
+</template>
+
+<script>
+import EmbedRenderer from '../components/EmbedRenderer.vue';
+
+export default {
+  name: 'CreatePage',
+  components: { EmbedRenderer },
+  data() {
+    return {
+      form: {
+        channelId: '',
+        title: '',
+        description: ''
+      },
+      created: null
+    };
+  },
+  methods: {
+    async submit() {
+      try {
+        const res = await fetch('/api/events', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            channelId: this.form.channelId,
+            title: this.form.title,
+            description: this.form.description,
+            time: new Date().toISOString()
+          })
+        });
+        if (res.ok) {
+          this.created = await res.json();
+        }
+      } catch (e) {
+        console.error('Failed to create event', e);
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.create {
+  padding: 1rem;
+}
+form div {
+  margin-bottom: 0.5rem;
+}
+textarea {
+  width: 100%;
+  height: 80px;
+}
+</style>
+

--- a/ui/pages/Officer.vue
+++ b/ui/pages/Officer.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="officer">
+    <h2>Officer Chat</h2>
+    <div class="controls">
+      <input v-model="apiKey" placeholder="API Key" />
+      <input v-model="channelId" placeholder="Channel ID" />
+      <button @click="setup">Connect</button>
+    </div>
+    <div class="messages">
+      <Message v-for="m in messages" :key="m.id" :message="m" />
+    </div>
+  </div>
+</template>
+
+<script>
+import Message from '../components/Message.vue';
+
+export default {
+  name: 'OfficerPage',
+  components: { Message },
+  data() {
+    return { apiKey: '', channelId: '', messages: [], ws: null };
+  },
+  beforeUnmount() {
+    if (this.ws) this.ws.close();
+  },
+  methods: {
+    async setup() {
+      if (!this.channelId) return;
+      await this.load();
+      this.connect();
+    },
+    async load() {
+      try {
+        const res = await fetch(`/api/officer-messages/${this.channelId}`);
+        if (res.ok) {
+          this.messages = await res.json();
+        }
+      } catch (e) {
+        console.error('Failed to load officer messages', e);
+      }
+    },
+    connect() {
+      if (this.ws) {
+        this.ws.close();
+        this.ws = null;
+      }
+      const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      let url = `${proto}://${window.location.host}/ws/officer-messages`;
+      if (this.apiKey) {
+        url += `?token=${encodeURIComponent(this.apiKey)}`;
+      }
+      this.ws = new WebSocket(url);
+      this.ws.onmessage = (ev) => {
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.channelId === this.channelId) {
+            this.messages.push(msg);
+          }
+        } catch (e) {
+          console.error('Bad officer message payload', e);
+        }
+      };
+    }
+  }
+};
+</script>
+
+<style scoped>
+.officer {
+  padding: 1rem;
+}
+.controls input {
+  margin-right: 0.5rem;
+}
+.messages {
+  margin-top: 1rem;
+}
+</style>
+

--- a/ui/pages/Requests.vue
+++ b/ui/pages/Requests.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="requests">
+    <h2>Request Board</h2>
+    <ul>
+      <li v-for="r in requests" :key="r.id">
+        {{ r.title || r.id }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'RequestsPage',
+  data() {
+    return { requests: [], ws: null };
+  },
+  async created() {
+    await this.load();
+    this.connect();
+  },
+  beforeUnmount() {
+    if (this.ws) this.ws.close();
+  },
+  methods: {
+    async load() {
+      try {
+        const res = await fetch('/api/requests');
+        if (res.ok) {
+          this.requests = await res.json();
+        }
+      } catch (e) {
+        console.error('Failed to load requests', e);
+      }
+    },
+    connect() {
+      const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      const url = `${proto}://${window.location.host}/ws/requests`;
+      this.ws = new WebSocket(url);
+      this.ws.onmessage = (ev) => {
+        try {
+          const req = JSON.parse(ev.data);
+          const idx = this.requests.findIndex((r) => r.id === req.id);
+          if (idx >= 0) this.requests.splice(idx, 1, req);
+          else this.requests.unshift(req);
+        } catch (e) {
+          console.error('Bad request payload', e);
+        }
+      };
+    }
+  }
+};
+</script>
+
+<style scoped>
+.requests {
+  padding: 1rem;
+}
+ul {
+  list-style: none;
+  padding: 0;
+}
+li {
+  margin-bottom: 0.5rem;
+}
+</style>
+

--- a/ui/pages/SyncShell.vue
+++ b/ui/pages/SyncShell.vue
@@ -1,0 +1,80 @@
+<template>
+  <div class="syncshell">
+    <h2>SyncShell</h2>
+    <div class="controls">
+      <input v-model="apiKey" placeholder="API Key" />
+      <input v-model="channelId" placeholder="Channel ID" />
+      <button @click="setup">Connect</button>
+    </div>
+    <div class="messages">
+      <Message v-for="m in messages" :key="m.id" :message="m" />
+    </div>
+  </div>
+</template>
+
+<script>
+import Message from '../components/Message.vue';
+
+export default {
+  name: 'SyncShellPage',
+  components: { Message },
+  data() {
+    return { apiKey: '', channelId: '', messages: [], ws: null };
+  },
+  beforeUnmount() {
+    if (this.ws) this.ws.close();
+  },
+  methods: {
+    async setup() {
+      if (!this.channelId) return;
+      await this.load();
+      this.connect();
+    },
+    async load() {
+      try {
+        const res = await fetch(`/api/messages/${this.channelId}`);
+        if (res.ok) {
+          this.messages = await res.json();
+        }
+      } catch (e) {
+        console.error('Failed to load messages', e);
+      }
+    },
+    connect() {
+      if (this.ws) {
+        this.ws.close();
+        this.ws = null;
+      }
+      const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      let url = `${proto}://${window.location.host}/ws/syncshell`;
+      if (this.apiKey) {
+        url += `?token=${encodeURIComponent(this.apiKey)}`;
+      }
+      this.ws = new WebSocket(url);
+      this.ws.onmessage = (ev) => {
+        try {
+          const msg = JSON.parse(ev.data);
+          if (msg.channelId === this.channelId) {
+            this.messages.push(msg);
+          }
+        } catch (e) {
+          console.error('Bad syncshell payload', e);
+        }
+      };
+    }
+  }
+};
+</script>
+
+<style scoped>
+.syncshell {
+  padding: 1rem;
+}
+.controls input {
+  margin-right: 0.5rem;
+}
+.messages {
+  margin-top: 1rem;
+}
+</style>
+

--- a/ui/pages/Templates.vue
+++ b/ui/pages/Templates.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="templates">
+    <h2>Templates</h2>
+    <div v-for="(t, i) in templates" :key="i" class="template">
+      <EmbedRenderer :embed="t" />
+    </div>
+  </div>
+</template>
+
+<script>
+import EmbedRenderer from '../components/EmbedRenderer.vue';
+
+export default {
+  name: 'TemplatesPage',
+  components: { EmbedRenderer },
+  data() {
+    return { templates: [], ws: null };
+  },
+  async created() {
+    await this.load();
+    this.connect();
+  },
+  beforeUnmount() {
+    if (this.ws) this.ws.close();
+  },
+  methods: {
+    async load() {
+      try {
+        const res = await fetch('/api/embeds');
+        if (res.ok) {
+          this.templates = await res.json();
+        }
+      } catch (e) {
+        console.error('Failed to load templates', e);
+      }
+    },
+    connect() {
+      const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      const url = `${proto}://${window.location.host}/ws/embeds`;
+      this.ws = new WebSocket(url);
+      this.ws.onmessage = (ev) => {
+        try {
+          const emb = JSON.parse(ev.data);
+          this.templates.unshift(emb);
+        } catch (e) {
+          console.error('Bad embed payload', e);
+        }
+      };
+    }
+  }
+};
+</script>
+
+<style scoped>
+.templates {
+  padding: 1rem;
+}
+.template {
+  margin-bottom: 1rem;
+}
+</style>
+

--- a/ui/router.js
+++ b/ui/router.js
@@ -1,0 +1,26 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import Events from './pages/Events.vue';
+import Create from './pages/Create.vue';
+import Templates from './pages/Templates.vue';
+import Requests from './pages/Requests.vue';
+import Chat from './pages/Chat.vue';
+import SyncShell from './pages/SyncShell.vue';
+import Officer from './pages/Officer.vue';
+
+const routes = [
+  { path: '/', redirect: '/events' },
+  { path: '/events', component: Events },
+  { path: '/create', component: Create },
+  { path: '/templates', component: Templates },
+  { path: '/requests', component: Requests },
+  { path: '/chat', component: Chat },
+  { path: '/syncshell', component: SyncShell },
+  { path: '/officer', component: Officer }
+];
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add Vue pages for Create, Templates, Requests, Chat, SyncShell, and Officer
- wire pages to REST and WebSocket endpoints and reuse existing components
- introduce router and navigation to expose new pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68b2f061ed508328bf40499dd79629d0