### PR TITLE
Add Syncshell token expiry and persistent rate limiting

### DIFF
--- a/demibot/demibot/db/migrations/versions/0030_add_syncshell_rate_limit_and_expiry.py
+++ b/demibot/demibot/db/migrations/versions/0030_add_syncshell_rate_limit_and_expiry.py
@@ -1,0 +1,38 @@
+"""add syncshell rate limit and pairing expiry
+
+Revision ID: 0030_add_syncshell_rate_limit_and_expiry
+Revises: 0029_add_syncshell_tables
+Create Date: 2025-01-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.mysql import BIGINT
+
+# revision identifiers, used by Alembic.
+revision = "0030_add_syncshell_rate_limit_and_expiry"
+down_revision = "0029_add_syncshell_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("syncshell_pairings", sa.Column("expires_at", sa.DateTime(), nullable=False))
+    op.create_index(
+        "ix_syncshell_pairings_expires_at",
+        "syncshell_pairings",
+        ["expires_at"],
+        unique=False,
+    )
+    op.create_table(
+        "syncshell_rate_limits",
+        sa.Column("user_id", BIGINT(unsigned=True), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column("requests", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("window_start", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("syncshell_rate_limits")
+    op.drop_index("ix_syncshell_pairings_expires_at", table_name="syncshell_pairings")
+    op.drop_column("syncshell_pairings", "expires_at")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -176,6 +176,7 @@ class SyncshellPairing(Base):
     )
     token: Mapped[str] = mapped_column(String(64), unique=True, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, index=True)
 
 
 class SyncshellManifest(Base):
@@ -189,6 +190,16 @@ class SyncshellManifest(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )
+
+
+class SyncshellRateLimit(Base):
+    __tablename__ = "syncshell_rate_limits"
+
+    user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True
+    )
+    requests: Mapped[int] = mapped_column(Integer, default=0)
+    window_start: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
 class Message(Base):

--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -1,35 +1,47 @@
 from __future__ import annotations
 
-import time
+import os
 from uuid import uuid4
 from typing import Any
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ...db.models import SyncshellPairing, SyncshellManifest
+from ...db.models import SyncshellPairing, SyncshellManifest, SyncshellRateLimit
 from ..vault import presign_upload, presign_download
 
 
 router = APIRouter(prefix="/api/syncshell", tags=["syncshell"])
 
-_rate_limiter: dict[int, list[float]] = {}
-
-RATE_LIMIT = 30  # max requests per minute per user
+RATE_LIMIT = int(os.getenv("SYNC_SHELL_MAX_REQUESTS_PER_MINUTE", "30"))
+TOKEN_TTL = int(os.getenv("SYNC_SHELL_TOKEN_TTL", "300"))  # seconds
 MAX_MANIFEST_BYTES = 1024 * 1024  # 1 MiB manifest payload cap
 
 
-def _check_rate_limit(user_id: int) -> None:
-    """Very small in-memory rate limiter."""
-    now = time.time()
-    bucket = _rate_limiter.setdefault(user_id, [])
-    bucket[:] = [t for t in bucket if now - t < 60]
-    if len(bucket) >= RATE_LIMIT:
-        raise HTTPException(status_code=429, detail="rate limit exceeded")
-    bucket.append(now)
+async def _check_rate_limit(user_id: int, db: AsyncSession) -> None:
+    now = datetime.utcnow()
+    record = await db.get(SyncshellRateLimit, user_id)
+    if record and (now - record.window_start).total_seconds() < 60:
+        if record.requests >= RATE_LIMIT:
+            raise HTTPException(status_code=429, detail="rate limit exceeded")
+        record.requests += 1
+    else:
+        if record:
+            record.requests = 1
+            record.window_start = now
+        else:
+            record = SyncshellRateLimit(user_id=user_id, requests=1, window_start=now)
+            db.add(record)
+    await db.commit()
+
+
+async def _require_pairing(ctx: RequestContext, db: AsyncSession) -> None:
+    pairing = await db.get(SyncshellPairing, ctx.user.id)
+    if not pairing or pairing.expires_at < datetime.utcnow():
+        raise HTTPException(status_code=401, detail="pairing token expired")
 
 
 @router.post("/pair")
@@ -38,14 +50,20 @@ async def pair(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Issue a short-lived pairing token for a client."""
-    _check_rate_limit(ctx.user.id)
+    await _check_rate_limit(ctx.user.id, db)
     token = uuid4().hex
     pairing = await db.get(SyncshellPairing, ctx.user.id)
     if pairing:
         pairing.token = token
         pairing.created_at = datetime.utcnow()
+        pairing.expires_at = datetime.utcnow() + timedelta(seconds=TOKEN_TTL)
     else:
-        pairing = SyncshellPairing(user_id=ctx.user.id, token=token)
+        pairing = SyncshellPairing(
+            user_id=ctx.user.id,
+            token=token,
+            created_at=datetime.utcnow(),
+            expires_at=datetime.utcnow() + timedelta(seconds=TOKEN_TTL),
+        )
         db.add(pairing)
     await db.commit()
     return {"token": token}
@@ -62,7 +80,8 @@ async def upload_manifest(
     The manifest is capped in size to prevent excessive memory usage and
     naive clients from overwhelming the API.
     """
-    _check_rate_limit(ctx.user.id)
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
     payload_size = len(str(manifest).encode())
     if payload_size > MAX_MANIFEST_BYTES:
         raise HTTPException(status_code=413, detail="manifest too large")
@@ -81,9 +100,11 @@ async def upload_manifest(
 @router.post("/asset/upload")
 async def request_asset_upload(
     ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
     """Return a pre-signed URL for chunked asset upload."""
-    _check_rate_limit(ctx.user.id)
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
     try:
         url = await presign_upload()
     except Exception as e:  # pragma: no cover - network failure
@@ -93,10 +114,13 @@ async def request_asset_upload(
 
 @router.get("/asset/download/{asset_id}")
 async def request_asset_download(
-    asset_id: str, ctx: RequestContext = Depends(api_key_auth)
+    asset_id: str,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
     """Return a pre-signed URL for asset download."""
-    _check_rate_limit(ctx.user.id)
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
     try:
         url = await presign_download(asset_id)
     except Exception as e:  # pragma: no cover - network failure
@@ -116,7 +140,8 @@ async def resync(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
-    _check_rate_limit(ctx.user.id)
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
     await _clear_manifest(ctx, db)
     return {"status": "ok"}
 
@@ -126,6 +151,7 @@ async def clear_cache(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
-    _check_rate_limit(ctx.user.id)
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
     await _clear_manifest(ctx, db)
     return {"status": "ok"}

--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -21,6 +21,7 @@ from .http.discord_client import set_discord_client
 from .repeat_events import recurring_event_poster
 from .channel_names import channel_name_resync
 from .asset_cleanup import purge_deleted_assets
+from .syncshell_cleanup import prune_syncshell
 
 
 async def main_async() -> None:
@@ -80,6 +81,7 @@ async def main_async() -> None:
             recurring_event_poster(),
             channel_name_resync(),
             purge_deleted_assets(),
+            prune_syncshell(),
         )
     except Exception:
         logging.exception("Failed to start services")

--- a/demibot/demibot/syncshell_cleanup.py
+++ b/demibot/demibot/syncshell_cleanup.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+from sqlalchemy import delete
+
+from .db.session import get_session
+from .db.models import SyncshellPairing, SyncshellRateLimit
+
+PRUNE_INTERVAL = 60
+
+
+async def prune_syncshell_once() -> None:
+    async for db in get_session():
+        now = datetime.utcnow()
+        await db.execute(delete(SyncshellPairing).where(SyncshellPairing.expires_at < now))
+        cutoff = now - timedelta(minutes=5)
+        await db.execute(
+            delete(SyncshellRateLimit).where(SyncshellRateLimit.window_start < cutoff)
+        )
+        await db.commit()
+        break
+
+
+async def prune_syncshell() -> None:
+    while True:
+        try:
+            await prune_syncshell_once()
+        except Exception:  # pragma: no cover - best effort
+            logging.exception("Syncshell cleanup failed")
+        await asyncio.sleep(PRUNE_INTERVAL)

--- a/tests/test_syncshell_limits.py
+++ b/tests/test_syncshell_limits.py
@@ -1,0 +1,60 @@
+import asyncio
+import pytest
+
+from demibot.db.session import init_db, get_session
+import demibot.db.session as db_session
+from demibot.db.models import User
+from demibot.http.deps import RequestContext
+import importlib.util
+import sys
+from pathlib import Path
+
+syncshell_path = (
+    Path(__file__).resolve().parents[1] / "demibot" / "demibot" / "http" / "routes" / "syncshell.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "demibot.http.routes.syncshell", syncshell_path
+)
+syncshell = importlib.util.module_from_spec(spec)
+sys.modules["demibot.http.routes.syncshell"] = syncshell
+spec.loader.exec_module(syncshell)
+
+
+def test_token_expiry():
+    async def _run():
+        db_session._engine = None
+        db_session._Session = None
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            user = User(id=2, discord_user_id=2, global_name="Test2")
+            db.add(user)
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.TOKEN_TTL = 1
+            await syncshell.pair(ctx=ctx, db=db)
+            await asyncio.sleep(1.1)
+            with pytest.raises(syncshell.HTTPException):
+                await syncshell.upload_manifest([], ctx=ctx, db=db)
+            break
+    asyncio.run(_run())
+
+
+def test_rate_limit_hits():
+    async def _run():
+        db_session._engine = None
+        db_session._Session = None
+        await init_db("sqlite+aiosqlite://")
+        async for db in get_session():
+            user = User(id=1, discord_user_id=1, global_name="Test")
+            db.add(user)
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.RATE_LIMIT = 2
+            await syncshell.pair(ctx=ctx, db=db)
+            await syncshell.upload_manifest([], ctx=ctx, db=db)
+            with pytest.raises(syncshell.HTTPException):
+                await syncshell.resync(ctx=ctx, db=db)
+            break
+    asyncio.run(_run())

--- a/tests/test_syncshell_resync_cache.py
+++ b/tests/test_syncshell_resync_cache.py
@@ -1,13 +1,28 @@
 import asyncio
 
 from demibot.db.session import init_db, get_session
+import demibot.db.session as db_session
 from demibot.db.models import User, SyncshellManifest
 from demibot.http.deps import RequestContext
-from demibot.http.routes.syncshell import upload_manifest, resync, clear_cache
+import importlib.util
+import sys
+from pathlib import Path
+
+syncshell_path = (
+    Path(__file__).resolve().parents[1] / "demibot" / "demibot" / "http" / "routes" / "syncshell.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "demibot.http.routes.syncshell", syncshell_path
+)
+syncshell = importlib.util.module_from_spec(spec)
+sys.modules["demibot.http.routes.syncshell"] = syncshell
+spec.loader.exec_module(syncshell)
 
 
 def test_resync_and_cache_clear():
     async def _run():
+        db_session._engine = None
+        db_session._Session = None
         await init_db("sqlite+aiosqlite://")
         async for db in get_session():
             user = User(id=1, discord_user_id=1, global_name="Test")
@@ -16,16 +31,17 @@ def test_resync_and_cache_clear():
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
             manifest = [{"id": "a"}]
-            await upload_manifest(manifest, ctx=ctx, db=db)
+            await syncshell.pair(ctx=ctx, db=db)
+            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert await db.get(SyncshellManifest, 1) is not None
 
-            await clear_cache(ctx=ctx, db=db)
+            await syncshell.clear_cache(ctx=ctx, db=db)
             assert await db.get(SyncshellManifest, 1) is None
 
-            await upload_manifest(manifest, ctx=ctx, db=db)
+            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert await db.get(SyncshellManifest, 1) is not None
 
-            await resync(ctx=ctx, db=db)
+            await syncshell.resync(ctx=ctx, db=db)
             assert await db.get(SyncshellManifest, 1) is None
             break
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add `expires_at` to `SyncshellPairing` and new `SyncshellRateLimit` model
- enforce pairing token TTL and DB-backed rate limiting in Syncshell routes
- schedule cleanup job to prune expired pairings and rate limit rows
- add tests for token expiration and rate limiting

## Testing
- `PYTHONPATH=demibot pytest tests/test_syncshell_resync_cache.py tests/test_syncshell_limits.py -q -W ignore::DeprecationWarning`

------
https://chatgpt.com/codex/tasks/task_e_68b834e4287c8328b6f9bfa0cd611bb7