### PR TITLE
Add emoji API and picker

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -38,8 +38,8 @@ public class ChatWindow : IDisposable
     protected readonly List<string> _attachments = new();
     protected string _newAttachmentPath = string.Empty;
     protected string? _replyToId;
-    protected readonly Dictionary<string, string> _reactionInputs = new();
     private static readonly string[] DefaultReactions = new[] { "👍", "👎", "❤️" };
+    private readonly EmojiPicker _emojiPicker;
     private ClientWebSocket? _ws;
     private Task? _wsTask;
     private CancellationTokenSource? _wsCts;
@@ -79,6 +79,7 @@ public class ChatWindow : IDisposable
         _httpClient = httpClient;
         _presence = presence;
         _presence.TextureLoader = LoadTexture;
+        _emojiPicker = new EmojiPicker(config, httpClient) { TextureLoader = LoadTexture };
         _channelId = config.ChatChannelId;
         _useCharacterName = config.UseCharacterName;
     }
@@ -224,10 +225,6 @@ public class ChatWindow : IDisposable
                     ImGui.SameLine();
                 }
             }
-            if (!_reactionInputs.ContainsKey(msg.Id))
-            {
-                _reactionInputs[msg.Id] = string.Empty;
-            }
             if (ImGui.SmallButton($"+##react{msg.Id}"))
             {
                 ImGui.OpenPopup($"reactPicker{msg.Id}");
@@ -245,13 +242,11 @@ public class ChatWindow : IDisposable
                     ImGui.SameLine();
                 }
                 ImGui.NewLine();
-                ImGui.InputText("Emoji", ref _reactionInputs[msg.Id], 16);
-                if (ImGui.Button("Add") && !string.IsNullOrWhiteSpace(_reactionInputs[msg.Id]))
+                _emojiPicker.Draw(selection =>
                 {
-                    _ = React(msg.Id, _reactionInputs[msg.Id], false);
-                    _reactionInputs[msg.Id] = string.Empty;
+                    _ = React(msg.Id, selection, false);
                     ImGui.CloseCurrentPopup();
-                }
+                });
                 ImGui.EndPopup();
             }
             ImGui.EndGroup();

--- a/DemiCatPlugin/EmojiPicker.cs
+++ b/DemiCatPlugin/EmojiPicker.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Textures;
+using System.Numerics;
+
+namespace DemiCatPlugin;
+
+public class EmojiPicker
+{
+    private readonly Config _config;
+    private readonly HttpClient _httpClient;
+    private readonly List<EmojiDto> _emojis = new();
+    private bool _loaded;
+
+    public Action<string?, Action<ISharedImmediateTexture?>>? TextureLoader { get; set; }
+
+    public EmojiPicker(Config config, HttpClient httpClient)
+    {
+        _config = config;
+        _httpClient = httpClient;
+    }
+
+    public void Draw(Action<string> onSelected)
+    {
+        if (!_loaded)
+        {
+            _ = Fetch();
+        }
+        var size = 24f;
+        var avail = ImGui.GetContentRegionAvail().X;
+        var perRow = Math.Max(1, (int)(avail / size));
+        var idx = 0;
+        foreach (var e in _emojis)
+        {
+            if (TextureLoader != null && e.Texture == null)
+            {
+                TextureLoader(e.ImageUrl, t => e.Texture = t);
+            }
+            if (e.Texture != null)
+            {
+                var wrap = e.Texture.GetWrapOrEmpty();
+                if (ImGui.ImageButton(wrap.Handle, new Vector2(size, size)))
+                {
+                    var formatted = e.IsAnimated ? $"<a:{e.Name}:{e.Id}>" : $"<:{e.Name}:{e.Id}>";
+                    onSelected(formatted);
+                }
+            }
+            else
+            {
+                ImGui.Dummy(new Vector2(size, size));
+            }
+            idx++;
+            if (idx % perRow != 0)
+            {
+                ImGui.SameLine();
+            }
+        }
+    }
+
+    private async Task Fetch()
+    {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            return;
+        }
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis");
+            if (!string.IsNullOrEmpty(_config.AuthToken))
+            {
+                request.Headers.Add("X-Api-Key", _config.AuthToken);
+            }
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                return;
+            }
+            var stream = await response.Content.ReadAsStreamAsync();
+            var list = await JsonSerializer.DeserializeAsync<List<EmojiDto>>(stream) ?? new List<EmojiDto>();
+            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+            {
+                _emojis.Clear();
+                _emojis.AddRange(list);
+                _loaded = true;
+            });
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    public class EmojiDto
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public bool IsAnimated { get; set; }
+        public string ImageUrl { get; set; } = string.Empty;
+        [JsonIgnore]
+        public ISharedImmediateTexture? Texture { get; set; }
+    }
+}

--- a/demibot/demibot/http/routes/emojis.py
+++ b/demibot/demibot/http/routes/emojis.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from time import monotonic
+from typing import Dict, List, Tuple
+
+from fastapi import APIRouter, Depends
+
+from ..deps import RequestContext, api_key_auth
+from ..discord_client import discord_client
+
+router = APIRouter(prefix="/api")
+
+_CACHE_TTL = 600  # seconds
+_emoji_cache: Dict[int, Tuple[List[dict], float]] = {}
+
+
+@router.get("/emojis")
+async def get_emojis(ctx: RequestContext = Depends(api_key_auth)) -> List[dict]:
+    cache_entry = _emoji_cache.get(ctx.guild.id)
+    if cache_entry:
+        data, ts = cache_entry
+        if monotonic() - ts < _CACHE_TTL:
+            return data
+    if discord_client:
+        guild = discord_client.get_guild(ctx.guild.discord_guild_id)
+        if guild is not None:
+            data = [
+                {
+                    "id": str(e.id),
+                    "name": e.name,
+                    "isAnimated": bool(getattr(e, "animated", False)),
+                    "imageUrl": str(e.url),
+                }
+                for e in guild.emojis
+            ]
+            _emoji_cache[ctx.guild.id] = (data, monotonic())
+            return data
+    return []

--- a/tests/test_emojis.py
+++ b/tests/test_emojis.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+import types
+import asyncio
+
+root = Path(__file__).resolve().parents[1] / 'demibot'
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType('demibot')
+demibot_pkg.__path__ = [str(root / 'demibot')]
+sys.modules.setdefault('demibot', demibot_pkg)
+http_pkg = types.ModuleType('demibot.http')
+http_pkg.__path__ = [str(root / 'demibot/http')]
+sys.modules.setdefault('demibot.http', http_pkg)
+routes_pkg = types.ModuleType('demibot.http.routes')
+routes_pkg.__path__ = [str(root / 'demibot/http/routes')]
+sys.modules.setdefault('demibot.http.routes', routes_pkg)
+
+from demibot.http.routes import emojis
+
+
+class DummyEmoji:
+    def __init__(self, eid, name, animated, url):
+        self.id = eid
+        self.name = name
+        self.animated = animated
+        self.url = url
+
+
+class DummyGuild:
+    def __init__(self, emojis):
+        self.emojis = emojis
+
+
+class DummyClient:
+    def __init__(self, guild):
+        self.guild = guild
+
+    def get_guild(self, guild_id):
+        return self.guild
+
+
+class StubCtx:
+    def __init__(self):
+        self.guild = types.SimpleNamespace(id=1, discord_guild_id=100)
+
+
+async def _run_test():
+    emojis._emoji_cache.clear()
+    guild = DummyGuild([DummyEmoji(1, 'foo', False, 'url1'), DummyEmoji(2, 'bar', True, 'url2')])
+    emojis.discord_client = DummyClient(guild)
+    ctx = StubCtx()
+    res1 = await emojis.get_emojis(ctx=ctx)
+    assert res1 == [
+        {'id': '1', 'name': 'foo', 'isAnimated': False, 'imageUrl': 'url1'},
+        {'id': '2', 'name': 'bar', 'isAnimated': True, 'imageUrl': 'url2'},
+    ]
+    emojis.discord_client = None
+    res2 = await emojis.get_emojis(ctx=ctx)
+    assert res2 == res1
+
+
+def test_get_emojis():
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- expose `/api/emojis` HTTP route with caching of guild emoji metadata
- add plugin-side `EmojiPicker` and hook it into chat reaction UI
- test emoji API behaviour and caching

## Testing
- `pytest` *(fails: 31 errors during collection)*
- `dotnet test` *(fails: command not found)*
- `pytest tests/test_emojis.py`


------
https://chatgpt.com/codex/tasks/task_e_68b44cad505483288bb7369322dde578