### PR TITLE
Persist channel webhooks

### DIFF
--- a/demibot/demibot/db/migrations/versions/0032_add_guild_channel_webhook_url.py
+++ b/demibot/demibot/db/migrations/versions/0032_add_guild_channel_webhook_url.py
@@ -1,0 +1,23 @@
+"""add webhook_url column to guild channels
+
+Revision ID: 0032_add_guild_channel_webhook_url
+Revises: 0031_add_membership_nick_avatar
+Create Date: 2025-01-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0032_add_guild_channel_webhook_url'
+down_revision = '0031_add_membership_nick_avatar'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('guild_channels', sa.Column('webhook_url', sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('guild_channels', 'webhook_url')

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -109,6 +109,7 @@ class GuildChannel(Base):
         SAEnum(ChannelKind, validate_strings=True), primary_key=True
     )
     name: Mapped[Optional[str]] = mapped_column(String(255))
+    webhook_url: Mapped[Optional[str]] = mapped_column(String(255))
 
 
 class User(Base):


### PR DESCRIPTION
## Summary
- store per-channel Discord webhook URLs in the database
- reuse and cache saved webhooks when sending messages
- reload webhook cache on startup and expose cleanup utility
- add regression test for webhook persistence

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py -k webhook_cache_persist_and_load -q`
- `PYTHONPATH=demibot pytest` *(fails: 30 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b97243a3208328b9a44b6a2cb43974