### PR TITLE
Forward refreshed flag in chat window channel fetches

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -103,13 +103,13 @@ public class FcChatWindow : ChatWindow
         return base.RefreshMessages();
     }
 
-    protected override Task FetchChannels()
+    protected override Task FetchChannels(bool refreshed = false)
     {
         if (!_config.EnableFcChat)
         {
             return Task.CompletedTask;
         }
-        return base.FetchChannels();
+        return base.FetchChannels(refreshed);
     }
 
     protected override async Task SendMessage()

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -76,7 +76,7 @@ public class OfficerChatWindow : ChatWindow
         }
     }
 
-    protected override async Task FetchChannels()
+    protected override async Task FetchChannels(bool refreshed = false)
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
@@ -124,7 +124,7 @@ public class OfficerChatWindow : ChatWindow
             {
                 _channelRefreshAttempted = true;
                 await RequestChannelRefresh();
-                await FetchChannels();
+                await FetchChannels(true);
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- Update Fc chat window's FetchChannels override to accept refreshed flag and forward to base
- Update officer chat window's FetchChannels override with refreshed flag and propagate on retries

## Testing
- `dotnet test` *(fails: A compatible .NET SDK for global.json version [9.0.100] could not be found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', fastapi, sqlalchemy, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b484007c1c8328b8c25d37342ff661