### PR TITLE
Render custom emoji textures in reactions

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -221,10 +221,36 @@ public class ChatWindow : IDisposable
             {
                 foreach (var reaction in msg.Reactions)
                 {
-                    if (ImGui.SmallButton($"{reaction.Emoji} {reaction.Count}##{msg.Id}{reaction.Emoji}"))
+                    ImGui.BeginGroup();
+                    var handled = false;
+                    if (!string.IsNullOrEmpty(reaction.EmojiId))
                     {
-                        _ = React(msg.Id, reaction.Emoji, reaction.Me);
+                        if (reaction.Texture == null)
+                        {
+                            var ext = reaction.IsAnimated ? "gif" : "png";
+                            var url = $"https://cdn.discordapp.com/emojis/{reaction.EmojiId}.{ext}";
+                            LoadTexture(url, t => reaction.Texture = t);
+                        }
+                        if (reaction.Texture != null)
+                        {
+                            var wrap = reaction.Texture.GetWrapOrEmpty();
+                            if (ImGui.ImageButton(wrap.Handle, new Vector2(20, 20)))
+                            {
+                                _ = React(msg.Id, reaction.Emoji, reaction.Me);
+                            }
+                            ImGui.SameLine();
+                            ImGui.TextUnformatted(reaction.Count.ToString());
+                            handled = true;
+                        }
                     }
+                    if (!handled)
+                    {
+                        if (ImGui.SmallButton($"{reaction.Emoji} {reaction.Count}##{msg.Id}{reaction.Emoji}"))
+                        {
+                            _ = React(msg.Id, reaction.Emoji, reaction.Me);
+                        }
+                    }
+                    ImGui.EndGroup();
                     ImGui.SameLine();
                 }
             }

--- a/DemiCatPlugin/DiscordMessageDto.cs
+++ b/DemiCatPlugin/DiscordMessageDto.cs
@@ -53,8 +53,12 @@ public class MessageReferenceDto
 public class ReactionDto
 {
     public string Emoji { get; set; } = string.Empty;
+    public string? EmojiId { get; set; }
+    public bool IsAnimated { get; set; }
     public int Count { get; set; }
     public bool Me { get; set; }
+    [JsonIgnore]
+    public ISharedImmediateTexture? Texture { get; set; }
 }
 
 public class ButtonComponentDto


### PR DESCRIPTION
## Summary
- Add EmojiId and IsAnimated fields to reaction DTOs and cache their textures
- Display emoji images next to reaction counts using shared texture cache

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b457187a7483289ea334d391f95759