### PR TITLE
Refresh presences after WebSocket reconnect

### DIFF
--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -181,7 +181,7 @@ public class PresenceSidebar : IDisposable
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
                 _loaded = false;
-                _ = Refresh();
+                await Refresh();
                 _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
                 var buffer = new byte[1024];
                 while (_ws.State == WebSocketState.Open && !token.IsCancellationRequested)


### PR DESCRIPTION
## Summary
- Refresh presence list when the WebSocket connection is re-established

## Testing
- `dotnet build` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b48842145083288e1a750b0b1048f1