### PR TITLE
Expose user roles in presence and users endpoints

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -66,7 +66,19 @@ public class FcChatWindow : ChatWindow
                 ImGui.Dummy(new Vector2(24, 24));
             }
             ImGui.SameLine();
-            if (ImGui.Selectable(user.Name))
+            var label = user.Name;
+            foreach (var roleId in user.Roles)
+            {
+                foreach (var role in RoleCache.Roles)
+                {
+                    if (role.Id == roleId)
+                    {
+                        label += $" [{role.Name}]";
+                        break;
+                    }
+                }
+            }
+            if (ImGui.Selectable(label))
             {
                 _input += $"@{user.Name} ";
             }

--- a/DemiCatPlugin/PresenceDto.cs
+++ b/DemiCatPlugin/PresenceDto.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using System.Collections.Generic;
 using Dalamud.Interface.Textures;
 
 namespace DemiCatPlugin;
@@ -10,4 +11,5 @@ public class PresenceDto
     [JsonPropertyName("status")] public string Status { get; set; } = string.Empty;
     [JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; }
     [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
+    [JsonPropertyName("roles")] public List<string> Roles { get; set; } = new();
 }

--- a/demibot/demibot/discordbot/cogs/presence.py
+++ b/demibot/demibot/discordbot/cogs/presence.py
@@ -24,11 +24,13 @@ class PresenceTracker(commands.Cog):
         return "online"
 
     async def _update(self, member: discord.Member) -> dict[str, str | None]:
+        role_ids = [r.id for r in member.roles if r.name != "@everyone"]
         data = StorePresence(
             id=member.id,
             name=member.display_name or member.name,
             status=self._status(member),
             avatar_url=str(member.display_avatar.url),
+            roles=role_ids,
         )
         set_presence(member.guild.id, data)
         async for db in get_session():
@@ -55,6 +57,7 @@ class PresenceTracker(commands.Cog):
             "name": data.name,
             "status": data.status,
             "avatar_url": data.avatar_url,
+            "roles": [str(r) for r in role_ids],
         }
 
     @commands.Cog.listener()

--- a/demibot/demibot/discordbot/presence_store.py
+++ b/demibot/demibot/discordbot/presence_store.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List
 
 
@@ -10,6 +10,7 @@ class Presence:
     name: str
     status: str
     avatar_url: str | None = None
+    roles: list[int] = field(default_factory=list)
 
 
 _presences: Dict[int, Dict[int, Presence]] = {}

--- a/demibot/demibot/http/routes/presences.py
+++ b/demibot/demibot/http/routes/presences.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from sqlalchemy import and_, select
 
 from ..deps import RequestContext, api_key_auth
-from ...db.models import Presence as DbPresence, User
+from ...db.models import (
+    Membership,
+    MembershipRole,
+    Presence as DbPresence,
+    Role,
+    User,
+)
 from ...db.session import get_session
 from ...discordbot.presence_store import get_presences
 from ..discord_client import discord_client
@@ -16,33 +22,59 @@ router = APIRouter(prefix="/api")
 @router.get("/presences")
 async def list_presences(
     ctx: RequestContext = Depends(api_key_auth),
-) -> list[dict[str, str | None]]:
-    db_presences: list[dict[str, str | None]] | None = None
+) -> list[dict[str, str | list[str] | None]]:
+    db_presences: list[dict[str, str | list[str] | None]] | None = None
     try:
         async for db in get_session():
             result = await db.execute(
-                select(DbPresence, User)
-                    .join(User, User.discord_user_id == DbPresence.user_id, isouter=True)
-                    .where(DbPresence.guild_id == ctx.guild.id)
+                select(DbPresence, User, Role.discord_role_id)
+                .join(User, User.discord_user_id == DbPresence.user_id, isouter=True)
+                .join(
+                    Membership,
+                    and_(
+                        Membership.guild_id == DbPresence.guild_id,
+                        Membership.user_id == User.id,
+                    ),
+                    isouter=True,
+                )
+                .join(
+                    MembershipRole,
+                    MembershipRole.membership_id == Membership.id,
+                    isouter=True,
+                )
+                .join(Role, MembershipRole.role_id == Role.id, isouter=True)
+                .where(DbPresence.guild_id == ctx.guild.id)
             )
             rows = result.all()
             if rows:
                 avatars: dict[int, str] = {}
                 if discord_client:
                     guild = discord_client.get_guild(getattr(ctx.guild, "discord_guild_id", ctx.guild.id))
-                    for p, _ in rows:
+                    for p, _, _ in rows:
                         member = guild.get_member(p.user_id) if guild else None
                         if member and member.display_avatar:
                             avatars[p.user_id] = str(member.display_avatar.url)
-                db_presences = [
-                    {
-                        "id": str(p.user_id),
-                        "name": (u.global_name or u.discriminator or str(p.user_id)) if u else str(p.user_id),
-                        "status": p.status,
-                        "avatar_url": avatars.get(p.user_id),
-                    }
-                    for p, u in rows
-                ]
+                user_map: dict[int, dict[str, object]] = {}
+                for p, u, rid in rows:
+                    entry = user_map.setdefault(
+                        p.user_id, {"presence": p, "user": u, "roles": set()}
+                    )
+                    if rid is not None:
+                        entry["roles"].add(rid)
+                db_presences = []
+                for data in user_map.values():
+                    p = data["presence"]  # type: ignore[assignment]
+                    u = data["user"]  # type: ignore[assignment]
+                    roles = [str(r) for r in sorted(data["roles"])]
+                    db_presences.append(
+                        {
+                            "id": str(p.user_id),
+                            "name": (u.global_name or u.discriminator or str(p.user_id)) if u else str(p.user_id),
+                            "status": p.status,
+                            "avatar_url": avatars.get(p.user_id),
+                            "roles": roles,
+                        }
+                    )
             break
     except RuntimeError:
         pass
@@ -54,6 +86,7 @@ async def list_presences(
             "name": p.name,
             "status": p.status,
             "avatar_url": p.avatar_url,
+            "roles": [str(r) for r in p.roles],
         }
         for p in get_presences(ctx.guild.id)
     ]

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -126,3 +126,4 @@ class PresenceDto(BaseModel):
     name: str
     status: str
     avatarUrl: str | None = Field(default=None, alias="avatar_url")
+    roles: List[str] = Field(default_factory=list)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -22,7 +22,13 @@ sys.modules.setdefault('demibot.discordbot', discordbot_pkg)
 
 from demibot.http.routes.users import get_users
 from demibot.discordbot.presence_store import set_presence, Presence as StorePresence
-from demibot.db.models import User, Membership, Presence as DbPresence
+from demibot.db.models import (
+    User,
+    Membership,
+    Presence as DbPresence,
+    Role,
+    MembershipRole,
+)
 from demibot.db.session import init_db, get_session
 from sqlalchemy import delete
 
@@ -37,20 +43,26 @@ def test_get_users_includes_status_from_cache():
     async def _run():
         await init_db('sqlite+aiosqlite://')
         async for db in get_session():
+            await db.execute(delete(MembershipRole))
+            await db.execute(delete(Role))
             await db.execute(delete(DbPresence))
             await db.execute(delete(Membership))
             await db.execute(delete(User))
             await db.commit()
             db.add(User(id=1, discord_user_id=10, global_name='Alice'))
             db.add(User(id=2, discord_user_id=20, global_name='Bob'))
-            db.add(Membership(guild_id=1, user_id=1))
-            db.add(Membership(guild_id=1, user_id=2))
+            db.add(Role(id=1, guild_id=1, discord_role_id=100, name='Officer'))
+            db.add(Membership(id=1, guild_id=1, user_id=1))
+            db.add(Membership(id=2, guild_id=1, user_id=2))
+            db.add(MembershipRole(membership_id=1, role_id=1))
             await db.commit()
             set_presence(1, StorePresence(id=10, name='Alice', status='online'))
             set_presence(1, StorePresence(id=20, name='Bob', status='offline'))
             ctx = StubContext(1)
             res = await get_users(ctx=ctx, db=db)
-            assert {(u['id'], u['status']) for u in res} == {('10', 'online'), ('20', 'offline')}
+            assert {
+                (u['id'], u['status'], tuple(u['roles'])) for u in res
+            } == {('10', 'online', ('100',)), ('20', 'offline', ())}
             break
     asyncio.run(_run())
 
@@ -59,6 +71,8 @@ def test_get_users_reads_presence_from_db():
     async def _run():
         await init_db('sqlite+aiosqlite://')
         async for db in get_session():
+            await db.execute(delete(MembershipRole))
+            await db.execute(delete(Role))
             await db.execute(delete(DbPresence))
             await db.execute(delete(Membership))
             await db.execute(delete(User))
@@ -72,6 +86,8 @@ def test_get_users_reads_presence_from_db():
             await db.commit()
             ctx = StubContext(1)
             res = await get_users(ctx=ctx, db=db)
-            assert {(u['id'], u['status']) for u in res} == {('30', 'online'), ('40', 'offline')}
+            assert {
+                (u['id'], u['status'], tuple(u['roles'])) for u in res
+            } == {('30', 'online', ()), ('40', 'offline', ())}
             break
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- include membership role IDs in `/users` and `/presences` responses
- add `roles` to presence DTOs and plugin models
- render role tags beside users in the chat member list

## Testing
- `pytest tests/test_users.py tests/test_presences.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5db870ad083289e62ccbc436bb98e