### PR TITLE
Log database profile and improve init_db resilience

### DIFF
--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -36,6 +36,16 @@ async def main_async() -> None:
     log_config.setup_logging()
     cfg = await ensure_config(force_reconfigure=args.reconfigure)
 
+    profile = cfg.database.active()
+    logging.info(
+        "Active DB profile: host=%s port=%s user=%s database=%s use_remote=%s password=***",
+        profile.host,
+        profile.port,
+        profile.user,
+        profile.database,
+        cfg.database.use_remote,
+    )
+
     db_url = cfg.database.url
     masked_url = re.sub(r":[^:@/]+@", ":***@", db_url)
     logging.info("Initialising database at %s", masked_url)


### PR DESCRIPTION
## Summary
- Log the active database profile before initialization, masking the password
- Add debug logging for async and sync DB URLs in `init_db`
- Wrap migration upgrades in OperationalError handling and support verbose SQL logging via `DEMIBOT_DEBUG_SQLALCHEMY`

## Testing
- `pytest tests/test_session.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34f8843548328a4e3188888dc1e21