### PR TITLE
Display Discord avatars in user and presence lists

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -78,6 +78,7 @@ public class ChatWindow : IDisposable
         _config = config;
         _httpClient = httpClient;
         _presence = presence;
+        _presence.TextureLoader = LoadTexture;
         _channelId = config.ChatChannelId;
         _useCharacterName = config.UseCharacterName;
     }
@@ -820,7 +821,7 @@ public class ChatWindow : IDisposable
         return builder.Uri;
     }
 
-    private void LoadTexture(string? url, Action<ISharedImmediateTexture?> set)
+    protected void LoadTexture(string? url, Action<ISharedImmediateTexture?> set)
     {
         if (string.IsNullOrEmpty(url))
         {

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Numerics;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Textures;
 
 namespace DemiCatPlugin;
 
@@ -45,6 +47,20 @@ public class FcChatWindow : ChatWindow
             ImGui.PushStyleColor(ImGuiCol.Text, color);
             ImGui.TextUnformatted("●");
             ImGui.PopStyleColor();
+            ImGui.SameLine();
+            if (!string.IsNullOrEmpty(user.AvatarUrl) && user.AvatarTexture == null)
+            {
+                LoadTexture(user.AvatarUrl, t => user.AvatarTexture = t);
+            }
+            if (user.AvatarTexture != null)
+            {
+                var wrap = user.AvatarTexture.GetWrapOrEmpty();
+                ImGui.Image(wrap.Handle, new Vector2(24, 24));
+            }
+            else
+            {
+                ImGui.Dummy(new Vector2(24, 24));
+            }
             ImGui.SameLine();
             if (ImGui.Selectable(user.Name))
             {
@@ -166,9 +182,11 @@ public class FcChatWindow : ChatWindow
 
     private class UserDto
     {
-        public string Id { get; set; } = string.Empty;
-        public string Name { get; set; } = string.Empty;
-        public string Status { get; set; } = string.Empty;
+        [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
+        [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("status")] public string Status { get; set; } = string.Empty;
+        [JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; }
+        [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
     }
 }
 

--- a/DemiCatPlugin/PresenceDto.cs
+++ b/DemiCatPlugin/PresenceDto.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Dalamud.Interface.Textures;
 
 namespace DemiCatPlugin;
 
@@ -7,4 +8,6 @@ public class PresenceDto
     [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
     [JsonPropertyName("status")] public string Status { get; set; } = string.Empty;
+    [JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; }
+    [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
 }

--- a/demibot/demibot/http/routes/users.py
+++ b/demibot/demibot/http/routes/users.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..deps import RequestContext, api_key_auth, get_db
 from ...db.models import Membership, Presence as DbPresence, User
 from ...discordbot.presence_store import get_presences
+from ..discord_client import discord_client
 
 router = APIRouter(prefix="/api")
 
@@ -32,11 +33,29 @@ async def get_users(
     result = await db.execute(stmt)
     rows = result.all()
     cache = {p.id: p.status for p in get_presences(ctx.guild.id)}
+    avatars: dict[int, str] = {}
+    if discord_client:
+        guild = discord_client.get_guild(ctx.guild.discord_guild_id)
+        for u, _ in rows:
+            avatar: str | None = None
+            member = guild.get_member(u.discord_user_id) if guild else None
+            if member and member.display_avatar:
+                avatar = str(member.display_avatar.url)
+            if avatar is None:
+                try:
+                    user_obj = discord_client.get_user(u.discord_user_id) or await discord_client.fetch_user(u.discord_user_id)  # type: ignore[attr-defined]
+                except Exception:
+                    user_obj = None
+                if user_obj and user_obj.display_avatar:
+                    avatar = str(user_obj.display_avatar.url)
+            if avatar is not None:
+                avatars[u.discord_user_id] = avatar
     return [
         {
             "id": str(u.discord_user_id),
             "name": u.global_name or str(u.discord_user_id),
             "status": s or cache.get(u.discord_user_id, "offline"),
+            "avatar_url": avatars.get(u.discord_user_id),
         }
         for u, s in rows
     ]


### PR DESCRIPTION
## Summary
- expose user avatar URLs from `/api/users`
- show avatars in FC chat user list using shared texture loader
- render presence avatars by fetching users and loading textures

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b3d4303fd88328b3af30a222f3151e