### PR TITLE
Fix stray breaks in backend utilities

### DIFF
--- a/demibot/demibot/asset_cleanup.py
+++ b/demibot/demibot/asset_cleanup.py
@@ -17,7 +17,6 @@ async def purge_deleted_assets_once(retention_days: int = 30) -> None:
         cutoff = datetime.utcnow() - timedelta(days=retention_days)
         await db.execute(delete(Asset).where(Asset.deleted_at < cutoff))
         await db.commit()
-        break
 
 
 async def purge_deleted_assets() -> None:

--- a/demibot/demibot/channel_names.py
+++ b/demibot/demibot/channel_names.py
@@ -79,14 +79,14 @@ async def ensure_channel_name(
             async with aiohttp.ClientSession() as session:
                 async with session.get(url, headers=headers) as resp:
                     if resp.status != 200:
-                logging.warning(
-                    "Failed to fetch channel %s (%s) in guild %s: HTTP %s",
-                    channel_id,
-                    kind.value,
-                    guild_id,
-                    resp.status,
-                )
-                return None
+                        logging.warning(
+                            "Failed to fetch channel %s (%s) in guild %s: HTTP %s",
+                            channel_id,
+                            kind.value,
+                            guild_id,
+                            resp.status,
+                        )
+                        return None
                     data = await resp.json()
         except Exception as exc:  # pragma: no cover - network errors
             logging.warning(
@@ -140,7 +140,6 @@ async def resync_channel_names_once() -> None:
             await db.commit()
             for guild_id in updated_guilds:
                 await manager.broadcast_text("update", guild_id, path="/ws/channels")
-        break
 
 
 async def retry_null_channel_names(max_attempts: int = 3) -> None:
@@ -186,7 +185,6 @@ async def retry_null_channel_names(max_attempts: int = 3) -> None:
                 guild_id,
                 max_attempts,
             )
-        break
 
 
 SYNC_INTERVAL = 3600

--- a/demibot/demibot/syncshell_cleanup.py
+++ b/demibot/demibot/syncshell_cleanup.py
@@ -21,7 +21,6 @@ async def prune_syncshell_once() -> None:
             delete(SyncshellRateLimit).where(SyncshellRateLimit.window_start < cutoff)
         )
         await db.commit()
-        break
 
 
 async def prune_syncshell() -> None:


### PR DESCRIPTION
## Summary
- fix indentation of Discord channel API call and remove stray `break` statements in `channel_names`
- drop invalid `break`s from asset and syncshell cleanup jobs

## Testing
- `python -m demibot.main` *(fails: prompts for config then interrupted)*
- `pytest` *(fails: 30 errors in test collection)*
- `dotnet build DemiCatPlugin` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8edf7f7ac8328b91e708dd8a31ba2