### PR TITLE
Support file attachments and replies in FC chat

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -177,6 +177,9 @@ async def save_message(
         name=ctx.user.global_name or ("Officer" if is_officer else "Player"),
         avatarUrl=None,
     )
+    attachments_json = (
+        json.dumps([a.model_dump() for a in attachments]) if attachments else None
+    )
     msg = Message(
         discord_message_id=discord_msg_id,
         channel_id=channel_id,
@@ -188,9 +191,7 @@ async def save_message(
         content_display=body.content,
         content=body.content,
         author_json=author.model_dump_json(),
-        attachments_json=(
-            json.dumps([a.model_dump() for a in attachments]) if attachments else None
-        ),
+        attachments_json=attachments_json,
         reference_json=json.dumps(body.messageReference)
         if body.messageReference
         else None,

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -52,11 +52,17 @@ async def post_message_with_attachments(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
+    ref = None
+    if message_reference:
+        try:
+            ref = json.loads(message_reference)
+        except Exception:
+            raise HTTPException(status_code=400, detail="invalid message_reference")
     body = PostBody(
         channelId=channel_id,
         content=content,
         useCharacterName=useCharacterName,
-        messageReference=json.loads(message_reference) if message_reference else None,
+        messageReference=ref,
     )
     return await save_message(body, ctx, db, is_officer=False, files=files)
 


### PR DESCRIPTION
## Summary
- add attachment and reply UI helpers to chat window
- send FC messages via multipart upload with optional message reference
- persist and broadcast attachments when saving messages on server

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b3cacc82a48328b78dea021779c54c