### PR TITLE
refactor: centralize channel name resolution

### DIFF
--- a/DemiCatPlugin/ChannelNameResolver.cs
+++ b/DemiCatPlugin/ChannelNameResolver.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DemiCatPlugin;
+
+internal static class ChannelNameResolver
+{
+    internal static bool Resolve(List<ChannelDto> channels)
+    {
+        var unresolved = false;
+        foreach (var c in channels)
+        {
+            if (string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit))
+            {
+                PluginServices.Instance!.Log.Warning($"Channel name missing or invalid for {c.Id}.");
+                c.Name = c.Id;
+                unresolved = true;
+            }
+        }
+        return unresolved;
+    }
+}

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -228,20 +228,6 @@ public class ChatWindow : IDisposable
         }
     }
 
-    protected bool ResolveChannelNames(List<ChannelDto> channels)
-    {
-        var invalid = false;
-        foreach (var c in channels)
-        {
-            if (string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit))
-            {
-                PluginServices.Instance!.Log.Warning($"Channel name missing or invalid for {c.Id}.");
-                c.Name = c.Id;
-                invalid = true;
-            }
-        }
-        return invalid;
-    }
 
     protected string FormatContent(DiscordMessageDto msg)
     {
@@ -475,7 +461,7 @@ public class ChatWindow : IDisposable
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
-            var invalid = ResolveChannelNames(dto.Chat);
+            var invalid = ChannelNameResolver.Resolve(dto.Chat);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Chat);

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -579,7 +579,7 @@ public class EventCreateWindow
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
-            var unresolved = ResolveChannelNames(dto.Event);
+            var unresolved = ChannelNameResolver.Resolve(dto.Event);
             if (unresolved && !refreshed)
             {
                 try
@@ -626,26 +626,6 @@ public class EventCreateWindow
                 _channelsLoaded = true;
             });
         }
-    }
-
-    private static bool ResolveChannelNames(List<ChannelDto> channels)
-    {
-        var unresolved = false;
-        foreach (var c in channels)
-        {
-            if (string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit))
-            {
-                PluginServices.Instance!.Log.Warning($"Channel name missing or invalid for {c.Id}.");
-                c.Name = c.Id;
-                unresolved = true;
-            }
-        }
-        return unresolved;
-    }
-
-    private class ChannelListDto
-    {
-        [JsonPropertyName("event")] public List<ChannelDto> Event { get; set; } = new();
     }
 
     private void SavePreset()

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -112,7 +112,7 @@ public class OfficerChatWindow : ChatWindow
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<OfficerChannelListDto>(stream) ?? new OfficerChannelListDto();
-            var invalid = ResolveChannelNames(dto.Officer);
+            var invalid = ChannelNameResolver.Resolve(dto.Officer);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Officer);

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -157,7 +157,7 @@ public class TemplatesWindow
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
-            var invalid = ResolveChannelNames(dto.Event);
+            var invalid = ChannelNameResolver.Resolve(dto.Event);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Event);
@@ -221,19 +221,6 @@ public class TemplatesWindow
         }
     }
 
-    private static bool ResolveChannelNames(List<ChannelDto> channels)
-    {
-        var invalid = false;
-        foreach (var c in channels)
-        {
-            if (string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit))
-            {
-                PluginServices.Instance!.Log.Warning($"Channel name missing or invalid for {c.Id}.");
-                c.Name = c.Id;
-                invalid = true;
-            }
-        }
-        return invalid;
     }
 
     private class ChannelListDto

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -462,7 +462,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
-            var invalid = ResolveChannelNames(dto.Event);
+            var invalid = ChannelNameResolver.Resolve(dto.Event);
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();
@@ -517,26 +517,6 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         }
         catch (Exception ex)
         {
-            PluginServices.Instance!.Log.Error(ex, "Error refreshing channels");
-        }
-    }
-
-    private static bool ResolveChannelNames(List<ChannelDto> channels)
-    {
-        var invalid = false;
-        foreach (var c in channels)
-        {
-            if (string.IsNullOrWhiteSpace(c.Name) || c.Name == c.Id || c.Name.All(char.IsDigit))
-            {
-                PluginServices.Instance!.Log.Warning($"Channel name missing or invalid for {c.Id}.");
-                c.Name = c.Id;
-                invalid = true;
-            }
-        }
-        return invalid;
-    }
-
-    private class ChannelListDto
     {
         [JsonPropertyName("event")] public List<ChannelDto> Event { get; set; } = new();
     }


### PR DESCRIPTION
## Summary
- add shared `ChannelNameResolver` to normalize channels
- use `ChannelNameResolver` across UI and chat windows

## Testing
- `dotnet build` *(fails: A compatible .NET SDK was not found, requested SDK version 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bfc0d98083288dad849a4b62c512