### PR TITLE
Expose user presence and show RSVP status

### DIFF
--- a/demibot/demibot/http/routes/users.py
+++ b/demibot/demibot/http/routes/users.py
@@ -50,12 +50,16 @@ async def get_users(
                     avatar = str(user_obj.display_avatar.url)
             if avatar is not None:
                 avatars[u.discord_user_id] = avatar
-    return [
-        {
-            "id": str(u.discord_user_id),
-            "name": u.global_name or str(u.discord_user_id),
-            "status": s or cache.get(u.discord_user_id, "offline"),
-            "avatar_url": avatars.get(u.discord_user_id),
-        }
-        for u, s in rows
-    ]
+    users: list[dict[str, str | None]] = []
+    for u, s in rows:
+        status = s or cache.get(u.discord_user_id)
+        status = "online" if status == "online" else "offline"
+        users.append(
+            {
+                "id": str(u.discord_user_id),
+                "name": u.global_name or str(u.discord_user_id),
+                "status": status,
+                "avatar_url": avatars.get(u.discord_user_id),
+            }
+        )
+    return users


### PR DESCRIPTION
## Summary
- Normalize `/api/users` status output to online/offline and include avatar lookup
- Fetch presence data when the Events tab opens and annotate event RSVPs with user status

## Testing
- `pytest tests/test_users.py`
- `pytest tests/test_presences.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3dd5fe5308328a03fd6b4a17dfa94