### PR TITLE
Skip presence sidebar when FC chat disabled

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -19,7 +19,7 @@ public class FcChatWindow : ChatWindow
     private readonly List<UserDto> _users = new();
     private DateTime _lastUserFetch = DateTime.MinValue;
 
-    public FcChatWindow(Config config, HttpClient httpClient, PresenceSidebar presence) : base(config, httpClient, presence)
+    public FcChatWindow(Config config, HttpClient httpClient, PresenceSidebar? presence) : base(config, httpClient, presence)
     {
         _channelId = config.FcChannelId;
     }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -12,7 +12,7 @@ public class MainWindow : IDisposable
     private readonly ChatWindow? _chat;
     private readonly OfficerChatWindow _officer;
     private readonly SettingsWindow _settings;
-    private readonly PresenceSidebar _presenceSidebar;
+    private readonly PresenceSidebar? _presenceSidebar;
     private readonly EventCreateWindow _create;
     private readonly TemplatesWindow _templates;
     private readonly RequestBoardWindow _requestBoard;
@@ -24,7 +24,7 @@ public class MainWindow : IDisposable
     public UiRenderer Ui => _ui;
     public EventCreateWindow EventCreateWindow => _create;
 
-    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, PresenceSidebar presenceSidebar, HttpClient httpClient)
+    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, PresenceSidebar? presenceSidebar, HttpClient httpClient)
     {
         _config = config;
         _ui = ui;
@@ -74,11 +74,9 @@ public class MainWindow : IDisposable
         {
             if (ImGui.BeginTabItem("Events"))
             {
-                if (_config.EnableFcChat)
+                if (_config.EnableFcChat && _presenceSidebar != null)
                 {
-                    ImGui.BeginChild("##presence", new Vector2(150, 0), true);
                     _presenceSidebar.Draw();
-                    ImGui.EndChild();
                     ImGui.SameLine();
                 }
                 ImGui.BeginChild("##eventsArea", ImGui.GetContentRegionAvail(), false);
@@ -113,10 +111,11 @@ public class MainWindow : IDisposable
 
             if (_config.EnableFcChat && _chat != null && ImGui.BeginTabItem("Chat"))
             {
-                ImGui.BeginChild("##presence", new Vector2(150, 0), true);
-                _presenceSidebar.Draw();
-                ImGui.EndChild();
-                ImGui.SameLine();
+                if (_presenceSidebar != null)
+                {
+                    _presenceSidebar.Draw();
+                    ImGui.SameLine();
+                }
                 ImGui.BeginChild("##chatArea", ImGui.GetContentRegionAvail(), false);
                 _chat.Draw();
                 ImGui.EndChild();
@@ -125,11 +124,9 @@ public class MainWindow : IDisposable
 
             if (HasOfficerRole && ImGui.BeginTabItem("Officer"))
             {
-                if (_config.EnableFcChat)
+                if (_config.EnableFcChat && _presenceSidebar != null)
                 {
-                    ImGui.BeginChild("##presence", new Vector2(150, 0), true);
                     _presenceSidebar.Draw();
-                    ImGui.EndChild();
                     ImGui.SameLine();
                 }
                 ImGui.BeginChild("##officerChatArea", ImGui.GetContentRegionAvail(), false);

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -10,7 +10,7 @@ namespace DemiCatPlugin;
 
 public class OfficerChatWindow : ChatWindow
 {
-    public OfficerChatWindow(Config config, HttpClient httpClient, PresenceSidebar presence) : base(config, httpClient, presence)
+    public OfficerChatWindow(Config config, HttpClient httpClient, PresenceSidebar? presence) : base(config, httpClient, presence)
     {
         _channelId = config.OfficerChannelId;
     }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -22,7 +22,7 @@ public class Plugin : IDalamudPlugin
     private readonly SettingsWindow _settings;
     private readonly ChatWindow _chatWindow;
     private readonly OfficerChatWindow _officerChatWindow;
-    private readonly PresenceSidebar _presenceSidebar;
+    private readonly PresenceSidebar? _presenceSidebar;
     private readonly MainWindow _mainWindow;
     private readonly ChannelWatcher _channelWatcher;
     private readonly RequestWatcher _requestWatcher;
@@ -50,7 +50,7 @@ public class Plugin : IDalamudPlugin
 
         _ui = new UiRenderer(_config, _httpClient);
         _settings = new SettingsWindow(_config, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
-        _presenceSidebar = new PresenceSidebar(_config, _httpClient);
+        _presenceSidebar = _config.EnableFcChat ? new PresenceSidebar(_config, _httpClient) : null;
         _chatWindow = new FcChatWindow(_config, _httpClient, _presenceSidebar);
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceSidebar);
         _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _presenceSidebar, _httpClient);
@@ -91,7 +91,7 @@ public class Plugin : IDalamudPlugin
         _services.PluginInterface.UiBuilder.OpenConfigUi -= _openConfigUi;
 
         _httpClient.Dispose();
-        _presenceSidebar.Dispose();
+        _presenceSidebar?.Dispose();
         _chatWindow.Dispose();
         _officerChatWindow.Dispose();
         _mainWindow.Dispose();
@@ -176,6 +176,7 @@ public class Plugin : IDalamudPlugin
                 if (!_config.EnableFcChat)
                 {
                     _chatWindow.StopNetworking();
+                    _presenceSidebar?.Dispose();
                 }
                 _services.PluginInterface.SavePluginConfig(_config);
             });

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -51,6 +51,8 @@ public class PresenceSidebar : IDisposable
 
     public void Draw()
     {
+        ImGui.BeginChild("##presence", new Vector2(150, 0), true);
+
         if (_wsTask == null)
         {
             _wsCts = new CancellationTokenSource();
@@ -80,6 +82,8 @@ public class PresenceSidebar : IDisposable
         {
             DrawPresence(p);
         }
+
+        ImGui.EndChild();
     }
 
     private void DrawPresence(PresenceDto p)

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -89,10 +89,12 @@ public class SettingsWindow : IDisposable
                         if (enableFc)
                         {
                             ChatWindow.StartNetworking();
+                            ChatWindow.Presence?.Reset();
                         }
                         else
                         {
                             ChatWindow.StopNetworking();
+                            ChatWindow.Presence?.Dispose();
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Encapsulate presence sidebar rendering in `PresenceSidebar` and remove sidebar layout code from `MainWindow`
- Only create and draw the presence sidebar when FC chat is enabled, and guard chat networking behind the same flag
- Toggle sidebar WebSocket connections based on the FC chat setting

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b494b909d88328a01660632bec8a45