### PR TITLE
Remove stray brace in TemplatesWindow

### DIFF
--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -221,8 +221,6 @@ public class TemplatesWindow
         }
     }
 
-    }
-
     private class ChannelListDto
     {
         [JsonPropertyName("event")] public List<ChannelDto> Event { get; set; } = new();


### PR DESCRIPTION
## Summary
- keep `ChannelListDto` nested inside `TemplatesWindow`

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: A compatible .NET SDK was not found)*
- `pytest` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c2ca704483288e673cd315c687bb