### PR TITLE
Send messages via cached webhooks and await WS echo

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -171,10 +171,22 @@ public class FcChatWindow : ChatWindow
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
+                string? id = null;
+                try
+                {
+                    var bodyText = await response.Content.ReadAsStringAsync();
+                    using var doc = JsonDocument.Parse(bodyText);
+                    if (doc.RootElement.TryGetProperty("id", out var idProp))
+                        id = idProp.GetString();
+                }
+                catch
+                {
+                    // ignore parse errors
+                }
                 _input = string.Empty;
                 _attachments.Clear();
                 _replyToId = null;
-                await RefreshMessages();
+                await WaitForEchoAndRefresh(id);
             }
         }
         catch

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -55,12 +55,24 @@ public class OfficerChatWindow : ChatWindow
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
+                string? id = null;
+                try
+                {
+                    var bodyText = await response.Content.ReadAsStringAsync();
+                    using var doc = JsonDocument.Parse(bodyText);
+                    if (doc.RootElement.TryGetProperty("id", out var idProp))
+                        id = idProp.GetString();
+                }
+                catch
+                {
+                    // ignore parse errors
+                }
                 _ = PluginServices.Instance!.Framework.RunOnTick(() =>
                 {
                     _input = string.Empty;
                     _statusMessage = string.Empty;
                 });
-                await RefreshMessages();
+                await WaitForEchoAndRefresh(id);
             }
             else
             {


### PR DESCRIPTION
## Summary
- send channel messages through cached Discord webhooks and set username to include optional character
- plugin waits for the websocket echo of a posted message before refreshing

## Testing
- `pytest` *(fails: sqlite3 IntegrityError)*

------
https://chatgpt.com/codex/tasks/task_e_68b49935b0f88328ac422fdd05fcd368