### PR TITLE
Add unique ID for chat message popup

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -280,7 +280,7 @@ public class ChatWindow : IDisposable
             }
             ImGui.EndGroup();
 
-            if (ImGui.BeginPopupContextItem())
+            if (ImGui.BeginPopupContextItem("messageContext"))
             {
                 if (ImGui.MenuItem("Reply"))
                 {


### PR DESCRIPTION
## Summary
- assign a unique string ID to chat message context popup in ChatWindow to avoid unnamed popup clashes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alembic')*

------
https://chatgpt.com/codex/tasks/task_e_68b45d6a1f108328b66b7441dfbaa3d6