### PR TITLE
Remove stray break statements and clean up tests

### DIFF
--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -99,7 +99,6 @@ async def delete_asset_cmd(
             return
         asset.deleted_at = datetime.utcnow()
         await db.commit()
-        break
     await interaction.response.send_message("Asset deleted", ephemeral=True)
 
 
@@ -115,7 +114,6 @@ async def rebuild_index_cmd(
         if forget:
             await db.execute(delete(UserInstallation))
         await db.commit()
-        break
     msg = "Index rebuilt"
     if forget:
         msg += " and user installations cleared"

--- a/demibot/demibot/discordbot/cogs/vault.py
+++ b/demibot/demibot/discordbot/cogs/vault.py
@@ -103,7 +103,6 @@ class Vault(commands.Cog):
             fc_id = await self._get_fc_id(db, message.guild)
             uploader_id = await self._ensure_user(db, message.author)
             await db.commit()
-            break
 
         errors: list[str] = []
         for attachment in message.attachments:

--- a/demibot/demibot/http/routes/presences.py
+++ b/demibot/demibot/http/routes/presences.py
@@ -75,7 +75,6 @@ async def list_presences(
                             "roles": roles,
                         }
                     )
-            break
     except RuntimeError:
         pass
     if db_presences is not None:

--- a/demibot/scripts/refresh_channels.py
+++ b/demibot/scripts/refresh_channels.py
@@ -36,7 +36,6 @@ async def _refresh() -> None:
                 updated = True
         if updated:
             await db.commit()
-        break
 
 
 if __name__ == "__main__":

--- a/tests/test_apollo_embed.py
+++ b/tests/test_apollo_embed.py
@@ -78,7 +78,6 @@ async def _run_test() -> None:
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
-        break
 
     emb = discord.Embed(title="Raid Night", description="Prepare")
     emb.set_footer(text="Powered by Apollo")
@@ -101,7 +100,6 @@ async def _run_test() -> None:
         assert result[0]["guildId"] == 1
         assert result[0]["channelId"] == 123
         assert result[0]["buttons"][0]["customId"] == "rsvp:yes"
-        break
 
 
 def test_apollo_embed_stored_and_retrieved() -> None:

--- a/tests/test_asset_purge.py
+++ b/tests/test_asset_purge.py
@@ -34,5 +34,4 @@ def test_purge_deleted_assets_once():
             assets = (await db.execute(select(Asset).order_by(Asset.id))).scalars().all()
             assert len(assets) == 1
             assert assets[0].id == 2
-            break
     asyncio.run(_run())

--- a/tests/test_assets_bundles_etag.py
+++ b/tests/test_assets_bundles_etag.py
@@ -2,6 +2,10 @@ import time
 import asyncio
 from datetime import datetime
 
+import asyncio
+import time
+from datetime import datetime
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import select
@@ -77,7 +81,6 @@ def test_assets_etag_and_last_pull():
         async with get_session() as db:
             db.add_all([user, fc, fcu, dep_asset, asset, dep_rel, cp])
             await db.commit()
-            break
 
     asyncio.run(_setup())
 
@@ -128,7 +131,6 @@ def test_bundles_etag_and_last_pull():
         async with get_session() as db:
             db.add_all([user, fc, fcu, asset, bundle, item, cp])
             await db.commit()
-            break
 
     asyncio.run(_setup())
 

--- a/tests/test_channel_name_retry.py
+++ b/tests/test_channel_name_retry.py
@@ -1,6 +1,6 @@
 import asyncio
-from pathlib import Path
 import logging
+from pathlib import Path
 import types
 
 import pytest
@@ -27,7 +27,6 @@ def _setup_db(path: str) -> None:
             db.add(guild)
             db.add(GuildChannel(guild_id=guild.id, channel_id=100, kind=ChannelKind.EVENT, name=None))
             await db.commit()
-            break
 
     asyncio.run(populate())
 

--- a/tests/test_channels_endpoint.py
+++ b/tests/test_channels_endpoint.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from sqlalchemy import select
 
+import asyncio
+
 from demibot.db.models import Guild, GuildChannel, ChannelKind
 from demibot.db.session import init_db, get_session
 from demibot.http.deps import RequestContext
@@ -27,7 +29,6 @@ def _setup_db(path: str) -> None:
                 )
             )
             await db.commit()
-            break
 
     asyncio.run(populate())
 

--- a/tests/test_create_event_mentions.py
+++ b/tests/test_create_event_mentions.py
@@ -1,8 +1,10 @@
 import sys
 from pathlib import Path
-import types
 import asyncio
 import json
+import sys
+import types
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 from sqlalchemy import select
@@ -56,7 +58,6 @@ async def _run_test() -> None:
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
-        break
 
     body = CreateEventBody(
         channelId="123",
@@ -80,7 +81,6 @@ async def _run_test() -> None:
         payload = json.loads(row.payload_json)
         assert payload["mentions"] == [1, 2]
         assert client.channel.last_content == "<@&1> <@&2>"
-        break
 
 
 def test_create_event_mentions() -> None:

--- a/tests/test_create_event_source.py
+++ b/tests/test_create_event_source.py
@@ -34,7 +34,6 @@ async def _run_test() -> None:
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
-        break
 
     body = CreateEventBody(
         channelId="123",
@@ -56,7 +55,6 @@ async def _run_test() -> None:
             )
         ).scalar_one()
         assert row.source == "demibot"
-        break
 
 
 def test_create_event_sets_source() -> None:

--- a/tests/test_delta_token.py
+++ b/tests/test_delta_token.py
@@ -26,5 +26,4 @@ def test_delta_token_updates_last_pull():
             since_dt = datetime.fromisoformat(res["since"])
             assert row.last_pull_at is not None
             assert abs(row.last_pull_at - since_dt) < timedelta(seconds=1)
-            break
     asyncio.run(_run())

--- a/tests/test_discord_id_header.py
+++ b/tests/test_discord_id_header.py
@@ -1,4 +1,5 @@
 import asyncio
+import asyncio
 import sys
 import types
 from pathlib import Path
@@ -52,7 +53,6 @@ def test_x_discord_id_overrides_user(tmp_path):
                 [guild, svc, user, officer, svc_membership, svc_role, key]
             )
             await db.commit()
-            break
 
     asyncio.run(populate())
 
@@ -79,7 +79,6 @@ def test_x_discord_id_requires_officer(tmp_path):
             key = UserKey(user_id=svc.id, guild_id=guild.id, token="svc")
             db.add_all([guild, svc, user, key])
             await db.commit()
-            break
 
     asyncio.run(populate())
 

--- a/tests/test_embeds_filters.py
+++ b/tests/test_embeds_filters.py
@@ -31,7 +31,6 @@ async def _run_test() -> None:
         db.add(Embed(discord_message_id=2, channel_id=10, guild_id=1, payload_json=json.dumps({"id": "2"}), buttons_json=None, source="test"))
         db.add(Embed(discord_message_id=3, channel_id=20, guild_id=1, payload_json=json.dumps({"id": "3"}), buttons_json=None, source="test"))
         await db.commit()
-        break
 
     ctx = SimpleNamespace(guild=SimpleNamespace(id=1), roles=["officer"])
     async with get_session() as db:
@@ -42,7 +41,6 @@ async def _run_test() -> None:
         assert len(res2) == 1
         res3 = await get_embeds(ctx=ctx, db=db, channel_id=10, limit=1)
         assert len(res3) == 1 and res3[0]["channelId"] == 10
-        break
 
 def test_embeds_filters() -> None:
     asyncio.run(_run_test())

--- a/tests/test_event_update.py
+++ b/tests/test_event_update.py
@@ -39,7 +39,6 @@ async def _run_test() -> None:
         db.add(guild)
         db.add(GuildChannel(guild_id=1, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
-        break
 
     ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
     body = CreateEventBody(
@@ -59,7 +58,6 @@ async def _run_test() -> None:
             dt.fromisoformat.side_effect = datetime.fromisoformat
             await create_event(body=body, ctx=ctx, db=db)
         await db.commit()
-        break
 
     body2 = CreateEventBody(
         channelId="123",
@@ -82,7 +80,6 @@ async def _run_test() -> None:
         res = await db.execute(select(Embed))
         embeds = res.scalars().all()
         assert len(embeds) == 1
-        break
 
 
 def test_event_update_existing() -> None:

--- a/tests/test_forget_me.py
+++ b/tests/test_forget_me.py
@@ -60,5 +60,4 @@ def test_forget_me_scrubs_user_and_assets():
                 await db.execute(select(Asset).where(Asset.id == 1))
             ).scalar_one()
             assert asset_row.deleted_at is not None
-            break
     asyncio.run(_run())

--- a/tests/test_guild_roles.py
+++ b/tests/test_guild_roles.py
@@ -36,7 +36,6 @@ async def _run_test() -> None:
         res = await get_guild_roles(ctx=ctx, db=db)
         pairs = {(r["id"], r["name"]) for r in res}
         assert pairs == {("10", "Alpha"), ("20", "Beta")}
-        break
 
 
 def test_get_guild_roles() -> None:

--- a/tests/test_installations.py
+++ b/tests/test_installations.py
@@ -57,5 +57,4 @@ def test_installations_flow():
             # only one row exists
             rows = (await db.execute(select(UserInstallation))).scalars().all()
             assert len(rows) == 1
-            break
     asyncio.run(_run())

--- a/tests/test_key_generation_roles.py
+++ b/tests/test_key_generation_roles.py
@@ -2,6 +2,10 @@ import asyncio
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 import types
 
 from sqlalchemy import select
@@ -86,7 +90,6 @@ async def _setup_db() -> None:
             )
         )
         await db.commit()
-        break
 
 
 async def _generate(user_roles):

--- a/tests/test_manifest_dependencies.py
+++ b/tests/test_manifest_dependencies.py
@@ -69,6 +69,5 @@ def test_manifest_declared_dependencies():
                 )
             )
             assert res.scalar_one() == dep_asset.id
-            break
 
     asyncio.run(_run())

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -2,6 +2,11 @@ import types
 import sys
 import asyncio
 import pytest
+import asyncio
+import sys
+import types
+
+import pytest
 from fastapi import HTTPException
 from pathlib import Path
 
@@ -108,7 +113,6 @@ def test_add_reaction_success():
             res = await messages.add_reaction("1", "1", "😀", ctx, db)
             assert res == {"ok": True}
             assert dummy_msg.called
-            break
     asyncio.run(run())
 
 
@@ -143,7 +147,6 @@ def test_add_reaction_not_found():
             with pytest.raises(HTTPException) as exc:
                 await messages.add_reaction("1", "1", "😀", ctx, db)
             assert exc.value.status_code == 404
-            break
     asyncio.run(run())
 
 
@@ -179,5 +182,4 @@ def test_add_reaction_forbidden():
             with pytest.raises(HTTPException) as exc:
                 await messages.add_reaction("1", "1", "😀", ctx, db)
             assert exc.value.status_code == 403
-            break
     asyncio.run(run())

--- a/tests/test_recurring_event_management.py
+++ b/tests/test_recurring_event_management.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 import sys
-import types
 import asyncio
+import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
+import types
 
 root = Path(__file__).resolve().parents[1] / "demibot"
 sys.path.append(str(root))
@@ -40,7 +42,6 @@ async def _setup_db(path: Path) -> None:
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
-        break
 
 
 async def _test_patch_delete() -> None:
@@ -59,7 +60,6 @@ async def _test_patch_delete() -> None:
         res = await create_event(body=body, ctx=ctx, db=db)
         ev_id = int(res["id"])
         await db.commit()
-        break
 
     new_time = (datetime.utcnow() + timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     patch_body = RepeatPatchBody(time=new_time, repeat="weekly")
@@ -71,7 +71,6 @@ async def _test_patch_delete() -> None:
         await delete_recurring_event(str(ev_id), ctx=ctx, db=db)
         row = await db.get(RecurringEvent, ev_id)
         assert row is None
-        break
 
 
 async def _test_cleanup() -> None:
@@ -90,13 +89,11 @@ async def _test_cleanup() -> None:
             )
         )
         await db.commit()
-        break
 
     repeat_events.discord_client = SimpleNamespace(get_channel=lambda _: None)
     await process_recurring_events_once()
     async with get_session() as db:
         assert (await db.get(RecurringEvent, 111)) is None
-        break
 
     async with get_session() as db:
         db.add(
@@ -110,7 +107,6 @@ async def _test_cleanup() -> None:
             )
         )
         await db.commit()
-        break
 
     class DummyChannel:
         async def fetch_message(self, _):
@@ -120,7 +116,6 @@ async def _test_cleanup() -> None:
     await process_recurring_events_once()
     async with get_session() as db:
         assert (await db.get(RecurringEvent, 222)) is None
-        break
 
     repeat_events.discord_client = None
 

--- a/tests/test_recurring_events.py
+++ b/tests/test_recurring_events.py
@@ -36,7 +36,6 @@ async def _run_test() -> None:
         db.add(guild)
         db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
-        break
 
     body = CreateEventBody(
         channelId="123",
@@ -56,7 +55,6 @@ async def _run_test() -> None:
         row = (await db.execute(select(RecurringEvent))).scalar_one()
         row.next_post_at = datetime.utcnow() - timedelta(seconds=1)
         await db.commit()
-        break
 
     await process_recurring_events_once()
 
@@ -65,7 +63,6 @@ async def _run_test() -> None:
         assert len(embeds) == 2
         row = (await db.execute(select(RecurringEvent))).scalar_one()
         assert row.next_post_at > datetime.utcnow()
-        break
 
 
 def test_recurring_event_reposted() -> None:

--- a/tests/test_request_status_permissions.py
+++ b/tests/test_request_status_permissions.py
@@ -4,9 +4,14 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
+import asyncio
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
 
 root = Path(__file__).resolve().parents[1] / "demibot"
 sys.path.append(str(root))
@@ -53,7 +58,6 @@ async def _setup_db(db_path: str) -> None:
         other = User(id=3, discord_user_id=3)
         db.add_all([guild, requester, assignee, other])
         await db.commit()
-        break
 
 
 @pytest.fixture()

--- a/tests/test_resync_membership_roles.py
+++ b/tests/test_resync_membership_roles.py
@@ -2,6 +2,10 @@ import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
 from sqlalchemy import select
 
 from demibot.discordbot.cogs import admin as admin_module
@@ -61,7 +65,6 @@ def _setup_db() -> None:
                 )
             )
             await db.commit()
-            break
 
     asyncio.run(populate())
 

--- a/tests/test_rsvp_max_signups.py
+++ b/tests/test_rsvp_max_signups.py
@@ -68,7 +68,6 @@ async def _run_test() -> None:
         )
         assert isinstance(resp, JSONResponse)
         assert resp.status_code == 400
-        break
 
 
 def test_max_signups_enforced() -> None:

--- a/tests/test_signup_presets.py
+++ b/tests/test_signup_presets.py
@@ -61,7 +61,6 @@ async def _run_test() -> None:
         await delete_signup_preset(preset_id=pid, ctx=ctx, db=db)
         presets = await list_signup_presets(ctx=ctx, db=db)
         assert presets == []
-        break
 
 
 def test_signup_presets() -> None:

--- a/tests/test_syncshell_limits.py
+++ b/tests/test_syncshell_limits.py
@@ -1,13 +1,15 @@
 import asyncio
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
 import pytest
 
 from demibot.db.session import init_db, get_session
 import demibot.db.session as db_session
 from demibot.db.models import User
 from demibot.http.deps import RequestContext
-import importlib.util
-import sys
-from pathlib import Path
 
 syncshell_path = (
     Path(__file__).resolve().parents[1] / "demibot" / "demibot" / "http" / "routes" / "syncshell.py"
@@ -36,7 +38,6 @@ def test_token_expiry():
             await asyncio.sleep(1.1)
             with pytest.raises(syncshell.HTTPException):
                 await syncshell.upload_manifest([], ctx=ctx, db=db)
-            break
     asyncio.run(_run())
 
 
@@ -56,5 +57,4 @@ def test_rate_limit_hits():
             await syncshell.upload_manifest([], ctx=ctx, db=db)
             with pytest.raises(syncshell.HTTPException):
                 await syncshell.resync(ctx=ctx, db=db)
-            break
     asyncio.run(_run())

--- a/tests/test_syncshell_resync_cache.py
+++ b/tests/test_syncshell_resync_cache.py
@@ -43,5 +43,4 @@ def test_resync_and_cache_clear():
 
             await syncshell.resync(ctx=ctx, db=db)
             assert await db.get(SyncshellManifest, 1) is None
-            break
     asyncio.run(_run())

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,9 +1,11 @@
 
 from pathlib import Path
+import asyncio
+from pathlib import Path
 import sys
 import types
+
 import pytest
-import asyncio
 
 root = Path(__file__).resolve().parents[1] / 'demibot'
 sys.path.append(str(root))
@@ -63,7 +65,6 @@ def test_get_users_includes_status_from_cache():
             assert {
                 (u['id'], u['status'], tuple(u['roles'])) for u in res
             } == {('10', 'online', ('100',)), ('20', 'offline', ())}
-            break
     asyncio.run(_run())
 
 
@@ -89,5 +90,4 @@ def test_get_users_reads_presence_from_db():
             assert {
                 (u['id'], u['status'], tuple(u['roles'])) for u in res
             } == {('30', 'online', ()), ('40', 'offline', ())}
-            break
     asyncio.run(_run())

--- a/tests/test_vault_fc_id.py
+++ b/tests/test_vault_fc_id.py
@@ -47,7 +47,6 @@ def test_vault_assigns_fc_id():
             await db.commit()
             bundle = (await db.execute(select(AppearanceBundle))).scalar_one()
             assert bundle.fc_id == 1
-            break
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary
- Remove stray `break` statements from presences route, refresh script, and admin/vault cogs
- Clean up tests by dropping orphan `break`s and adding missing imports
- Ensure Python modules compile without syntax errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b985eda530832899d4a62b90e5ad88