### PR TITLE
Normalize timestamp parsing with Pydantic validators

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -20,7 +20,7 @@ public class EventCreateWindow
 
     private string _title = string.Empty;
     private string _description = string.Empty;
-    private string _time = DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'");
+    private string _time = DateTime.UtcNow.ToString("O");
     private string _imageUrl = string.Empty;
     private string _url = string.Empty;
     private string _thumbnailUrl = string.Empty;
@@ -92,7 +92,7 @@ public class EventCreateWindow
             DateTime.TryParse(_time, null, DateTimeStyles.AdjustToUniversal, out var baseTime))
         {
             var next = _repeat == RepeatOption.Daily ? baseTime.AddDays(1) : baseTime.AddDays(7);
-            var nextStr = next.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'");
+            var nextStr = next.ToUniversalTime().ToString("O");
             ImGui.TextUnformatted($"Next: {nextStr}");
         }
         ImGui.InputTextMultiline("Description", ref _description, 4096, new Vector2(400, 100));
@@ -331,7 +331,7 @@ public class EventCreateWindow
         _title = template.Title;
         _description = template.Description;
         _time = string.IsNullOrEmpty(template.Time)
-            ? DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'")
+            ? DateTime.UtcNow.ToString("O")
             : template.Time;
         _url = template.Url;
         _imageUrl = template.ImageUrl;

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -252,7 +252,7 @@ public class TemplatesWindow
                 channelId = _channelId,
                 title = tmpl.Title,
                 time = string.IsNullOrWhiteSpace(tmpl.Time)
-                    ? DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'")
+                    ? DateTime.UtcNow.ToString("O")
                     : tmpl.Time,
                 description = tmpl.Description,
                 url = string.IsNullOrWhiteSpace(tmpl.Url) ? null : tmpl.Url,

--- a/tests/test_time_validation.py
+++ b/tests/test_time_validation.py
@@ -1,0 +1,74 @@
+import pytest
+import sys
+import types
+from pathlib import Path
+from datetime import datetime, timezone
+from fastapi import HTTPException
+
+# Ensure the demo package is importable
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+routes_pkg = types.ModuleType("demibot.http.routes")
+routes_pkg.__path__ = [str(root / "demibot/http/routes")]
+sys.modules.setdefault("demibot.http.routes", routes_pkg)
+
+# Stub dependencies used during import
+alembic_stub = types.ModuleType("alembic")
+alembic_stub.command = types.SimpleNamespace()
+sys.modules.setdefault("alembic", alembic_stub)
+alembic_config_stub = types.ModuleType("alembic.config")
+alembic_config_stub.Config = object
+sys.modules.setdefault("alembic.config", alembic_config_stub)
+deps_stub = types.ModuleType("demibot.http.deps")
+deps_stub.RequestContext = object
+deps_stub.api_key_auth = object
+deps_stub.get_db = object
+sys.modules.setdefault("demibot.http.deps", deps_stub)
+
+import importlib.util
+events_spec = importlib.util.spec_from_file_location(
+    "demibot.http.routes.events", root / "demibot/http/routes/events.py"
+)
+events = importlib.util.module_from_spec(events_spec)
+sys.modules[events_spec.name] = events
+events_spec.loader.exec_module(events)
+
+CreateEventBody = events.CreateEventBody
+RepeatPatchBody = events.RepeatPatchBody
+
+
+def test_create_event_body_normalizes_timezone():
+    body = CreateEventBody(
+        channelId="123",
+        title="t",
+        time="2024-05-01T12:30:00+02:00",
+        description="d",
+    )
+    assert body.time == datetime(2024, 5, 1, 10, 30, 0, tzinfo=timezone.utc)
+
+
+def test_create_event_body_invalid_time():
+    with pytest.raises(HTTPException):
+        CreateEventBody(
+            channelId="123",
+            title="t",
+            time="not-a-time",
+            description="d",
+        )
+
+
+def test_repeat_patch_body_timezone():
+    body = RepeatPatchBody(time="2024-05-01T12:00:00-05:30")
+    assert body.time == datetime(2024, 5, 1, 17, 30, 0, tzinfo=timezone.utc)
+
+
+def test_repeat_patch_body_invalid():
+    with pytest.raises(HTTPException):
+        RepeatPatchBody(time="bad")


### PR DESCRIPTION
## Summary
- Use Pydantic `field_validator` to parse and normalize timestamps to UTC, returning HTTP 400 on errors
- Send RFC3339 timestamps from DemiCat plugin
- Add tests for valid and invalid timestamp formats and timezone offsets

## Testing
- `pytest tests/test_time_validation.py -q`
- `pytest -q` *(fails: SyntaxError/ModuleNotFoundError: httpx and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ea9d0fa48328a7a03a0889cc2297