### PR TITLE
feat: add embed preview editor and parity

### DIFF
--- a/tests/test_event_preview_parity.py
+++ b/tests/test_event_preview_parity.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+import types
+from types import SimpleNamespace
+import asyncio
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.db.models import Guild, GuildChannel, ChannelKind
+from demibot.db.session import init_db, get_session
+from demibot.http.routes.events import create_event, list_events, CreateEventBody
+
+
+async def _run_test() -> None:
+    db_path = Path("test_preview.db")
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    async with get_session() as db:
+        guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
+        db.add(guild)
+        db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
+        await db.commit()
+
+    embed = {"title": "Sample", "description": "Desc"}
+    body = CreateEventBody(channelId="123", title="Sample", description="Desc", embeds=[embed])
+    ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
+    async with get_session() as db:
+        await create_event(body=body, ctx=ctx, db=db)
+        events = await list_events(ctx=ctx, db=db)
+        assert events[0]["embeds"][0] == embed
+
+
+def test_preview_matches_server():
+    asyncio.run(_run_test())

--- a/ui/utils/embed.js
+++ b/ui/utils/embed.js
@@ -1,0 +1,70 @@
+export const TITLE_LIMIT = 256;
+export const DESCRIPTION_LIMIT = 4096;
+export const FIELD_NAME_LIMIT = 256;
+export const FIELD_VALUE_LIMIT = 1024;
+export const FIELD_COUNT_LIMIT = 25;
+export const FOOTER_TEXT_LIMIT = 2048;
+export const AUTHOR_NAME_LIMIT = 256;
+export const TOTAL_CHAR_LIMIT = 6000;
+export const BUTTON_LABEL_LIMIT = 80;
+export const BUTTON_COUNT_LIMIT = 25;
+
+function checkUrl(name, url) {
+  if (url && !/^https?:\/\//i.test(url)) {
+    return `Invalid ${name}`;
+  }
+  return null;
+}
+
+export function validateEmbed(dto, buttons = []) {
+  let total = 0;
+  if (dto.title) {
+    if (dto.title.length > TITLE_LIMIT) return 'Title too long';
+    total += dto.title.length;
+  }
+  if (dto.description) {
+    if (dto.description.length > DESCRIPTION_LIMIT) return 'Description too long';
+    total += dto.description.length;
+  }
+  if (dto.footerText) {
+    if (dto.footerText.length > FOOTER_TEXT_LIMIT) return 'Footer too long';
+    total += dto.footerText.length;
+  }
+  if (dto.authorName) {
+    if (dto.authorName.length > AUTHOR_NAME_LIMIT) return 'Author name too long';
+    total += dto.authorName.length;
+  }
+  if (dto.fields) {
+    if (dto.fields.length > FIELD_COUNT_LIMIT) return 'Too many fields';
+    for (const f of dto.fields) {
+      if (f.name.length > FIELD_NAME_LIMIT) return 'Field name too long';
+      if (f.value.length > FIELD_VALUE_LIMIT) return 'Field value too long';
+      total += f.name.length + f.value.length;
+    }
+  }
+  if (total > TOTAL_CHAR_LIMIT) return 'Embed too large';
+
+  let err;
+  if ((err = checkUrl('url', dto.url))) return err;
+  if ((err = checkUrl('thumbnail url', dto.thumbnailUrl))) return err;
+  if ((err = checkUrl('image url', dto.imageUrl))) return err;
+  if ((err = checkUrl('provider url', dto.providerUrl))) return err;
+  if ((err = checkUrl('footer icon url', dto.footerIconUrl))) return err;
+  if ((err = checkUrl('author icon url', dto.authorIconUrl))) return err;
+  if ((err = checkUrl('video url', dto.videoUrl))) return err;
+  if (dto.authors) {
+    for (const a of dto.authors) {
+      if (a.name && a.name.length > AUTHOR_NAME_LIMIT) return 'Author name too long';
+      if ((err = checkUrl('author url', a.url))) return err;
+      if ((err = checkUrl('author icon url', a.iconUrl))) return err;
+    }
+  }
+  if (buttons) {
+    if (buttons.length > BUTTON_COUNT_LIMIT) return 'Too many buttons';
+    for (const b of buttons) {
+      if (b.label && b.label.length > BUTTON_LABEL_LIMIT) return 'Button label too long';
+      if ((err = checkUrl('button url', b.url))) return err;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- replace Create.vue form with two-pane editor and client-side validation
- render and post preview payload from EventCreateWindow with camelCase serialization
- add test to ensure preview structure matches server events

## Testing
- `pytest` *(fails: 45 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68bc2832b56c83288ead4615c87df60e