### PR TITLE
Refresh presence after WebSocket connect

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -799,6 +799,7 @@ public class ChatWindow : IDisposable
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
                 // Refresh presence information in case updates were missed while offline.
+                _presence?.Reload();
                 _ = _presence?.Refresh();
                 _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
 


### PR DESCRIPTION
## Summary
- Ensure presence sidebar reloads after message WebSocket reconnects by clearing cache and refreshing

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68b4aa468e148328bb7370dc0ff8f735