### PR TITLE
feat: show user online status

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -807,6 +807,8 @@ public class ChatWindow : IDisposable
                 }
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
+                // Refresh presence information in case updates were missed while offline.
+                _ = _presence.Refresh();
                 _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
 
                 var buffer = new byte[8192];

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -84,6 +84,15 @@ public class PresenceSidebar : IDisposable
 
     private void DrawPresence(PresenceDto p)
     {
+        // Status indicator
+        var color = p.Status == "online"
+            ? new Vector4(0f, 1f, 0f, 1f)
+            : new Vector4(0.5f, 0.5f, 0.5f, 1f);
+        ImGui.PushStyleColor(ImGuiCol.Text, color);
+        ImGui.TextUnformatted("●");
+        ImGui.PopStyleColor();
+        ImGui.SameLine();
+
         if (TextureLoader != null && !string.IsNullOrEmpty(p.AvatarUrl) && p.AvatarTexture == null)
         {
             TextureLoader(p.AvatarUrl, t => p.AvatarTexture = t);
@@ -107,7 +116,7 @@ public class PresenceSidebar : IDisposable
         _ws?.Dispose();
     }
 
-    private async Task Refresh()
+    public async Task Refresh()
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {

--- a/demibot/demibot/http/routes/users.py
+++ b/demibot/demibot/http/routes/users.py
@@ -52,8 +52,10 @@ async def get_users(
                 avatars[u.discord_user_id] = avatar
     users: list[dict[str, str | None]] = []
     for u, s in rows:
+        # Default to the cached presence if the database value is missing.
         status = s or cache.get(u.discord_user_id)
-        status = "online" if status == "online" else "offline"
+        # Anything that is not explicitly offline counts as online.
+        status = "offline" if status in (None, "offline") else "online"
         users.append(
             {
                 "id": str(u.discord_user_id),


### PR DESCRIPTION
## Summary
- expose user online/offline status from users API
- render presence indicators and refresh status after reconnect

## Testing
- `pytest` *(fails: No module named 'alembic', 'httpx')*
- `dotnet build DemiCatPlugin` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b4645c9d0483289651e425fda327ad