### PR TITLE
Refresh presences after WebSocket reconnection

### DIFF
--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -147,6 +147,8 @@ public class PresenceSidebar : IDisposable
                 }
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
+                _loaded = false;
+                _ = Refresh();
                 _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
                 var buffer = new byte[1024];
                 while (_ws.State == WebSocketState.Open && !token.IsCancellationRequested)


### PR DESCRIPTION
## Summary
- Reset loaded flag and trigger refresh after reconnecting presence WebSocket

## Testing
- `dotnet build` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alembic')*


------
https://chatgpt.com/codex/tasks/task_e_68b3bfc841b48328b8016a30d34815a9