### PR TITLE
Guard FC chat networking with config flag

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -442,9 +442,9 @@ public class ChatWindow : IDisposable
         }
     }
 
-    public async Task RefreshMessages()
+    public virtual async Task RefreshMessages()
     {
-        if (!_config.EnableFcChat || !ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrEmpty(_channelId))
+        if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrEmpty(_channelId))
         {
             return;
         }
@@ -578,10 +578,6 @@ public class ChatWindow : IDisposable
 
     protected virtual async Task FetchChannels()
     {
-        if (!_config.EnableFcChat)
-        {
-            return;
-        }
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
             PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -94,6 +94,24 @@ public class FcChatWindow : ChatWindow
         }
     }
 
+    public override Task RefreshMessages()
+    {
+        if (!_config.EnableFcChat)
+        {
+            return Task.CompletedTask;
+        }
+        return base.RefreshMessages();
+    }
+
+    protected override Task FetchChannels()
+    {
+        if (!_config.EnableFcChat)
+        {
+            return Task.CompletedTask;
+        }
+        return base.FetchChannels();
+    }
+
     protected override async Task SendMessage()
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config))

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -429,7 +429,10 @@ public class SettingsWindow : IDisposable
 
                     try
                     {
-                        ChatWindow?.StartNetworking();
+                        if (_config.EnableFcChat)
+                        {
+                            ChatWindow?.StartNetworking();
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -447,7 +450,10 @@ public class SettingsWindow : IDisposable
 
                     try
                     {
-                        _ = ChatWindow?.RefreshChannels();
+                        if (_config.EnableFcChat)
+                        {
+                            _ = ChatWindow?.RefreshChannels();
+                        }
                         _ = OfficerChatWindow?.RefreshChannels();
                     }
                     catch (Exception ex)
@@ -457,7 +463,10 @@ public class SettingsWindow : IDisposable
 
                     try
                     {
-                        _ = ChatWindow?.RefreshMessages();
+                        if (_config.EnableFcChat)
+                        {
+                            _ = ChatWindow?.RefreshMessages();
+                        }
                         _ = OfficerChatWindow?.RefreshMessages();
                     }
                     catch (Exception ex)


### PR DESCRIPTION
## Summary
- Allow ChatWindow to refresh without FC-specific gating
- Skip FC chat network calls when disabled in FcChatWindow
- Only launch FC chat networking from settings when enabled

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: missing modules such as fastapi and sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68b446c37f4c83288bc3c6922d4e5803