### PR TITLE
Reset presence service when chat networking restarts

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -103,6 +103,7 @@ public class ChatWindow : IDisposable
         _ws = null;
         _wsCts = new CancellationTokenSource();
         _wsTask = RunWebSocket(_wsCts.Token);
+        _presence?.Reset();
     }
 
     public void StopNetworking()
@@ -110,6 +111,7 @@ public class ChatWindow : IDisposable
         _wsCts?.Cancel();
         _ws?.Dispose();
         _ws = null;
+        _presence?.Reset();
     }
 
     public virtual void Draw()

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -89,7 +89,6 @@ public class SettingsWindow : IDisposable
                         if (enableFc)
                         {
                             ChatWindow.StartNetworking();
-                            ChatWindow.Presence?.Reset();
                         }
                         else
                         {


### PR DESCRIPTION
## Summary
- Re-establish presence WebSocket whenever chat networking starts or stops
- Let chat window manage presence lifecycle directly when FC chat is toggled

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e35b56888328a93607ae097a7967