### PR TITLE
Start watchers on token link events

### DIFF
--- a/DemiCatPlugin/TokenManager.cs
+++ b/DemiCatPlugin/TokenManager.cs
@@ -22,6 +22,9 @@ public class TokenManager
 
     public static TokenManager? Instance { get; private set; }
 
+    public event Action? OnLinked;
+    public event Action? OnUnlinked;
+
     public TokenManager()
     {
         _pluginInterface = null!;
@@ -75,6 +78,7 @@ public class TokenManager
             File.WriteAllBytes(path, encrypted);
             _token = token;
             State = LinkState.Linked;
+            OnLinked?.Invoke();
         }
         catch
         {
@@ -97,6 +101,7 @@ public class TokenManager
         }
         _token = null;
         State = LinkState.Unlinked;
+        OnUnlinked?.Invoke();
     }
 }
 


### PR DESCRIPTION
## Summary
- Start/stop watchers in response to TokenManager link events
- Add TokenManager dependency and readiness checks to ChannelWatcher and RequestWatcher
- Expose TokenManager.OnLinked/OnUnlinked events

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 41 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bace60159c832899e5a0c0c8c7c800