### PR TITLE
Surface Discord relay failures in message saving

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -584,7 +584,18 @@ public class ChatWindow : IDisposable
             {
                 var responseBody = await response.Content.ReadAsStringAsync();
                 PluginServices.Instance!.Log.Warning($"Failed to send message. Status: {response.StatusCode}. Response Body: {responseBody}");
-                _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = "Failed to send message");
+                var msg = "Failed to send message";
+                try
+                {
+                    using var doc = JsonDocument.Parse(responseBody);
+                    if (doc.RootElement.TryGetProperty("detail", out var detail))
+                        msg = detail.GetString() ?? msg;
+                }
+                catch
+                {
+                    // ignore parse errors
+                }
+                _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = msg);
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- raise HTTP 502 when webhook relay fails instead of generating fallback ID
- show relay failure detail in plugin status message
- cover webhook failure and success paths in message route tests

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py` *(fails: ValidationError for ChatMessage in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68b9046ae028832887ed6f93ba8dc0c2