### PR TITLE
Use WebSocket ping control frames

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -78,16 +78,6 @@ public class ChannelWatcher : IDisposable
                     {
                         break;
                     }
-                    if (message == "ping")
-                    {
-                        await _ws.SendAsync(
-                            new ArraySegment<byte>(Encoding.UTF8.GetBytes("pong")),
-                            WebSocketMessageType.Text,
-                            true,
-                            token
-                        );
-                        continue;
-                    }
                     if (message == "update" && _tokenManager.IsReady())
                     {
                         _ = PluginServices.Instance!.Framework.RunOnTick(() =>

--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -127,12 +127,6 @@ public class ChatBridge : IDisposable
                     }
 
                     var json = Encoding.UTF8.GetString(ms.ToArray());
-                    if (json == "ping")
-                    {
-                        await _ws.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes("pong")), WebSocketMessageType.Text, true, token);
-                        continue;
-                    }
-
                     MessageReceived?.Invoke(json);
                 }
             }

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net.Http;
 using System.Net.WebSockets;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -67,16 +66,6 @@ public class RequestWatcher : IDisposable
                     var (message, type) = await ChannelWatcher.ReceiveMessageAsync(_ws, buffer, token);
                     if (type == WebSocketMessageType.Close)
                         break;
-                    if (message == "ping")
-                    {
-                        await _ws.SendAsync(
-                            new ArraySegment<byte>(Encoding.UTF8.GetBytes("pong")),
-                            WebSocketMessageType.Text,
-                            true,
-                            token
-                        );
-                        continue;
-                    }
                     HandleMessage(message);
                 }
                 if (_ws.CloseStatus == WebSocketCloseStatus.PolicyViolation)

--- a/tests/test_officer_ws.py
+++ b/tests/test_officer_ws.py
@@ -16,6 +16,9 @@ class StubWebSocket:
     async def send_text(self, message: str):
         self.sent.append(message)
 
+    async def ping(self):
+        return None
+
 class StubContext:
     def __init__(self, guild_id: int, roles):
         self.guild = types.SimpleNamespace(id=guild_id)
@@ -69,8 +72,11 @@ class EndpointStubWebSocket:
         self.close_code = code
         self.close_reason = reason
 
-    async def receive_text(self) -> str:  # pragma: no cover - should not be called
-        raise RuntimeError("receive_text should not be called")
+    async def receive(self) -> str:  # pragma: no cover - should not be called
+        raise RuntimeError("receive should not be called")
+
+    async def ping(self):
+        return None
 
 
 def test_officer_path_requires_role(monkeypatch):

--- a/tests/test_ws_api_key.py
+++ b/tests/test_ws_api_key.py
@@ -1,4 +1,5 @@
 import asyncio
+import asyncio
 import types
 import pytest
 from fastapi import HTTPException, WebSocketDisconnect
@@ -22,8 +23,11 @@ class StubWebSocket:
         self.close_code = code
         self.close_reason = reason
 
-    async def receive_text(self):
+    async def receive(self):
         raise WebSocketDisconnect()
+
+    async def ping(self):
+        return None
 
 
 class DummySession:


### PR DESCRIPTION
## Summary
- use `WebSocket.ping()` for connection keep-alive in WebSocket managers
- drop text-based ping/pong handling on both server and client
- refactor tests for new WebSocket behaviour

## Testing
- `PYTHONPATH=demibot pytest tests/test_ws_api_key.py tests/test_officer_ws.py -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_68bb779f28308328b5da3844e20ea58b