### PR TITLE
Centralize channel name resolution and refresh across windows

### DIFF
--- a/DemiCatPlugin/ChannelNameResolver.cs
+++ b/DemiCatPlugin/ChannelNameResolver.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace DemiCatPlugin;
 
@@ -19,5 +21,36 @@ internal static class ChannelNameResolver
             }
         }
         return unresolved;
+    }
+
+    internal static async Task<bool> Resolve(
+        List<ChannelDto> channels,
+        HttpClient httpClient,
+        Config config,
+        bool refreshed,
+        Func<Task> reload)
+    {
+        var unresolved = Resolve(channels);
+        if (unresolved && !refreshed && ApiHelpers.ValidateApiBaseUrl(config))
+        {
+            try
+            {
+                var refreshReq = new HttpRequestMessage(HttpMethod.Post,
+                    $"{config.ApiBaseUrl.TrimEnd('/')}/api/channels/refresh");
+                if (!string.IsNullOrEmpty(config.AuthToken))
+                {
+                    refreshReq.Headers.Add("X-Api-Key", config.AuthToken);
+                }
+                await httpClient.SendAsync(refreshReq);
+            }
+            catch (Exception ex)
+            {
+                PluginServices.Instance!.Log.Warning(ex, "Error refreshing channel names");
+            }
+            await reload();
+            return true;
+        }
+
+        return false;
     }
 }

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -546,25 +546,7 @@ public class EventCreateWindow
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
-            var unresolved = ChannelNameResolver.Resolve(dto.Event);
-            if (unresolved && !refreshed)
-            {
-                try
-                {
-                    var refreshReq = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/refresh");
-                    if (!string.IsNullOrEmpty(_config.AuthToken))
-                    {
-                        refreshReq.Headers.Add("X-Api-Key", _config.AuthToken);
-                    }
-                    await _httpClient.SendAsync(refreshReq);
-                }
-                catch
-                {
-                    // ignored
-                }
-                await FetchChannels(true);
-                return;
-            }
+            if (await ChannelNameResolver.Resolve(dto.Event, _httpClient, _config, refreshed, () => FetchChannels(true))) return;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();


### PR DESCRIPTION
## Summary
- centralize channel name placeholder and refresh logic in `ChannelNameResolver.Resolve`
- update event creation, template, and chat windows to use resolver and retain unresolved channels

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*
- `pytest -q` *(fails: missing dependencies such as fastapi and sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68b477df119483289f3f2d8f8dceaf3e