### PR TITLE
Refresh presences after websocket reconnect

### DIFF
--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -180,8 +180,8 @@ public class PresenceSidebar : IDisposable
                 }
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
+                await Refresh();
                 _loaded = false;
-                _ = Refresh();
                 _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
                 var buffer = new byte[1024];
                 while (_ws.State == WebSocketState.Open && !token.IsCancellationRequested)


### PR DESCRIPTION
## Summary
- Refresh sidebar data after each successful WebSocket reconnection
- Reset the loaded flag so UI rebuilds with latest presences

## Testing
- `~/.dotnet/dotnet build DemiCatPlugin/DemiCatPlugin.csproj` (fails: Dalamud installation not found)
- `pytest` (fails: ModuleNotFoundError: No module named 'discord')

------
https://chatgpt.com/codex/tasks/task_e_68b47914031083288dee1199087b3ab8