### PR TITLE
Inject TokenManager into chat windows

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -10,13 +10,20 @@ namespace DemiCatPlugin;
 
 public class FcChatWindow : ChatWindow
 {
-    public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence) : base(config, httpClient, presence)
+    public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager)
+        : base(config, httpClient, presence, tokenManager)
     {
         _channelId = config.FcChannelId;
     }
 
     public override void Draw()
     {
+        if (!_tokenManager.IsReady())
+        {
+            base.Draw();
+            return;
+        }
+
         var originalChatChannel = _config.ChatChannelId;
 
         _ = RoleCache.EnsureLoaded(_httpClient, _config);

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -56,8 +56,8 @@ public class Plugin : IDalamudPlugin
         _ui = new UiRenderer(_config, _httpClient);
         _settings = new SettingsWindow(_config, _tokenManager, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
         _presenceService = _config.EnableFcChat ? new DiscordPresenceService(_config, _httpClient) : null;
-        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService);
-        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService);
+        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager);
+        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager);
         _presenceSidebar = _presenceService != null ? new PresenceSidebar(_presenceService) : null;
         if (_presenceSidebar != null)
         {

--- a/DemiCatPlugin/TokenManager.cs
+++ b/DemiCatPlugin/TokenManager.cs
@@ -22,6 +22,14 @@ public class TokenManager
 
     public static TokenManager? Instance { get; private set; }
 
+    public TokenManager()
+    {
+        _pluginInterface = null!;
+        _token = "test";
+        State = LinkState.Linked;
+        Instance = this;
+    }
+
     public TokenManager(IDalamudPluginInterface pluginInterface)
     {
         _pluginInterface = pluginInterface;

--- a/tests/ChatWindowWebSocketTests.cs
+++ b/tests/ChatWindowWebSocketTests.cs
@@ -74,7 +74,7 @@ public class ChatWindowWebSocketTests
     private class TestChatWindow : ChatWindow
     {
         private readonly Uri _uri;
-        public TestChatWindow(Config config, HttpClient httpClient, Uri uri) : base(config, httpClient, null)
+        public TestChatWindow(Config config, HttpClient httpClient, Uri uri) : base(config, httpClient, null, new TokenManager())
         {
             _uri = uri;
         }


### PR DESCRIPTION
## Summary
- inject TokenManager into ChatWindow and check readiness before channel operations
- show “Link DemiCat…” when not linked and skip channel/network calls
- update derived windows and plugin wiring for new dependency

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba46532da48328beaf3b42fb587011