### PR TITLE
Make Syncshell opt-in with development placeholders

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -28,7 +28,7 @@ public class Config : IPluginConfiguration
     public List<SignupPreset> SignupPresets { get; set; } = new();
 
     [JsonPropertyName("syncEnabled")]
-    public bool SyncEnabled { get; set; } = true;
+    public bool SyncEnabled { get; set; } = false;
 
     [JsonPropertyName("autoApply")]
     public Dictionary<string, bool> AutoApply { get; set; } = new();

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -93,7 +93,7 @@ public class MainWindow : IDisposable
                 ImGui.EndTabItem();
             }
 
-            if (ImGui.BeginTabItem("Syncshell"))
+            if (_config.SyncEnabled && ImGui.BeginTabItem("Syncshell"))
             {
                 _syncshell.Draw();
                 ImGui.EndTabItem();
@@ -112,6 +112,11 @@ public class MainWindow : IDisposable
             }
 
             ImGui.EndTabBar();
+        }
+
+        if (!_config.SyncEnabled)
+        {
+            ImGui.TextUnformatted("Feature in development");
         }
 
         ImGui.End();

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -65,6 +65,11 @@ public class SyncshellWindow : IDisposable
     {
         if (!_config.SyncEnabled)
         {
+            const string message = "SyncShell is under development";
+            var size = ImGui.CalcTextSize(message);
+            var avail = ImGui.GetContentRegionAvail();
+            ImGui.SetCursorPos(new Vector2((avail.X - size.X) / 2, (avail.Y - size.Y) / 2));
+            ImGui.TextUnformatted(message);
             return;
         }
 


### PR DESCRIPTION
## Summary
- disable Syncshell feature by default
- show a "Feature in development" message when Syncshell is disabled
- render a centered notice in the Syncshell window when feature is off

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found; requires 9.0.100)*
- `pytest` *(fails: 28 failed, 16 passed, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b304c7d8a483289dfba4451a1f7f59