### PR TITLE
fix: remove stray break in asset download route

### DIFF
--- a/demibot/demibot/http/routes/assets.py
+++ b/demibot/demibot/http/routes/assets.py
@@ -138,7 +138,6 @@ async def download_asset(
             )
             if res.scalar_one_or_none() is None:
                 raise HTTPException(status_code=404)
-            break
     base = Path(os.environ.get("ASSET_STORAGE_PATH", "assets")).resolve()
     file_path = (base / object_key).resolve()
     if not str(file_path).startswith(str(base)) or not file_path.is_file():


### PR DESCRIPTION
## Summary
- remove stray `break` that caused syntax error in asset download handler

## Testing
- `PYTHONPATH=demibot pytest tests/test_asset_download.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b98474de288328adf9a6c33e6dce0c