### PR TITLE
refactor: centralize API key header

### DIFF
--- a/DemiCatPlugin/ApiHelpers.cs
+++ b/DemiCatPlugin/ApiHelpers.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Net.Http;
+using System.Net.WebSockets;
 
 namespace DemiCatPlugin;
 
@@ -13,6 +15,28 @@ internal static class ApiHelpers
             return false;
         }
         return true;
+    }
+
+    internal static void AddAuthHeader(HttpRequestMessage request, Config config)
+        => AddAuthHeader(request, config.AuthToken);
+
+    internal static void AddAuthHeader(HttpRequestMessage request, string? token)
+    {
+        if (!string.IsNullOrEmpty(token))
+        {
+            request.Headers.Add("X-Api-Key", token);
+        }
+    }
+
+    internal static void AddAuthHeader(ClientWebSocket socket, Config config)
+        => AddAuthHeader(socket, config.AuthToken);
+
+    internal static void AddAuthHeader(ClientWebSocket socket, string? token)
+    {
+        if (!string.IsNullOrEmpty(token))
+        {
+            socket.Options.SetRequestHeader("X-Api-Key", token);
+        }
     }
 }
 

--- a/DemiCatPlugin/ChannelNameResolver.cs
+++ b/DemiCatPlugin/ChannelNameResolver.cs
@@ -37,10 +37,7 @@ internal static class ChannelNameResolver
             {
                 var refreshReq = new HttpRequestMessage(HttpMethod.Post,
                     $"{config.ApiBaseUrl.TrimEnd('/')}/api/channels/refresh");
-                if (!string.IsNullOrEmpty(config.AuthToken))
-                {
-                    refreshReq.Headers.Add("X-Api-Key", config.AuthToken);
-                }
+                ApiHelpers.AddAuthHeader(refreshReq, config);
                 await httpClient.SendAsync(refreshReq);
             }
             catch (Exception ex)

--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -53,7 +53,7 @@ public class ChannelWatcher : IDisposable
             {
                 _ws?.Dispose();
                 _ws = new ClientWebSocket();
-                _ws.Options.SetRequestHeader("X-Api-Key", _config.AuthToken);
+                ApiHelpers.AddAuthHeader(_ws, _config);
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
                 delay = TimeSpan.FromSeconds(5);

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -381,10 +381,7 @@ public class ChatWindow : IDisposable
             try
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis");
-                if (!string.IsNullOrEmpty(_config.AuthToken))
-                {
-                    request.Headers.Add("X-Api-Key", _config.AuthToken);
-                }
+                ApiHelpers.AddAuthHeader(request, _config);
                 var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode)
                 {
@@ -489,10 +486,7 @@ public class ChatWindow : IDisposable
             var body = new { channelId = _channelId, content = _input, useCharacterName = _useCharacterName };
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/messages");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -546,10 +540,7 @@ public class ChatWindow : IDisposable
             var method = remove ? HttpMethod.Delete : HttpMethod.Put;
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{_channelId}/messages/{messageId}/reactions/{Uri.EscapeDataString(emoji)}";
             var request = new HttpRequestMessage(method, url);
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -605,10 +596,7 @@ public class ChatWindow : IDisposable
                 }
 
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
-                if (!string.IsNullOrEmpty(_config.AuthToken))
-                {
-                    request.Headers.Add("X-Api-Key", _config.AuthToken);
-                }
+                ApiHelpers.AddAuthHeader(request, _config);
 
                 var response = await _httpClient.SendAsync(request);
                 if (!response.IsSuccessStatusCode)
@@ -743,10 +731,7 @@ public class ChatWindow : IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -809,10 +794,7 @@ public class ChatWindow : IDisposable
             {
                 _ws?.Dispose();
                 _ws = new ClientWebSocket();
-                if (!string.IsNullOrEmpty(_config.AuthToken))
-                {
-                    _ws.Options.SetRequestHeader("X-Api-Key", _config.AuthToken);
-                }
+                ApiHelpers.AddAuthHeader(_ws, _config);
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
                 // Refresh presence information in case updates were missed while offline.

--- a/DemiCatPlugin/EmojiPicker.cs
+++ b/DemiCatPlugin/EmojiPicker.cs
@@ -71,10 +71,7 @@ public class EmojiPicker
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -281,10 +281,7 @@ public class EventCreateWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/repeat");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -316,10 +313,7 @@ public class EventCreateWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Delete, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/{id}/repeat");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -466,10 +460,7 @@ public class EventCreateWindow
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
 
             var response = await _httpClient.SendAsync(request);
             _lastResult = response.IsSuccessStatusCode ? "Event posted" : $"Error: {response.StatusCode}";
@@ -527,10 +518,7 @@ public class EventCreateWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -341,10 +341,7 @@ public class EventView : IDisposable
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/interactions");
             var body = new { MessageId = _dto.Id, ChannelId = _dto.ChannelId, CustomId = customId };
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             _lastResult = response.IsSuccessStatusCode ? "Signup updated" : "Signup failed";
             if (response.IsSuccessStatusCode)

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -164,10 +164,7 @@ public class FcChatWindow : ChatWindow
             {
                 Content = form
             };
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -202,10 +199,7 @@ public class FcChatWindow : ChatWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -48,10 +48,7 @@ public class OfficerChatWindow : ChatWindow
             var body = new { channelId = _channelId, content = _input, useCharacterName = _useCharacterName };
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/officer-messages");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -105,10 +102,7 @@ public class OfficerChatWindow : ChatWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -112,10 +112,7 @@ public class Plugin : IDalamudPlugin
         {
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/roles";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             log.Info($"Requesting roles from {url}");
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
@@ -130,10 +127,7 @@ public class Plugin : IDalamudPlugin
 
             var channelUrl = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels";
             var channelRequest = new HttpRequestMessage(HttpMethod.Get, channelUrl);
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                channelRequest.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(channelRequest, _config);
             List<ChannelDto> chatChannels = new();
             try
             {

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -131,10 +131,7 @@ public class PresenceSidebar : IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -178,10 +175,7 @@ public class PresenceSidebar : IDisposable
             {
                 _ws?.Dispose();
                 _ws = new ClientWebSocket();
-                if (!string.IsNullOrEmpty(_config.AuthToken))
-                {
-                    _ws.Options.SetRequestHeader("X-Api-Key", _config.AuthToken);
-                }
+                ApiHelpers.AddAuthHeader(_ws, _config);
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
                 _loaded = false;

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -145,7 +145,7 @@ public class RequestBoardWindow
                 var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/requests/{req.Id}/{action}";
                 var json = JsonSerializer.Serialize(new { version = req.Version });
                 var msg = new HttpRequestMessage(HttpMethod.Post, url);
-                msg.Headers.Add("X-Api-Key", _config.AuthToken);
+                ApiHelpers.AddAuthHeader(msg, _config);
                 msg.Content = new StringContent(json, Encoding.UTF8, "application/json");
                 var resp = await _httpClient.SendAsync(msg);
                 if (resp.IsSuccessStatusCode)
@@ -219,7 +219,7 @@ public class RequestBoardWindow
         {
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/requests/{id}";
             var msg = new HttpRequestMessage(HttpMethod.Get, url);
-            msg.Headers.Add("X-Api-Key", _config.AuthToken);
+            ApiHelpers.AddAuthHeader(msg, _config);
             var resp = await _httpClient.SendAsync(msg);
             if (resp.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -64,8 +64,7 @@ internal static class RequestStateService
         {
             var url = $"{config.ApiBaseUrl.TrimEnd('/')}/api/requests";
             var msg = new HttpRequestMessage(HttpMethod.Get, url);
-            if (!string.IsNullOrEmpty(config.AuthToken))
-                msg.Headers.Add("X-Api-Key", config.AuthToken);
+            ApiHelpers.AddAuthHeader(msg, config);
             var resp = await httpClient.SendAsync(msg);
             if (!resp.IsSuccessStatusCode) return;
             var stream = await resp.Content.ReadAsStreamAsync();

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -45,7 +45,7 @@ public class RequestWatcher : IDisposable
             {
                 _ws?.Dispose();
                 _ws = new ClientWebSocket();
-                _ws.Options.SetRequestHeader("X-Api-Key", _config.AuthToken);
+                ApiHelpers.AddAuthHeader(_ws, _config);
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
                 delay = TimeSpan.FromSeconds(5);

--- a/DemiCatPlugin/RoleCache.cs
+++ b/DemiCatPlugin/RoleCache.cs
@@ -41,10 +41,7 @@ internal static class RoleCache
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/guild-roles");
-            if (!string.IsNullOrEmpty(config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, config);
             var response = await httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -200,7 +200,7 @@ public class SettingsWindow : IDisposable
 
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/settings";
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            request.Headers.Add("X-Api-Key", _config.AuthToken);
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
                 return;
@@ -263,7 +263,7 @@ public class SettingsWindow : IDisposable
             {
                 Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
             };
-            request.Headers.Add("X-Api-Key", _config.AuthToken);
+            ApiHelpers.AddAuthHeader(request, _config);
             await _httpClient.SendAsync(request);
         }
         catch (Exception ex)
@@ -289,7 +289,7 @@ public class SettingsWindow : IDisposable
 
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/forget";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
-            request.Headers.Add("X-Api-Key", _config.AuthToken);
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -356,10 +356,7 @@ public class SettingsWindow : IDisposable
                 {
                     Content = new StringContent(JsonSerializer.Serialize(new { key }), Encoding.UTF8, "application/json")
                 };
-                if (!string.IsNullOrEmpty(key))
-                {
-                    request.Headers.Add("X-Api-Key", key);
-                }
+                ApiHelpers.AddAuthHeader(request, key);
 
                 _log.Info($"Sync URL: {url}");
                 _log.Info($"Headers: {string.Join(", ", request.Headers.Select(h => $"{h.Key}: {string.Join(";", h.Value)}"))}");

--- a/DemiCatPlugin/SignupPresetService.cs
+++ b/DemiCatPlugin/SignupPresetService.cs
@@ -33,10 +33,7 @@ internal static class SignupPresetService
         try
         {
             var req = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets");
-            if (!string.IsNullOrEmpty(config.AuthToken))
-            {
-                req.Headers.Add("X-Api-Key", config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(req, config);
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
             {
@@ -58,10 +55,7 @@ internal static class SignupPresetService
         try
         {
             var req = new HttpRequestMessage(HttpMethod.Post, $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets");
-            if (!string.IsNullOrEmpty(config.AuthToken))
-            {
-                req.Headers.Add("X-Api-Key", config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(req, config);
             req.Content = new StringContent(JsonSerializer.Serialize(preset), Encoding.UTF8, "application/json");
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
@@ -81,10 +75,7 @@ internal static class SignupPresetService
         try
         {
             var req = new HttpRequestMessage(HttpMethod.Delete, $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets/{id}");
-            if (!string.IsNullOrEmpty(config.AuthToken))
-            {
-                req.Headers.Add("X-Api-Key", config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(req, config);
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -224,8 +224,7 @@ public class SyncshellWindow : IDisposable
                 url += $"?since={Uri.EscapeDataString(state.LastPullAt.Value.ToString("O"))}";
 
             var req = new HttpRequestMessage(HttpMethod.Get, url);
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-                req.Headers.Add("X-Api-Key", _config.AuthToken);
+            ApiHelpers.AddAuthHeader(req, _config);
             if (!string.IsNullOrEmpty(_etag))
                 req.Headers.IfNoneMatch.Add(new EntityTagHeaderValue(_etag));
 
@@ -295,8 +294,7 @@ public class SyncshellWindow : IDisposable
             url += $"?since={Uri.EscapeDataString(since.Value.ToString("O"))}";
 
         var req = new HttpRequestMessage(HttpMethod.Get, url);
-        if (!string.IsNullOrEmpty(_config.AuthToken))
-            req.Headers.Add("X-Api-Key", _config.AuthToken);
+        ApiHelpers.AddAuthHeader(req, _config);
 
         var resp = await _httpClient.SendAsync(req);
         if (!resp.IsSuccessStatusCode)
@@ -565,7 +563,7 @@ public class SyncshellWindow : IDisposable
             {
                 Content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json")
             };
-            request.Headers.Add("X-Api-Key", _config.AuthToken);
+            ApiHelpers.AddAuthHeader(request, _config);
             await _httpClient.SendAsync(request);
 
             _installations[assetId] = new Installation { AssetId = assetId, Status = status, UpdatedAt = DateTimeOffset.UtcNow };
@@ -677,7 +675,7 @@ public class SyncshellWindow : IDisposable
 
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/installations";
             var req = new HttpRequestMessage(HttpMethod.Get, url);
-            req.Headers.Add("X-Api-Key", _config.AuthToken);
+            ApiHelpers.AddAuthHeader(req, _config);
             var resp = await _httpClient.SendAsync(req);
             if (!resp.IsSuccessStatusCode)
                 return;

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -136,10 +136,7 @@ public class TemplatesWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -274,10 +271,7 @@ public class TemplatesWindow
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             await _httpClient.SendAsync(request);
             _lastResult = "Template posted";
         }

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -138,10 +138,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode) return;
             var stream = await response.Content.ReadAsStreamAsync();
@@ -212,10 +209,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 url += $"?channel_id={_channelId}";
             }
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -266,10 +260,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             try
             {
                 _webSocket = new ClientWebSocket();
-                if (!string.IsNullOrEmpty(_config.AuthToken))
-                {
-                    _webSocket.Options.SetRequestHeader("X-Api-Key", _config.AuthToken);
-                }
+                ApiHelpers.AddAuthHeader(_webSocket, _config);
                 var baseUrl = _config.ApiBaseUrl.TrimEnd('/');
                 var wsUrl = new Uri(($"{baseUrl}/ws/embeds")
                     .Replace("http://", "ws://")
@@ -428,10 +419,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 url += $"?channel_id={_channelId}";
             }
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -532,10 +520,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -598,10 +583,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/refresh");
-            if (!string.IsNullOrEmpty(_config.AuthToken))
-            {
-                request.Headers.Add("X-Api-Key", _config.AuthToken);
-            }
+            ApiHelpers.AddAuthHeader(request, _config);
             await _httpClient.SendAsync(request);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- add `ApiHelpers.AddAuthHeader` to attach `X-Api-Key`
- replace manual header logic in UI components with helper

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68b49fa8493c8328b0dc537cc12f2376