### PR TITLE
Refresh presence list after websocket reconnect

### DIFF
--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -180,8 +180,8 @@ public class PresenceSidebar : IDisposable
                 }
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
-                await Refresh();
                 _loaded = false;
+                _ = Refresh();
                 _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
                 var buffer = new byte[1024];
                 while (_ws.State == WebSocketState.Open && !token.IsCancellationRequested)


### PR DESCRIPTION
## Summary
- Refresh presences and reset loaded flag when websocket reconnects

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68b481da67448328a5567a8545b05f6b