### PR TITLE
Respect manual FC chat toggle

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -22,6 +22,7 @@ public class Config : IPluginConfiguration
     public string FcChannelName { get; set; } = string.Empty;
     public string OfficerChannelId { get; set; } = string.Empty;
     public bool EnableFcChat { get; set; } = true;
+    public bool EnableFcChatUserSet { get; set; } = false;
     public bool UseCharacterName { get; set; } = false;
     public List<string> Roles { get; set; } = new();
     public List<Template> Templates { get; set; } = new();

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -159,7 +159,17 @@ public class Plugin : IDalamudPlugin
                 dto.Roles.RemoveAll(r => r == "chat");
                 _config.Roles = dto.Roles;
                 _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
-                _config.EnableFcChat = hasChat;
+
+                if (!hasChat)
+                {
+                    _config.EnableFcChat = false;
+                    _config.EnableFcChatUserSet = false;
+                }
+                else if (!_config.EnableFcChatUserSet)
+                {
+                    _config.EnableFcChat = true;
+                }
+
                 _chatWindow.ChannelsLoaded = false;
                 _services.PluginInterface.SavePluginConfig(_config);
             });

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -81,6 +81,7 @@ public class SettingsWindow : IDisposable
                 if (ImGui.Checkbox("Enable FC Chat", ref enableFc))
                 {
                     _config.EnableFcChat = enableFc;
+                    _config.EnableFcChatUserSet = true;
                     SaveConfig();
                     if (ChatWindow != null) ChatWindow.ChannelsLoaded = false;
                 }


### PR DESCRIPTION
## Summary
- Track when the FC chat option is explicitly toggled by the user
- Avoid overwriting user preference during role refresh unless no chat channels exist

## Testing
- ❌ `dotnet test` (command not found)
- ❌ `pytest` (missing modules: discord, fastapi, sqlalchemy, demibot)


------
https://chatgpt.com/codex/tasks/task_e_68b38a4c84748328a18933ac98865a87