### PR TITLE
Add REST RSVP endpoints and event signup model

### DIFF
--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -338,8 +338,9 @@ public class EventView : IDisposable
 
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/interactions");
-            var body = new { messageId = _dto.Id, channelId = _dto.ChannelId, customId = customId };
+            var tag = customId.Contains(':') ? customId.Split(':', 2)[1] : customId;
+            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/{_dto.Id}/rsvp");
+            var body = new { tag = tag };
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
             ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -269,14 +269,20 @@ class Embed(Base):
     )
 
 
-class Attendance(Base):
-    __tablename__ = "attendance"
-
-    discord_message_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
-    user_id: Mapped[int] = mapped_column(
-        BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True
+class EventSignup(Base):
+    __tablename__ = "event_signups"
+    __table_args__ = (
+        UniqueConstraint("message_id", "user_id", name="uq_event_signups_message_user"),
+        Index("ix_event_signups_message_tag", "message_id", "tag"),
     )
-    choice: Mapped[str] = mapped_column(String(50))
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    message_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), index=True)
+    user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), index=True
+    )
+    tag: Mapped[str] = mapped_column(String(50))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
 class Presence(Base):

--- a/tests/test_rsvp_max_signups.py
+++ b/tests/test_rsvp_max_signups.py
@@ -19,7 +19,13 @@ sys.modules.setdefault("demibot.http", http_pkg)
 
 from demibot.db.models import Guild, GuildChannel, User, ChannelKind
 from demibot.db.session import init_db, get_session
-from demibot.http.routes.events import create_event, CreateEventBody
+from demibot.http.routes.events import (
+    create_event,
+    CreateEventBody,
+    rsvp_event,
+    RsvpBody,
+    list_attendees,
+)
 from demibot.http.routes.interactions import post_interaction, InteractionBody
 from unittest.mock import patch
 
@@ -39,7 +45,7 @@ async def _run_test() -> None:
         await db.commit()
 
         body = CreateEventBody(
-            channel_id="123",
+            channelId="123",
             title="Test",
             time="2024-01-01T00:00:00Z",
             description="desc",
@@ -55,14 +61,14 @@ async def _run_test() -> None:
 
         ctx1 = SimpleNamespace(user=SimpleNamespace(id=1), guild=SimpleNamespace(id=1))
         await post_interaction(
-            body=InteractionBody(message_id=result["id"], custom_id="rsvp:join"),
+            body=InteractionBody(messageId=result["id"], customId="rsvp:join"),
             ctx=ctx1,
             db=db,
         )
 
         ctx2 = SimpleNamespace(user=SimpleNamespace(id=2), guild=SimpleNamespace(id=1))
         resp = await post_interaction(
-            body=InteractionBody(message_id=result["id"], custom_id="rsvp:join"),
+            body=InteractionBody(messageId=result["id"], customId="rsvp:join"),
             ctx=ctx2,
             db=db,
         )
@@ -72,3 +78,48 @@ async def _run_test() -> None:
 
 def test_max_signups_enforced() -> None:
     asyncio.run(_run_test())
+
+
+async def _run_rest_test() -> None:
+    db_path = Path("test_rsvp_rest.db")
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    async with get_session() as db:
+        guild = Guild(id=2, discord_guild_id=2, name="Test Guild")
+        db.add(guild)
+        db.add(GuildChannel(guild_id=guild.id, channel_id=124, kind=ChannelKind.EVENT))
+        db.add(User(id=3, discord_user_id=3))
+        db.add(User(id=4, discord_user_id=4))
+        await db.commit()
+
+        body = CreateEventBody(
+            channelId="124",
+            title="Test",
+            time="2024-01-01T00:00:00Z",
+            description="desc",
+            buttons=[{"label": "Join", "customId": "rsvp:join", "maxSignups": 1}],
+        )
+        ctx = SimpleNamespace(guild=SimpleNamespace(id=2))
+        original_dumps = json.dumps
+        with patch(
+            "demibot.http.routes.events.json.dumps",
+            lambda obj, *a, **k: original_dumps(obj, default=str, *a, **k),
+        ):
+            result = await create_event(body=body, ctx=ctx, db=db)
+
+        ctx1 = SimpleNamespace(user=SimpleNamespace(id=3), guild=SimpleNamespace(id=2))
+        await rsvp_event(event_id=result["id"], body=RsvpBody(tag="join"), ctx=ctx1, db=db)
+
+        ctx2 = SimpleNamespace(user=SimpleNamespace(id=4), guild=SimpleNamespace(id=2))
+        resp = await rsvp_event(event_id=result["id"], body=RsvpBody(tag="join"), ctx=ctx2, db=db)
+        assert isinstance(resp, JSONResponse)
+        assert resp.status_code == 400
+
+        attendees = await list_attendees(event_id=result["id"], ctx=ctx1, db=db)
+        assert attendees == [{"tag": "join", "userId": 3}]
+
+
+def test_rest_rsvp_and_attendees() -> None:
+    asyncio.run(_run_rest_test())

--- a/ui/components/EmbedRenderer.vue
+++ b/ui/components/EmbedRenderer.vue
@@ -24,6 +24,15 @@
         </span>
         <span class="footer-text">{{ embed.footer.text }}</span>
       </div>
+      <div v-if="embed.buttons && embed.buttons.length" class="embed-buttons">
+        <button
+          v-for="(btn, i) in embed.buttons"
+          :key="i"
+          @click="rsvp(btn.customId)"
+        >
+          <span v-if="btn.emoji">{{ btn.emoji }} </span>{{ btn.label }}
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -35,6 +44,10 @@ export default {
     embed: {
       type: Object,
       required: true
+    },
+    eventId: {
+      type: String,
+      required: false
     }
   },
   computed: {
@@ -42,6 +55,20 @@ export default {
       if (!this.embed.color) return {};
       const color = `#${this.embed.color.toString(16).padStart(6, '0')}`;
       return { borderColor: color };
+    }
+  },
+  methods: {
+    async rsvp(customId) {
+      const tag = customId.includes(':') ? customId.split(':', 2)[1] : customId;
+      try {
+        await fetch(`/api/events/${this.eventId || this.embed.id}/rsvp`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tag })
+        });
+      } catch (e) {
+        console.error('RSVP failed', e);
+      }
     }
   }
 };

--- a/ui/pages/Events.vue
+++ b/ui/pages/Events.vue
@@ -12,7 +12,7 @@
         </div>
       </div>
       <div v-if="event.embeds">
-        <EmbedRenderer v-for="(emb, i) in event.embeds" :key="i" :embed="emb" />
+        <EmbedRenderer v-for="(emb, i) in event.embeds" :key="i" :embed="emb" :event-id="event.id" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- replace Attendance model with EventSignup and support tag-based signups
- add REST RSVP and attendee export endpoints with websocket updates
- wire up plugin and web UI RSVP calls and cover with tests

## Testing
- `pytest tests/test_rsvp_max_signups.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc1ee646ac83289eed4944c7034fbf