### PR TITLE
Add Syncshell resync and cache endpoints

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -52,6 +52,12 @@ public class Config : IPluginConfiguration
         [JsonPropertyName("seenAssets")]
         public HashSet<string> SeenAssets { get; set; } = new();
 
+        [JsonPropertyName("paused")]
+        public bool Paused { get; set; }
+
+        [JsonPropertyName("lastResyncAt")]
+        public DateTimeOffset? LastResyncAt { get; set; }
+
         [JsonExtensionData]
         public Dictionary<string, JsonElement>? ExtensionData { get; set; }
     }

--- a/tests/test_syncshell_resync_cache.py
+++ b/tests/test_syncshell_resync_cache.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from demibot.db.session import init_db, get_session
+from demibot.db.models import User, SyncshellManifest
+from demibot.http.deps import RequestContext
+from demibot.http.routes.syncshell import upload_manifest, resync, clear_cache
+
+
+def test_resync_and_cache_clear():
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            user = User(id=1, discord_user_id=1, global_name="Test")
+            db.add(user)
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            manifest = [{"id": "a"}]
+            await upload_manifest(manifest, ctx=ctx, db=db)
+            assert await db.get(SyncshellManifest, 1) is not None
+
+            await clear_cache(ctx=ctx, db=db)
+            assert await db.get(SyncshellManifest, 1) is None
+
+            await upload_manifest(manifest, ctx=ctx, db=db)
+            assert await db.get(SyncshellManifest, 1) is not None
+
+            await resync(ctx=ctx, db=db)
+            assert await db.get(SyncshellManifest, 1) is None
+            break
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add persisted Syncshell pause and resync state
- wire up Syncshell window controls and manifest upload helpers
- add `/api/syncshell/resync` and `/api/syncshell/cache` endpoints
- cover resync and cache clearing with unit tests

## Testing
- `/usr/share/dotnet/dotnet test` *(fails: Dalamud installation not found)*
- `pytest` *(fails: missing modules like discord)*
- `PYTHONPATH=demibot pytest tests/test_syncshell_resync_cache.py` *(fails: ModuleNotFoundError: aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_68b8328e7d088328b167add89115f237