### PR TITLE
Ensure token readiness before network operations

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -115,7 +115,7 @@ public class ChatWindow : IDisposable
     public void StopNetworking()
     {
         _bridge.Stop();
-        _presence?.Reset();
+        _presence?.Stop();
     }
 
     public virtual void Draw()

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -54,6 +54,15 @@ public class RequestWatcher : IDisposable
             }
             try
             {
+                var ping = new HttpRequestMessage(HttpMethod.Head, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/ping");
+                ApiHelpers.AddAuthHeader(ping, _tokenManager);
+                var pingResponse = await _httpClient.SendAsync(ping, token);
+                if (!pingResponse.IsSuccessStatusCode)
+                {
+                    try { await Task.Delay(delay, token); } catch { }
+                    delay = TimeSpan.FromSeconds(5);
+                    continue;
+                }
                 _ws?.Dispose();
                 _ws = new ClientWebSocket();
                 ApiHelpers.AddAuthHeader(_ws, _tokenManager);

--- a/DemiCatPlugin/TokenManager.cs
+++ b/DemiCatPlugin/TokenManager.cs
@@ -103,5 +103,15 @@ public class TokenManager
         State = LinkState.Unlinked;
         OnUnlinked?.Invoke();
     }
+
+    public void RegisterWatcher(Action start, Action stop)
+    {
+        OnLinked += start;
+        OnUnlinked += stop;
+        if (IsReady())
+        {
+            start();
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- perform `/api/ping` before each websocket ConnectAsync
- stop or pause watchers when token is not linked
- add TokenManager.RegisterWatcher to drive watcher start/stop

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: command not found: dotnet)*
- `pytest tests/test_channel_kind_enum.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68bb80758b188328953db46612475949