### PR TITLE
Support Discord message component interactions

### DIFF
--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -12,7 +12,7 @@ public static class EmbedRenderer
 {
     private static readonly Dictionary<string, ISharedImmediateTexture?> ThumbnailCache = new();
 
-    public static void Draw(EmbedDto dto, Action<string?, Action<ISharedImmediateTexture?>> loadTexture)
+    public static void Draw(EmbedDto dto, Action<string?, Action<ISharedImmediateTexture?>> loadTexture, Action<string>? onButtonClick = null)
     {
         if (!string.IsNullOrEmpty(dto.Title))
         {
@@ -99,6 +99,10 @@ public static class EmbedRenderer
                     if (!string.IsNullOrEmpty(button.Url))
                     {
                         try { Process.Start(new ProcessStartInfo(button.Url) { UseShellExecute = true }); } catch { }
+                    }
+                    else if (!string.IsNullOrEmpty(button.CustomId))
+                    {
+                        onButtonClick?.Invoke(button.CustomId);
                     }
                 }
                 if (styled)


### PR DESCRIPTION
## Summary
- allow `EmbedRenderer.Draw` to notify callers of button clicks
- render message-level components and forward button interactions to backend
- post interaction events so buttons such as RSVP can sync

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud.NET.Sdk: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*
- `pytest` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c04a03408328980811aa01b92cfd