### PR TITLE
Persist channel names for wizard-selected channels

### DIFF
--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -578,36 +578,33 @@ class ConfigWizard(discord.ui.View):
                     )
                 )
                 channel_name_lookup = {
-                    int(opt.value): opt.label for opt in self.channel_options
+                    ch.id: ch.name for ch in self.guild.text_channels
                 }
                 for cid in self.event_channel_ids:
-                    channel = self.guild.get_channel(cid)
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
                             kind="event",
-                            name=channel.name if channel else channel_name_lookup.get(cid),
+                            name=channel_name_lookup.get(cid),
                         )
                     )
                 for cid in self.fc_chat_channel_ids:
-                    channel = self.guild.get_channel(cid)
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
                             kind="fc_chat",
-                            name=channel.name if channel else channel_name_lookup.get(cid),
+                            name=channel_name_lookup.get(cid),
                         )
                     )
                 for cid in self.officer_chat_channel_ids:
-                    channel = self.guild.get_channel(cid)
                     db.add(
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
                             kind="officer_chat",
-                            name=channel.name if channel else channel_name_lookup.get(cid),
+                            name=channel_name_lookup.get(cid),
                         )
                     )
                 await db.commit()

--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -40,6 +40,8 @@ async def get_channels(
             GuildChannel.guild_id == ctx.guild.id
         )
     )
+    # Include human-friendly channel names so the plugin can display readable
+    # labels in dropdowns.
     by_kind: dict[str, list[dict[str, str]]] = {
         "event": [],
         "fc_chat": [],


### PR DESCRIPTION
## Summary
- Save each channel's name when the admin wizard stores guild channel settings
- Return stored channel names from `/api/channels` so clients can display readable labels

## Testing
- `pytest` *(fails: sqlite3.IntegrityError: UNIQUE constraint failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b486dded448328be89af9d24fb9831