### PR TITLE
Support Discord message component interactions

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -39,6 +39,9 @@ public class ChatWindow : IDisposable
     protected readonly List<string> _attachments = new();
     protected string _newAttachmentPath = string.Empty;
     protected string? _replyToId;
+    protected string? _editingMessageId;
+    protected string _editingChannelId = string.Empty;
+    protected string _editContent = string.Empty;
     private static readonly string[] DefaultReactions = new[] { "👍", "👎", "❤️" };
     private readonly EmojiPicker _emojiPicker;
     private readonly Dictionary<string, EmojiPicker.EmojiDto> _emojiCatalog = new();
@@ -182,11 +185,18 @@ public class ChatWindow : IDisposable
             }
 
             FormatContent(msg);
+            if (msg.EditedTimestamp != null)
+            {
+                ImGui.SameLine();
+                ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.6f, 0.6f, 0.6f, 1f));
+                ImGui.TextUnformatted("(edited)");
+                ImGui.PopStyleColor();
+            }
             if (msg.Embeds != null)
             {
                 foreach (var embed in msg.Embeds)
                 {
-                    EmbedRenderer.Draw(embed, LoadTexture);
+                    EmbedRenderer.Draw(embed, LoadTexture, cid => _ = Interact(msg.Id, msg.ChannelId, cid));
                 }
             }
             if (msg.Attachments != null)
@@ -217,6 +227,19 @@ public class ChatWindow : IDisposable
                         ImGui.PopStyleColor();
                     }
                 }
+            }
+            if (msg.Components != null && msg.Components.Count > 0)
+            {
+                var buttons = msg.Components.Select(c => new EmbedButtonDto
+                {
+                    Label = c.Label,
+                    CustomId = c.CustomId,
+                    Url = c.Url,
+                    Emoji = c.Emoji,
+                    Style = c.Style
+                }).ToList();
+                var pseudo = new EmbedDto { Id = msg.Id + "_components", Buttons = buttons };
+                EmbedRenderer.Draw(pseudo, LoadTexture, cid => _ = Interact(msg.Id, msg.ChannelId, cid));
             }
             ImGui.Spacing();
             if (msg.Reactions != null)
@@ -288,6 +311,17 @@ public class ChatWindow : IDisposable
                 {
                     _replyToId = msg.Id;
                 }
+                if (ImGui.MenuItem("Edit"))
+                {
+                    _editingMessageId = msg.Id;
+                    _editingChannelId = msg.ChannelId;
+                    _editContent = msg.Content ?? string.Empty;
+                    ImGui.OpenPopup("editMessage");
+                }
+                if (ImGui.MenuItem("Delete"))
+                {
+                    _ = DeleteMessage(msg.Id, msg.ChannelId);
+                }
                 ImGui.EndPopup();
             }
 
@@ -310,6 +344,27 @@ public class ChatWindow : IDisposable
                     _replyToId = null;
                 }
             }
+        }
+
+        if (ImGui.BeginPopup("editMessage"))
+        {
+            ImGui.InputTextMultiline("##editContent", ref _editContent, 1024, new Vector2(400, ImGui.GetTextLineHeight() * 5));
+            if (ImGui.Button("Save"))
+            {
+                if (_editingMessageId != null)
+                {
+                    _ = EditMessage(_editingMessageId, _editingChannelId, _editContent);
+                }
+                _editingMessageId = null;
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Cancel"))
+            {
+                _editingMessageId = null;
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.EndPopup();
         }
 
         if (ImGui.Button("Attach"))
@@ -556,6 +611,108 @@ public class ChatWindow : IDisposable
         catch (Exception ex)
         {
             PluginServices.Instance!.Log.Error(ex, "Error reacting to message");
+        }
+    }
+
+    protected virtual async Task EditMessage(string messageId, string channelId, string content)
+    {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            PluginServices.Instance!.Log.Warning("Cannot edit: API base URL is not configured.");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(channelId) || string.IsNullOrWhiteSpace(messageId) || string.IsNullOrWhiteSpace(content))
+        {
+            return;
+        }
+
+        try
+        {
+            var body = new { content };
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{channelId}/messages/{messageId}";
+            var request = new HttpRequestMessage(HttpMethod.Patch, url);
+            request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+            ApiHelpers.AddAuthHeader(request, _config);
+            var response = await _httpClient.SendAsync(request);
+            if (response.IsSuccessStatusCode)
+            {
+                await RefreshMessages();
+            }
+            else
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                PluginServices.Instance!.Log.Warning($"Failed to edit message. Status: {response.StatusCode}. Response Body: {responseBody}");
+            }
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance!.Log.Error(ex, "Error editing message");
+        }
+    }
+
+    protected virtual async Task DeleteMessage(string messageId, string channelId)
+    {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            PluginServices.Instance!.Log.Warning("Cannot delete: API base URL is not configured.");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(channelId) || string.IsNullOrWhiteSpace(messageId))
+        {
+            return;
+        }
+
+        try
+        {
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{channelId}/messages/{messageId}";
+            var request = new HttpRequestMessage(HttpMethod.Delete, url);
+            ApiHelpers.AddAuthHeader(request, _config);
+            var response = await _httpClient.SendAsync(request);
+            if (response.IsSuccessStatusCode)
+            {
+                await RefreshMessages();
+            }
+            else
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                PluginServices.Instance!.Log.Warning($"Failed to delete message. Status: {response.StatusCode}. Response Body: {responseBody}");
+            }
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance!.Log.Error(ex, "Error deleting message");
+        }
+    }
+
+    protected virtual async Task Interact(string messageId, string channelId, string customId)
+    {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            PluginServices.Instance!.Log.Warning("Cannot interact: API base URL is not configured.");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(messageId) || string.IsNullOrWhiteSpace(customId))
+        {
+            return;
+        }
+
+        try
+        {
+            long? cid = long.TryParse(channelId, out var parsed) ? parsed : null;
+            var body = new { MessageId = messageId, ChannelId = cid, CustomId = customId };
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/interactions");
+            request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+            ApiHelpers.AddAuthHeader(request, _config);
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                PluginServices.Instance!.Log.Warning($"Failed to send interaction. Status: {response.StatusCode}. Response Body: {responseBody}");
+            }
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance!.Log.Error(ex, "Error sending interaction");
         }
     }
 

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -12,7 +12,7 @@ public static class EmbedRenderer
 {
     private static readonly Dictionary<string, ISharedImmediateTexture?> ThumbnailCache = new();
 
-    public static void Draw(EmbedDto dto, Action<string?, Action<ISharedImmediateTexture?>> loadTexture)
+    public static void Draw(EmbedDto dto, Action<string?, Action<ISharedImmediateTexture?>> loadTexture, Action<string>? onButtonClick = null)
     {
         if (!string.IsNullOrEmpty(dto.Title))
         {
@@ -99,6 +99,10 @@ public static class EmbedRenderer
                     if (!string.IsNullOrEmpty(button.Url))
                     {
                         try { Process.Start(new ProcessStartInfo(button.Url) { UseShellExecute = true }); } catch { }
+                    }
+                    else if (!string.IsNullOrEmpty(button.CustomId))
+                    {
+                        onButtonClick?.Invoke(button.CustomId);
                     }
                 }
                 if (styled)


### PR DESCRIPTION
## Summary
- allow `EmbedRenderer.Draw` to notify callers of button clicks
- render message-level components and forward button interactions to backend
- post interaction events so buttons such as RSVP can sync
- add context menu options to edit or delete messages and show an `(edited)` marker

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Requested SDK version 9.0.100 not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c04a03408328980811aa01b92cfd