### PR TITLE
refactor: centralize mention parsing

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -543,10 +543,13 @@ public class ChatWindow : IDisposable
         try
         {
             // Build request body (includes reply threading if set)
+            var presences = _presence?.Presences ?? new List<PresenceDto>();
+            var content = MentionResolver.Resolve(_input, presences, RoleCache.Roles);
+
             var body = new
             {
                 channelId = _channelId,
-                content = _input,
+                content,
                 useCharacterName = _useCharacterName,
                 messageReference = _replyToId != null
                     ? new { messageId = _replyToId, channelId = _channelId }

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -5,7 +5,6 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Numerics;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
@@ -128,16 +127,8 @@ public class FcChatWindow : ChatWindow
             return;
         }
 
-        var content = _input;
         var presences = _presence?.Presences ?? new List<PresenceDto>();
-        foreach (var u in presences)
-        {
-            content = Regex.Replace(content, $"@{Regex.Escape(u.Name)}\\b", $"<@{u.Id}>");
-        }
-        foreach (var r in RoleCache.Roles)
-        {
-            content = Regex.Replace(content, $"@{Regex.Escape(r.Name)}\\b", $"<@&{r.Id}>");
-        }
+        var content = MentionResolver.Resolve(_input, presences, RoleCache.Roles);
 
         try
         {

--- a/DemiCatPlugin/MentionResolver.cs
+++ b/DemiCatPlugin/MentionResolver.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace DemiCatPlugin;
+
+public static class MentionResolver
+{
+    public static string Resolve(string content, IEnumerable<PresenceDto> presences, IEnumerable<RoleDto> roles)
+    {
+        foreach (var u in presences)
+        {
+            content = Regex.Replace(content, $"@{Regex.Escape(u.Name)}\\b", $"<@{u.Id}>");
+        }
+        foreach (var r in roles)
+        {
+            content = Regex.Replace(content, $"@{Regex.Escape(r.Name)}\\b", $"<@&{r.Id}>");
+        }
+        return content;
+    }
+}

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -46,10 +46,13 @@ public class OfficerChatWindow : ChatWindow
         try
         {
             // Build request body (includes reply threading if set)
+            var presences = _presence?.Presences ?? new List<PresenceDto>();
+            var content = MentionResolver.Resolve(_input, presences, RoleCache.Roles);
+
             var body = new
             {
                 channelId = _channelId,
-                content = _input,
+                content,
                 useCharacterName = _useCharacterName,
                 messageReference = _replyToId != null
                     ? new { messageId = _replyToId, channelId = _channelId }

--- a/tests/ChatWindowTests.cs
+++ b/tests/ChatWindowTests.cs
@@ -13,4 +13,16 @@ public class ChatWindowTests
 
         Assert.Equal(expected, result);
     }
+
+    [Fact]
+    public void MentionResolver_ReplacesUserAndRoleMentions()
+    {
+        var presences = new[] { new PresenceDto { Id = "1", Name = "Alice" } };
+        var roles = new[] { new RoleDto { Id = "2", Name = "Admin" } };
+        var input = "Hello @Alice and @Admin";
+
+        var result = MentionResolver.Resolve(input, presences, roles);
+
+        Assert.Equal("Hello <@1> and <@&2>", result);
+    }
 }


### PR DESCRIPTION
## Summary
- centralize mention parsing into a reusable `MentionResolver`
- resolve `@Name` and `@Role` to Discord mentions before sending messages across chat windows
- add unit tests for mention parsing

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found. Requested SDK version: 9.0.100)*
- `pytest` *(fails: 40 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b975bf777883288d0ec827ae9a5275