### PR TITLE
Implement basic Discord message model with reply support

### DIFF
--- a/DemiCatPlugin/DiscordMessageDto.cs
+++ b/DemiCatPlugin/DiscordMessageDto.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Dalamud.Interface.Textures;
+using DiscordHelper;
+
+namespace DemiCatPlugin;
+
+public class DiscordMessageDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string ChannelId { get; set; } = string.Empty;
+    public DiscordUserDto Author { get; set; } = new();
+    public string Content { get; set; } = string.Empty;
+    public List<EmbedDto>? Embeds { get; set; }
+    public List<DiscordAttachmentDto>? Attachments { get; set; }
+    public List<DiscordMentionDto>? Mentions { get; set; }
+    public MessageReferenceDto? Reference { get; set; }
+    public List<ButtonComponentDto>? Components { get; set; }
+    public DateTime Timestamp { get; set; }
+    public DateTime? EditedTimestamp { get; set; }
+    public List<ReactionDto>? Reactions { get; set; }
+    [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
+}
+
+public class DiscordUserDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? AvatarUrl { get; set; }
+}
+
+public class DiscordMentionDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}
+
+public class DiscordAttachmentDto
+{
+    public string Url { get; set; } = string.Empty;
+    public string? Filename { get; set; }
+    public string? ContentType { get; set; }
+    [JsonIgnore] public ISharedImmediateTexture? Texture { get; set; }
+}
+
+public class MessageReferenceDto
+{
+    public string MessageId { get; set; } = string.Empty;
+    public string ChannelId { get; set; } = string.Empty;
+}
+
+public class ReactionDto
+{
+    public string Emoji { get; set; } = string.Empty;
+    public int Count { get; set; }
+    public bool Me { get; set; }
+}
+
+public class ButtonComponentDto
+{
+    public string Label { get; set; } = string.Empty;
+    public string? CustomId { get; set; }
+    public string? Url { get; set; }
+    public ButtonStyle Style { get; set; } = ButtonStyle.Primary;
+    public string? Emoji { get; set; }
+}


### PR DESCRIPTION
## Summary
- Introduce `DiscordMessageDto` to represent Discord messages including author data, attachments, references and components
- Update chat window to use the new model and show reply previews when a message references another

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*
- `pytest` *(fails: sqlite3.IntegrityError during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f9435b4c83289fcd86720d469bf3