### PR TITLE
Centralize presence sidebar and stop chat networking when disabled

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -110,13 +110,6 @@ public class ChatWindow : IDisposable
             _ = FetchChannels();
         }
 
-        ImGui.BeginChild("##presence", new Vector2(150, 0), true);
-        _presence.Draw();
-        ImGui.EndChild();
-        ImGui.SameLine();
-
-        ImGui.BeginChild("##chatArea", ImGui.GetContentRegionAvail(), false);
-
         if (_channels.Count > 0)
         {
             var channelNames = _channels.Select(c => c.Name).ToArray();
@@ -345,8 +338,6 @@ public class ChatWindow : IDisposable
         {
             ImGui.TextUnformatted(_statusMessage);
         }
-
-        ImGui.EndChild();
     }
 
     public void SetChannels(List<ChannelDto> channels)

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -74,10 +74,13 @@ public class MainWindow : IDisposable
         {
             if (ImGui.BeginTabItem("Events"))
             {
-                ImGui.BeginChild("##presence", new Vector2(150, 0), true);
-                _presenceSidebar.Draw();
-                ImGui.EndChild();
-                ImGui.SameLine();
+                if (_config.EnableFcChat)
+                {
+                    ImGui.BeginChild("##presence", new Vector2(150, 0), true);
+                    _presenceSidebar.Draw();
+                    ImGui.EndChild();
+                    ImGui.SameLine();
+                }
                 ImGui.BeginChild("##eventsArea", ImGui.GetContentRegionAvail(), false);
                 _ui.Draw();
                 ImGui.EndChild();
@@ -110,13 +113,28 @@ public class MainWindow : IDisposable
 
             if (_config.EnableFcChat && _chat != null && ImGui.BeginTabItem("Chat"))
             {
+                ImGui.BeginChild("##presence", new Vector2(150, 0), true);
+                _presenceSidebar.Draw();
+                ImGui.EndChild();
+                ImGui.SameLine();
+                ImGui.BeginChild("##chatArea", ImGui.GetContentRegionAvail(), false);
                 _chat.Draw();
+                ImGui.EndChild();
                 ImGui.EndTabItem();
             }
 
             if (HasOfficerRole && ImGui.BeginTabItem("Officer"))
             {
+                if (_config.EnableFcChat)
+                {
+                    ImGui.BeginChild("##presence", new Vector2(150, 0), true);
+                    _presenceSidebar.Draw();
+                    ImGui.EndChild();
+                    ImGui.SameLine();
+                }
+                ImGui.BeginChild("##officerChatArea", ImGui.GetContentRegionAvail(), false);
                 _officer.Draw();
+                ImGui.EndChild();
                 ImGui.EndTabItem();
             }
 

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -173,6 +173,10 @@ public class Plugin : IDalamudPlugin
                 }
 
                 _chatWindow.ChannelsLoaded = false;
+                if (!_config.EnableFcChat)
+                {
+                    _chatWindow.StopNetworking();
+                }
                 _services.PluginInterface.SavePluginConfig(_config);
             });
             await RoleCache.Refresh(_httpClient, _config);


### PR DESCRIPTION
## Summary
- Stop drawing presence inside `ChatWindow` and let `MainWindow` render the sidebar for tabs that need it
- Hide the presence sidebar whenever FC Chat is disabled and render it for Chat and Officer tabs from `MainWindow`
- Stop chat networking when role refresh or settings disable FC Chat

## Testing
- `~/.dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47e404b5c8328967d744a7cefd0c4