### PR TITLE
Use 127.0.0.1 as default DB host

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ plugin authentication.
 ### 3. Configure the Dalamud plugin
 Update `DemiCatPlugin/DemiCatPlugin.json` with the usual plugin metadata. In-game,
 open the plugin configuration and set the `ApiBaseUrl` if needed (default
-`http://localhost:5050`).
+`http://127.0.0.1:5050`).
 
 Use the API key obtained from `/demibot embed` and enter it in the plugin
 **Settings** window under **API Key**. Press **Sync** to validate the key and

--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -33,7 +33,7 @@ class ServerConfig:
 class DBProfile:
     """Connection information for a single database profile."""
 
-    host: str = "localhost"
+    host: str = "127.0.0.1"
     port: int = 3306
     database: str = "demibot"
     user: str = ""

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 def test_password_with_special_chars() -> None:
     """Engine parses credentials with special characters."""
     password = "p@ss/w:rd?123"
-    url = f"mysql+aiomysql://user:{quote_plus(password)}@localhost/test"
+    url = f"mysql+aiomysql://user:{quote_plus(password)}@127.0.0.1/test"
 
     engine = create_async_engine(url)
     assert engine.url.password == password
@@ -30,5 +30,5 @@ def test_sync_url_converts_aiomysql() -> None:
 
     from demibot.db.session import _sync_url
 
-    url = "mysql+aiomysql://user:pass@localhost/test"
-    assert _sync_url(url) == "mysql+pymysql://user:***@localhost/test"
+    url = "mysql+aiomysql://user:pass@127.0.0.1/test"
+    assert _sync_url(url) == "mysql+pymysql://user:***@127.0.0.1/test"


### PR DESCRIPTION
## Summary
- default DBProfile host to 127.0.0.1
- adjust tests and README to match new default

## Testing
- `pytest tests/test_session.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32a23fbc88328b7471cc9780a98f4