### PR TITLE
Refactor DB session handling and test websocket cleanup

### DIFF
--- a/demibot/demibot/asset_cleanup.py
+++ b/demibot/demibot/asset_cleanup.py
@@ -13,7 +13,7 @@ PURGE_INTERVAL = 3600
 
 
 async def purge_deleted_assets_once(retention_days: int = 30) -> None:
-    async for db in get_session():
+    async with get_session() as db:
         cutoff = datetime.utcnow() - timedelta(days=retention_days)
         await db.execute(delete(Asset).where(Asset.deleted_at < cutoff))
         await db.commit()

--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -111,7 +111,7 @@ async def ensure_channel_name(
 async def resync_channel_names_once() -> None:
     """Refresh channel names for all guilds once."""
 
-    async for db in get_session():
+    async with get_session() as db:
         result = await db.execute(
             select(
                 GuildChannel.guild_id,
@@ -139,7 +139,7 @@ async def retry_null_channel_names(max_attempts: int = 3) -> None:
     logged with their guild and channel IDs for further investigation.
     """
 
-    async for db in get_session():
+    async with get_session() as db:
         unresolved: list[tuple[int, int]] = []
         for attempt in range(max_attempts):
             result = await db.execute(

--- a/demibot/demibot/db/session.py
+++ b/demibot/demibot/db/session.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import AsyncGenerator
+from typing import AsyncIterator
 
 import asyncio
 import logging
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
+from contextlib import asynccontextmanager
 
 from .base import Base
 
@@ -98,7 +99,8 @@ async def init_db(url: str) -> AsyncEngine:
         return _engine
 
 
-async def get_session() -> AsyncGenerator[AsyncSession, None]:
+@asynccontextmanager
+async def get_session() -> AsyncIterator[AsyncSession]:
     if _Session is None:
         raise RuntimeError("Engine not initialized")
     async with _Session() as session:

--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -38,7 +38,7 @@ class Admin(commands.Cog):
 
 async def _authorized_role_ids(guild_id: int) -> set[int]:
     """Return a set of Discord role IDs authorized for the guild."""
-    async for db in get_session():
+    async with get_session() as db:
         guild_res = await db.execute(
             select(Guild).where(Guild.discord_guild_id == guild_id)
         )
@@ -57,7 +57,7 @@ async def _authorized_role_ids(guild_id: int) -> set[int]:
 
 @demibot.command(name="clear", description="Delete all user records for this guild")
 async def clear_users(interaction: discord.Interaction) -> None:
-    async for db in get_session():
+    async with get_session() as db:
         guild_res = await db.execute(
             select(Guild).where(Guild.discord_guild_id == interaction.guild.id)
         )
@@ -88,7 +88,7 @@ async def clear_users(interaction: discord.Interaction) -> None:
 async def delete_asset_cmd(
     interaction: discord.Interaction, asset_id: int
 ) -> None:
-    async for db in get_session():
+    async with get_session() as db:
         result = await db.execute(select(Asset).where(Asset.id == asset_id))
         asset = result.scalar_one_or_none()
         if asset is None:
@@ -109,7 +109,7 @@ async def delete_asset_cmd(
 async def rebuild_index_cmd(
     interaction: discord.Interaction, forget: bool = False
 ) -> None:
-    async for db in get_session():
+    async with get_session() as db:
         await db.execute(delete(IndexCheckpoint))
         if forget:
             await db.execute(delete(UserInstallation))
@@ -165,7 +165,7 @@ async def key_embed(interaction: discord.Interaction) -> None:
         ) -> None:
             token = secrets.token_hex(16)
             try:
-                async for db in get_session():
+                async with get_session() as db:
                     guild_res = await db.execute(
                         select(Guild).where(
                             Guild.discord_guild_id == button_inter.guild.id
@@ -265,7 +265,7 @@ async def reset_guild(interaction: discord.Interaction) -> None:
     if interaction.user.id != interaction.guild.owner_id:
         await interaction.response.send_message("Owner only", ephemeral=True)
         return
-    async for db in get_session():
+    async with get_session() as db:
         guild_res = await db.execute(
             select(Guild).where(Guild.discord_guild_id == interaction.guild.id)
         )
@@ -300,7 +300,7 @@ async def resync_members(interaction: discord.Interaction) -> None:
         await interaction.response.send_message("Admin only", ephemeral=True)
         return
     count = 0
-    async for db in get_session():
+    async with get_session() as db:
         guild_res = await db.execute(
             select(Guild).where(Guild.discord_guild_id == interaction.guild.id)
         )
@@ -530,7 +530,7 @@ class ConfigWizard(discord.ui.View):
             )
             return
         try:
-            async for db in get_session():
+            async with get_session() as db:
                 guild_res = await db.execute(
                     select(Guild).where(Guild.discord_guild_id == self.guild.id)
                 )

--- a/demibot/demibot/discordbot/cogs/keygen.py
+++ b/demibot/demibot/discordbot/cogs/keygen.py
@@ -29,7 +29,7 @@ class KeyGen(commands.Cog):
 async def key_command(interaction: discord.Interaction) -> None:
     token = secrets.token_hex(16)
     try:
-        async for db in get_session():
+        async with get_session() as db:
             guild_res = await db.execute(
                 select(Guild).where(Guild.discord_guild_id == interaction.guild.id)
             )

--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -74,7 +74,7 @@ class Mirror(commands.Cog):
 
     async def _reconcile_channels(self) -> None:
         async with self._reconcile_lock:
-            async for db in get_session():
+            async with get_session() as db:
                 try:
                     for guild in self.bot.guilds:
                         result = await db.execute(
@@ -146,7 +146,7 @@ class Mirror(commands.Cog):
         channel_id = message.channel.id
 
         if ApolloHelper.IsApolloMessage(message):
-            async for db in get_session():
+            async with get_session() as db:
                 result = await db.execute(
                     select(GuildChannel.kind, GuildChannel.guild_id).where(
                         GuildChannel.channel_id == channel_id
@@ -203,7 +203,7 @@ class Mirror(commands.Cog):
         if message.author.bot:
             return
 
-        async for db in get_session():
+        async with get_session() as db:
             result = await db.execute(
                 select(GuildChannel.kind, GuildChannel.guild_id).where(
                     GuildChannel.channel_id == channel_id
@@ -256,7 +256,7 @@ class Mirror(commands.Cog):
     ) -> None:
         channel_id = after.channel.id
 
-        async for db in get_session():
+        async with get_session() as db:
             result = await db.execute(
                 select(GuildChannel.kind, GuildChannel.guild_id).where(
                     GuildChannel.channel_id == channel_id
@@ -344,7 +344,7 @@ class Mirror(commands.Cog):
     ) -> None:
         """Persist and broadcast reaction additions."""
 
-        async for db in get_session():
+        async with get_session() as db:
             msg = await db.get(Message, reaction.message.id)
             if msg is None:
                 break
@@ -374,7 +374,7 @@ class Mirror(commands.Cog):
     ) -> None:
         """Persist and broadcast reaction removals."""
 
-        async for db in get_session():
+        async with get_session() as db:
             msg = await db.get(Message, reaction.message.id)
             if msg is None:
                 break
@@ -402,7 +402,7 @@ class Mirror(commands.Cog):
     async def on_message_delete(self, message: discord.Message) -> None:
         channel_id = message.channel.id
 
-        async for db in get_session():
+        async with get_session() as db:
             result = await db.execute(
                 select(GuildChannel.kind, GuildChannel.guild_id).where(
                     GuildChannel.channel_id == channel_id

--- a/demibot/demibot/discordbot/cogs/presence.py
+++ b/demibot/demibot/discordbot/cogs/presence.py
@@ -33,7 +33,7 @@ class PresenceTracker(commands.Cog):
             roles=role_ids,
         )
         set_presence(member.guild.id, data)
-        async for db in get_session():
+        async with get_session() as db:
             stmt = select(DbPresence).where(
                 DbPresence.guild_id == member.guild.id,
                 DbPresence.user_id == member.id,

--- a/demibot/demibot/discordbot/cogs/vault.py
+++ b/demibot/demibot/discordbot/cogs/vault.py
@@ -99,7 +99,7 @@ class Vault(commands.Cog):
         if not message.attachments:
             return
 
-        async for db in get_session():
+        async with get_session() as db:
             fc_id = await self._get_fc_id(db, message.guild)
             uploader_id = await self._ensure_user(db, message.author)
             await db.commit()
@@ -125,7 +125,7 @@ class Vault(commands.Cog):
             except Exception:
                 errors.append(f"{attachment.filename}: failed to store file")
                 continue
-            async for db in get_session():
+            async with get_session() as db:
                 asset = await self._upsert_asset(
                     db,
                     fc_id,

--- a/demibot/demibot/http/deps.py
+++ b/demibot/demibot/http/deps.py
@@ -20,7 +20,7 @@ class RequestContext:
 
 
 async def get_db() -> AsyncSession:
-    async for session in get_session():
+    async with get_session() as session:
         yield session
 
 

--- a/demibot/demibot/http/routes/assets.py
+++ b/demibot/demibot/http/routes/assets.py
@@ -130,7 +130,7 @@ async def download_asset(
     asset_id: int | None = None,
 ):
     if asset_id is not None:
-        async for db in get_session():
+        async with get_session() as db:
             res = await db.execute(
                 select(Asset.id).where(
                     Asset.id == asset_id, Asset.deleted_at.is_(None)

--- a/demibot/demibot/http/routes/presences.py
+++ b/demibot/demibot/http/routes/presences.py
@@ -25,7 +25,7 @@ async def list_presences(
 ) -> list[dict[str, str | list[str] | None]]:
     db_presences: list[dict[str, str | list[str] | None]] | None = None
     try:
-        async for db in get_session():
+        async with get_session() as db:
             result = await db.execute(
                 select(DbPresence, User, Role.discord_role_id)
                 .join(User, User.discord_user_id == DbPresence.user_id, isouter=True)

--- a/demibot/demibot/http/ws.py
+++ b/demibot/demibot/http/ws.py
@@ -127,7 +127,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     token = header_token
 
     ctx: RequestContext | None = None
-    async for db in get_session():
+    async with get_session() as db:
         try:
             ctx = await api_key_auth(
                 x_api_key=token,
@@ -143,7 +143,8 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
             )
             await websocket.close(code=1008, reason="auth failed")
             return
-        break
+        finally:
+            await db.close()
 
     if ctx is None:
         logging.error("WS %s api_key_auth returned no context", path)

--- a/demibot/demibot/repeat_events.py
+++ b/demibot/demibot/repeat_events.py
@@ -15,7 +15,7 @@ from .http.discord_client import discord_client
 
 
 async def process_recurring_events_once() -> None:
-    async for db in get_session():
+    async with get_session() as db:
         now = datetime.utcnow()
         res = await db.execute(select(RecurringEvent))
         events = list(res.scalars())

--- a/demibot/demibot/syncshell_cleanup.py
+++ b/demibot/demibot/syncshell_cleanup.py
@@ -13,7 +13,7 @@ PRUNE_INTERVAL = 60
 
 
 async def prune_syncshell_once() -> None:
-    async for db in get_session():
+    async with get_session() as db:
         now = datetime.utcnow()
         await db.execute(delete(SyncshellPairing).where(SyncshellPairing.expires_at < now))
         cutoff = now - timedelta(minutes=5)

--- a/demibot/scripts/refresh_channels.py
+++ b/demibot/scripts/refresh_channels.py
@@ -12,7 +12,7 @@ from demibot.db.session import get_session, init_db
 async def _refresh() -> None:
     cfg = await ensure_config()
     await init_db(cfg.database.url)
-    async for db in get_session():
+    async with get_session() as db:
         result = await db.execute(
             select(
                 GuildChannel.guild_id,

--- a/tests/test_apollo_embed.py
+++ b/tests/test_apollo_embed.py
@@ -73,7 +73,7 @@ async def _run_test() -> None:
     bot = DummyBot(url)
     Mirror(bot)  # initializes DB
 
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
@@ -87,7 +87,7 @@ async def _run_test() -> None:
     mirror = Mirror(bot)
     await mirror.on_message(msg)
 
-    async for db in get_session():
+    async with get_session() as db:
         row = (
             await db.execute(
                 select(Embed).where(Embed.discord_message_id == msg.id)

--- a/tests/test_asset_purge.py
+++ b/tests/test_asset_purge.py
@@ -11,7 +11,7 @@ from demibot.asset_cleanup import purge_deleted_assets_once
 def test_purge_deleted_assets_once():
     async def _run():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             old = Asset(
                 id=1,
                 kind=AssetKind.FILE,

--- a/tests/test_assets_bundles_etag.py
+++ b/tests/test_assets_bundles_etag.py
@@ -32,7 +32,7 @@ def _override_auth(user):
 
 def _get_last_pull(user_id=1, fc_id=1):
     async def _run():
-        async for db in get_session():
+        async with get_session() as db:
             res = await db.execute(
                 select(FcUser.last_pull_at).where(
                     FcUser.fc_id == fc_id, FcUser.user_id == user_id
@@ -74,7 +74,7 @@ def test_assets_etag_and_last_pull():
 
     async def _setup():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             db.add_all([user, fc, fcu, dep_asset, asset, dep_rel, cp])
             await db.commit()
             break
@@ -125,7 +125,7 @@ def test_bundles_etag_and_last_pull():
 
     async def _setup():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             db.add_all([user, fc, fcu, asset, bundle, item, cp])
             await db.commit()
             break

--- a/tests/test_channel_name_retry.py
+++ b/tests/test_channel_name_retry.py
@@ -22,7 +22,7 @@ def _setup_db(path: str) -> None:
     asyncio.run(init_db(url))
 
     async def populate() -> None:
-        async for db in get_session():
+        async with get_session() as db:
             guild = Guild(id=1, discord_guild_id=1, name="Test")
             db.add(guild)
             db.add(GuildChannel(guild_id=guild.id, channel_id=100, kind="event", name=None))
@@ -53,7 +53,7 @@ def test_fetch_channel_updates_name(monkeypatch):
     monkeypatch.setattr(cn.manager, "broadcast_text", dummy_broadcast)
 
     async def run() -> str | None:
-        async for db in get_session():
+        async with get_session() as db:
             await cn.ensure_channel_name(db, 1, 100, "event", None)
             row = (
                 await db.execute(
@@ -107,7 +107,7 @@ def test_rest_fallback_updates_name(monkeypatch):
     monkeypatch.setattr(cn.manager, "broadcast_text", dummy_broadcast)
 
     async def run() -> str | None:
-        async for db in get_session():
+        async with get_session() as db:
             await cn.ensure_channel_name(db, 1, 100, "event", None)
             row = (
                 await db.execute(
@@ -140,7 +140,7 @@ def test_retry_null_channel_names_logs_failure(caplog):
     asyncio.run(cn.retry_null_channel_names(max_attempts=2))
 
     async def get_name() -> str | None:
-        async for db in get_session():
+        async with get_session() as db:
             row = (
                 await db.execute(
                     select(GuildChannel.name).where(

--- a/tests/test_channels_endpoint.py
+++ b/tests/test_channels_endpoint.py
@@ -18,7 +18,7 @@ def _setup_db(path: str) -> None:
     asyncio.run(init_db(url))
 
     async def populate() -> None:
-        async for db in get_session():
+        async with get_session() as db:
             guild = Guild(id=1, discord_guild_id=1, name="Test")
             db.add(guild)
             db.add(
@@ -49,7 +49,7 @@ def test_get_channels_returns_placeholder_and_flags_retry(monkeypatch):
         pass
 
     async def run():
-        async for db in get_session():
+        async with get_session() as db:
             guild = (await db.execute(select(Guild).where(Guild.id == 1))).scalar_one()
             ctx = RequestContext(user=Dummy(), guild=guild, key=Dummy(), roles=[])
             resp = await channel_routes.get_channels(ctx=ctx, db=db)

--- a/tests/test_create_event_mentions.py
+++ b/tests/test_create_event_mentions.py
@@ -51,7 +51,7 @@ async def _run_test() -> None:
         db_path.unlink()
     url = f"sqlite+aiosqlite:///{db_path}"
     await init_db(url)
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
@@ -67,7 +67,7 @@ async def _run_test() -> None:
     )
     ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
     client = DummyClient()
-    async for db in get_session():
+    async with get_session() as db:
         original_dumps = json.dumps
         with patch("demibot.http.routes.events.json.dumps", lambda obj, *a, **k: original_dumps(obj, default=str, *a, **k)):
             with patch("demibot.http.routes.events.discord_client", client):

--- a/tests/test_create_event_source.py
+++ b/tests/test_create_event_source.py
@@ -29,7 +29,7 @@ async def _run_test() -> None:
         db_path.unlink()
     url = f"sqlite+aiosqlite:///{db_path}"
     await init_db(url)
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
@@ -43,7 +43,7 @@ async def _run_test() -> None:
         description="desc",
     )
     ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
-    async for db in get_session():
+    async with get_session() as db:
         original_dumps = json.dumps
         with patch(
             "demibot.http.routes.events.json.dumps",

--- a/tests/test_delta_token.py
+++ b/tests/test_delta_token.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 def test_delta_token_updates_last_pull():
     async def _run():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             user = User(id=1, discord_user_id=1, global_name="Test")
             guild = Guild(id=1, discord_guild_id=1, name="Guild")
             fc = Fc(id=1, name="FC", world="World")

--- a/tests/test_discord_id_header.py
+++ b/tests/test_discord_id_header.py
@@ -32,7 +32,7 @@ def test_x_discord_id_overrides_user(tmp_path):
     asyncio.run(init_db(f"sqlite+aiosqlite:///{db_path}"))
 
     async def populate():
-        async for db in get_session():
+        async with get_session() as db:
             guild = Guild(id=1, discord_guild_id=1, name="Test")
             svc = User(id=1, discord_user_id=10)
             user = User(id=2, discord_user_id=20)
@@ -57,7 +57,7 @@ def test_x_discord_id_overrides_user(tmp_path):
     asyncio.run(populate())
 
     async def run():
-        async for db in get_session():
+        async with get_session() as db:
             ctx = await api_key_auth(x_api_key="svc", x_discord_id=20, db=db)
             return ctx.user.id
 
@@ -72,7 +72,7 @@ def test_x_discord_id_requires_officer(tmp_path):
     asyncio.run(init_db(f"sqlite+aiosqlite:///{db_path}"))
 
     async def populate():
-        async for db in get_session():
+        async with get_session() as db:
             guild = Guild(id=1, discord_guild_id=1, name="Test")
             svc = User(id=1, discord_user_id=10)
             user = User(id=2, discord_user_id=20)
@@ -84,7 +84,7 @@ def test_x_discord_id_requires_officer(tmp_path):
     asyncio.run(populate())
 
     async def run():
-        async for db in get_session():
+        async with get_session() as db:
             await api_key_auth(x_api_key="svc", x_discord_id=20, db=db)
 
     with pytest.raises(HTTPException) as exc:

--- a/tests/test_embeds_filters.py
+++ b/tests/test_embeds_filters.py
@@ -22,7 +22,7 @@ async def _run_test() -> None:
         db_path.unlink()
     url = f"sqlite+aiosqlite:///{db_path}"
     await init_db(url)
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test")
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=10, kind="event"))
@@ -34,7 +34,7 @@ async def _run_test() -> None:
         break
 
     ctx = SimpleNamespace(guild=SimpleNamespace(id=1), roles=["officer"])
-    async for db in get_session():
+    async with get_session() as db:
         res = await get_embeds(ctx=ctx, db=db, channel_id=10)
         assert len(res) == 2
         assert all(e["channelId"] == 10 for e in res)

--- a/tests/test_event_update.py
+++ b/tests/test_event_update.py
@@ -34,7 +34,7 @@ async def _run_test() -> None:
     constant = datetime(2024, 1, 1)
     eid = str(int(constant.timestamp() * 1000))
 
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test")
         db.add(guild)
         db.add(GuildChannel(guild_id=1, channel_id=123, kind="event"))
@@ -49,7 +49,7 @@ async def _run_test() -> None:
         description="desc",
     )
 
-    async for db in get_session():
+    async with get_session() as db:
         original_dumps = json.dumps
         with patch(
             "demibot.http.routes.events.json.dumps",
@@ -67,7 +67,7 @@ async def _run_test() -> None:
         time="2024-01-01T00:00:00Z",
         description="desc",
     )
-    async for db in get_session():
+    async with get_session() as db:
         original_dumps = json.dumps
         with patch(
             "demibot.http.routes.events.json.dumps",

--- a/tests/test_forget_me.py
+++ b/tests/test_forget_me.py
@@ -21,7 +21,7 @@ from demibot.http.routes.user_settings import forget_me
 def test_forget_me_scrubs_user_and_assets():
     async def _run():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             user = User(
                 id=1,
                 discord_user_id=1,

--- a/tests/test_guild_roles.py
+++ b/tests/test_guild_roles.py
@@ -26,7 +26,7 @@ async def _run_test() -> None:
         db_path.unlink()
     url = f"sqlite+aiosqlite:///{db_path}"
     await init_db(url)
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
         db.add(Role(guild_id=guild.id, discord_role_id=10, name="Alpha"))

--- a/tests/test_installations.py
+++ b/tests/test_installations.py
@@ -23,7 +23,7 @@ from demibot.http.routes.installations import (
 def test_installations_flow():
     async def _run():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             user = User(id=1, discord_user_id=1, global_name="Test")
             guild = Guild(id=1, discord_guild_id=1, name="Guild")
             asset = Asset(id=1, kind=AssetKind.FILE, name="A", hash="h", size=1)

--- a/tests/test_key_generation_roles.py
+++ b/tests/test_key_generation_roles.py
@@ -65,7 +65,7 @@ async def _setup_db() -> None:
         db_path.unlink()
     url = f"sqlite+aiosqlite:///{db_path}"
     await init_db(url)
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
         db.add(
@@ -105,7 +105,7 @@ async def _generate(user_roles):
     button_inter = ButtonInteraction(user)
     await view.children[0].callback(button_inter)
 
-    async for db in get_session():
+    async with get_session() as db:
         user_row = (
             await db.execute(select(User).where(User.discord_user_id == user.id))
         ).scalar_one()

--- a/tests/test_manifest_dependencies.py
+++ b/tests/test_manifest_dependencies.py
@@ -31,7 +31,7 @@ def test_manifest_declared_dependencies():
 
     async def _run():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             user = User(id=1, discord_user_id=1)
             fc = Fc(id=1, name="FC", world="World")
             fcu = FcUser(fc_id=1, user_id=1, joined_at=datetime.utcnow())

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -18,7 +18,7 @@ class DummyKey:
 def test_save_and_fetch_messages(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
             db.add(User(id=1, discord_user_id=10, global_name="Alice"))
             await db.commit()
@@ -52,7 +52,7 @@ def test_save_and_fetch_messages(monkeypatch):
 def test_officer_flow(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
             db.add(User(id=1, discord_user_id=10, global_name="Alice"))
             await db.commit()
@@ -86,7 +86,7 @@ def test_officer_flow(monkeypatch):
 def test_officer_requires_role(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
             db.add(User(id=1, discord_user_id=10, global_name="Alice"))
             await db.commit()
@@ -107,7 +107,7 @@ def test_officer_requires_role(monkeypatch):
 def test_fetch_messages_pagination():
     async def _run():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
             db.add(User(id=1, discord_user_id=10, global_name="Alice"))
             await db.commit()

--- a/tests/test_presences.py
+++ b/tests/test_presences.py
@@ -97,7 +97,7 @@ def test_list_presences_reads_from_db():
         db_session._Session = None
         url = "sqlite+aiosqlite://"
         await init_db(url)
-        async for db in get_session():
+        async with get_session() as db:
             db.add(User(id=1, discord_user_id=10, global_name="Alice"))
             db.add(User(id=2, discord_user_id=20, global_name="Bob"))
             db.add(DbPresence(guild_id=1, user_id=10, status="online"))

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -84,7 +84,7 @@ def test_add_reaction_success():
         session_module._engine = None
         session_module._Session = None
         await init_db(f"sqlite+aiosqlite:///{db_path}")
-        async for db in get_session():
+        async with get_session() as db:
             db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
             db.add(User(id=1, discord_user_id=10, global_name="Alice"))
             db.add(
@@ -120,7 +120,7 @@ def test_add_reaction_not_found():
         session_module._engine = None
         session_module._Session = None
         await init_db(f"sqlite+aiosqlite:///{db_path}")
-        async for db in get_session():
+        async with get_session() as db:
             db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
             db.add(User(id=1, discord_user_id=10, global_name="Alice"))
             db.add(
@@ -155,7 +155,7 @@ def test_add_reaction_forbidden():
         session_module._engine = None
         session_module._Session = None
         await init_db(f"sqlite+aiosqlite:///{db_path}")
-        async for db in get_session():
+        async with get_session() as db:
             db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
             db.add(User(id=1, discord_user_id=10, global_name="Alice"))
             db.add(

--- a/tests/test_recurring_events.py
+++ b/tests/test_recurring_events.py
@@ -31,7 +31,7 @@ async def _run_test() -> None:
         db_path.unlink()
     url = f"sqlite+aiosqlite:///{db_path}"
     await init_db(url)
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test")
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
@@ -46,7 +46,7 @@ async def _run_test() -> None:
         repeat="daily",
     )
     ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
-    async for db in get_session():
+    async with get_session() as db:
         original_dumps = json.dumps
         with patch(
             "demibot.http.routes.events.json.dumps",
@@ -60,7 +60,7 @@ async def _run_test() -> None:
 
     await process_recurring_events_once()
 
-    async for db in get_session():
+    async with get_session() as db:
         embeds = (await db.execute(select(Embed))).scalars().all()
         assert len(embeds) == 2
         row = (await db.execute(select(RecurringEvent))).scalar_one()

--- a/tests/test_request_status_permissions.py
+++ b/tests/test_request_status_permissions.py
@@ -46,7 +46,7 @@ import demibot.http.routes.requests as request_routes
 
 async def _setup_db(db_path: str) -> None:
     await init_db(f"sqlite+aiosqlite:///{db_path}")
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         requester = User(id=1, discord_user_id=1)
         assignee = User(id=2, discord_user_id=2)
@@ -75,7 +75,7 @@ def patch_broadcast(monkeypatch):
 
 def test_start_requires_assignee(db_setup):
     async def run():
-        async for db in get_session():
+        async with get_session() as db:
             guild = await db.get(Guild, 1)
             requester = await db.get(User, 1)
             assignee = await db.get(User, 2)
@@ -103,7 +103,7 @@ def test_start_requires_assignee(db_setup):
 
 def test_complete_requires_assignee(db_setup):
     async def run():
-        async for db in get_session():
+        async with get_session() as db:
             guild = await db.get(Guild, 1)
             requester = await db.get(User, 1)
             assignee = await db.get(User, 2)
@@ -131,7 +131,7 @@ def test_complete_requires_assignee(db_setup):
 
 def test_confirm_requires_requester(db_setup):
     async def run():
-        async for db in get_session():
+        async with get_session() as db:
             guild = await db.get(Guild, 1)
             requester = await db.get(User, 1)
             assignee = await db.get(User, 2)
@@ -159,7 +159,7 @@ def test_confirm_requires_requester(db_setup):
 
 def test_cancel_requires_requester(db_setup):
     async def run():
-        async for db in get_session():
+        async with get_session() as db:
             guild = await db.get(Guild, 1)
             requester = await db.get(User, 1)
             assignee = await db.get(User, 2)
@@ -187,7 +187,7 @@ def test_cancel_requires_requester(db_setup):
 
 def test_cancel_returns_dto(db_setup):
     async def run():
-        async for db in get_session():
+        async with get_session() as db:
             guild = await db.get(Guild, 1)
             requester = await db.get(User, 1)
             req = DbRequest(

--- a/tests/test_resync_membership_roles.py
+++ b/tests/test_resync_membership_roles.py
@@ -39,7 +39,7 @@ def _setup_db() -> None:
     asyncio.run(init_db(url))
 
     async def populate():
-        async for db in get_session():
+        async with get_session() as db:
             guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
             db.add(guild)
             db.add(
@@ -73,7 +73,7 @@ def test_resync_rebuilds_membership_and_roles():
     asyncio.run(admin_module.resync_members.callback(inter))
 
     async def check():
-        async for db in get_session():
+        async with get_session() as db:
             membership = (
                 await db.execute(
                     select(Membership).where(

--- a/tests/test_rsvp_max_signups.py
+++ b/tests/test_rsvp_max_signups.py
@@ -30,7 +30,7 @@ async def _run_test() -> None:
         db_path.unlink()
     url = f"sqlite+aiosqlite:///{db_path}"
     await init_db(url)
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))

--- a/tests/test_signup_presets.py
+++ b/tests/test_signup_presets.py
@@ -31,7 +31,7 @@ async def _run_test() -> None:
         db_path.unlink()
     url = f"sqlite+aiosqlite:///{db_path}"
     await init_db(url)
-    async for db in get_session():
+    async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
         await db.commit()

--- a/tests/test_syncshell_limits.py
+++ b/tests/test_syncshell_limits.py
@@ -25,7 +25,7 @@ def test_token_expiry():
         db_session._engine = None
         db_session._Session = None
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             user = User(id=2, discord_user_id=2, global_name="Test2")
             db.add(user)
             await db.commit()
@@ -45,7 +45,7 @@ def test_rate_limit_hits():
         db_session._engine = None
         db_session._Session = None
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             user = User(id=1, discord_user_id=1, global_name="Test")
             db.add(user)
             await db.commit()

--- a/tests/test_syncshell_resync_cache.py
+++ b/tests/test_syncshell_resync_cache.py
@@ -24,7 +24,7 @@ def test_resync_and_cache_clear():
         db_session._engine = None
         db_session._Session = None
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             user = User(id=1, discord_user_id=1, global_name="Test")
             db.add(user)
             await db.commit()

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -42,7 +42,7 @@ class StubContext:
 def test_get_users_includes_status_from_cache():
     async def _run():
         await init_db('sqlite+aiosqlite://')
-        async for db in get_session():
+        async with get_session() as db:
             await db.execute(delete(MembershipRole))
             await db.execute(delete(Role))
             await db.execute(delete(DbPresence))
@@ -70,7 +70,7 @@ def test_get_users_includes_status_from_cache():
 def test_get_users_reads_presence_from_db():
     async def _run():
         await init_db('sqlite+aiosqlite://')
-        async for db in get_session():
+        async with get_session() as db:
             await db.execute(delete(MembershipRole))
             await db.execute(delete(Role))
             await db.execute(delete(DbPresence))

--- a/tests/test_vault_fc_id.py
+++ b/tests/test_vault_fc_id.py
@@ -16,7 +16,7 @@ from demibot.db.session import get_session, init_db
 def test_vault_assigns_fc_id():
     async def _run():
         await init_db("sqlite+aiosqlite://")
-        async for db in get_session():
+        async with get_session() as db:
             guild = Guild(id=1, discord_guild_id=1, name="Guild")
             fc = Fc(id=1, name="FC", world="World")
             user = User(id=1, discord_user_id=1)


### PR DESCRIPTION
## Summary
- expose `get_session` as async context manager
- use `async with get_session()` in websocket endpoint with proper cleanup
- verify websocket authentication releases database sessions

## Testing
- `PYTHONPATH=demibot pytest tests/test_ws_api_key.py tests/test_officer_ws.py`

------
https://chatgpt.com/codex/tasks/task_e_68b83bfdcc8c832884084cd068387cf5