### PR TITLE
Use shared channel name resolver in officer chat

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -111,8 +111,9 @@ public class OfficerChatWindow : ChatWindow
                 return;
             }
             var stream = await response.Content.ReadAsStreamAsync();
-            var dto = await JsonSerializer.DeserializeAsync<OfficerChannelListDto>(stream) ?? new OfficerChannelListDto();
-            var invalid = ChannelNameResolver.Resolve(dto.Officer);
+            var dto = await JsonSerializer.DeserializeAsync<OfficerChannelListDto>(stream) ?? new();
+            if (await ChannelNameResolver.Resolve(dto.Officer, _httpClient, _config, refreshed, () => FetchChannels(true)))
+                return;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(dto.Officer);
@@ -120,12 +121,6 @@ public class OfficerChatWindow : ChatWindow
                 _channelFetchFailed = false;
                 _channelErrorMessage = string.Empty;
             });
-            if (invalid && !_channelRefreshAttempted)
-            {
-                _channelRefreshAttempted = true;
-                await RequestChannelRefresh();
-                await FetchChannels(true);
-            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- Switch OfficerChatWindow to async ChannelNameResolver with auto-refresh
- Remove obsolete channel refresh flags

## Testing
- `dotnet build DemiCatPlugin` *(fails: A compatible .NET SDK was not found; requires 9.0.100)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b485c258d483288204c4014b49177e