### PR TITLE
feat: persist and expose message reactions

### DIFF
--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -216,6 +216,7 @@ class Message(Base):
     mentions_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     reference_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     components_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    reactions_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     edited_timestamp: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     is_officer: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -17,7 +17,11 @@ from ...http.schemas import (
     AttachmentDto,
     MessageAuthor,
 )
-from ...http.discord_helpers import embed_to_dto, message_to_chat_message
+from ...http.discord_helpers import (
+    embed_to_dto,
+    message_to_chat_message,
+    reaction_to_dto,
+)
 from ...http.ws import manager
 
 
@@ -302,6 +306,15 @@ class Mirror(commands.Cog):
                 except Exception:
                     components_json = None
 
+            reactions_json = None
+            if message.reactions:
+                try:
+                    reactions_json = json.dumps(
+                        [reaction_to_dto(r).model_dump() for r in message.reactions]
+                    )
+                except Exception:
+                    reactions_json = None
+
             db.add(
                 Message(
                     discord_message_id=message.id,
@@ -319,6 +332,7 @@ class Mirror(commands.Cog):
                     embeds_json=embeds_json,
                     reference_json=reference_json,
                     components_json=components_json,
+                    reactions_json=reactions_json,
                     edited_timestamp=message.edited_at,
                     is_officer=is_officer,
                 )
@@ -480,6 +494,15 @@ class Mirror(commands.Cog):
                     except Exception:
                         components_json = None
 
+                reactions_json = None
+                if after.reactions:
+                    try:
+                        reactions_json = json.dumps(
+                            [reaction_to_dto(r).model_dump() for r in after.reactions]
+                        )
+                    except Exception:
+                        reactions_json = None
+
                 msg.content_raw = after.content
                 msg.content_display = after.content
                 msg.content = after.content
@@ -491,6 +514,7 @@ class Mirror(commands.Cog):
                 msg.embeds_json = embeds_json
                 msg.reference_json = reference_json
                 msg.components_json = components_json
+                msg.reactions_json = reactions_json
                 msg.edited_timestamp = after.edited_at
                 await db.commit()
 

--- a/demibot/demibot/http/discord_helpers.py
+++ b/demibot/demibot/http/discord_helpers.py
@@ -21,6 +21,7 @@ from .schemas import (
     EmbedFieldDto,
     Mention,
     MessageAuthor,
+    ReactionDto,
 )
 
 
@@ -37,6 +38,21 @@ def mention_to_dto(user: discord.abc.User) -> Mention:
     """Convert a Discord user/member into a :class:`Mention`."""
     name = getattr(user, "display_name", None) or getattr(user, "name", "")
     return Mention(id=str(user.id), name=name)
+
+
+def reaction_to_dto(reaction: discord.Reaction) -> ReactionDto:
+    """Convert a Discord reaction into a :class:`ReactionDto`."""
+    emoji = reaction.emoji
+    emoji_name = getattr(emoji, "name", str(emoji))
+    emoji_id = getattr(emoji, "id", None)
+    is_animated = getattr(emoji, "animated", False)
+    return ReactionDto(
+        emoji=emoji_name,
+        emojiId=str(emoji_id) if emoji_id else None,
+        isAnimated=is_animated,
+        count=reaction.count,
+        me=reaction.me,
+    )
 
 
 def embed_to_dto(
@@ -145,6 +161,8 @@ def message_to_chat_message(message: discord.Message) -> ChatMessage:
         except Exception:
             components = None
 
+    reactions = [reaction_to_dto(r) for r in message.reactions] or None
+
     return ChatMessage(
         id=str(message.id),
         channelId=str(message.channel.id),
@@ -158,6 +176,7 @@ def message_to_chat_message(message: discord.Message) -> ChatMessage:
         embeds=embeds,
         reference=reference,
         components=components,
+        reactions=reactions,
         editedTimestamp=message.edited_at,
     )
 

--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext
-from ..schemas import ChatMessage, AttachmentDto, MessageAuthor, Mention
+from ..schemas import ChatMessage, AttachmentDto, MessageAuthor, Mention, ReactionDto
 from ..ws import manager
 from ...db.models import Message
 from ..discord_client import discord_client
@@ -100,6 +100,14 @@ async def fetch_messages(
             except Exception:
                 components = None
 
+        reactions = None
+        if m.reactions_json:
+            try:
+                data = json.loads(m.reactions_json)
+                reactions = [ReactionDto(**a) for a in data]
+            except Exception:
+                reactions = None
+
         out.append(
             ChatMessage(
                 id=str(m.discord_message_id),
@@ -114,6 +122,7 @@ async def fetch_messages(
                 embeds=embeds,
                 reference=reference,
                 components=components,
+                reactions=reactions,
                 editedTimestamp=m.edited_timestamp,
                 useCharacterName=getattr(author, "useCharacterName", False),
             )

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -79,6 +79,14 @@ class MessageAuthor(BaseModel):
     useCharacterName: bool | None = False
 
 
+class ReactionDto(BaseModel):
+    emoji: str
+    emojiId: str | None = None
+    isAnimated: bool
+    count: int
+    me: bool
+
+
 class ChatMessage(BaseModel):
     id: str
     channelId: str
@@ -92,6 +100,7 @@ class ChatMessage(BaseModel):
     embeds: List[dict] | None = None
     reference: dict | None = None
     components: List[dict] | None = None
+    reactions: List[ReactionDto] | None = None
     editedTimestamp: Optional[datetime] = None
     useCharacterName: bool | None = False
 


### PR DESCRIPTION
## Summary
- support Discord message reactions in API schema
- store reactions JSON when mirroring messages
- return stored reactions from message queries

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'alembic'; The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b59b991c1c8328b06fa9877d0c05a9