### PR TITLE
Respect FC chat toggle

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -76,7 +76,8 @@ public class ChannelWatcher : IDisposable
                     _ = PluginServices.Instance!.Framework.RunOnTick(() =>
                     {
                         _ = SafeRefresh(_ui.RefreshChannels);
-                        _ = SafeRefresh(_chatWindow.RefreshChannels);
+                        if (_config.EnableFcChat)
+                            _ = SafeRefresh(_chatWindow.RefreshChannels);
                         _ = SafeRefresh(_officerChatWindow.RefreshChannels);
                     });
                 }
@@ -101,7 +102,8 @@ public class ChannelWatcher : IDisposable
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _ = SafeRefresh(_ui.RefreshChannels);
-                _ = SafeRefresh(_chatWindow.RefreshChannels);
+                if (_config.EnableFcChat)
+                    _ = SafeRefresh(_chatWindow.RefreshChannels);
                 _ = SafeRefresh(_officerChatWindow.RefreshChannels);
             });
             try { await Task.Delay(delay, token); } catch { }

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -86,6 +86,13 @@ public class ChatWindow : IDisposable
         _wsTask = RunWebSocket(_wsCts.Token);
     }
 
+    public void StopNetworking()
+    {
+        _wsCts?.Cancel();
+        _ws?.Dispose();
+        _ws = null;
+    }
+
     public virtual void Draw()
     {
         if (!_channelsLoaded)
@@ -293,7 +300,7 @@ public class ChatWindow : IDisposable
 
     public async Task RefreshMessages()
     {
-        if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrEmpty(_channelId))
+        if (!_config.EnableFcChat || !ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrEmpty(_channelId))
         {
             return;
         }
@@ -408,8 +415,7 @@ public class ChatWindow : IDisposable
 
     public void Dispose()
     {
-        _wsCts?.Cancel();
-        _ws?.Dispose();
+        StopNetworking();
         ClearTextureCache();
     }
 
@@ -427,6 +433,10 @@ public class ChatWindow : IDisposable
 
     protected virtual async Task FetchChannels()
     {
+        if (!_config.EnableFcChat)
+        {
+            return;
+        }
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
             PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -83,7 +83,18 @@ public class SettingsWindow : IDisposable
                     _config.EnableFcChat = enableFc;
                     _config.EnableFcChatUserSet = true;
                     SaveConfig();
-                    if (ChatWindow != null) ChatWindow.ChannelsLoaded = false;
+                    if (ChatWindow != null)
+                    {
+                        ChatWindow.ChannelsLoaded = false;
+                        if (enableFc)
+                        {
+                            ChatWindow.StartNetworking();
+                        }
+                        else
+                        {
+                            ChatWindow.StopNetworking();
+                        }
+                    }
                 }
 
                 var syncEnabled = _config.SyncEnabled;


### PR DESCRIPTION
## Summary
- Add `StopNetworking` to stop chat websocket
- Skip channel/message fetches when FC chat is disabled
- Only refresh channels when FC chat is enabled

## Testing
- `/root/.dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: sqlite integrity errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c943cdd483289e528c0df76f4c85