### PR TITLE
feat: track member nickname and avatar for messages

### DIFF
--- a/demibot/demibot/db/migrations/versions/0031_add_membership_nick_avatar.py
+++ b/demibot/demibot/db/migrations/versions/0031_add_membership_nick_avatar.py
@@ -1,0 +1,15 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0031_add_membership_nick_avatar'
+down_revision = '0030_add_syncshell_rate_limit_and_expiry'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.add_column('memberships', sa.Column('nickname', sa.String(length=255), nullable=True))
+    op.add_column('memberships', sa.Column('avatar_url', sa.String(length=255), nullable=True))
+
+def downgrade() -> None:
+    op.drop_column('memberships', 'avatar_url')
+    op.drop_column('memberships', 'nickname')

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -156,6 +156,8 @@ class Membership(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
     user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), ForeignKey("users.id"))
+    nickname: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    avatar_url: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
 
 
 class Role(Base):


### PR DESCRIPTION
## Summary
- store per-guild nickname and avatar URL on memberships
- sync nickname/avatar during presence updates and member updates
- use stored nickname/avatar when saving messages and include in author DTO

## Testing
- `pytest tests/test_messages_common.py::test_save_and_fetch_messages -q` *(fails: SyntaxError: 'break' outside loop)*
- `pytest tests/test_asset_download.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b8f75c7a1c8328ba232470dd83f2e0