### PR TITLE
Guard avatar loading against null author

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -149,7 +149,9 @@ public class ChatWindow : IDisposable
         {
             ImGui.PushID(msg.Id);
             ImGui.BeginGroup();
-            if (!string.IsNullOrEmpty(msg.Author.AvatarUrl) && msg.AvatarTexture == null)
+            if (msg.Author != null &&
+                !string.IsNullOrEmpty(msg.Author.AvatarUrl) &&
+                msg.AvatarTexture == null)
             {
                 LoadTexture(msg.Author.AvatarUrl, t => msg.AvatarTexture = t);
             }


### PR DESCRIPTION
## Summary
- Safely load message author avatars by checking for null authors before loading textures

## Testing
- `dotnet build DemiCatPlugin` *(fails: Could not resolve Dalamud-related assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_68b9808d68108328a7f3d4a277c9faef