### PR TITLE
Add TokenManager for encrypted auth token storage

### DIFF
--- a/DemiCatPlugin/ApiHelpers.cs
+++ b/DemiCatPlugin/ApiHelpers.cs
@@ -17,8 +17,8 @@ internal static class ApiHelpers
         return true;
     }
 
-    internal static void AddAuthHeader(HttpRequestMessage request, Config config)
-        => AddAuthHeader(request, config.AuthToken);
+    internal static void AddAuthHeader(HttpRequestMessage request, TokenManager tokenManager)
+        => AddAuthHeader(request, tokenManager.Token);
 
     internal static void AddAuthHeader(HttpRequestMessage request, string? token)
     {
@@ -28,8 +28,8 @@ internal static class ApiHelpers
         }
     }
 
-    internal static void AddAuthHeader(ClientWebSocket socket, Config config)
-        => AddAuthHeader(socket, config.AuthToken);
+    internal static void AddAuthHeader(ClientWebSocket socket, TokenManager tokenManager)
+        => AddAuthHeader(socket, tokenManager.Token);
 
     internal static void AddAuthHeader(ClientWebSocket socket, string? token)
     {

--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -44,7 +44,7 @@ public class ChannelWatcher : IDisposable
         var delay = TimeSpan.FromSeconds(5);
         while (!token.IsCancellationRequested)
         {
-            if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrEmpty(_config.AuthToken) || !_config.Enabled)
+            if (!ApiHelpers.ValidateApiBaseUrl(_config) || !TokenManager.Instance!.IsReady() || !_config.Enabled)
             {
                 try { await Task.Delay(delay, token); } catch { }
                 delay = TimeSpan.FromSeconds(5);
@@ -54,7 +54,7 @@ public class ChannelWatcher : IDisposable
             {
                 _ws?.Dispose();
                 _ws = new ClientWebSocket();
-                ApiHelpers.AddAuthHeader(_ws, _config);
+                ApiHelpers.AddAuthHeader(_ws, TokenManager.Instance!);
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
                 delay = TimeSpan.FromSeconds(5);

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -442,7 +442,7 @@ public class ChatWindow : IDisposable
             try
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis");
-                ApiHelpers.AddAuthHeader(request, _config);
+                ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
                 var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
                 if (!response.IsSuccessStatusCode)
                 {
@@ -568,7 +568,7 @@ public class ChatWindow : IDisposable
                 request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}{MessagesPath}");
                 request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
             }
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -668,7 +668,7 @@ public class ChatWindow : IDisposable
             var method = remove ? HttpMethod.Delete : HttpMethod.Put;
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{_channelId}/messages/{messageId}/reactions/{Uri.EscapeDataString(emoji)}";
             var request = new HttpRequestMessage(method, url);
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -704,7 +704,7 @@ public class ChatWindow : IDisposable
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{channelId}/messages/{messageId}";
             var request = new HttpRequestMessage(HttpMethod.Patch, url);
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -738,7 +738,7 @@ public class ChatWindow : IDisposable
         {
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{channelId}/messages/{messageId}";
             var request = new HttpRequestMessage(HttpMethod.Delete, url);
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -774,7 +774,7 @@ public class ChatWindow : IDisposable
             var body = new { messageId = messageId, channelId = cid, customId = customId };
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/interactions");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -831,7 +831,7 @@ public class ChatWindow : IDisposable
                 }
 
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
-                ApiHelpers.AddAuthHeader(request, _config);
+                ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
 
                 var response = await _httpClient.SendAsync(request);
                 if (!response.IsSuccessStatusCode)
@@ -966,7 +966,7 @@ public class ChatWindow : IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -1031,7 +1031,7 @@ public class ChatWindow : IDisposable
                 _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = "Connecting...");
                 _ws?.Dispose();
                 _ws = new ClientWebSocket();
-                ApiHelpers.AddAuthHeader(_ws, _config);
+                ApiHelpers.AddAuthHeader(_ws, TokenManager.Instance!);
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
                 // Refresh presence information in case updates were missed while offline.

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -15,7 +15,6 @@ public class Config : IPluginConfiguration
     public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
     public string WebSocketPath { get; set; } = "/ws/embeds";
     public int PollIntervalSeconds { get; set; } = 5;
-    public string? AuthToken { get; set; }
     public string ChatChannelId { get; set; } = string.Empty;
     public string EventChannelId { get; set; } = string.Empty;
     public string FcChannelId { get; set; } = string.Empty;

--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -79,7 +79,7 @@ public class DiscordPresenceService : IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -123,7 +123,7 @@ public class DiscordPresenceService : IDisposable
             {
                 _ws?.Dispose();
                 _ws = new ClientWebSocket();
-                ApiHelpers.AddAuthHeader(_ws, _config);
+                ApiHelpers.AddAuthHeader(_ws, TokenManager.Instance!);
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
                 _loaded = false;

--- a/DemiCatPlugin/EmojiPicker.cs
+++ b/DemiCatPlugin/EmojiPicker.cs
@@ -71,7 +71,7 @@ public class EmojiPicker
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -281,7 +281,7 @@ public class EventCreateWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/repeat");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -313,7 +313,7 @@ public class EventCreateWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Delete, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/{id}/repeat");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (response.IsSuccessStatusCode)
             {
@@ -460,7 +460,7 @@ public class EventCreateWindow
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
 
             var response = await _httpClient.SendAsync(request);
             _lastResult = response.IsSuccessStatusCode ? "Event posted" : $"Error: {response.StatusCode}";
@@ -518,7 +518,7 @@ public class EventCreateWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -341,7 +341,7 @@ public class EventView : IDisposable
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/interactions");
             var body = new { messageId = _dto.Id, channelId = _dto.ChannelId, customId = customId };
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             _lastResult = response.IsSuccessStatusCode ? "Signup updated" : "Signup failed";
             if (response.IsSuccessStatusCode)

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -46,7 +46,7 @@ public class OfficerChatWindow : ChatWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -145,7 +145,7 @@ public class RequestBoardWindow
                 var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/requests/{req.Id}/{action}";
                 var json = JsonSerializer.Serialize(new { version = req.Version });
                 var msg = new HttpRequestMessage(HttpMethod.Post, url);
-                ApiHelpers.AddAuthHeader(msg, _config);
+                ApiHelpers.AddAuthHeader(msg, TokenManager.Instance!);
                 msg.Content = new StringContent(json, Encoding.UTF8, "application/json");
                 var resp = await _httpClient.SendAsync(msg);
                 if (resp.IsSuccessStatusCode)
@@ -219,7 +219,7 @@ public class RequestBoardWindow
         {
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/requests/{id}";
             var msg = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(msg, _config);
+            ApiHelpers.AddAuthHeader(msg, TokenManager.Instance!);
             var resp = await _httpClient.SendAsync(msg);
             if (resp.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -35,7 +35,7 @@ public class RequestWatcher : IDisposable
         var delay = TimeSpan.FromSeconds(5);
         while (!token.IsCancellationRequested)
         {
-            if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrEmpty(_config.AuthToken) || !_config.Enabled)
+            if (!ApiHelpers.ValidateApiBaseUrl(_config) || !TokenManager.Instance!.IsReady() || !_config.Enabled)
             {
                 try { await Task.Delay(delay, token); } catch { }
                 delay = TimeSpan.FromSeconds(5);
@@ -45,7 +45,7 @@ public class RequestWatcher : IDisposable
             {
                 _ws?.Dispose();
                 _ws = new ClientWebSocket();
-                ApiHelpers.AddAuthHeader(_ws, _config);
+                ApiHelpers.AddAuthHeader(_ws, TokenManager.Instance!);
                 var uri = BuildWebSocketUri();
                 await _ws.ConnectAsync(uri, token);
                 delay = TimeSpan.FromSeconds(5);

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -231,7 +231,7 @@ public class SyncshellWindow : IDisposable
                 url += $"?since={Uri.EscapeDataString(state.LastPullAt.Value.ToString("O"))}";
 
             var req = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(req, _config);
+            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
             if (!string.IsNullOrEmpty(_etag))
                 req.Headers.IfNoneMatch.Add(new EntityTagHeaderValue(_etag));
 
@@ -301,7 +301,7 @@ public class SyncshellWindow : IDisposable
             url += $"?since={Uri.EscapeDataString(since.Value.ToString("O"))}";
 
         var req = new HttpRequestMessage(HttpMethod.Get, url);
-        ApiHelpers.AddAuthHeader(req, _config);
+        ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
 
         var resp = await _httpClient.SendAsync(req);
         if (!resp.IsSuccessStatusCode)
@@ -561,7 +561,7 @@ public class SyncshellWindow : IDisposable
     {
         try
         {
-            if (string.IsNullOrEmpty(_config.AuthToken) || !ApiHelpers.ValidateApiBaseUrl(_config))
+            if (!TokenManager.Instance!.IsReady() || !ApiHelpers.ValidateApiBaseUrl(_config))
                 return;
 
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/installations";
@@ -570,7 +570,7 @@ public class SyncshellWindow : IDisposable
             {
                 Content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json")
             };
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             await _httpClient.SendAsync(request);
 
             _installations[assetId] = new Installation { AssetId = assetId, Status = status, UpdatedAt = DateTimeOffset.UtcNow };
@@ -677,11 +677,11 @@ public class SyncshellWindow : IDisposable
     {
         try
         {
-            if (string.IsNullOrEmpty(_config.AuthToken) || !ApiHelpers.ValidateApiBaseUrl(_config))
+            if (!TokenManager.Instance!.IsReady() || !ApiHelpers.ValidateApiBaseUrl(_config))
                 return;
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}{path}";
             var req = new HttpRequestMessage(HttpMethod.Post, url);
-            ApiHelpers.AddAuthHeader(req, _config);
+            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
             await _httpClient.SendAsync(req);
         }
         catch
@@ -694,14 +694,14 @@ public class SyncshellWindow : IDisposable
     {
         try
         {
-            if (string.IsNullOrEmpty(_config.AuthToken) || !ApiHelpers.ValidateApiBaseUrl(_config))
+            if (!TokenManager.Instance!.IsReady() || !ApiHelpers.ValidateApiBaseUrl(_config))
                 return;
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/syncshell/manifest";
             var req = new HttpRequestMessage(HttpMethod.Post, url)
             {
                 Content = new StringContent("[]", Encoding.UTF8, "application/json")
             };
-            ApiHelpers.AddAuthHeader(req, _config);
+            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
             await _httpClient.SendAsync(req);
         }
         catch
@@ -733,12 +733,12 @@ public class SyncshellWindow : IDisposable
     {
         try
         {
-            if (string.IsNullOrEmpty(_config.AuthToken) || !ApiHelpers.ValidateApiBaseUrl(_config))
+            if (!TokenManager.Instance!.IsReady() || !ApiHelpers.ValidateApiBaseUrl(_config))
                 return;
 
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/installations";
             var req = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(req, _config);
+            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
             var resp = await _httpClient.SendAsync(req);
             if (!resp.IsSuccessStatusCode)
                 return;

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -136,7 +136,7 @@ public class TemplatesWindow
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -271,7 +271,7 @@ public class TemplatesWindow
 
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events");
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             await _httpClient.SendAsync(request);
             _lastResult = "Template posted";
         }

--- a/DemiCatPlugin/TokenManager.cs
+++ b/DemiCatPlugin/TokenManager.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Security.Cryptography;
+using Dalamud.Plugin;
+
+namespace DemiCatPlugin;
+
+public enum LinkState
+{
+    Unlinked,
+    Linking,
+    Linked
+}
+
+public class TokenManager
+{
+    private const string TokenFileName = "token.dat";
+    private readonly IDalamudPluginInterface _pluginInterface;
+    private string? _token;
+    public LinkState State { get; private set; } = LinkState.Unlinked;
+
+    public static TokenManager? Instance { get; private set; }
+
+    public TokenManager(IDalamudPluginInterface pluginInterface)
+    {
+        _pluginInterface = pluginInterface;
+        Instance = this;
+        Load();
+    }
+
+    public bool IsReady() => State == LinkState.Linked;
+
+    public string? Token => _token;
+
+    public void Load()
+    {
+        try
+        {
+            var path = Path.Combine(_pluginInterface.ConfigDirectory.FullName, TokenFileName);
+            if (!File.Exists(path))
+            {
+                State = LinkState.Unlinked;
+                _token = null;
+                return;
+            }
+
+            var encrypted = File.ReadAllBytes(path);
+            var bytes = ProtectedData.Unprotect(encrypted, null, DataProtectionScope.CurrentUser);
+            _token = Encoding.UTF8.GetString(bytes);
+            State = string.IsNullOrEmpty(_token) ? LinkState.Unlinked : LinkState.Linked;
+        }
+        catch
+        {
+            _token = null;
+            State = LinkState.Unlinked;
+        }
+    }
+
+    public void Set(string token)
+    {
+        try
+        {
+            var path = Path.Combine(_pluginInterface.ConfigDirectory.FullName, TokenFileName);
+            var bytes = Encoding.UTF8.GetBytes(token);
+            var encrypted = ProtectedData.Protect(bytes, null, DataProtectionScope.CurrentUser);
+            File.WriteAllBytes(path, encrypted);
+            _token = token;
+            State = LinkState.Linked;
+        }
+        catch
+        {
+            _token = null;
+            State = LinkState.Unlinked;
+        }
+    }
+
+    public void Clear()
+    {
+        try
+        {
+            var path = Path.Combine(_pluginInterface.ConfigDirectory.FullName, TokenFileName);
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // ignore
+        }
+        _token = null;
+        State = LinkState.Unlinked;
+    }
+}
+

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -94,7 +94,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             _webSocket = null;
         }
 
-        if (string.IsNullOrEmpty(_config.AuthToken) || !_config.Enabled)
+        if (!TokenManager.Instance!.IsReady() || !_config.Enabled)
         {
             return;
         }
@@ -137,7 +137,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode) return;
             var stream = await response.Content.ReadAsStreamAsync();
@@ -208,7 +208,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 url += $"?channel_id={_channelId}";
             }
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -259,7 +259,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             try
             {
                 _webSocket = new ClientWebSocket();
-                ApiHelpers.AddAuthHeader(_webSocket, _config);
+                ApiHelpers.AddAuthHeader(_webSocket, TokenManager.Instance!);
                 var baseUrl = _config.ApiBaseUrl.TrimEnd('/');
                 var wsUrl = new Uri(($"{baseUrl}/ws/embeds")
                     .Replace("http://", "ws://")
@@ -418,7 +418,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 url += $"?channel_id={_channelId}";
             }
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -518,7 +518,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            ApiHelpers.AddAuthHeader(request, _config);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
## Summary
- add TokenManager with LinkState and encrypted token persistence
- remove plaintext AuthToken from Config and switch consumers to TokenManager
- check TokenManager.IsReady before making network requests

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68ba44142c2483289806f57ef4effa35