### PR TITLE
Save channel names when storing guild channels

### DIFF
--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -577,28 +577,46 @@ class ConfigWizard(discord.ui.View):
                         GuildChannel.kind.in_(["event", "fc_chat", "officer_chat"]),
                     )
                 )
+                channel_name_map = {
+                    int(opt.value): opt.label for opt in self.channel_options
+                }
                 for cid in self.event_channel_ids:
+                    name = channel_name_map.get(cid)
+                    if name is None:
+                        ch = self.guild.get_channel(cid)
+                        name = ch.name if ch else None
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
                             kind="event",
+                            name=name,
                         )
                     )
                 for cid in self.fc_chat_channel_ids:
+                    name = channel_name_map.get(cid)
+                    if name is None:
+                        ch = self.guild.get_channel(cid)
+                        name = ch.name if ch else None
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
                             kind="fc_chat",
+                            name=name,
                         )
                     )
                 for cid in self.officer_chat_channel_ids:
+                    name = channel_name_map.get(cid)
+                    if name is None:
+                        ch = self.guild.get_channel(cid)
+                        name = ch.name if ch else None
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
                             kind="officer_chat",
+                            name=name,
                         )
                     )
                 await db.commit()


### PR DESCRIPTION
## Summary
- store channel names when saving GuildChannel entries in settings wizard

## Testing
- `pytest` *(fails: sqlite3.IntegrityError UNIQUE constraint failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bceb6dd083289b73aafac2f3a48e