### PR TITLE
Introduce channel kind enum and plugin constants

### DIFF
--- a/DemiCatPlugin/ChannelKind.cs
+++ b/DemiCatPlugin/ChannelKind.cs
@@ -1,0 +1,10 @@
+namespace DemiCatPlugin;
+
+public static class ChannelKind
+{
+    public const string Chat = "chat";
+    public const string Event = "event";
+    public const string FcChat = "fc_chat";
+    public const string OfficerChat = "officer_chat";
+    public const string OfficerVisible = "officer_visible";
+}

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1192,6 +1192,6 @@ public class ChatWindow : IDisposable
 
     protected class ChannelListDto
     {
-        [JsonPropertyName("fc_chat")] public List<ChannelDto> Chat { get; set; } = new();
+        [JsonPropertyName(ChannelKind.FcChat)] public List<ChannelDto> Chat { get; set; } = new();
     }
 }

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -635,7 +635,7 @@ public class EventCreateWindow
 
     private class ChannelListDto
     {
-        [JsonPropertyName("event")] public List<ChannelDto> Event { get; set; } = new();
+        [JsonPropertyName(ChannelKind.Event)] public List<ChannelDto> Event { get; set; } = new();
     }
 
     private class RepeatSchedule

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -169,7 +169,7 @@ public class OfficerChatWindow : ChatWindow
 
     private class OfficerChannelListDto
     {
-        [JsonPropertyName("officer_chat")]
+        [JsonPropertyName(ChannelKind.OfficerChat)]
         public List<ChannelDto> Officer { get; set; } = new();
     }
 }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -203,6 +203,6 @@ public class Plugin : IDalamudPlugin
 
     private class ChannelListDto
     {
-        [JsonPropertyName("fc_chat")] public List<ChannelDto> Chat { get; set; } = new();
+        [JsonPropertyName(ChannelKind.FcChat)] public List<ChannelDto> Chat { get; set; } = new();
     }
 }

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -190,7 +190,7 @@ public class TemplatesWindow
 
     private class ChannelListDto
     {
-        [JsonPropertyName("event")] public List<ChannelDto> Event { get; set; } = new();
+        [JsonPropertyName(ChannelKind.Event)] public List<ChannelDto> Event { get; set; } = new();
     }
 
     private EmbedDto ToEmbedDto(Template tmpl)

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -567,7 +567,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     private class ChannelListDto
     {
-        [JsonPropertyName("event")] public List<ChannelDto> Event { get; set; } = new();
+        [JsonPropertyName(ChannelKind.Event)] public List<ChannelDto> Event { get; set; } = new();
     }
 
     public async ValueTask DisposeAsync()

--- a/demibot/demibot/db/migrations/versions/0001_initial.py
+++ b/demibot/demibot/db/migrations/versions/0001_initial.py
@@ -39,7 +39,18 @@ def upgrade() -> None:
         "guild_channels",
         sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), primary_key=True),
         sa.Column("channel_id", sa.BigInteger(), primary_key=True),
-        sa.Column("kind", sa.String(length=24), primary_key=True),
+        sa.Column(
+            "kind",
+            sa.Enum(
+                "chat",
+                "event",
+                "fc_chat",
+                "officer_chat",
+                "officer_visible",
+                name="channelkind",
+            ),
+            primary_key=True,
+        ),
     )
 
     op.create_table(

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -60,6 +60,14 @@ class InstallStatus(str, Enum):
     FAILED = "FAILED"
 
 
+class ChannelKind(str, Enum):
+    CHAT = "chat"
+    EVENT = "event"
+    FC_CHAT = "fc_chat"
+    OFFICER_CHAT = "officer_chat"
+    OFFICER_VISIBLE = "officer_visible"
+
+
 class Guild(Base):
     __tablename__ = "guilds"
 
@@ -97,7 +105,9 @@ class GuildChannel(Base):
 
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"), primary_key=True)
     channel_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
-    kind: Mapped[str] = mapped_column(String(24), primary_key=True)
+    kind: Mapped[ChannelKind] = mapped_column(
+        SAEnum(ChannelKind, validate_strings=True), primary_key=True
+    )
     name: Mapped[Optional[str]] = mapped_column(String(255))
 
 

--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -22,6 +22,7 @@ from ...db.models import (
     Asset,
     IndexCheckpoint,
     UserInstallation,
+    ChannelKind,
 )
 from ...db.session import get_session
 
@@ -574,7 +575,9 @@ class ConfigWizard(discord.ui.View):
                 await db.execute(
                     delete(GuildChannel).where(
                         GuildChannel.guild_id == guild.id,
-                        GuildChannel.kind.in_(["event", "fc_chat", "officer_chat"]),
+                        GuildChannel.kind.in_(
+                            [ChannelKind.EVENT, ChannelKind.FC_CHAT, ChannelKind.OFFICER_CHAT]
+                        ),
                     )
                 )
                 channel_name_lookup = {
@@ -585,7 +588,7 @@ class ConfigWizard(discord.ui.View):
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
-                            kind="event",
+                            kind=ChannelKind.EVENT,
                             name=channel_name_lookup.get(cid),
                         )
                     )
@@ -594,7 +597,7 @@ class ConfigWizard(discord.ui.View):
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
-                            kind="fc_chat",
+                            kind=ChannelKind.FC_CHAT,
                             name=channel_name_lookup.get(cid),
                         )
                     )
@@ -603,7 +606,7 @@ class ConfigWizard(discord.ui.View):
                         GuildChannel(
                             guild_id=guild.id,
                             channel_id=cid,
-                            kind="officer_chat",
+                            kind=ChannelKind.OFFICER_CHAT,
                             name=channel_name_lookup.get(cid),
                         )
                     )

--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from ...db.models import Embed, Guild, GuildChannel, Message
+from ...db.models import Embed, Guild, GuildChannel, Message, ChannelKind
 from ...db.session import get_session
 from ...http.schemas import EmbedButtonDto, EmbedDto
 from ...http.discord_helpers import (
@@ -118,7 +118,7 @@ class Mirror(commands.Cog):
                                     GuildChannel(
                                         guild_id=db_guild.id,
                                         channel_id=ch.id,
-                                        kind="chat",
+                                        kind=ChannelKind.CHAT,
                                         name=ch.name,
                                     )
                                 )
@@ -157,7 +157,7 @@ class Mirror(commands.Cog):
                     return  # channel not registered
 
                 kind, guild_id = row
-                is_officer = kind == "officer_chat"
+                is_officer = kind == ChannelKind.OFFICER_CHAT
 
                 stored = False
                 buttons = extract_embed_buttons(message)
@@ -214,7 +214,7 @@ class Mirror(commands.Cog):
                 return  # channel not registered
 
             kind, guild_id = row
-            is_officer = kind == "officer_chat"
+            is_officer = kind == ChannelKind.OFFICER_CHAT
 
             # Persist and broadcast the message
             dto, fragments = serialize_message(message)
@@ -267,7 +267,7 @@ class Mirror(commands.Cog):
                 return  # channel not registered
 
             kind, guild_id = row
-            is_officer = kind == "officer_chat"
+            is_officer = kind == ChannelKind.OFFICER_CHAT
 
             if after.author.bot:
                 emb_row = await db.get(Embed, after.id)
@@ -413,7 +413,7 @@ class Mirror(commands.Cog):
                 return  # channel not registered
 
             kind, guild_id = row
-            is_officer = kind == "officer_chat"
+            is_officer = kind == ChannelKind.OFFICER_CHAT
 
             if message.author.bot:
                 emb_row = await db.get(Embed, message.id)

--- a/demibot/demibot/http/routes/embeds.py
+++ b/demibot/demibot/http/routes/embeds.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ...db.models import Embed, GuildChannel
+from ...db.models import Embed, GuildChannel, ChannelKind
 
 router = APIRouter(prefix="/api")
 
@@ -28,7 +28,7 @@ async def get_embeds(
     if "officer" not in ctx.roles:
         stmt = stmt.join(
             GuildChannel, GuildChannel.channel_id == Embed.channel_id
-        ).where(GuildChannel.kind != "officer_chat")
+        ).where(GuildChannel.kind != ChannelKind.OFFICER_CHAT)
     stmt = stmt.order_by(Embed.updated_at.desc())
     if limit is not None:
         stmt = stmt.limit(limit)

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -15,7 +15,7 @@ from ..deps import RequestContext, api_key_auth, get_db
 from ..schemas import EmbedDto, EmbedFieldDto, EmbedButtonDto, AttachmentDto
 from ..ws import manager
 from ..discord_client import discord_client
-from ...db.models import Embed, EventButton, GuildChannel, RecurringEvent
+from ...db.models import Embed, EventButton, GuildChannel, RecurringEvent, ChannelKind
 from models.event import Event
 
 router = APIRouter(prefix="/api")
@@ -243,14 +243,14 @@ async def create_event(
             select(GuildChannel.kind).where(
                 GuildChannel.guild_id == ctx.guild.id,
                 GuildChannel.channel_id == channel_id,
-                GuildChannel.kind == "officer_chat",
+                GuildChannel.kind == ChannelKind.OFFICER_CHAT,
             )
         )
     ).scalar_one_or_none()
     await manager.broadcast_text(
         json.dumps(dto.model_dump(mode="json")),
         ctx.guild.id,
-        officer_only=kind == "officer_chat",
+        officer_only=kind == ChannelKind.OFFICER_CHAT,
         path="/ws/embeds",
     )
     return {"ok": True, "id": eid}

--- a/demibot/demibot/http/routes/interactions.py
+++ b/demibot/demibot/http/routes/interactions.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
 from ..ws import manager
-from ...db.models import Attendance, Embed, EventButton, GuildChannel, User
+from ...db.models import Attendance, Embed, EventButton, GuildChannel, User, ChannelKind
 
 router = APIRouter(prefix="/api")
 
@@ -128,7 +128,7 @@ async def post_interaction(
         await manager.broadcast_text(
             json.dumps(payload),
             embed.guild_id,
-            officer_only=kind == "officer_chat",
+            officer_only=kind == ChannelKind.OFFICER_CHAT,
             path="/ws/embeds",
         )
 

--- a/tests/test_apollo_embed.py
+++ b/tests/test_apollo_embed.py
@@ -24,7 +24,7 @@ http_pkg.__path__ = [str(root / "demibot/http")]
 sys.modules.setdefault("demibot.http", http_pkg)
 
 from demibot.discordbot.cogs.mirror import Mirror
-from demibot.db.models import Embed, Guild, GuildChannel
+from demibot.db.models import Embed, Guild, GuildChannel, ChannelKind
 from demibot.db.session import get_session, init_db
 from demibot.http.routes.embeds import get_embeds
 
@@ -76,7 +76,7 @@ async def _run_test() -> None:
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
-        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
+        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
         break
 

--- a/tests/test_channel_kind_enum.py
+++ b/tests/test_channel_kind_enum.py
@@ -1,0 +1,38 @@
+import asyncio
+from pathlib import Path
+import sys
+import types
+
+import pytest
+from sqlalchemy.exc import StatementError
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+from demibot.db.models import Guild, GuildChannel, ChannelKind
+from demibot.db.session import init_db, get_session
+
+
+def test_enum_rejects_invalid_value():
+    with pytest.raises(ValueError):
+        ChannelKind("bogus")
+
+
+def test_db_rejects_invalid_kind(tmp_path):
+    db_path = tmp_path / "chan_kind.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    asyncio.run(init_db(url))
+
+    async def attempt_insert():
+        async with get_session() as db:
+            guild = Guild(id=1, discord_guild_id=1, name="Test")
+            db.add(guild)
+            db.add(GuildChannel(guild_id=1, channel_id=1, kind="bogus"))
+            await db.flush()
+
+    with pytest.raises((ValueError, StatementError)):
+        asyncio.run(attempt_insert())

--- a/tests/test_channel_name_retry.py
+++ b/tests/test_channel_name_retry.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy import select
 
 from demibot import channel_names as cn
-from demibot.db.models import Guild, GuildChannel
+from demibot.db.models import Guild, GuildChannel, ChannelKind
 from demibot.db.session import init_db, get_session
 import demibot.db.session as db_session
 
@@ -25,7 +25,7 @@ def _setup_db(path: str) -> None:
         async with get_session() as db:
             guild = Guild(id=1, discord_guild_id=1, name="Test")
             db.add(guild)
-            db.add(GuildChannel(guild_id=guild.id, channel_id=100, kind="event", name=None))
+            db.add(GuildChannel(guild_id=guild.id, channel_id=100, kind=ChannelKind.EVENT, name=None))
             await db.commit()
             break
 
@@ -54,13 +54,13 @@ def test_fetch_channel_updates_name(monkeypatch):
 
     async def run() -> str | None:
         async with get_session() as db:
-            await cn.ensure_channel_name(db, 1, 100, "event", None)
+            await cn.ensure_channel_name(db, 1, 100, ChannelKind.EVENT, None)
             row = (
                 await db.execute(
                     select(GuildChannel).where(
                         GuildChannel.guild_id == 1,
                         GuildChannel.channel_id == 100,
-                        GuildChannel.kind == "event",
+                        GuildChannel.kind == ChannelKind.EVENT,
                     )
                 )
             ).scalar_one()
@@ -108,13 +108,13 @@ def test_rest_fallback_updates_name(monkeypatch):
 
     async def run() -> str | None:
         async with get_session() as db:
-            await cn.ensure_channel_name(db, 1, 100, "event", None)
+            await cn.ensure_channel_name(db, 1, 100, ChannelKind.EVENT, None)
             row = (
                 await db.execute(
                     select(GuildChannel.name).where(
                         GuildChannel.guild_id == 1,
                         GuildChannel.channel_id == 100,
-                        GuildChannel.kind == "event",
+                        GuildChannel.kind == ChannelKind.EVENT,
                     )
                 )
             ).scalar_one()
@@ -146,7 +146,7 @@ def test_retry_null_channel_names_logs_failure(caplog):
                     select(GuildChannel.name).where(
                         GuildChannel.guild_id == 1,
                         GuildChannel.channel_id == 100,
-                        GuildChannel.kind == "event",
+                        GuildChannel.kind == ChannelKind.EVENT,
                     )
                 )
             ).scalar_one()

--- a/tests/test_channels_endpoint.py
+++ b/tests/test_channels_endpoint.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from sqlalchemy import select
 
-from demibot.db.models import Guild, GuildChannel
+from demibot.db.models import Guild, GuildChannel, ChannelKind
 from demibot.db.session import init_db, get_session
 from demibot.http.deps import RequestContext
 from demibot.http.routes import channels as channel_routes
@@ -23,7 +23,7 @@ def _setup_db(path: str) -> None:
             db.add(guild)
             db.add(
                 GuildChannel(
-                    guild_id=guild.id, channel_id=100, kind="event", name="12345"
+                    guild_id=guild.id, channel_id=100, kind=ChannelKind.EVENT, name="12345"
                 )
             )
             await db.commit()
@@ -59,13 +59,13 @@ def test_get_channels_returns_placeholder_and_flags_retry(monkeypatch):
                     select(GuildChannel).where(
                         GuildChannel.guild_id == 1,
                         GuildChannel.channel_id == 100,
-                        GuildChannel.kind == "event",
+                        GuildChannel.kind == ChannelKind.EVENT,
                     )
                 )
             ).scalar_one()
             return data, row.name
 
     data, name = asyncio.run(run())
-    assert data["event"][0]["name"] == "100"
+    assert data[ChannelKind.EVENT.value][0]["name"] == "100"
     assert name is None
 

--- a/tests/test_create_event_mentions.py
+++ b/tests/test_create_event_mentions.py
@@ -18,7 +18,7 @@ http_pkg = types.ModuleType("demibot.http")
 http_pkg.__path__ = [str(root / "demibot/http")]
 sys.modules.setdefault("demibot.http", http_pkg)
 
-from demibot.db.models import Embed, Guild, GuildChannel
+from demibot.db.models import Embed, Guild, GuildChannel, ChannelKind
 
 import discord
 from demibot.db.session import init_db, get_session
@@ -54,7 +54,7 @@ async def _run_test() -> None:
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
-        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
+        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
         break
 

--- a/tests/test_create_event_source.py
+++ b/tests/test_create_event_source.py
@@ -18,7 +18,7 @@ http_pkg = types.ModuleType("demibot.http")
 http_pkg.__path__ = [str(root / "demibot/http")]
 sys.modules.setdefault("demibot.http", http_pkg)
 
-from demibot.db.models import Embed, Guild, GuildChannel
+from demibot.db.models import Embed, Guild, GuildChannel, ChannelKind
 from demibot.db.session import init_db, get_session
 from demibot.http.routes.events import create_event, CreateEventBody
 
@@ -32,7 +32,7 @@ async def _run_test() -> None:
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
-        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
+        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
         break
 

--- a/tests/test_embeds_filters.py
+++ b/tests/test_embeds_filters.py
@@ -12,7 +12,7 @@ demibot_pkg = types.ModuleType("demibot")
 demibot_pkg.__path__ = [str(root / "demibot")]
 sys.modules.setdefault("demibot", demibot_pkg)
 
-from demibot.db.models import Embed, Guild, GuildChannel
+from demibot.db.models import Embed, Guild, GuildChannel, ChannelKind
 from demibot.db.session import init_db, get_session
 from demibot.http.routes.embeds import get_embeds
 
@@ -25,8 +25,8 @@ async def _run_test() -> None:
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test")
         db.add(guild)
-        db.add(GuildChannel(guild_id=guild.id, channel_id=10, kind="event"))
-        db.add(GuildChannel(guild_id=guild.id, channel_id=20, kind="event"))
+        db.add(GuildChannel(guild_id=guild.id, channel_id=10, kind=ChannelKind.EVENT))
+        db.add(GuildChannel(guild_id=guild.id, channel_id=20, kind=ChannelKind.EVENT))
         db.add(Embed(discord_message_id=1, channel_id=10, guild_id=1, payload_json=json.dumps({"id": "1"}), buttons_json=None, source="test"))
         db.add(Embed(discord_message_id=2, channel_id=10, guild_id=1, payload_json=json.dumps({"id": "2"}), buttons_json=None, source="test"))
         db.add(Embed(discord_message_id=3, channel_id=20, guild_id=1, payload_json=json.dumps({"id": "3"}), buttons_json=None, source="test"))

--- a/tests/test_event_update.py
+++ b/tests/test_event_update.py
@@ -19,7 +19,7 @@ http_pkg = types.ModuleType("demibot.http")
 http_pkg.__path__ = [str(root / "demibot/http")]
 sys.modules.setdefault("demibot.http", http_pkg)
 
-from demibot.db.models import Embed, Guild, GuildChannel
+from demibot.db.models import Embed, Guild, GuildChannel, ChannelKind
 from demibot.db.session import init_db, get_session
 from demibot.http.routes.events import create_event, CreateEventBody
 
@@ -37,7 +37,7 @@ async def _run_test() -> None:
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test")
         db.add(guild)
-        db.add(GuildChannel(guild_id=1, channel_id=123, kind="event"))
+        db.add(GuildChannel(guild_id=1, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
         break
 

--- a/tests/test_recurring_event_management.py
+++ b/tests/test_recurring_event_management.py
@@ -17,7 +17,7 @@ http_pkg = types.ModuleType("demibot.http")
 http_pkg.__path__ = [str(root / "demibot/http")]
 sys.modules.setdefault("demibot.http", http_pkg)
 
-from demibot.db.models import Guild, GuildChannel, RecurringEvent
+from demibot.db.models import Guild, GuildChannel, RecurringEvent, ChannelKind
 from demibot.db.session import init_db, get_session
 from demibot.http.routes.events import (
     create_event,
@@ -38,7 +38,7 @@ async def _setup_db(path: Path) -> None:
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test")
         db.add(guild)
-        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
+        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
         break
 

--- a/tests/test_recurring_events.py
+++ b/tests/test_recurring_events.py
@@ -19,7 +19,7 @@ http_pkg = types.ModuleType("demibot.http")
 http_pkg.__path__ = [str(root / "demibot/http")]
 sys.modules.setdefault("demibot.http", http_pkg)
 
-from demibot.db.models import Embed, Guild, GuildChannel, RecurringEvent
+from demibot.db.models import Embed, Guild, GuildChannel, RecurringEvent, ChannelKind
 from demibot.db.session import init_db, get_session
 from demibot.http.routes.events import create_event, CreateEventBody
 from demibot.repeat_events import process_recurring_events_once
@@ -34,7 +34,7 @@ async def _run_test() -> None:
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test")
         db.add(guild)
-        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
+        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
         break
 

--- a/tests/test_rsvp_max_signups.py
+++ b/tests/test_rsvp_max_signups.py
@@ -17,7 +17,7 @@ http_pkg = types.ModuleType("demibot.http")
 http_pkg.__path__ = [str(root / "demibot/http")]
 sys.modules.setdefault("demibot.http", http_pkg)
 
-from demibot.db.models import Guild, GuildChannel, User
+from demibot.db.models import Guild, GuildChannel, User, ChannelKind
 from demibot.db.session import init_db, get_session
 from demibot.http.routes.events import create_event, CreateEventBody
 from demibot.http.routes.interactions import post_interaction, InteractionBody
@@ -33,7 +33,7 @@ async def _run_test() -> None:
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
         db.add(guild)
-        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind="event"))
+        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         db.add(User(id=1, discord_user_id=1))
         db.add(User(id=2, discord_user_id=2))
         await db.commit()


### PR DESCRIPTION
## Summary
- add ChannelKind enum and use SQLAlchemy Enum for GuildChannel.kind
- build channel responses dynamically from ChannelKind
- expose ChannelKind constants to plugin and test invalid kinds

## Testing
- `pytest` *(fails: SyntaxError in existing tests)*
- `pytest tests/test_channel_kind_enum.py::test_db_rejects_invalid_kind`

------
https://chatgpt.com/codex/tasks/task_e_68b8cbb9e67c8328a01ead005bee160e