### PR TITLE
Mirror reactions and update message persistence

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -292,12 +292,60 @@ async def edit_message(
                 await discord_msg.edit(content=content)
             except Exception:
                 pass
+    attachments = None
+    if msg.attachments_json:
+        try:
+            data = json.loads(msg.attachments_json)
+            attachments = [AttachmentDto(**a) for a in data]
+        except Exception:
+            attachments = None
+
+    mentions = None
+    if msg.mentions_json:
+        try:
+            data = json.loads(msg.mentions_json)
+            mentions = [Mention(**m) for m in data]
+        except Exception:
+            mentions = None
+
     author = None
     if msg.author_json:
         try:
             author = MessageAuthor(**json.loads(msg.author_json))
         except Exception:
             author = None
+
+    embeds = None
+    if msg.embeds_json:
+        try:
+            data = json.loads(msg.embeds_json)
+            embeds = [EmbedDto(**e) for e in data]
+        except Exception:
+            embeds = None
+
+    reference = None
+    if msg.reference_json:
+        try:
+            reference = json.loads(msg.reference_json)
+        except Exception:
+            reference = None
+
+    components = None
+    if msg.components_json:
+        try:
+            data = json.loads(msg.components_json)
+            components = [ButtonComponentDto(**c) for c in data]
+        except Exception:
+            components = None
+
+    reactions = None
+    if msg.reactions_json:
+        try:
+            data = json.loads(msg.reactions_json)
+            reactions = [ReactionDto(**r) for r in data]
+        except Exception:
+            reactions = None
+
     dto = ChatMessage(
         id=str(message_id),
         channelId=str(channel_id),
@@ -305,8 +353,14 @@ async def edit_message(
         authorAvatarUrl=msg.author_avatar_url,
         timestamp=msg.created_at,
         content=content,
-        editedTimestamp=msg.edited_timestamp,
+        attachments=attachments,
+        mentions=mentions,
         author=author,
+        embeds=embeds,
+        reference=reference,
+        components=components,
+        reactions=reactions,
+        editedTimestamp=msg.edited_timestamp,
         useCharacterName=getattr(author, "useCharacterName", False),
     )
     await manager.broadcast_text(

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -80,28 +80,28 @@ async def add_reaction(
         raise HTTPException(status_code=503, detail="Discord client unavailable")
     row = await db.get(Message, int(message_id))
     if not row or row.channel_id != int(channel_id):
-        raise HTTPException(status_code=404)
+        raise HTTPException(status_code=404, detail="message not found")
     if row.is_officer:
         if "officer" not in ctx.roles:
-            raise HTTPException(status_code=403)
+            raise HTTPException(status_code=403, detail="forbidden")
     elif "chat" not in ctx.roles:
-        raise HTTPException(status_code=403)
+        raise HTTPException(status_code=403, detail="forbidden")
     channel = discord_client.get_channel(int(channel_id))
     if not channel or not isinstance(channel, discord.abc.Messageable):
-        raise HTTPException(status_code=404)
+        raise HTTPException(status_code=404, detail="channel not found")
     try:
         msg = await channel.fetch_message(int(message_id))
     except discord.NotFound:
-        raise HTTPException(status_code=404)
+        raise HTTPException(status_code=404, detail="message not found")
     except discord.Forbidden:
-        raise HTTPException(status_code=403)
+        raise HTTPException(status_code=403, detail="forbidden")
 
     try:
         await msg.add_reaction(emoji)
     except discord.NotFound:
-        raise HTTPException(status_code=404)
+        raise HTTPException(status_code=404, detail="message not found")
     except discord.Forbidden:
-        raise HTTPException(status_code=403)
+        raise HTTPException(status_code=403, detail="forbidden")
 
     return {"ok": True}
 
@@ -118,15 +118,15 @@ async def remove_reaction(
         raise HTTPException(status_code=503, detail="Discord client unavailable")
     row = await db.get(Message, int(message_id))
     if not row or row.channel_id != int(channel_id):
-        raise HTTPException(status_code=404)
+        raise HTTPException(status_code=404, detail="message not found")
     if row.is_officer:
         if "officer" not in ctx.roles:
-            raise HTTPException(status_code=403)
+            raise HTTPException(status_code=403, detail="forbidden")
     elif "chat" not in ctx.roles:
-        raise HTTPException(status_code=403)
+        raise HTTPException(status_code=403, detail="forbidden")
     channel = discord_client.get_channel(int(channel_id))
     if not channel or not isinstance(channel, discord.abc.Messageable):
-        raise HTTPException(status_code=404)
+        raise HTTPException(status_code=404, detail="channel not found")
     try:
         msg = await channel.fetch_message(int(message_id))
         await msg.remove_reaction(emoji, discord_client.user)


### PR DESCRIPTION
## Summary
- mirror Discord reactions in DB and broadcast updates
- include reaction data when editing messages
- improve reaction API error handling

## Testing
- `PYTHONPATH=demibot pytest tests/test_reactions.py::test_add_reaction_success tests/test_reactions.py::test_add_reaction_not_found tests/test_reactions.py::test_add_reaction_forbidden`
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_save_and_fetch_messages`


------
https://chatgpt.com/codex/tasks/task_e_68b5b08e0e1c8328a47fa1b7eb67b8fd