### PR TITLE
Fix channel refresh catch block

### DIFF
--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -517,6 +517,11 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         }
         catch (Exception ex)
         {
+            PluginServices.Instance!.Log.Error(ex, "Error refreshing channel names");
+        }
+    }
+
+    private class ChannelListDto
     {
         [JsonPropertyName("event")] public List<ChannelDto> Event { get; set; } = new();
     }


### PR DESCRIPTION
## Summary
- close RefreshChannelNames catch block with an error log
- move ChannelListDto outside RefreshChannelNames

## Testing
- `pytest` *(fails: Interrupted: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c3d6a31883289ef43f5430f7149d