### PR TITLE
Implement basic Discord message model with reply support

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -23,7 +23,7 @@ public class ChatWindow : IDisposable
 {
     protected readonly Config _config;
     protected readonly HttpClient _httpClient;
-    protected readonly List<ChatMessageDto> _messages = new();
+    protected readonly List<DiscordMessageDto> _messages = new();
     protected readonly List<ChannelDto> _channels = new();
     protected int _selectedIndex;
     protected bool _channelsLoaded;
@@ -38,6 +38,10 @@ public class ChatWindow : IDisposable
     private ClientWebSocket? _ws;
     private Task? _wsTask;
     private CancellationTokenSource? _wsCts;
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
     private const int TextureCacheCapacity = 100;
     private readonly Dictionary<string, TextureCacheEntry> _textureCache = new();
     private readonly LinkedList<string> _textureLru = new();
@@ -122,9 +126,9 @@ public class ChatWindow : IDisposable
         foreach (var msg in _messages)
         {
             ImGui.BeginGroup();
-            if (!string.IsNullOrEmpty(msg.AuthorAvatarUrl) && msg.AvatarTexture == null)
+            if (!string.IsNullOrEmpty(msg.Author.AvatarUrl) && msg.AvatarTexture == null)
             {
-                LoadTexture(msg.AuthorAvatarUrl, t => msg.AvatarTexture = t);
+                LoadTexture(msg.Author.AvatarUrl, t => msg.AvatarTexture = t);
             }
             if (msg.AvatarTexture != null)
             {
@@ -138,9 +142,23 @@ public class ChatWindow : IDisposable
             ImGui.SameLine();
 
             ImGui.BeginGroup();
-            ImGui.TextUnformatted(msg.AuthorName);
+            ImGui.TextUnformatted(msg.Author.Name);
             ImGui.SameLine();
             ImGui.TextUnformatted(msg.Timestamp.ToLocalTime().ToString());
+
+            if (msg.Reference?.MessageId != null)
+            {
+                var refMsg = _messages.Find(m => m.Id == msg.Reference.MessageId);
+                if (refMsg != null)
+                {
+                    var preview = refMsg.Content ?? string.Empty;
+                    if (preview.Length > 50) preview = preview.Substring(0, 50) + "...";
+                    ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.7f, 0.7f, 0.7f, 1f));
+                    ImGui.TextUnformatted($"> {refMsg.Author.Name}: {preview}");
+                    ImGui.PopStyleColor();
+                }
+            }
+
             ImGui.TextWrapped(FormatContent(msg));
             if (msg.Attachments != null)
             {
@@ -223,7 +241,7 @@ public class ChatWindow : IDisposable
         return invalid;
     }
 
-    protected string FormatContent(ChatMessageDto msg)
+    protected string FormatContent(DiscordMessageDto msg)
     {
         var text = msg.Content;
         if (msg.Mentions != null)
@@ -295,7 +313,7 @@ public class ChatWindow : IDisposable
         try
         {
             const int PageSize = 50;
-            var all = new List<ChatMessageDto>();
+            var all = new List<DiscordMessageDto>();
             string? before = null;
             while (true)
             {
@@ -320,7 +338,7 @@ public class ChatWindow : IDisposable
                 }
 
                 var stream = await response.Content.ReadAsStreamAsync();
-                var msgs = await JsonSerializer.DeserializeAsync<List<ChatMessageDto>>(stream) ?? new List<ChatMessageDto>();
+                var msgs = await JsonSerializer.DeserializeAsync<List<DiscordMessageDto>>(stream, JsonOpts) ?? new List<DiscordMessageDto>();
                 if (msgs.Count == 0)
                 {
                     break;
@@ -340,9 +358,9 @@ public class ChatWindow : IDisposable
                 foreach (var m in all)
                 {
                     _messages.Add(m);
-                    if (!string.IsNullOrEmpty(m.AuthorAvatarUrl))
+                    if (!string.IsNullOrEmpty(m.Author.AvatarUrl))
                     {
-                        LoadTexture(m.AuthorAvatarUrl, t => m.AvatarTexture = t);
+                        LoadTexture(m.Author.AvatarUrl, t => m.AvatarTexture = t);
                     }
                     if (m.Attachments != null)
                     {
@@ -363,7 +381,7 @@ public class ChatWindow : IDisposable
         }
     }
 
-    private void DisposeMessageTextures(ChatMessageDto msg)
+    private void DisposeMessageTextures(DiscordMessageDto msg)
     {
         if (msg.AvatarTexture?.GetWrapOrEmpty() is IDisposable wrap)
         {
@@ -574,7 +592,7 @@ public class ChatWindow : IDisposable
                         }
                         else
                         {
-                            var msg = document.RootElement.Deserialize<ChatMessageDto>();
+                            var msg = document.RootElement.Deserialize<DiscordMessageDto>(JsonOpts);
                             if (msg != null)
                             {
                                 _ = PluginServices.Instance!.Framework.RunOnTick(() =>
@@ -591,9 +609,9 @@ public class ChatWindow : IDisposable
                                         {
                                             _messages.Add(msg);
                                         }
-                                        if (!string.IsNullOrEmpty(msg.AuthorAvatarUrl))
+                                        if (!string.IsNullOrEmpty(msg.Author.AvatarUrl))
                                         {
-                                            LoadTexture(msg.AuthorAvatarUrl, t => msg.AvatarTexture = t);
+                                            LoadTexture(msg.Author.AvatarUrl, t => msg.AvatarTexture = t);
                                         }
                                         if (msg.Attachments != null)
                                         {
@@ -712,33 +730,6 @@ public class ChatWindow : IDisposable
                 _ = PluginServices.Instance!.Framework.RunOnTick(() => set(null));
             }
         });
-    }
-
-    protected class ChatMessageDto
-    {
-        public string Id { get; set; } = string.Empty;
-        public string ChannelId { get; set; } = string.Empty;
-        public string AuthorName { get; set; } = string.Empty;
-        public string? AuthorAvatarUrl { get; set; }
-        public DateTime Timestamp { get; set; }
-        public string Content { get; set; } = string.Empty;
-        public List<AttachmentDto>? Attachments { get; set; }
-        public List<MentionDto>? Mentions { get; set; }
-        [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
-    }
-
-    protected class MentionDto
-    {
-        public string Id { get; set; } = string.Empty;
-        public string Name { get; set; } = string.Empty;
-    }
-
-    protected class AttachmentDto
-    {
-        public string Url { get; set; } = string.Empty;
-        public string? Filename { get; set; }
-        public string? ContentType { get; set; }
-        [JsonIgnore] public ISharedImmediateTexture? Texture { get; set; }
     }
 
     protected class ChannelListDto

--- a/DemiCatPlugin/DiscordMessageDto.cs
+++ b/DemiCatPlugin/DiscordMessageDto.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Dalamud.Interface.Textures;
+using DiscordHelper;
+
+namespace DemiCatPlugin;
+
+public class DiscordMessageDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string ChannelId { get; set; } = string.Empty;
+    public DiscordUserDto Author { get; set; } = new();
+    public string Content { get; set; } = string.Empty;
+    public List<EmbedDto>? Embeds { get; set; }
+    public List<DiscordAttachmentDto>? Attachments { get; set; }
+    public List<DiscordMentionDto>? Mentions { get; set; }
+    public MessageReferenceDto? Reference { get; set; }
+    public List<ButtonComponentDto>? Components { get; set; }
+    public DateTime Timestamp { get; set; }
+    public DateTime? EditedTimestamp { get; set; }
+    public List<ReactionDto>? Reactions { get; set; }
+    [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
+}
+
+public class DiscordUserDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? AvatarUrl { get; set; }
+}
+
+public class DiscordMentionDto
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}
+
+public class DiscordAttachmentDto
+{
+    public string Url { get; set; } = string.Empty;
+    public string? Filename { get; set; }
+    public string? ContentType { get; set; }
+    [JsonIgnore] public ISharedImmediateTexture? Texture { get; set; }
+}
+
+public class MessageReferenceDto
+{
+    public string MessageId { get; set; } = string.Empty;
+    public string ChannelId { get; set; } = string.Empty;
+}
+
+public class ReactionDto
+{
+    public string Emoji { get; set; } = string.Empty;
+    public int Count { get; set; }
+    public bool Me { get; set; }
+}
+
+public class ButtonComponentDto
+{
+    public string Label { get; set; } = string.Empty;
+    public string? CustomId { get; set; }
+    public string? Url { get; set; }
+    public ButtonStyle Style { get; set; } = ButtonStyle.Primary;
+    public string? Emoji { get; set; }
+}

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -34,6 +34,10 @@ public class UiRenderer : IAsyncDisposable, IDisposable
     private readonly SemaphoreSlim _connectGate = new(1, 1);
     private DateTime _lastSync;
     private int _failureCount;
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
 
     public UiRenderer(Config config, HttpClient httpClient)
     {
@@ -146,7 +150,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 return false;
             }
             var stream = await response.Content.ReadAsStreamAsync();
-            var embeds = await JsonSerializer.DeserializeAsync<List<EmbedDto>>(stream) ?? new List<EmbedDto>();
+            var embeds = await JsonSerializer.DeserializeAsync<List<EmbedDto>>(stream, JsonOpts) ?? new List<EmbedDto>();
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _embedDtos.Clear();
@@ -266,7 +270,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                     }
                     else
                     {
-                        var embed = document.RootElement.Deserialize<EmbedDto>();
+                        var embed = document.RootElement.Deserialize<EmbedDto>(JsonOpts);
                         if (embed != null)
                         {
                             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
@@ -351,7 +355,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 return;
             }
             var stream = await response.Content.ReadAsStreamAsync();
-            var embeds = await JsonSerializer.DeserializeAsync<List<EmbedDto>>(stream) ?? new List<EmbedDto>();
+            var embeds = await JsonSerializer.DeserializeAsync<List<EmbedDto>>(stream, JsonOpts) ?? new List<EmbedDto>();
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _embedDtos.Clear();


### PR DESCRIPTION
## Summary
- Introduce `DiscordMessageDto` to represent Discord messages including author data, attachments, references and components
- Update chat window to use the new model and show reply previews when a message references another
- Ensure message and embed deserialization is case-insensitive to match backend JSON

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found: dotnet)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f9435b4c83289fcd86720d469bf3