### PR TITLE
Add Apollo message helper and source filtering

### DIFF
--- a/demibot/demibot/http/routes/embeds.py
+++ b/demibot/demibot/http/routes/embeds.py
@@ -17,11 +17,14 @@ async def get_embeds(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
     channel_id: int | None = None,
+    source: str | None = None,
     limit: int | None = None,
 ):
     stmt = select(Embed).where(Embed.guild_id == ctx.guild.id)
     if channel_id is not None:
         stmt = stmt.where(Embed.channel_id == channel_id)
+    if source is not None:
+        stmt = stmt.where(Embed.source == source)
     if "officer" not in ctx.roles:
         stmt = stmt.join(
             GuildChannel, GuildChannel.channel_id == Embed.channel_id

--- a/tests/test_apollo_embed.py
+++ b/tests/test_apollo_embed.py
@@ -96,7 +96,7 @@ async def _run_test() -> None:
         assert row.source == "apollo"
         assert row.buttons_json is not None
         ctx = SimpleNamespace(guild=SimpleNamespace(id=1), roles=["officer"])
-        result = await get_embeds(ctx=ctx, db=db)
+        result = await get_embeds(ctx=ctx, db=db, source="apollo", channel_id=123)
         assert result and result[0]["id"] == str(msg.id)
         assert result[0]["guildId"] == 1
         assert result[0]["channelId"] == 123


### PR DESCRIPTION
## Summary
- detect Apollo embeds via new `ApolloHelper.IsApolloMessage`
- store Apollo embeds and broadcast over `/ws/embeds`
- allow filtering embeds by `source` and `channel_id`

## Testing
- `pytest tests/test_apollo_embed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3da7c9df88328ae09fd61e47e1c7b