### PR TITLE
feat: enforce camelCase JSON field naming

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -714,7 +714,7 @@ public class ChatWindow : IDisposable
         try
         {
             long? cid = long.TryParse(channelId, out var parsed) ? parsed : null;
-            var body = new { MessageId = messageId, ChannelId = cid, CustomId = customId };
+            var body = new { messageId = messageId, channelId = cid, customId = customId };
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/interactions");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
             ApiHelpers.AddAuthHeader(request, _config);

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -339,7 +339,7 @@ public class EventView : IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/interactions");
-            var body = new { MessageId = _dto.Id, ChannelId = _dto.ChannelId, CustomId = customId };
+            var body = new { messageId = _dto.Id, channelId = _dto.ChannelId, customId = customId };
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
             ApiHelpers.AddAuthHeader(request, _config);
             var response = await _httpClient.SendAsync(request);

--- a/DemiCatPlugin/PresenceDto.cs
+++ b/DemiCatPlugin/PresenceDto.cs
@@ -9,7 +9,7 @@ public class PresenceDto
     [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
     [JsonPropertyName("status")] public string Status { get; set; } = string.Empty;
-    [JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; }
+    [JsonPropertyName("avatarUrl")] public string? AvatarUrl { get; set; }
     [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
     [JsonPropertyName("roles")] public List<string> Roles { get; set; } = new();
 }

--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -82,13 +82,13 @@ internal static class RequestStateService
                 var title = payload.TryGetProperty("title", out var titleEl) ? titleEl.GetString() ?? "Request" : "Request";
                 var statusString = payload.TryGetProperty("status", out var statusEl) ? statusEl.GetString() : null;
                 var version = payload.TryGetProperty("version", out var verEl) ? verEl.GetInt32() : 0;
-                var itemId = payload.TryGetProperty("item_id", out var itemEl) ? itemEl.GetUInt32() : (uint?)null;
-                var dutyId = payload.TryGetProperty("duty_id", out var dutyEl) ? dutyEl.GetUInt32() : (uint?)null;
+                var itemId = payload.TryGetProperty("itemId", out var itemEl) ? itemEl.GetUInt32() : (uint?)null;
+                var dutyId = payload.TryGetProperty("dutyId", out var dutyEl) ? dutyEl.GetUInt32() : (uint?)null;
                 var hq = payload.TryGetProperty("hq", out var hqEl) && hqEl.GetBoolean();
                 var quantity = payload.TryGetProperty("quantity", out var qtyEl) ? qtyEl.GetInt32() : 0;
-                var assigneeId = payload.TryGetProperty("assignee_id", out var aEl) ? aEl.GetUInt32() : (uint?)null;
+                var assigneeId = payload.TryGetProperty("assigneeId", out var aEl) ? aEl.GetUInt32() : (uint?)null;
                 var description = payload.TryGetProperty("description", out var descEl) ? descEl.GetString() ?? string.Empty : string.Empty;
-                var createdBy = payload.TryGetProperty("created_by", out var cbEl) ? cbEl.GetString() ?? string.Empty : string.Empty;
+                var createdBy = payload.TryGetProperty("createdBy", out var cbEl) ? cbEl.GetString() ?? string.Empty : string.Empty;
                 DateTime createdAt = DateTime.MinValue;
                 if (payload.TryGetProperty("created", out var cEl))
                     cEl.TryGetDateTime(out createdAt);

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 DemiCat connects Final Fantasy XIV with Discord by embedding Apollo event posts directly into the game.
 
+All public HTTP APIs now use **camelCase** for JSON field names. Python and C# code may use snake_case or PascalCase internally, but requests and responses over the wire are consistently camelCase.
+
 ```
 DemiCat/
 ├── demibot/         # Python Discord bot and REST interface

--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -224,8 +224,8 @@ class Mirror(commands.Cog):
                     channel_id=channel_id,
                     guild_id=guild_id,
                     author_id=message.author.id,
-                    author_name=dto.authorName,
-                    author_avatar_url=dto.authorAvatarUrl,
+                    author_name=dto.author_name,
+                    author_avatar_url=dto.author_avatar_url,
                     content_raw=message.content,
                     content_display=message.content,
                     content=message.content,
@@ -320,8 +320,8 @@ class Mirror(commands.Cog):
                 msg.content = after.content
                 msg.attachments_json = fragments["attachments_json"]
                 msg.mentions_json = fragments["mentions_json"]
-                msg.author_name = dto.authorName
-                msg.author_avatar_url = dto.authorAvatarUrl
+                msg.author_name = dto.author_name
+                msg.author_avatar_url = dto.author_avatar_url
                 msg.author_json = fragments["author_json"]
                 msg.embeds_json = fragments["embeds_json"]
                 msg.reference_json = fragments["reference_json"]

--- a/demibot/demibot/http/discord_helpers.py
+++ b/demibot/demibot/http/discord_helpers.py
@@ -34,7 +34,7 @@ def attachment_to_dto(attachment: discord.Attachment) -> AttachmentDto:
     return AttachmentDto(
         url=attachment.url,
         filename=attachment.filename,
-        contentType=attachment.content_type,
+        content_type=attachment.content_type,
     )
 
 
@@ -52,8 +52,8 @@ def reaction_to_dto(reaction: discord.Reaction) -> ReactionDto:
     is_animated = getattr(emoji, "animated", False)
     return ReactionDto(
         emoji=emoji_name,
-        emojiId=str(emoji_id) if emoji_id else None,
-        isAnimated=is_animated,
+        emoji_id=str(emoji_id) if emoji_id else None,
+        is_animated=is_animated,
         count=reaction.count,
         me=reaction.me,
     )
@@ -92,7 +92,7 @@ def embed_to_dto(
         EmbedAuthorDto(
             name=a.get("name"),
             url=a.get("url"),
-            iconUrl=a.get("icon_url"),
+            icon_url=a.get("icon_url"),
         )
         for a in author_list
         if a
@@ -102,8 +102,8 @@ def embed_to_dto(
         id=str(message.id),
         timestamp=embed.timestamp,
         color=embed.color.value if embed.color else None,
-        authorName=first_author.get("name") if first_author else None,
-        authorIconUrl=first_author.get("icon_url") if first_author else None,
+        author_name=first_author.get("name") if first_author else None,
+        author_icon_url=first_author.get("icon_url") if first_author else None,
         authors=authors,
         title=embed.title,
         description=embed.description,
@@ -113,17 +113,17 @@ def embed_to_dto(
             for f in embed.fields
         ]
         or None,
-        thumbnailUrl=embed.thumbnail.url if embed.thumbnail else None,
-        imageUrl=embed.image.url if embed.image else None,
-        providerName=provider_data.get("name"),
-        providerUrl=provider_data.get("url"),
-        footerText=footer_data.get("text"),
-        footerIconUrl=footer_data.get("icon_url"),
-        videoUrl=video_data.get("url"),
-        videoWidth=video_data.get("width"),
-        videoHeight=video_data.get("height"),
+        thumbnail_url=embed.thumbnail.url if embed.thumbnail else None,
+        image_url=embed.image.url if embed.image else None,
+        provider_name=provider_data.get("name"),
+        provider_url=provider_data.get("url"),
+        footer_text=footer_data.get("text"),
+        footer_icon_url=footer_data.get("icon_url"),
+        video_url=video_data.get("url"),
+        video_width=video_data.get("width"),
+        video_height=video_data.get("height"),
         buttons=buttons or None,
-        channelId=message.channel.id if hasattr(message, "channel") else None,
+        channel_id=message.channel.id if hasattr(message, "channel") else None,
         mentions=[m.id for m in message.mentions] or None,
     )
 
@@ -150,7 +150,7 @@ def components_to_dtos(message: discord.Message) -> List[ButtonComponentDto] | N
             components.append(
                 ButtonComponentDto(
                     label=getattr(comp, "label", None),
-                    customId=getattr(comp, "custom_id", None),
+                    custom_id=getattr(comp, "custom_id", None),
                     url=getattr(comp, "url", None),
                     style=style_val,
                     emoji=emoji_str,
@@ -181,7 +181,7 @@ def extract_embed_buttons(message: discord.Message) -> List[EmbedButtonDto]:
                 emoji_str = str(emoji) if emoji else None
                 buttons.append(
                     EmbedButtonDto(
-                        customId=getattr(comp, "custom_id", None),
+                        custom_id=getattr(comp, "custom_id", None),
                         label=getattr(comp, "label", None),
                         style=style_val,
                         emoji=emoji_str,
@@ -213,7 +213,7 @@ def serialize_message(
     author = MessageAuthor(
         id=str(message.author.id),
         name=message.author.display_name or message.author.name,
-        avatarUrl=(
+        avatar_url=(
             str(message.author.display_avatar.url)
             if getattr(message.author, "display_avatar", None)
             else None
@@ -238,8 +238,8 @@ def serialize_message(
     reference_json = None
     if message.reference:
         reference = MessageReferenceDto(
-            messageId=str(message.reference.message_id),
-            channelId=str(message.reference.channel_id),
+            message_id=str(message.reference.message_id),
+            channel_id=str(message.reference.channel_id),
         )
         reference_json = reference.model_dump_json()
 
@@ -260,9 +260,9 @@ def serialize_message(
 
     dto = ChatMessage(
         id=str(message.id),
-        channelId=str(message.channel.id),
-        authorName=author.name,
-        authorAvatarUrl=author.avatarUrl,
+        channel_id=str(message.channel.id),
+        author_name=author.name,
+        author_avatar_url=author.avatar_url,
         timestamp=message.created_at,
         content=message.content,
         attachments=attachments,
@@ -272,7 +272,7 @@ def serialize_message(
         reference=reference,
         components=components,
         reactions=reactions,
-        editedTimestamp=message.edited_at,
+        edited_timestamp=message.edited_at,
     )
 
     fragments: Dict[str, str | None] = {

--- a/demibot/demibot/http/routes/interactions.py
+++ b/demibot/demibot/http/routes/interactions.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,9 +17,9 @@ router = APIRouter(prefix="/api")
 
 
 class InteractionBody(BaseModel):
-    MessageId: str
-    ChannelId: int | None = None
-    CustomId: str
+    message_id: str = Field(alias="messageId")
+    channel_id: int | None = Field(default=None, alias="channelId")
+    custom_id: str = Field(alias="customId")
 
 
 def summarize(att: Dict[str, List[str]], labels: Dict[str, str], order: List[str]) -> List[dict]:
@@ -37,8 +37,8 @@ async def post_interaction(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    choice = body.CustomId.split(":", 1)[1] if ":" in body.CustomId else body.CustomId
-    message_id = int(body.MessageId)
+    choice = body.custom_id.split(":", 1)[1] if ":" in body.custom_id else body.custom_id
+    message_id = int(body.message_id)
     embed = (
         await db.execute(select(Embed).where(Embed.discord_message_id == message_id))
     ).scalar_one_or_none()

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -60,10 +60,10 @@ async def post_message_with_attachments(
         except Exception:
             raise HTTPException(status_code=400, detail="invalid message_reference")
     body = PostBody(
-        channelId=channel_id,
+        channel_id=channel_id,
         content=content,
-        useCharacterName=useCharacterName,
-        messageReference=ref,
+        use_character_name=useCharacterName,
+        message_reference=ref,
     )
     return await save_message(body, ctx, db, is_officer=False, files=files)
 

--- a/demibot/demibot/http/routes/requests.py
+++ b/demibot/demibot/http/routes/requests.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 import logging
 import discord
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -50,11 +50,11 @@ class RequestDto(BaseModel):
     status: str
     urgency: Urgency | None = None
     version: int
-    item_id: int | None = None
-    duty_id: int | None = None
+    item_id: int | None = Field(default=None, alias="itemId")
+    duty_id: int | None = Field(default=None, alias="dutyId")
     hq: bool | None = None
     quantity: int | None = None
-    assignee_id: int | None = None
+    assignee_id: int | None = Field(default=None, alias="assigneeId")
 
 
 def _status(status: RequestStatus) -> str:

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -24,39 +24,39 @@ class ButtonStyle(IntEnum):
 class EmbedButtonDto(BaseModel):
     label: str
     url: Optional[str] = None
-    customId: Optional[str] = None
+    custom_id: Optional[str] = Field(default=None, alias="customId")
     emoji: Optional[str] = None
     style: Optional[ButtonStyle] = None
-    maxSignups: Optional[int] = None
+    max_signups: Optional[int] = Field(default=None, alias="maxSignups")
 
 
 class EmbedAuthorDto(BaseModel):
     name: Optional[str] = None
     url: Optional[str] = None
-    iconUrl: Optional[str] = None
+    icon_url: Optional[str] = Field(default=None, alias="iconUrl")
 
 class EmbedDto(BaseModel):
     id: str
     timestamp: Optional[datetime] = None
     color: Optional[int] = None
-    authorName: Optional[str] = None
-    authorIconUrl: Optional[str] = None
+    author_name: Optional[str] = Field(default=None, alias="authorName")
+    author_icon_url: Optional[str] = Field(default=None, alias="authorIconUrl")
     authors: List[EmbedAuthorDto] | None = None
     title: Optional[str] = None
     description: Optional[str] = None
     url: Optional[str] = None
     fields: List[EmbedFieldDto] | None = None
-    thumbnailUrl: Optional[str] = None
-    imageUrl: Optional[str] = None
-    providerName: Optional[str] = None
-    providerUrl: Optional[str] = None
-    footerText: Optional[str] = None
-    footerIconUrl: Optional[str] = None
-    videoUrl: Optional[str] = None
-    videoWidth: Optional[int] = None
-    videoHeight: Optional[int] = None
+    thumbnail_url: Optional[str] = Field(default=None, alias="thumbnailUrl")
+    image_url: Optional[str] = Field(default=None, alias="imageUrl")
+    provider_name: Optional[str] = Field(default=None, alias="providerName")
+    provider_url: Optional[str] = Field(default=None, alias="providerUrl")
+    footer_text: Optional[str] = Field(default=None, alias="footerText")
+    footer_icon_url: Optional[str] = Field(default=None, alias="footerIconUrl")
+    video_url: Optional[str] = Field(default=None, alias="videoUrl")
+    video_width: Optional[int] = Field(default=None, alias="videoWidth")
+    video_height: Optional[int] = Field(default=None, alias="videoHeight")
     buttons: List[EmbedButtonDto] | None = None
-    channelId: Optional[int] = None
+    channel_id: Optional[int] = Field(default=None, alias="channelId")
     mentions: List[int] | None = None
 
 # ---- Chat ----
@@ -69,12 +69,12 @@ class Mention(BaseModel):
 class AttachmentDto(BaseModel):
     url: str
     filename: Optional[str] = None
-    contentType: Optional[str] = None
+    content_type: Optional[str] = Field(default=None, alias="contentType")
 
 
 class ButtonComponentDto(BaseModel):
     label: str
-    customId: Optional[str] = None
+    custom_id: Optional[str] = Field(default=None, alias="customId")
     url: Optional[str] = None
     style: ButtonStyle
     emoji: Optional[str] = None
@@ -83,28 +83,28 @@ class ButtonComponentDto(BaseModel):
 class MessageAuthor(BaseModel):
     id: str
     name: str
-    avatarUrl: Optional[str] = None
-    useCharacterName: bool | None = False
+    avatar_url: Optional[str] = Field(default=None, alias="avatarUrl")
+    use_character_name: bool | None = Field(default=False, alias="useCharacterName")
 
 
 class ReactionDto(BaseModel):
     emoji: str
-    emojiId: str | None = None
-    isAnimated: bool
+    emoji_id: str | None = Field(default=None, alias="emojiId")
+    is_animated: bool = Field(alias="isAnimated")
     count: int
     me: bool
 
 
 class MessageReferenceDto(BaseModel):
-    messageId: str
-    channelId: str
+    message_id: str = Field(alias="messageId")
+    channel_id: str = Field(alias="channelId")
 
 
 class ChatMessage(BaseModel):
     id: str
-    channelId: str
-    authorName: str
-    authorAvatarUrl: Optional[str] = None
+    channel_id: str = Field(alias="channelId")
+    author_name: str = Field(alias="authorName")
+    author_avatar_url: Optional[str] = Field(default=None, alias="authorAvatarUrl")
     timestamp: Optional[datetime] = None
     content: str
     attachments: List[AttachmentDto] | None = None
@@ -114,8 +114,8 @@ class ChatMessage(BaseModel):
     reference: MessageReferenceDto | None = None
     components: List[ButtonComponentDto] | None = None
     reactions: List[ReactionDto] | None = None
-    editedTimestamp: Optional[datetime] = None
-    useCharacterName: bool | None = False
+    edited_timestamp: Optional[datetime] = Field(default=None, alias="editedTimestamp")
+    use_character_name: bool | None = Field(default=False, alias="useCharacterName")
 
 
 # ---- Presence ----
@@ -125,5 +125,5 @@ class PresenceDto(BaseModel):
     id: str
     name: str
     status: str
-    avatarUrl: str | None = Field(default=None, alias="avatar_url")
+    avatar_url: str | None = Field(default=None, alias="avatarUrl")
     roles: List[str] = Field(default_factory=list)

--- a/tests/test_message_components.py
+++ b/tests/test_message_components.py
@@ -59,5 +59,5 @@ def test_message_components_to_dtos():
     dto = message_to_chat_message(msg)
     assert dto.components is not None
     assert dto.components[0].label == "Test"
-    assert dto.components[0].customId == "test"
+    assert dto.components[0].custom_id == "test"
     assert dto.components[0].style == ButtonStyle.primary

--- a/tests/test_rsvp_max_signups.py
+++ b/tests/test_rsvp_max_signups.py
@@ -39,7 +39,7 @@ async def _run_test() -> None:
         await db.commit()
 
         body = CreateEventBody(
-            channelId="123",
+            channel_id="123",
             title="Test",
             time="2024-01-01T00:00:00Z",
             description="desc",
@@ -55,14 +55,14 @@ async def _run_test() -> None:
 
         ctx1 = SimpleNamespace(user=SimpleNamespace(id=1), guild=SimpleNamespace(id=1))
         await post_interaction(
-            body=InteractionBody(MessageId=result["id"], CustomId="rsvp:join"),
+            body=InteractionBody(message_id=result["id"], custom_id="rsvp:join"),
             ctx=ctx1,
             db=db,
         )
 
         ctx2 = SimpleNamespace(user=SimpleNamespace(id=2), guild=SimpleNamespace(id=1))
         resp = await post_interaction(
-            body=InteractionBody(MessageId=result["id"], CustomId="rsvp:join"),
+            body=InteractionBody(message_id=result["id"], custom_id="rsvp:join"),
             ctx=ctx2,
             db=db,
         )


### PR DESCRIPTION
## Summary
- standardize API payloads on camelCase and add Pydantic aliases for snake_case models
- align route handlers, helpers, and plugin DTOs with new naming
- document camelCase requirement in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b8397b12188328971597ff13c57418