### PR TITLE
Handle watcher cancellation on shutdown

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -99,16 +99,16 @@ public class Plugin : IDalamudPlugin
         _services.PluginInterface.UiBuilder.OpenMainUi -= _openMainUi;
         _services.PluginInterface.UiBuilder.OpenConfigUi -= _openConfigUi;
 
-        _httpClient.Dispose();
+        _channelWatcher.Dispose();
+        _requestWatcher.Dispose();
         _presenceSidebar?.Dispose();
         _presenceService?.Dispose();
         _chatWindow.Dispose();
         _officerChatWindow.Dispose();
         _mainWindow.Dispose();
         _ui.DisposeAsync().GetAwaiter().GetResult();
-        _channelWatcher.Dispose();
-        _requestWatcher.Dispose();
         _settings.Dispose();
+        _httpClient.Dispose();
     }
 
     private async Task<bool> RefreshRoles(IPluginLog log)


### PR DESCRIPTION
## Summary
- Guard channel watcher against cancellation and exit loop early when the plugin unloads
- Handle request watcher cancellation and clean up background tasks
- Dispose watchers before HttpClient to prevent disposed-client exceptions during shutdown

## Testing
- ⚠️ `dotnet test tests/DemiCatPlugin.Tests.csproj` (missing: command not found)
- ⚠️ `pytest` (41 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_68b98a73f16883289f42d92315da05ca