### PR TITLE
Configure default local MySQL URLs in setup script

### DIFF
--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -78,6 +78,9 @@ if [ ! -d .venv ]; then
 fi
 # shellcheck disable=SC1091
 source .venv/bin/activate
+: "${DEMIBOT_FORCED_URL:=mysql+pymysql://demibot:Admin@127.0.0.1:3306/demibot}"
+: "${DEMIBOT_DATABASE_URL:=mysql+aiomysql://demibot:Admin@127.0.0.1:3306/demibot}"
+export DEMIBOT_FORCED_URL DEMIBOT_DATABASE_URL
 pip install --upgrade pip
 
 # Install dependencies from demibot/pyproject.toml


### PR DESCRIPTION
## Summary
- set default DEMIBOT_FORCED_URL and DEMIBOT_DATABASE_URL after activating venv so Alembic and app share local MySQL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b46d77e9a48328a209666b7f45f827