### PR TITLE
Expose avatar URLs in presence data

### DIFF
--- a/demibot/demibot/discordbot/cogs/presence.py
+++ b/demibot/demibot/discordbot/cogs/presence.py
@@ -23,11 +23,12 @@ class PresenceTracker(commands.Cog):
             return "offline"
         return "online"
 
-    async def _update(self, member: discord.Member) -> dict[str, str]:
+    async def _update(self, member: discord.Member) -> dict[str, str | None]:
         data = StorePresence(
             id=member.id,
             name=member.display_name or member.name,
             status=self._status(member),
+            avatar_url=str(member.display_avatar.url),
         )
         set_presence(member.guild.id, data)
         async for db in get_session():
@@ -49,7 +50,12 @@ class PresenceTracker(commands.Cog):
                 row.status = data.status
                 row.updated_at = datetime.utcnow()
             await db.commit()
-        return {"id": str(member.id), "name": data.name, "status": data.status}
+        return {
+            "id": str(member.id),
+            "name": data.name,
+            "status": data.status,
+            "avatar_url": data.avatar_url,
+        }
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:

--- a/demibot/demibot/discordbot/presence_store.py
+++ b/demibot/demibot/discordbot/presence_store.py
@@ -9,6 +9,7 @@ class Presence:
     id: int
     name: str
     status: str
+    avatar_url: str | None = None
 
 
 _presences: Dict[int, Dict[int, Presence]] = {}
@@ -16,6 +17,9 @@ _presences: Dict[int, Dict[int, Presence]] = {}
 
 def set_presence(guild_id: int, presence: Presence) -> None:
     guild = _presences.setdefault(guild_id, {})
+    existing = guild.get(presence.id)
+    if existing and presence.avatar_url is None:
+        presence.avatar_url = existing.avatar_url
     guild[presence.id] = presence
 
 

--- a/demibot/demibot/http/routes/presences.py
+++ b/demibot/demibot/http/routes/presences.py
@@ -7,6 +7,7 @@ from ..deps import RequestContext, api_key_auth
 from ...db.models import Presence as DbPresence, User
 from ...db.session import get_session
 from ...discordbot.presence_store import get_presences
+from ..discord_client import discord_client
 
 
 router = APIRouter(prefix="/api")
@@ -15,8 +16,8 @@ router = APIRouter(prefix="/api")
 @router.get("/presences")
 async def list_presences(
     ctx: RequestContext = Depends(api_key_auth),
-) -> list[dict[str, str]]:
-    db_presences: list[dict[str, str]] | None = None
+) -> list[dict[str, str | None]]:
+    db_presences: list[dict[str, str | None]] | None = None
     try:
         async for db in get_session():
             result = await db.execute(
@@ -26,11 +27,19 @@ async def list_presences(
             )
             rows = result.all()
             if rows:
+                avatars: dict[int, str] = {}
+                if discord_client:
+                    guild = discord_client.get_guild(getattr(ctx.guild, "discord_guild_id", ctx.guild.id))
+                    for p, _ in rows:
+                        member = guild.get_member(p.user_id) if guild else None
+                        if member and member.display_avatar:
+                            avatars[p.user_id] = str(member.display_avatar.url)
                 db_presences = [
                     {
                         "id": str(p.user_id),
                         "name": (u.global_name or u.discriminator or str(p.user_id)) if u else str(p.user_id),
                         "status": p.status,
+                        "avatar_url": avatars.get(p.user_id),
                     }
                     for p, u in rows
                 ]
@@ -40,6 +49,11 @@ async def list_presences(
     if db_presences is not None:
         return db_presences
     return [
-        {"id": str(p.id), "name": p.name, "status": p.status}
+        {
+            "id": str(p.id),
+            "name": p.name,
+            "status": p.status,
+            "avatar_url": p.avatar_url,
+        }
         for p in get_presences(ctx.guild.id)
     ]

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime
 from enum import IntEnum
 
@@ -120,3 +120,4 @@ class PresenceDto(BaseModel):
     id: str
     name: str
     status: str
+    avatarUrl: str | None = Field(default=None, alias="avatar_url")

--- a/tests/test_presences.py
+++ b/tests/test_presences.py
@@ -56,11 +56,32 @@ def test_presence_broadcast_filtered_by_path():
 
 def test_list_presences_returns_data():
     async def _run():
-        set_presence(1, StorePresence(id=10, name="Alice", status="online"))
-        set_presence(1, StorePresence(id=20, name="Bob", status="offline"))
+        set_presence(
+            1,
+            StorePresence(
+                id=10,
+                name="Alice",
+                status="online",
+                avatar_url="https://example.com/a.png",
+            ),
+        )
+        set_presence(
+            1,
+            StorePresence(
+                id=20,
+                name="Bob",
+                status="offline",
+                avatar_url="https://example.com/b.png",
+            ),
+        )
         ctx = StubContext(1)
         res = await list_presences(ctx=ctx)
-        assert {(p["id"], p["status"]) for p in res} == {("10", "online"), ("20", "offline")}
+        assert {
+            (p["id"], p["status"], p["avatar_url"]) for p in res
+        } == {
+            ("10", "online", "https://example.com/a.png"),
+            ("20", "offline", "https://example.com/b.png"),
+        }
 
     asyncio.run(_run())
 
@@ -77,6 +98,8 @@ def test_list_presences_reads_from_db():
             await db.commit()
         ctx = StubContext(1)
         res = await list_presences(ctx=ctx)
-        assert {(p["id"], p["status"]) for p in res} == {("10", "online"), ("20", "offline")}
+        assert {
+            (p["id"], p["status"], p["avatar_url"]) for p in res
+        } == {("10", "online", None), ("20", "offline", None)}
 
     asyncio.run(_run())

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -37,6 +37,10 @@ def test_get_users_includes_status_from_cache():
     async def _run():
         await init_db('sqlite+aiosqlite://')
         async for db in get_session():
+            await db.execute(delete(DbPresence))
+            await db.execute(delete(Membership))
+            await db.execute(delete(User))
+            await db.commit()
             db.add(User(id=1, discord_user_id=10, global_name='Alice'))
             db.add(User(id=2, discord_user_id=20, global_name='Bob'))
             db.add(Membership(guild_id=1, user_id=1))


### PR DESCRIPTION
## Summary
- include `avatarUrl` field in presence DTO
- store member avatar URLs in presence cache and websocket payloads
- expose avatar URLs via presences API and tests

## Testing
- `pytest tests/test_presences.py tests/test_users.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ac23ee7c83288da014dbba74e6af