### PR TITLE
Broadcast channel name updates

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -73,13 +73,16 @@ public class ChannelWatcher : IDisposable
                         );
                         continue;
                     }
-                    _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                    if (message == "update")
                     {
-                        _ = SafeRefresh(_ui.RefreshChannels);
-                        if (_config.EnableFcChat)
-                            _ = SafeRefresh(_chatWindow.RefreshChannels);
-                        _ = SafeRefresh(_officerChatWindow.RefreshChannels);
-                    });
+                        _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                        {
+                            _ = SafeRefresh(_ui.RefreshChannels);
+                            if (_config.EnableFcChat)
+                                _ = SafeRefresh(_chatWindow.RefreshChannels);
+                            _ = SafeRefresh(_officerChatWindow.RefreshChannels);
+                        });
+                    }
                 }
                 if (_ws.CloseStatus == WebSocketCloseStatus.PolicyViolation)
                 {

--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -94,6 +94,8 @@ async def ensure_channel_name(
         )
         .values(name=name)
     )
+    if name != current_name:
+        await manager.broadcast_text("update", guild_id, path="/ws/channels")
     return name
 
 


### PR DESCRIPTION
## Summary
- notify clients when channel names change
- refresh plugin windows when channel update is received
- adjust tests for new broadcast behaviour

## Testing
- `PYTHONPATH=demibot pytest tests/test_channel_name_retry.py -q`
- `PYTHONPATH=demibot pytest tests/test_channels_endpoint.py::test_get_channels_returns_placeholder_and_flags_retry -q`
- `PYTHONPATH=demibot pytest` (fails: sqlite integrity errors)
- `dotnet build DemiCatPlugin` (fails: missing .NET 9.0 SDK)


------
https://chatgpt.com/codex/tasks/task_e_68b3cec68d8c8328b1518d7347a1bbdc