### PR TITLE
feat: flatten Discord message components

### DIFF
--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -17,7 +17,11 @@ from ...http.schemas import (
     AttachmentDto,
     MessageAuthor,
 )
-from ...http.discord_helpers import embed_to_dto, message_to_chat_message
+from ...http.discord_helpers import (
+    embed_to_dto,
+    message_to_chat_message,
+    components_to_dtos,
+)
 from ...http.ws import manager
 
 
@@ -296,8 +300,9 @@ class Mirror(commands.Cog):
             components_json = None
             if getattr(message, "components", None):
                 try:
-                    components_json = json.dumps(
-                        [c.to_dict() for c in message.components]
+                    comps = components_to_dtos(message)
+                    components_json = (
+                        json.dumps([c.model_dump() for c in comps]) if comps else None
                     )
                 except Exception:
                     components_json = None
@@ -474,8 +479,11 @@ class Mirror(commands.Cog):
                 components_json = None
                 if getattr(after, "components", None):
                     try:
-                        components_json = json.dumps(
-                            [c.to_dict() for c in after.components]
+                        comps = components_to_dtos(after)
+                        components_json = (
+                            json.dumps([c.model_dump() for c in comps])
+                            if comps
+                            else None
                         )
                     except Exception:
                         components_json = None

--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -11,7 +11,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext
-from ..schemas import ChatMessage, AttachmentDto, MessageAuthor, Mention
+from ..schemas import (
+    ChatMessage,
+    AttachmentDto,
+    MessageAuthor,
+    Mention,
+    ButtonComponentDto,
+)
 from ..ws import manager
 from ...db.models import Message
 from ..discord_client import discord_client
@@ -96,7 +102,8 @@ async def fetch_messages(
         components = None
         if m.components_json:
             try:
-                components = json.loads(m.components_json)
+                data = json.loads(m.components_json)
+                components = [ButtonComponentDto(**c) for c in data]
             except Exception:
                 components = None
 

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -72,6 +72,14 @@ class AttachmentDto(BaseModel):
     contentType: Optional[str] = None
 
 
+class ButtonComponentDto(BaseModel):
+    label: str
+    customId: Optional[str] = None
+    url: Optional[str] = None
+    style: ButtonStyle
+    emoji: Optional[str] = None
+
+
 class MessageAuthor(BaseModel):
     id: str
     name: str
@@ -91,7 +99,7 @@ class ChatMessage(BaseModel):
     author: MessageAuthor | None = None
     embeds: List[dict] | None = None
     reference: dict | None = None
-    components: List[dict] | None = None
+    components: List[ButtonComponentDto] | None = None
     editedTimestamp: Optional[datetime] = None
     useCharacterName: bool | None = False
 

--- a/tests/test_message_components.py
+++ b/tests/test_message_components.py
@@ -1,0 +1,63 @@
+import types
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.http.discord_helpers import message_to_chat_message
+from demibot.http.schemas import ButtonStyle
+
+
+class DummyAuthor:
+    def __init__(self):
+        self.id = 1
+        self.display_name = "Author"
+        self.name = "Author"
+        self.display_avatar = None
+
+
+class DummyChannel:
+    def __init__(self):
+        self.id = 123
+
+
+class DummyMessage:
+    def __init__(self):
+        btn = types.SimpleNamespace(
+            type=2,
+            custom_id="test",
+            label="Test",
+            style=1,
+            emoji=None,
+            url="https://example.com",
+        )
+        row = types.SimpleNamespace(children=[btn])
+        self.components = [row]
+        self.attachments = []
+        self.mentions = []
+        self.embeds = []
+        self.reference = None
+        self.author = DummyAuthor()
+        self.channel = DummyChannel()
+        self.id = 42
+        self.content = "hello"
+        self.created_at = None
+        self.edited_at = None
+
+
+def test_message_components_to_dtos():
+    msg = DummyMessage()
+    dto = message_to_chat_message(msg)
+    assert dto.components is not None
+    assert dto.components[0].label == "Test"
+    assert dto.components[0].customId == "test"
+    assert dto.components[0].style == ButtonStyle.primary


### PR DESCRIPTION
## Summary
- flatten Discord action rows into ButtonComponentDto objects
- expose button components via ChatMessage schema and API
- test message component flattening

## Testing
- `python -m pytest tests/test_message_components.py -q`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'alembic')*

------
https://chatgpt.com/codex/tasks/task_e_68b59bb3142c8328b31befdd7f1d3f9a