### PR TITLE
Add ChannelListDto DTO for EventCreateWindow channel fetch

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -655,6 +655,11 @@ public class EventCreateWindow
         public bool Inline;
     }
 
+    private class ChannelListDto
+    {
+        [JsonPropertyName("event")] public List<ChannelDto> Event { get; set; } = new();
+    }
+
     private class RepeatSchedule
     {
         public string Id { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- add ChannelListDto model in EventCreateWindow mirroring UiRenderer
- deserialize channel list using ChannelListDto

## Testing
- `dotnet build` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b45e892234832887162f3eb3d7a8be