### PR TITLE
Broadcast channel name updates to clients

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -10,16 +10,18 @@ public class ChannelWatcher : IDisposable
 {
     private readonly Config _config;
     private readonly UiRenderer _ui;
+    private readonly EventCreateWindow _eventCreateWindow;
     private readonly ChatWindow _chatWindow;
     private readonly OfficerChatWindow _officerChatWindow;
     private ClientWebSocket? _ws;
     private Task? _task;
     private CancellationTokenSource? _cts;
 
-    public ChannelWatcher(Config config, UiRenderer ui, ChatWindow chatWindow, OfficerChatWindow officerChatWindow)
+    public ChannelWatcher(Config config, UiRenderer ui, EventCreateWindow eventCreateWindow, ChatWindow chatWindow, OfficerChatWindow officerChatWindow)
     {
         _config = config;
         _ui = ui;
+        _eventCreateWindow = eventCreateWindow;
         _chatWindow = chatWindow;
         _officerChatWindow = officerChatWindow;
     }
@@ -78,6 +80,7 @@ public class ChannelWatcher : IDisposable
                         _ = PluginServices.Instance!.Framework.RunOnTick(() =>
                         {
                             _ = SafeRefresh(_ui.RefreshChannels);
+                            _ = SafeRefresh(_eventCreateWindow.RefreshChannels);
                             if (_config.EnableFcChat)
                                 _ = SafeRefresh(_chatWindow.RefreshChannels);
                             _ = SafeRefresh(_officerChatWindow.RefreshChannels);
@@ -105,6 +108,7 @@ public class ChannelWatcher : IDisposable
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _ = SafeRefresh(_ui.RefreshChannels);
+                _ = SafeRefresh(_eventCreateWindow.RefreshChannels);
                 if (_config.EnableFcChat)
                     _ = SafeRefresh(_chatWindow.RefreshChannels);
                 _ = SafeRefresh(_officerChatWindow.RefreshChannels);

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -502,6 +502,14 @@ public class EventCreateWindow
         PluginServices.Instance!.PluginInterface.SavePluginConfig(_config);
     }
 
+    public Task RefreshChannels()
+    {
+        _channelsLoaded = false;
+        _channelFetchFailed = false;
+        _channelErrorMessage = string.Empty;
+        return FetchChannels();
+    }
+
     private async Task FetchChannels(bool refreshed = false)
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config))

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -22,6 +22,7 @@ public class MainWindow : IDisposable
     public bool IsOpen;
     public bool HasOfficerRole { get; set; }
     public UiRenderer Ui => _ui;
+    public EventCreateWindow EventCreateWindow => _create;
 
     public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, PresenceSidebar presenceSidebar, HttpClient httpClient)
     {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -54,7 +54,7 @@ public class Plugin : IDalamudPlugin
         _chatWindow = new FcChatWindow(_config, _httpClient, _presenceSidebar);
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceSidebar);
         _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _presenceSidebar, _httpClient);
-        _channelWatcher = new ChannelWatcher(_config, _ui, _chatWindow, _officerChatWindow);
+        _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _chatWindow, _officerChatWindow);
         _requestWatcher = new RequestWatcher(_config, _httpClient);
         _settings.MainWindow = _mainWindow;
         _settings.ChatWindow = _chatWindow;

--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -38,6 +38,7 @@ async def ensure_channel_name(
             )
             .values(name=current_name)
         )
+        await manager.broadcast_text("update", guild_id, path="/ws/channels")
         return current_name
 
     # Try to resolve via Discord gateway client if available, otherwise fall
@@ -103,8 +104,7 @@ async def ensure_channel_name(
         )
         .values(name=name)
     )
-    if name != current_name:
-        await manager.broadcast_text("update", guild_id, path="/ws/channels")
+    await manager.broadcast_text("update", guild_id, path="/ws/channels")
     return name
 
 

--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -577,40 +577,37 @@ class ConfigWizard(discord.ui.View):
                         GuildChannel.kind.in_(["event", "fc_chat", "officer_chat"]),
                     )
                 )
-                channel_name_map = {
+                channel_name_lookup = {
                     int(opt.value): opt.label for opt in self.channel_options
                 }
                 for cid in self.event_channel_ids:
-                    ch = self.guild.get_channel(cid)
-                    name = ch.name if ch else channel_name_map.get(cid)
+                    channel = self.guild.get_channel(cid)
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
                             kind="event",
-                            name=name,
+                            name=channel.name if channel else channel_name_lookup.get(cid),
                         )
                     )
                 for cid in self.fc_chat_channel_ids:
-                    ch = self.guild.get_channel(cid)
-                    name = ch.name if ch else channel_name_map.get(cid)
+                    channel = self.guild.get_channel(cid)
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
                             kind="fc_chat",
-                            name=name,
+                            name=channel.name if channel else channel_name_lookup.get(cid),
                         )
                     )
                 for cid in self.officer_chat_channel_ids:
-                    ch = self.guild.get_channel(cid)
-                    name = ch.name if ch else channel_name_map.get(cid)
+                    channel = self.guild.get_channel(cid)
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
                             kind="officer_chat",
-                            name=name,
+                            name=channel.name if channel else channel_name_lookup.get(cid),
                         )
                     )
                 await db.commit()


### PR DESCRIPTION
## Summary
- record channel IDs and names when configuration wizard finishes
- broadcast channel name updates through websocket
- refresh plugin channel lists when updates occur

## Testing
- `pytest`
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4624dd9688328bac7889d0ebd06b6