### PR TITLE
feat: expose character name option in chat messages

### DIFF
--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -76,6 +76,7 @@ class MessageAuthor(BaseModel):
     id: str
     name: str
     avatarUrl: Optional[str] = None
+    useCharacterName: bool | None = False
 
 
 class ChatMessage(BaseModel):
@@ -92,6 +93,7 @@ class ChatMessage(BaseModel):
     reference: dict | None = None
     components: List[dict] | None = None
     editedTimestamp: Optional[datetime] = None
+    useCharacterName: bool | None = False
 
 # ---- Presence ----
 


### PR DESCRIPTION
## Summary
- include character names in chat message prefixes when requested
- expose `useCharacterName` flag in `ChatMessage` DTO so clients can mirror identity logic

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py` *(fails: sqlite3.IntegrityError: UNIQUE constraint failed: guilds.id)*

------
https://chatgpt.com/codex/tasks/task_e_68b44b746f4483289b20405a5c9682ea