### PR TITLE
Filter incoming embeds by channel and support Apollo RSVP buttons

### DIFF
--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -205,7 +205,7 @@ public class EventView : IDisposable
 
     public void DrawButtons()
     {
-        if (Buttons != null)
+        if (Buttons != null && Buttons.Count > 0)
         {
             foreach (var button in Buttons)
             {
@@ -236,11 +236,46 @@ public class EventView : IDisposable
                 }
             }
         }
+        else if (IsApolloEvent(_dto))
+        {
+            if (ImGui.Button($"Yes##rsvpYes{_dto.Id}", new Vector2(-1, 0)))
+            {
+                _ = SendInteraction("rsvp:yes");
+            }
+            if (ImGui.Button($"Maybe##rsvpMaybe{_dto.Id}", new Vector2(-1, 0)))
+            {
+                _ = SendInteraction("rsvp:maybe");
+            }
+            if (ImGui.Button($"No##rsvpNo{_dto.Id}", new Vector2(-1, 0)))
+            {
+                _ = SendInteraction("rsvp:no");
+            }
+        }
 
         if (!string.IsNullOrEmpty(_lastResult))
         {
             ImGui.TextUnformatted(_lastResult);
         }
+    }
+
+    private static bool IsApolloEvent(EmbedDto dto)
+    {
+        if (!string.IsNullOrEmpty(dto.FooterText) &&
+            dto.FooterText.Contains("apollo", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        if (!string.IsNullOrEmpty(dto.ProviderName) &&
+            dto.ProviderName.Contains("apollo", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        if (!string.IsNullOrEmpty(dto.AuthorName) &&
+            dto.AuthorName.Contains("apollo", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        return false;
     }
 
     private static Vector4 GetStyleColor(ButtonStyle style)

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -273,19 +273,23 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                         var embed = document.RootElement.Deserialize<EmbedDto>(JsonOpts);
                         if (embed != null)
                         {
-                            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                            if (string.IsNullOrEmpty(_channelId) ||
+                                embed.ChannelId?.ToString() == _channelId)
                             {
-                                var index = _embedDtos.FindIndex(e => e.Id == embed.Id);
-                                if (index >= 0)
+                                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
                                 {
-                                    _embedDtos[index] = embed;
-                                }
-                                else
-                                {
-                                    _embedDtos.Add(embed);
-                                }
-                                SetEmbeds(_embedDtos);
-                            });
+                                    var index = _embedDtos.FindIndex(e => e.Id == embed.Id);
+                                    if (index >= 0)
+                                    {
+                                        _embedDtos[index] = embed;
+                                    }
+                                    else
+                                    {
+                                        _embedDtos.Add(embed);
+                                    }
+                                    SetEmbeds(_embedDtos);
+                                });
+                            }
                         }
                     }
                 }
@@ -383,6 +387,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 _channelId = _channels[_selectedIndex].Id;
                 _config.EventChannelId = _channelId;
                 SaveConfig();
+                _ = FetchChannels();
                 _ = RefreshEmbeds();
             }
         }


### PR DESCRIPTION
## Summary
- refresh channel list and embed data when switching channels
- ignore websocket embeds from other channels
- add Apollo event RSVP buttons that post custom interactions

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b3dc4950dc83289fdf22bde1ba4d7b