### PR TITLE
Include presence status in user listings

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -151,21 +150,11 @@ public class FcChatWindow : ChatWindow
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var users = await JsonSerializer.DeserializeAsync<List<UserDto>>(stream) ?? new List<UserDto>();
-            var merged = users.Select(u =>
-            {
-                var presence = _presence.Presences.FirstOrDefault(p => p.Id == u.Id);
-                return new UserDto
-                {
-                    Id = u.Id,
-                    Name = u.Name,
-                    Status = presence?.Status ?? "offline"
-                };
-            }).ToList();
 
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _users.Clear();
-                _users.AddRange(merged);
+                _users.AddRange(users);
                 _lastUserFetch = DateTime.UtcNow;
             });
         }

--- a/demibot/demibot/http/routes/users.py
+++ b/demibot/demibot/http/routes/users.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ...db.models import User, Membership
+from ...db.models import Membership, Presence as DbPresence, User
+from ...discordbot.presence_store import get_presences
 
 router = APIRouter(prefix="/api")
 
@@ -16,15 +17,26 @@ async def get_users(
     db: AsyncSession = Depends(get_db),
 ):
     stmt = (
-        select(User)
+        select(User, DbPresence.status)
         .join(Membership, Membership.user_id == User.id)
+        .join(
+            DbPresence,
+            and_(
+                DbPresence.guild_id == Membership.guild_id,
+                DbPresence.user_id == User.discord_user_id,
+            ),
+            isouter=True,
+        )
         .where(Membership.guild_id == ctx.guild.id)
     )
     result = await db.execute(stmt)
+    rows = result.all()
+    cache = {p.id: p.status for p in get_presences(ctx.guild.id)}
     return [
         {
             "id": str(u.discord_user_id),
             "name": u.global_name or str(u.discord_user_id),
+            "status": s or cache.get(u.discord_user_id, "offline"),
         }
-        for u in result.scalars()
+        for u, s in rows
     ]

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,73 @@
+
+from pathlib import Path
+import sys
+import types
+import pytest
+import asyncio
+
+root = Path(__file__).resolve().parents[1] / 'demibot'
+sys.path.append(str(root))
+demibot_pkg = types.ModuleType('demibot')
+demibot_pkg.__path__ = [str(root / 'demibot')]
+sys.modules.setdefault('demibot', demibot_pkg)
+http_pkg = types.ModuleType('demibot.http')
+http_pkg.__path__ = [str(root / 'demibot/http')]
+sys.modules.setdefault('demibot.http', http_pkg)
+routes_pkg = types.ModuleType('demibot.http.routes')
+routes_pkg.__path__ = [str(root / 'demibot/http/routes')]
+sys.modules.setdefault('demibot.http.routes', routes_pkg)
+discordbot_pkg = types.ModuleType('demibot.discordbot')
+discordbot_pkg.__path__ = [str(root / 'demibot/discordbot')]
+sys.modules.setdefault('demibot.discordbot', discordbot_pkg)
+
+from demibot.http.routes.users import get_users
+from demibot.discordbot.presence_store import set_presence, Presence as StorePresence
+from demibot.db.models import User, Membership, Presence as DbPresence
+from demibot.db.session import init_db, get_session
+from sqlalchemy import delete
+
+
+class StubContext:
+    def __init__(self, guild_id: int):
+        self.guild = types.SimpleNamespace(id=guild_id)
+        self.roles = []
+
+
+def test_get_users_includes_status_from_cache():
+    async def _run():
+        await init_db('sqlite+aiosqlite://')
+        async for db in get_session():
+            db.add(User(id=1, discord_user_id=10, global_name='Alice'))
+            db.add(User(id=2, discord_user_id=20, global_name='Bob'))
+            db.add(Membership(guild_id=1, user_id=1))
+            db.add(Membership(guild_id=1, user_id=2))
+            await db.commit()
+            set_presence(1, StorePresence(id=10, name='Alice', status='online'))
+            set_presence(1, StorePresence(id=20, name='Bob', status='offline'))
+            ctx = StubContext(1)
+            res = await get_users(ctx=ctx, db=db)
+            assert {(u['id'], u['status']) for u in res} == {('10', 'online'), ('20', 'offline')}
+            break
+    asyncio.run(_run())
+
+
+def test_get_users_reads_presence_from_db():
+    async def _run():
+        await init_db('sqlite+aiosqlite://')
+        async for db in get_session():
+            await db.execute(delete(DbPresence))
+            await db.execute(delete(Membership))
+            await db.execute(delete(User))
+            await db.commit()
+            db.add(User(id=3, discord_user_id=30, global_name='Alice'))
+            db.add(User(id=4, discord_user_id=40, global_name='Bob'))
+            db.add(Membership(guild_id=1, user_id=3))
+            db.add(Membership(guild_id=1, user_id=4))
+            db.add(DbPresence(guild_id=1, user_id=30, status='online'))
+            db.add(DbPresence(guild_id=1, user_id=40, status='offline'))
+            await db.commit()
+            ctx = StubContext(1)
+            res = await get_users(ctx=ctx, db=db)
+            assert {(u['id'], u['status']) for u in res} == {('30', 'online'), ('40', 'offline')}
+            break
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Include presence status when listing users by joining the presence table or cache
- Consume status directly in `FcChatWindow.RefreshUsers` without cross-referencing `PresenceSidebar`
- Test user listing to ensure statuses come from cache and database

## Testing
- `pytest tests/test_users.py`
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cc1a1bd08328944843548354e568