### PR TITLE
Use MessageReferenceDto for message references

### DIFF
--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -17,6 +17,7 @@ from ...http.schemas import (
     Mention,
     AttachmentDto,
     MessageAuthor,
+    MessageReferenceDto,
 )
 from ...http.discord_helpers import (
     embed_to_dto,
@@ -274,13 +275,10 @@ class Mirror(commands.Cog):
                 )
             reference_json = None
             if message.reference:
-                reference_json = json.dumps(
-                    {
-                        "messageId": message.reference.message_id,
-                        "channelId": message.reference.channel_id,
-                        "guildId": message.reference.guild_id,
-                    }
-                )
+                reference_json = MessageReferenceDto(
+                    messageId=str(message.reference.message_id),
+                    channelId=str(message.reference.channel_id),
+                ).model_dump_json()
             components_json = None
             if getattr(message, "components", None):
                 try:
@@ -444,13 +442,10 @@ class Mirror(commands.Cog):
                     )
                 reference_json = None
                 if after.reference:
-                    reference_json = json.dumps(
-                        {
-                            "messageId": after.reference.message_id,
-                            "channelId": after.reference.channel_id,
-                            "guildId": after.reference.guild_id,
-                        }
-                    )
+                    reference_json = MessageReferenceDto(
+                        messageId=str(after.reference.message_id),
+                        channelId=str(after.reference.channel_id),
+                    ).model_dump_json()
                 components_json = None
                 if getattr(after, "components", None):
                     try:

--- a/demibot/demibot/http/discord_helpers.py
+++ b/demibot/demibot/http/discord_helpers.py
@@ -23,6 +23,7 @@ from .schemas import (
     EmbedFieldDto,
     Mention,
     MessageAuthor,
+    MessageReferenceDto,
     ReactionDto,
 )
 
@@ -229,11 +230,10 @@ def message_to_chat_message(message: discord.Message) -> ChatMessage:
 
     reference = None
     if message.reference:
-        reference = {
-            "messageId": message.reference.message_id,
-            "channelId": message.reference.channel_id,
-            "guildId": message.reference.guild_id,
-        }
+        reference = MessageReferenceDto(
+            messageId=str(message.reference.message_id),
+            channelId=str(message.reference.channel_id),
+        )
 
     components = None
     if getattr(message, "components", None):

--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -19,6 +19,7 @@ from ..schemas import (
     ButtonComponentDto,
     ReactionDto,
     EmbedDto,
+    MessageReferenceDto,
 )
 
 from ..ws import manager
@@ -34,7 +35,7 @@ class PostBody(BaseModel):
     channelId: str
     content: str
     useCharacterName: bool | None = False
-    messageReference: dict | None = None
+    messageReference: MessageReferenceDto | None = None
 
 
 async def fetch_messages(
@@ -99,7 +100,7 @@ async def fetch_messages(
         reference = None
         if m.reference_json:
             try:
-                reference = json.loads(m.reference_json)
+                reference = MessageReferenceDto(**json.loads(m.reference_json))
             except Exception:
                 reference = None
 
@@ -235,9 +236,8 @@ async def save_message(
         content=body.content,
         author_json=author.model_dump_json(),
         attachments_json=attachments_json,
-        reference_json=json.dumps(body.messageReference)
-        if body.messageReference
-        else None,
+        reference_json=
+        body.messageReference.model_dump_json() if body.messageReference else None,
         is_officer=is_officer,
     )
     db.add(msg)
@@ -326,7 +326,7 @@ async def edit_message(
     reference = None
     if msg.reference_json:
         try:
-            reference = json.loads(msg.reference_json)
+            reference = MessageReferenceDto(**json.loads(msg.reference_json))
         except Exception:
             reference = None
 

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -6,7 +6,7 @@ import json
 import discord
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ..schemas import ChatMessage
+from ..schemas import ChatMessage, MessageReferenceDto
 from ._messages_common import (
     PostBody,
     fetch_messages,
@@ -56,7 +56,7 @@ async def post_message_with_attachments(
     ref = None
     if message_reference:
         try:
-            ref = json.loads(message_reference)
+            ref = MessageReferenceDto(**json.loads(message_reference))
         except Exception:
             raise HTTPException(status_code=400, detail="invalid message_reference")
     body = PostBody(

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -95,6 +95,11 @@ class ReactionDto(BaseModel):
     me: bool
 
 
+class MessageReferenceDto(BaseModel):
+    messageId: str
+    channelId: str
+
+
 class ChatMessage(BaseModel):
     id: str
     channelId: str
@@ -106,7 +111,7 @@ class ChatMessage(BaseModel):
     mentions: List[Mention] | None = None
     author: MessageAuthor | None = None
     embeds: List[EmbedDto] | None = None
-    reference: dict | None = None
+    reference: MessageReferenceDto | None = None
     components: List[ButtonComponentDto] | None = None
     reactions: List[ReactionDto] | None = None
     editedTimestamp: Optional[datetime] = None


### PR DESCRIPTION
## Summary
- introduce `MessageReferenceDto` with message and channel identifiers
- persist and return typed message references instead of raw dicts
- handle typed message references in API routes and Discord mirror

## Testing
- `pytest tests/test_message_components.py::test_message_components_to_dtos -q`
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_save_and_fetch_messages -q`
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_officer_flow -q`
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_officer_requires_role -q`
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_fetch_messages_pagination -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b459307c8328a00dbbdd13db5a2b