### PR TITLE
Show create and templates tabs for all users

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -83,13 +83,13 @@ public class MainWindow : IDisposable
                 ImGui.EndTabItem();
             }
 
-            if (HasOfficerRole && ImGui.BeginTabItem("Create"))
+            if (ImGui.BeginTabItem("Create"))
             {
                 _create.Draw();
                 ImGui.EndTabItem();
             }
 
-            if (HasOfficerRole && ImGui.BeginTabItem("Templates"))
+            if (ImGui.BeginTabItem("Templates"))
             {
                 _templates.Draw();
                 ImGui.EndTabItem();


### PR DESCRIPTION
## Summary
- Display Create and Templates tabs for all users regardless of role
- Retain officer check for Officer tab

## Testing
- `/root/.dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: missing modules such as discord, fastapi, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68b381e7d9f88328830d69290ebb7b0b