### PR TITLE
Remove stray break in recurring events processor

### DIFF
--- a/demibot/demibot/repeat_events.py
+++ b/demibot/demibot/repeat_events.py
@@ -49,7 +49,6 @@ async def process_recurring_events_once() -> None:
                 elif ev.repeat == "weekly":
                     ev.next_post_at += timedelta(days=7)
         await db.commit()
-        break
 
 
 async def recurring_event_poster() -> None:


### PR DESCRIPTION
## Summary
- remove stray `break` after committing recurring events

## Testing
- `python -m demibot.main` *(fails: IndentationError: expected an indented block after 'if' statement on line 81 in channel_names.py)*
- `pytest` *(fails: SyntaxError: 'break' outside loop in several test files; RuntimeError: starlette.testclient requires httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68b980904b448328a7bee67fbf560517