### PR TITLE
Use 127.0.0.1 for local configs

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -12,7 +12,7 @@ public class Config : IPluginConfiguration
     public int Version { get; set; } = 3;
 
     public bool Enabled { get; set; } = true;
-    public string ApiBaseUrl { get; set; } = "http://localhost:5050";
+    public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
     public string WebSocketPath { get; set; } = "/ws/embeds";
     public int PollIntervalSeconds { get; set; } = 5;
     public string? AuthToken { get; set; }

--- a/SyncShellClient/SyncShellClient.cs
+++ b/SyncShellClient/SyncShellClient.cs
@@ -40,7 +40,7 @@ public class SyncShellClient : IDalamudPlugin
     {
         try
         {
-            await _http.GetAsync("http://localhost:5050/api/presences");
+            await _http.GetAsync("http://127.0.0.1:5050/api/presences");
         }
         catch
         {
@@ -104,7 +104,7 @@ public class SyncShellClient : IDalamudPlugin
             return false;
 
         _ws.Options.SetRequestHeader("X-Api-Key", _token);
-        await _ws.ConnectAsync(new Uri("ws://localhost:5050/ws/syncshell"), CancellationToken.None);
+        await _ws.ConnectAsync(new Uri("ws://127.0.0.1:5050/ws/syncshell"), CancellationToken.None);
         return true;
     }
 
@@ -115,7 +115,7 @@ public class SyncShellClient : IDalamudPlugin
 
         try
         {
-            var resp = await _http.PostAsync("http://localhost:5050/api/syncshell/pair", null);
+            var resp = await _http.PostAsync("http://127.0.0.1:5050/api/syncshell/pair", null);
             if (!resp.IsSuccessStatusCode)
                 return false;
             var json = await resp.Content.ReadAsStringAsync();

--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -36,8 +36,8 @@ class DBProfile:
     host: str = "127.0.0.1"
     port: int = 3306
     database: str = "demibot"
-    user: str = ""
-    password: str = ""
+    user: str = "demibot"
+    password: str = "Admin"
 
 
 @dataclass

--- a/demibot/demibot/db/migrations/env.py
+++ b/demibot/demibot/db/migrations/env.py
@@ -45,7 +45,7 @@ env_url = (os.getenv("DEMIBOT_DATABASE_URL")
 
 # Fallback sensible default for local dev
 if not env_url:
-    env_url = "mysql+pymysql://demibot:Admin@127.0.0.1:3306/demibot?charset=utf8mb4"
+    env_url = "mysql+pymysql://demibot:Admin@127.0.0.1:3306/demibot"
 
 norm_url = _normalize_sqlalchemy_url(env_url)
 config.set_main_option("sqlalchemy.url", norm_url)

--- a/demibot/demibot/discordbot/cogs/events.py
+++ b/demibot/demibot/discordbot/cogs/events.py
@@ -24,7 +24,7 @@ async def create_event(
 ) -> None:
     host = interaction.client.cfg.server.host
     if host == "0.0.0.0":
-        host = "localhost"
+        host = "127.0.0.1"
     base_url = f"http://{host}:{interaction.client.cfg.server.port}"
     body = {
         "channelId": str(interaction.channel_id or interaction.channel.id),

--- a/demibot/demibot/discordbot/cogs/requests.py
+++ b/demibot/demibot/discordbot/cogs/requests.py
@@ -21,7 +21,7 @@ async def _create_request(
 ) -> None:
     host = interaction.client.cfg.server.host
     if host == "0.0.0.0":
-        host = "localhost"
+        host = "127.0.0.1"
     base_url = f"http://{host}:{interaction.client.cfg.server.port}"
     body = {
         "title": title,

--- a/demibot/scripts/first_run_wizard.py
+++ b/demibot/scripts/first_run_wizard.py
@@ -7,7 +7,7 @@ from demibot.config import CONFIG_PATH, AppConfig, DatabaseConfig, DiscordConfig
 
 def run_wizard() -> None:
     token = input("Discord bot token: ")
-    db_url = input("Database URL [mysql+aiomysql://user:pass@127.0.0.1:3306/demibot]: ") or "mysql+aiomysql://user:pass@127.0.0.1:3306/demibot"
+    db_url = input("Database URL [mysql+aiomysql://demibot:Admin@127.0.0.1:3306/demibot]: ") or "mysql+aiomysql://demibot:Admin@127.0.0.1:3306/demibot"
     host = input("HTTP host [127.0.0.1]: ") or "127.0.0.1"
     port = int(input("HTTP port [8123]: ") or "8123")
 


### PR DESCRIPTION
## Summary
- default Alembic and setup wizards to mysql+pymysql/mysql+aiomysql on 127.0.0.1
- update plugin and client code to call 127.0.0.1 instead of localhost
- default DB profile uses demibot/Admin credentials

## Testing
- `pytest` *(fails: No module named 'discord', 'fastapi', 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b37498d6d08328ab6ab9204550f0bf