### PR TITLE
Handle officer-gated template update events

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -41,6 +41,7 @@ public class ChatBridge : IDisposable
     public event Action? Unlinked;
     public event Action<string>? StatusChanged;
     public event Action<string, long>? ResyncRequested;
+    public event Action? TemplatesUpdated;
 
     public ChatBridge(Config config, HttpClient httpClient, TokenManager tokenManager, Func<Uri> uriBuilder)
     {
@@ -219,6 +220,15 @@ public class ChatBridge : IDisposable
         {
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
+            if (root.TryGetProperty("topic", out var topicEl))
+            {
+                var topic = topicEl.GetString();
+                if (topic == "templates.updated")
+                {
+                    TemplatesUpdated?.Invoke();
+                }
+                return;
+            }
             var op = root.GetProperty("op").GetString();
             switch (op)
             {

--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -413,6 +413,13 @@ class Mirror(commands.Cog):
                     officer_only=is_officer,
                     path="/ws/embeds",
                 )
+                await emit_event(
+                    {
+                        "channel": str(channel_id),
+                        "op": "eu",
+                        "d": dto.model_dump(mode="json", by_alias=True, exclude_none=True),
+                    }
+                )
             else:
                 msg = await db.get(Message, after.id)
                 if msg is None:
@@ -568,6 +575,13 @@ class Mirror(commands.Cog):
                         guild_id,
                         officer_only=is_officer,
                         path="/ws/embeds",
+                    )
+                    await emit_event(
+                        {
+                            "channel": str(channel_id),
+                            "op": "ed",
+                            "d": {"id": str(message.id)},
+                        }
                     )
                 else:
                     msg = await db.get(Message, message.id)

--- a/demibot/demibot/http/ws.py
+++ b/demibot/demibot/http/ws.py
@@ -63,13 +63,15 @@ class ConnectionManager:
         for ws, info in list(self.connections.items()):
             if info.guild_id != guild_id:
                 continue
-            if officer_only:
-                if "officer" not in info.roles or info.path != "/ws/officer-messages":
-                    continue
-            elif path is not None:
+            if path is not None:
                 if info.path != path:
                     continue
+            elif officer_only:
+                if info.path != "/ws/officer-messages":
+                    continue
             elif info.path == "/ws/officer-messages":
+                continue
+            if officer_only and "officer" not in info.roles:
                 continue
             targets.append(ws)
             coros.append(asyncio.wait_for(ws.send_text(message), SEND_TIMEOUT))

--- a/tests/test_template_ws.py
+++ b/tests/test_template_ws.py
@@ -1,0 +1,43 @@
+import types
+import asyncio
+
+from demibot.http.ws import ConnectionManager
+
+
+class StubWebSocket:
+    def __init__(self, path: str):
+        self.scope = {"path": path}
+        self.sent: list[str] = []
+
+    async def accept(self):
+        pass
+
+    async def send_text(self, message: str):
+        self.sent.append(message)
+
+    async def ping(self):
+        return None
+
+
+class StubContext:
+    def __init__(self, guild_id: int, roles):
+        self.guild = types.SimpleNamespace(id=guild_id)
+        self.roles = roles
+
+
+def test_officer_filter_on_templates_path():
+    async def _run():
+        manager = ConnectionManager()
+        ws_officer = StubWebSocket("/ws/templates")
+        ctx_officer = StubContext(1, ["officer"])
+        await manager.connect(ws_officer, ctx_officer)
+        ws_member = StubWebSocket("/ws/templates")
+        ctx_member = StubContext(1, [])
+        await manager.connect(ws_member, ctx_member)
+
+        await manager.broadcast_text("hi", 1, officer_only=True, path="/ws/templates")
+
+        assert ws_officer.sent == ["hi"]
+        assert ws_member.sent == []
+
+    asyncio.run(_run())

--- a/ui/pages/Templates.vue
+++ b/ui/pages/Templates.vue
@@ -44,7 +44,19 @@ export default {
         try {
           const msg = JSON.parse(ev.data);
           if (msg.topic === 'templates.updated') {
-            this.load();
+            const p = msg.payload || {};
+            if (p.deleted) {
+              this.templates = this.templates.filter(t => t.id !== p.id);
+            } else if (p.id) {
+              const idx = this.templates.findIndex(t => t.id === p.id);
+              if (idx >= 0) {
+                this.templates.splice(idx, 1, p);
+              } else {
+                this.templates.push(p);
+              }
+            } else {
+              this.load();
+            }
           }
         } catch (e) {
           console.error('Bad embed payload', e);
@@ -56,7 +68,6 @@ export default {
     },
     async remove(id) {
       await fetch(`/api/templates/${id}`, { method: 'DELETE' });
-      await this.load();
     }
   }
 };


### PR DESCRIPTION
## Summary
- Honor channel kind when broadcasting `templates.updated`
- Emit websocket events when event messages are edited or deleted on Discord
- Refresh templates in UI and plugin via new websocket topic
- Cover officer-only template subscriptions in tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d46be5c832894c661ed26cd020b