### PR TITLE
Store channel names during setup

### DIFF
--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -23,12 +23,21 @@ async def ensure_channel_name(
 ) -> str | None:
     """Ensure the channel's name is stored in the database.
 
-    If ``current_name`` is falsy or composed solely of digits, the Discord API
-    is queried for the channel's name and the database is updated.  The
-    resolved name is returned (or ``None`` if it could not be resolved).
+    If ``current_name`` is provided and not composed solely of digits, it is stored
+    in the database. Otherwise, the Discord API is queried for the channel's name
+    and the database is updated. The resolved name is returned (or ``None`` if it could not be resolved).
     """
 
     if current_name and not current_name.isdigit():
+        await db.execute(
+            update(GuildChannel)
+            .where(
+                GuildChannel.guild_id == guild_id,
+                GuildChannel.channel_id == channel_id,
+                GuildChannel.kind == kind,
+            )
+            .values(name=current_name)
+        )
         return current_name
 
     # Try to resolve via Discord gateway client if available, otherwise fall

--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -581,10 +581,8 @@ class ConfigWizard(discord.ui.View):
                     int(opt.value): opt.label for opt in self.channel_options
                 }
                 for cid in self.event_channel_ids:
-                    name = channel_name_map.get(cid)
-                    if name is None:
-                        ch = self.guild.get_channel(cid)
-                        name = ch.name if ch else None
+                    ch = self.guild.get_channel(cid)
+                    name = ch.name if ch else channel_name_map.get(cid)
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
@@ -594,10 +592,8 @@ class ConfigWizard(discord.ui.View):
                         )
                     )
                 for cid in self.fc_chat_channel_ids:
-                    name = channel_name_map.get(cid)
-                    if name is None:
-                        ch = self.guild.get_channel(cid)
-                        name = ch.name if ch else None
+                    ch = self.guild.get_channel(cid)
+                    name = ch.name if ch else channel_name_map.get(cid)
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
@@ -607,10 +603,8 @@ class ConfigWizard(discord.ui.View):
                         )
                     )
                 for cid in self.officer_chat_channel_ids:
-                    name = channel_name_map.get(cid)
-                    if name is None:
-                        ch = self.guild.get_channel(cid)
-                        name = ch.name if ch else None
+                    ch = self.guild.get_channel(cid)
+                    name = ch.name if ch else channel_name_map.get(cid)
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,


### PR DESCRIPTION
## Summary
- Save current channel names when the setup wizard finishes
- Persist resolved channel names so API responses include names on first sync

## Testing
- `pytest` *(fails: Interrupted: 31 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d8ebbe208328ab588f140e6d1d6e