### PR TITLE
Split events tab with presence sidebar

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -12,6 +12,7 @@ public class MainWindow : IDisposable
     private readonly ChatWindow? _chat;
     private readonly OfficerChatWindow _officer;
     private readonly SettingsWindow _settings;
+    private readonly PresenceSidebar _presenceSidebar;
     private readonly EventCreateWindow _create;
     private readonly TemplatesWindow _templates;
     private readonly RequestBoardWindow _requestBoard;
@@ -22,13 +23,14 @@ public class MainWindow : IDisposable
     public bool HasOfficerRole { get; set; }
     public UiRenderer Ui => _ui;
 
-    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient)
+    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, PresenceSidebar presenceSidebar, HttpClient httpClient)
     {
         _config = config;
         _ui = ui;
         _chat = chat;
         _officer = officer;
         _settings = settings;
+        _presenceSidebar = presenceSidebar;
         _httpClient = httpClient;
         _create = new EventCreateWindow(config, httpClient);
         _templates = new TemplatesWindow(config, httpClient);
@@ -71,7 +73,13 @@ public class MainWindow : IDisposable
         {
             if (ImGui.BeginTabItem("Events"))
             {
+                ImGui.BeginChild("##presence", new Vector2(150, 0), true);
+                _presenceSidebar.Draw();
+                ImGui.EndChild();
+                ImGui.SameLine();
+                ImGui.BeginChild("##eventsArea", ImGui.GetContentRegionAvail(), false);
                 _ui.Draw();
+                ImGui.EndChild();
                 ImGui.EndTabItem();
             }
 

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -53,7 +53,7 @@ public class Plugin : IDalamudPlugin
         _presenceSidebar = new PresenceSidebar(_config, _httpClient);
         _chatWindow = new FcChatWindow(_config, _httpClient, _presenceSidebar);
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceSidebar);
-        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);
+        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _presenceSidebar, _httpClient);
         _channelWatcher = new ChannelWatcher(_config, _ui, _chatWindow, _officerChatWindow);
         _requestWatcher = new RequestWatcher(_config, _httpClient);
         _settings.MainWindow = _mainWindow;


### PR DESCRIPTION
## Summary
- Show presence sidebar in Events tab alongside event embeds
- Pass shared PresenceSidebar instance into MainWindow

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(failed: Dalamud.NET.Sdk: Dalamud installation not found)*
- `pytest` *(errors during collection: 30 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b308e2d7588328b1001efc73b67689