### PR TITLE
Track event signup timestamps with composite index

### DIFF
--- a/demibot/demibot/db/migrations/versions/0034_add_event_signup_timestamp.py
+++ b/demibot/demibot/db/migrations/versions/0034_add_event_signup_timestamp.py
@@ -1,0 +1,35 @@
+import sqlalchemy as sa
+from alembic import op
+from datetime import datetime
+
+# revision identifiers, used by Alembic.
+revision = "0034_add_event_signup_timestamp"
+down_revision = "0033_add_event_templates"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "event_signups",
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index(
+        "ix_event_signups_discord_message_id_choice",
+        "event_signups",
+        ["message_id", "tag"],
+    )
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("UPDATE event_signups SET created_at = :now WHERE created_at IS NULL"),
+        {"now": datetime.utcnow()},
+    )
+    op.alter_column("event_signups", "created_at", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_event_signups_discord_message_id_choice",
+        table_name="event_signups",
+    )
+    op.drop_column("event_signups", "created_at")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -273,15 +273,21 @@ class EventSignup(Base):
     __tablename__ = "event_signups"
     __table_args__ = (
         UniqueConstraint("message_id", "user_id", name="uq_event_signups_message_user"),
-        Index("ix_event_signups_message_tag", "message_id", "tag"),
+        Index(
+            "ix_event_signups_discord_message_id_choice",
+            "message_id",
+            "tag",
+        ),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    message_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), index=True)
+    discord_message_id: Mapped[int] = mapped_column(
+        "message_id", BIGINT(unsigned=True), index=True
+    )
     user_id: Mapped[int] = mapped_column(
         BIGINT(unsigned=True), ForeignKey("users.id"), index=True
     )
-    tag: Mapped[str] = mapped_column(String(50))
+    choice: Mapped[str] = mapped_column("tag", String(50))
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 

--- a/tests/test_rsvp_timestamp_index.py
+++ b/tests/test_rsvp_timestamp_index.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from sqlalchemy import select, text
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+import sys, types
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.db.models import Guild, GuildChannel, User, ChannelKind, EventSignup
+from demibot.db.session import init_db, get_session
+from demibot.http.routes.events import (
+    create_event,
+    CreateEventBody,
+    rsvp_event,
+    RsvpBody,
+)
+
+async def _run_test():
+    db_path = Path("test_rsvp_timestamp.db")
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    async with get_session() as db:
+        guild = Guild(id=10, discord_guild_id=10, name="Test Guild")
+        db.add(guild)
+        db.add(GuildChannel(guild_id=guild.id, channel_id=555, kind=ChannelKind.EVENT))
+        db.add(User(id=20, discord_user_id=20))
+        await db.commit()
+
+        body = CreateEventBody(
+            channelId="555",
+            title="Test",
+            time="2024-01-01T00:00:00Z",
+            description="desc",
+            buttons=[
+                {"label": "Join", "customId": "rsvp:join"},
+                {"label": "Maybe", "customId": "rsvp:maybe"},
+            ],
+        )
+        ctx = SimpleNamespace(guild=SimpleNamespace(id=10))
+        original_dumps = json.dumps
+        with patch(
+            "demibot.http.routes.events.json.dumps",
+            lambda obj, *a, **k: original_dumps(obj, default=str, *a, **k),
+        ):
+            result = await create_event(body=body, ctx=ctx, db=db)
+
+        ctx_user = SimpleNamespace(user=SimpleNamespace(id=20), guild=SimpleNamespace(id=10))
+        await rsvp_event(event_id=result["id"], body=RsvpBody(tag="join"), ctx=ctx_user, db=db)
+
+        row = (
+            await db.execute(
+                select(EventSignup).where(
+                    EventSignup.discord_message_id == int(result["id"]),
+                    EventSignup.user_id == 20,
+                )
+            )
+        ).scalar_one()
+        first_time = row.created_at
+        assert first_time is not None
+
+        await rsvp_event(event_id=result["id"], body=RsvpBody(tag="maybe"), ctx=ctx_user, db=db)
+        row2 = (
+            await db.execute(
+                select(EventSignup).where(
+                    EventSignup.discord_message_id == int(result["id"]),
+                    EventSignup.user_id == 20,
+                )
+            )
+        ).scalar_one()
+        assert row2.choice == "maybe"
+        assert row2.created_at > first_time
+
+        idx_rows = await db.execute(text("PRAGMA index_list('event_signups')"))
+        index_names = [r[1] for r in idx_rows]
+        assert "ix_event_signups_discord_message_id_choice" in index_names
+
+
+def test_timestamp_and_index():
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- record timestamped event signups and expose `discord_message_id`/`choice` fields
- populate and update signup timestamps in interaction and REST RSVP handlers
- export attendees ordered by choice and add migration with composite index

## Testing
- `pytest tests/test_rsvp_max_signups.py tests/test_rsvp_timestamp_index.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2f96bfe48328975dd551f6658cef