### PR TITLE
Add feature flags and settings endpoint

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -34,6 +34,10 @@ public class ChannelWatcher : IDisposable
 
     public async Task Start()
     {
+        if (!_config.Events && !_config.SyncedChat && !_config.Officer)
+        {
+            return;
+        }
         _cts?.Cancel();
         if (_task != null)
         {
@@ -96,7 +100,7 @@ public class ChannelWatcher : IDisposable
                         {
                             _ = SafeRefresh(_ui.RefreshChannels);
                             _ = SafeRefresh(_eventCreateWindow.RefreshChannels);
-                            if (_config.EnableFcChat)
+                            if (_config.SyncedChat && _config.EnableFcChat)
                                 _ = SafeRefresh(_chatWindow.RefreshChannels);
                             _ = SafeRefresh(_officerChatWindow.RefreshChannels);
                         });
@@ -133,7 +137,7 @@ public class ChannelWatcher : IDisposable
                 {
                     _ = SafeRefresh(_ui.RefreshChannels);
                     _ = SafeRefresh(_eventCreateWindow.RefreshChannels);
-                    if (_config.EnableFcChat)
+                    if (_config.SyncedChat && _config.EnableFcChat)
                         _ = SafeRefresh(_chatWindow.RefreshChannels);
                     _ = SafeRefresh(_officerChatWindow.RefreshChannels);
                 });

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -101,12 +101,8 @@ public class ChatWindow : IDisposable
         });
     }
 
-    public void StartNetworking()
+    public virtual void StartNetworking()
     {
-        if (!_config.EnableFcChat)
-        {
-            return;
-        }
         _bridge.Start();
         _bridge.Subscribe(_channelId);
         _presence?.Reset();

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -23,10 +23,24 @@ public class Config : IPluginConfiguration
     public string OfficerChannelId { get; set; } = string.Empty;
     public bool EnableFcChat { get; set; } = true;
     public bool EnableFcChatUserSet { get; set; } = false;
+
+    [JsonPropertyName("syncedChat")]
+    public bool SyncedChat { get; set; } = true;
+    [JsonPropertyName("events")]
+    public bool Events { get; set; } = true;
+    [JsonPropertyName("templatesEnabled")]
+    public bool Templates { get; set; } = true;
+    [JsonPropertyName("requests")]
+    public bool Requests { get; set; } = true;
+    [JsonPropertyName("officer")]
+    public bool Officer { get; set; } = true;
+    [JsonPropertyName("fcSyncShell")]
+    public bool FCSyncShell { get; set; } = false;
     public bool UseCharacterName { get; set; } = false;
     public List<string> Roles { get; set; } = new();
     public List<RoleDto> GuildRoles { get; set; } = new();
-    public List<Template> Templates { get; set; } = new();
+    [JsonPropertyName("templates")]
+    public List<Template> TemplateData { get; set; } = new();
     public List<SignupPreset> SignupPresets { get; set; } = new();
 
     [JsonPropertyName("requestStates")]
@@ -35,8 +49,6 @@ public class Config : IPluginConfiguration
     [JsonPropertyName("requestsDeltaToken")]
     public string? RequestsDeltaToken { get; set; }
 
-    [JsonPropertyName("syncEnabled")]
-    public bool SyncEnabled { get; set; } = false;
 
     [JsonPropertyName("autoApply")]
     public Dictionary<string, bool> AutoApply { get; set; } = new();

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -58,11 +58,19 @@ public class EventCreateWindow
         _httpClient = httpClient;
         _channelId = config.EventChannelId;
         ResetDefaultButtons();
-        _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
+        if (_config.Events)
+        {
+            _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
+        }
     }
 
     public void Draw()
     {
+        if (!_config.Events)
+        {
+            ImGui.TextUnformatted("Feature disabled");
+            return;
+        }
         if (!_channelsLoaded)
         {
             _ = FetchChannels();
@@ -418,7 +426,7 @@ public class EventCreateWindow
             Mentions = _mentions.Select(ulong.Parse).ToList()
         };
 
-        _config.Templates.Add(tmpl);
+        _config.TemplateData.Add(tmpl);
         PluginServices.Instance!.PluginInterface.SavePluginConfig(_config);
         _lastResult = "Template saved";
     }
@@ -522,6 +530,11 @@ public class EventCreateWindow
 
     public Task RefreshChannels()
     {
+        if (!_config.Events)
+        {
+            _channelsLoaded = true;
+            return Task.CompletedTask;
+        }
         _channelsLoaded = false;
         _channelFetchFailed = false;
         _channelErrorMessage = string.Empty;
@@ -530,6 +543,11 @@ public class EventCreateWindow
 
     private async Task FetchChannels(bool refreshed = false)
     {
+        if (!_config.Events)
+        {
+            _channelsLoaded = true;
+            return;
+        }
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
             PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -16,8 +16,23 @@ public class FcChatWindow : ChatWindow
         _channelId = config.FcChannelId;
     }
 
+    public override void StartNetworking()
+    {
+        if (!_config.SyncedChat || !_config.EnableFcChat)
+        {
+            return;
+        }
+        base.StartNetworking();
+    }
+
     public override void Draw()
     {
+        if (!_config.SyncedChat)
+        {
+            ImGui.TextUnformatted("Feature disabled");
+            return;
+        }
+
         if (!_tokenManager.IsReady())
         {
             base.Draw();
@@ -101,7 +116,7 @@ public class FcChatWindow : ChatWindow
 
     public override Task RefreshMessages()
     {
-        if (!_config.EnableFcChat)
+        if (!_config.SyncedChat || !_config.EnableFcChat)
         {
             return Task.CompletedTask;
         }
@@ -110,7 +125,7 @@ public class FcChatWindow : ChatWindow
 
     protected override Task FetchChannels(bool refreshed = false)
     {
-        if (!_config.EnableFcChat)
+        if (!_config.SyncedChat || !_config.EnableFcChat)
         {
             return Task.CompletedTask;
         }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -36,7 +36,7 @@ public class MainWindow : IDisposable
         _create = new EventCreateWindow(config, httpClient);
         _templates = new TemplatesWindow(config, httpClient);
         _requestBoard = new RequestBoardWindow(config, httpClient);
-        _syncshell = new SyncshellWindow(config, httpClient);
+        _syncshell = config.FCSyncShell ? new SyncshellWindow(config, httpClient) : null;
     }
 
     public void Draw()
@@ -81,7 +81,7 @@ public class MainWindow : IDisposable
         {
             if (ImGui.BeginTabItem("Events"))
             {
-                if (_config.EnableFcChat && _presenceSidebar != null)
+                if (_config.SyncedChat && _presenceSidebar != null)
                 {
                     if (!linked)
                     {
@@ -124,13 +124,20 @@ public class MainWindow : IDisposable
                 ImGui.EndTabItem();
             }
 
-            if (_config.SyncEnabled && ImGui.BeginTabItem("Syncshell"))
+            if (ImGui.BeginTabItem("Syncshell"))
             {
-                _syncshell.Draw();
+                if (_config.FCSyncShell && _syncshell != null)
+                {
+                    _syncshell.Draw();
+                }
+                else
+                {
+                    ImGui.TextUnformatted("Feature disabled");
+                }
                 ImGui.EndTabItem();
             }
 
-            if (_config.EnableFcChat && _chat != null)
+            if (_chat != null)
             {
                 if (!linked)
                 {
@@ -161,7 +168,7 @@ public class MainWindow : IDisposable
                 }
                 else if (ImGui.BeginTabItem("Officer"))
                 {
-                    if (_config.EnableFcChat && _presenceSidebar != null)
+                    if (_config.SyncedChat && _presenceSidebar != null)
                     {
                         _presenceSidebar.Draw();
                         ImGui.SameLine();
@@ -176,10 +183,6 @@ public class MainWindow : IDisposable
             ImGui.EndTabBar();
         }
 
-        if (!_config.SyncEnabled)
-        {
-            ImGui.TextUnformatted("Feature in development");
-        }
 
         ImGui.End();
         ImGui.PopStyleColor(5);

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -15,8 +15,23 @@ public class OfficerChatWindow : ChatWindow
         _channelId = config.OfficerChannelId;
     }
 
+    public override void StartNetworking()
+    {
+        if (!_config.Officer)
+        {
+            return;
+        }
+        base.StartNetworking();
+    }
+
     public override void Draw()
     {
+        if (!_config.Officer)
+        {
+            ImGui.TextUnformatted("Feature disabled");
+            return;
+        }
+
         if (!_tokenManager.IsReady())
         {
             base.Draw();

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -35,11 +35,19 @@ public class RequestBoardWindow
         _config = config;
         _httpClient = httpClient;
         _gameData = new GameDataCache(httpClient);
-        _ = RequestStateService.RefreshAll(httpClient, config);
+        if (config.Requests)
+        {
+            _ = RequestStateService.RefreshAll(httpClient, config);
+        }
     }
 
     public void Draw()
     {
+        if (!_config.Requests)
+        {
+            ImGui.TextUnformatted("Feature disabled");
+            return;
+        }
         var mode = (int)_sortMode;
         if (ImGui.Combo("Sort By", ref mode, SortLabels, SortLabels.Length))
             _sortMode = (SortMode)mode;

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -25,6 +25,10 @@ public class RequestWatcher : IDisposable
 
     public void Start()
     {
+        if (!_config.Requests)
+        {
+            return;
+        }
         _cts?.Cancel();
         _ws?.Dispose();
         _cts = new CancellationTokenSource();
@@ -46,7 +50,7 @@ public class RequestWatcher : IDisposable
         var delay = TimeSpan.FromSeconds(5);
         while (!token.IsCancellationRequested)
         {
-            if (!ApiHelpers.ValidateApiBaseUrl(_config) || !_tokenManager.IsReady() || !_config.Enabled)
+            if (!ApiHelpers.ValidateApiBaseUrl(_config) || !_tokenManager.IsReady() || !_config.Enabled || !_config.Requests)
             {
                 try { await Task.Delay(delay, token); } catch { }
                 delay = TimeSpan.FromSeconds(5);

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -115,10 +115,10 @@ public class SettingsWindow : IDisposable
                         ImGui.SetTooltip("Link DemiCat to enable chat and presence.");
                 }
 
-                var syncEnabled = _config.SyncEnabled;
+                var syncEnabled = _config.FCSyncShell;
                 if (ImGui.Checkbox("Enable Sync", ref syncEnabled))
                 {
-                    _config.SyncEnabled = syncEnabled;
+                    _config.FCSyncShell = syncEnabled;
                     SaveConfig();
                     _ = Task.Run(PushSettings);
                 }
@@ -225,7 +225,7 @@ public class SettingsWindow : IDisposable
             using var doc = JsonDocument.Parse(body);
             if (doc.RootElement.TryGetProperty("consent_sync", out var consent))
             {
-                _config.SyncEnabled = consent.GetBoolean();
+                _config.FCSyncShell = consent.GetBoolean();
             }
 
             if (doc.RootElement.TryGetProperty("settings", out var settings) && settings.ValueKind == JsonValueKind.Object)
@@ -272,7 +272,7 @@ public class SettingsWindow : IDisposable
                     categories = _categoryToggles,
                     autoApply = _config.AutoApply
                 },
-                consent_sync = _config.SyncEnabled
+                consent_sync = _config.FCSyncShell
             };
 
             var request = new HttpRequestMessage(HttpMethod.Put, url)

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -49,6 +49,10 @@ public class SyncshellWindow : IDisposable
     {
         _config = config;
         _httpClient = httpClient;
+        if (!_config.FCSyncShell)
+        {
+            return;
+        }
 
         if (!_config.Categories.TryGetValue("syncshell", out var state))
         {
@@ -72,7 +76,7 @@ public class SyncshellWindow : IDisposable
 
     public void Draw()
     {
-        if (!_config.SyncEnabled)
+        if (!_config.FCSyncShell)
         {
             const string message = "SyncShell is under development";
             var size = ImGui.CalcTextSize(message);
@@ -212,7 +216,7 @@ public class SyncshellWindow : IDisposable
 
     private async Task Refresh()
     {
-        if (!_config.SyncEnabled || _loading || _syncPaused)
+        if (!_config.FCSyncShell || _loading || _syncPaused)
             return;
 
         try
@@ -394,7 +398,7 @@ public class SyncshellWindow : IDisposable
     {
         try
         {
-            if (!_config.SyncEnabled)
+            if (!_config.FCSyncShell)
                 return (false, "Sync disabled");
             if (!ApiHelpers.ValidateApiBaseUrl(_config))
                 return (false, "Invalid API URL");
@@ -543,7 +547,7 @@ public class SyncshellWindow : IDisposable
 
     private void ApplyIpc(string channel, string payload)
     {
-        if (!_config.SyncEnabled)
+        if (!_config.FCSyncShell)
             return;
 
         try
@@ -781,7 +785,7 @@ public class SyncshellWindow : IDisposable
                 await Task.Delay(TimeSpan.FromMinutes(5), _cts.Token);
                 if (_cts.IsCancellationRequested)
                     break;
-                if (_config.SyncEnabled)
+                if (_config.FCSyncShell)
                     await Refresh();
             }
             catch (TaskCanceledException)

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -36,6 +36,11 @@ public class TemplatesWindow
 
     public void Draw()
     {
+        if (!_config.Templates)
+        {
+            ImGui.TextUnformatted("Feature disabled");
+            return;
+        }
         if (!_channelsLoaded)
         {
             _ = FetchChannels();
@@ -57,7 +62,7 @@ public class TemplatesWindow
 
         _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
         ImGui.BeginChild("TemplateList", new Vector2(150, 0), true);
-        var filteredTemplates = _config.Templates.Where(t => t.Type == TemplateType.Event).ToList();
+        var filteredTemplates = _config.TemplateData.Where(t => t.Type == TemplateType.Event).ToList();
         for (var i = 0; i < filteredTemplates.Count; i++)
         {
             var name = filteredTemplates[i].Name;
@@ -115,12 +120,22 @@ public class TemplatesWindow
 
     public Task RefreshChannels()
     {
+        if (!_config.Templates)
+        {
+            _channelsLoaded = true;
+            return Task.CompletedTask;
+        }
         _channelsLoaded = false;
         return FetchChannels();
     }
 
     private async Task FetchChannels(bool refreshed = false)
     {
+        if (!_config.Templates)
+        {
+            _channelsLoaded = true;
+            return;
+        }
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
             PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -94,7 +94,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             _webSocket = null;
         }
 
-        if (!TokenManager.Instance!.IsReady() || !_config.Enabled)
+        if (!TokenManager.Instance!.IsReady() || !_config.Enabled || !_config.Events)
         {
             return;
         }
@@ -130,7 +130,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             while (!token.IsCancellationRequested)
             {
                 await Task.Delay(delay, token);
-                if (!TokenManager.Instance!.IsReady() || !_config.Enabled)
+                if (!TokenManager.Instance!.IsReady() || !_config.Enabled || !_config.Events)
                 {
                     continue;
                 }
@@ -472,6 +472,12 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     public void Draw()
     {
+        if (!_config.Events)
+        {
+            ImGui.TextUnformatted("Feature disabled");
+            return;
+        }
+
         if (!_presenceLoaded)
         {
             _ = LoadPresences();

--- a/demibot/demibot/http/routes/settings.py
+++ b/demibot/demibot/http/routes/settings.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api")
+
+@router.get("/settings")
+async def get_settings():
+    return {
+        "syncedChat": True,
+        "events": True,
+        "templates": True,
+        "requests": True,
+        "officer": True,
+        "fcSyncShell": False,
+    }

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -1,0 +1,27 @@
+using System.Net.Http;
+using DemiCatPlugin;
+using Xunit;
+
+public class ConfigDefaultsTests
+{
+    [Fact]
+    public void FeatureFlags_DefaultValues()
+    {
+        var cfg = new Config();
+        Assert.True(cfg.SyncedChat);
+        Assert.True(cfg.Events);
+        Assert.True(cfg.Templates);
+        Assert.True(cfg.Requests);
+        Assert.True(cfg.Officer);
+        Assert.False(cfg.FCSyncShell);
+    }
+
+    [Fact]
+    public void Syncshell_Disabled_PreventsInstance()
+    {
+        SyncshellWindow.Instance?.Dispose();
+        var cfg = new Config { FCSyncShell = false };
+        var window = new SyncshellWindow(cfg, new HttpClient());
+        Assert.Null(SyncshellWindow.Instance);
+    }
+}

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -1,0 +1,13 @@
+import pytest
+from httpx import AsyncClient
+from demibot.http.api import create_app
+
+@pytest.mark.asyncio
+async def test_settings_endpoint():
+    app = create_app()
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get("/api/settings")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["syncedChat"] is True
+    assert data["fcSyncShell"] is False

--- a/ui/App.vue
+++ b/ui/App.vue
@@ -1,21 +1,25 @@
 <template>
   <div id="app">
     <nav class="nav">
-      <router-link to="/events">Events</router-link>
-      <router-link to="/create">Create</router-link>
-      <router-link to="/templates">Templates</router-link>
-      <router-link to="/requests">Requests</router-link>
-      <router-link to="/chat">Chat</router-link>
-      <router-link to="/syncshell">SyncShell</router-link>
-      <router-link to="/officer">Officer</router-link>
+      <router-link v-if="settings.events" to="/events">Events</router-link>
+      <router-link v-if="settings.events" to="/create">Create</router-link>
+      <router-link v-if="settings.templates" to="/templates">Templates</router-link>
+      <router-link v-if="settings.requests" to="/requests">Requests</router-link>
+      <router-link v-if="settings.syncedChat" to="/chat">Chat</router-link>
+      <router-link v-if="settings.fcSyncShell" to="/syncshell">SyncShell</router-link>
+      <router-link v-if="settings.officer" to="/officer">Officer</router-link>
     </nav>
     <router-view />
   </div>
 </template>
 
 <script>
+import settings from './utils/settings';
 export default {
-  name: 'App'
+  name: 'App',
+  data() {
+    return { settings };
+  }
 };
 </script>
 

--- a/ui/pages/Chat.vue
+++ b/ui/pages/Chat.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="chat">
+  <div v-if="settings.syncedChat" class="chat">
     <h2>Chat</h2>
     <div class="controls">
       <input v-model="apiKey" placeholder="API Key" />
@@ -10,16 +10,18 @@
       <Message v-for="m in messages" :key="m.id" :message="m" />
     </div>
   </div>
+  <p v-else>Feature disabled</p>
 </template>
 
 <script>
 import Message from '../components/Message.vue';
+import settings from '../utils/settings';
 
 export default {
   name: 'ChatPage',
   components: { Message },
   data() {
-    return { apiKey: '', channelId: '', messages: [], ws: null };
+    return { apiKey: '', channelId: '', messages: [], ws: null, settings };
   },
   beforeUnmount() {
     if (this.ws) this.ws.close();

--- a/ui/pages/Create.vue
+++ b/ui/pages/Create.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="create">
+  <div v-if="settings.events" class="create">
     <h2>Create Event</h2>
     <div class="pane">
       <div class="editor">
@@ -15,11 +15,13 @@
       </div>
     </div>
   </div>
+  <p v-else>Feature disabled</p>
 </template>
 
 <script>
 import EmbedRenderer from '../components/EmbedRenderer.vue';
 import { validateEmbed } from '../utils/embed.js';
+import settings from '../utils/settings';
 
 export default {
   name: 'CreatePage',
@@ -27,7 +29,8 @@ export default {
   data() {
     return {
       channelId: '',
-      raw: '{"title":"","description":""}'
+      raw: '{"title":"","description":""}',
+      settings
     };
   },
   computed: {
@@ -45,7 +48,7 @@ export default {
   },
   methods: {
     async submit() {
-      if (this.error) return;
+      if (this.error || !this.settings.events) return;
       const payload = Object.assign({ channelId: this.channelId }, this.preview);
       try {
         await fetch('/api/events', {

--- a/ui/pages/Events.vue
+++ b/ui/pages/Events.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="events">
+  <div v-if="settings.events" class="events">
     <div v-for="event in events" :key="event.id" class="event">
       <div class="attachments" v-if="event.attachments">
         <div v-for="(att, i) in event.attachments" :key="i">
@@ -16,20 +16,24 @@
       </div>
     </div>
   </div>
+  <p v-else>Feature disabled</p>
 </template>
 
 <script>
 import EmbedRenderer from '../components/EmbedRenderer.vue';
+import settings from '../utils/settings';
 
 export default {
   name: 'EventsPage',
   components: { EmbedRenderer },
   data() {
     return {
-      events: []
+      events: [],
+      settings
     };
   },
   async created() {
+    if (!this.settings.events) return;
     try {
       const res = await fetch('/api/events');
       if (res.ok) {

--- a/ui/pages/Officer.vue
+++ b/ui/pages/Officer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="officer">
+  <div v-if="settings.officer" class="officer">
     <h2>Officer Chat</h2>
     <div class="controls">
       <input v-model="apiKey" placeholder="API Key" />
@@ -10,16 +10,18 @@
       <Message v-for="m in messages" :key="m.id" :message="m" />
     </div>
   </div>
+  <p v-else>Feature disabled</p>
 </template>
 
 <script>
 import Message from '../components/Message.vue';
+import settings from '../utils/settings';
 
 export default {
   name: 'OfficerPage',
   components: { Message },
   data() {
-    return { apiKey: '', channelId: '', messages: [], ws: null };
+    return { apiKey: '', channelId: '', messages: [], ws: null, settings };
   },
   beforeUnmount() {
     if (this.ws) this.ws.close();

--- a/ui/pages/Requests.vue
+++ b/ui/pages/Requests.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="requests">
+  <div v-if="settings.requests" class="requests">
     <h2>Request Board</h2>
     <ul>
       <li v-for="r in requests" :key="r.id">
@@ -7,15 +7,19 @@
       </li>
     </ul>
   </div>
+  <p v-else>Feature disabled</p>
 </template>
 
 <script>
+import settings from '../utils/settings';
+
 export default {
   name: 'RequestsPage',
   data() {
-    return { requests: [], ws: null };
+    return { requests: [], ws: null, settings };
   },
   async created() {
+    if (!this.settings.requests) return;
     await this.load();
     this.connect();
   },
@@ -24,6 +28,7 @@ export default {
   },
   methods: {
     async load() {
+      if (!this.settings.requests) return;
       try {
         const res = await fetch('/api/requests');
         if (res.ok) {
@@ -34,6 +39,7 @@ export default {
       }
     },
     connect() {
+      if (!this.settings.requests) return;
       const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
       const url = `${proto}://${window.location.host}/ws/requests`;
       this.ws = new WebSocket(url);

--- a/ui/pages/SyncShell.vue
+++ b/ui/pages/SyncShell.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="syncshell">
+  <div v-if="settings.fcSyncShell" class="syncshell">
     <h2>SyncShell</h2>
     <div class="controls">
       <input v-model="apiKey" placeholder="API Key" />
@@ -10,27 +10,30 @@
       <Message v-for="m in messages" :key="m.id" :message="m" />
     </div>
   </div>
+  <p v-else>Feature disabled</p>
 </template>
 
 <script>
 import Message from '../components/Message.vue';
+import settings from '../utils/settings';
 
 export default {
   name: 'SyncShellPage',
   components: { Message },
   data() {
-    return { apiKey: '', channelId: '', messages: [], ws: null };
+    return { apiKey: '', channelId: '', messages: [], ws: null, settings };
   },
   beforeUnmount() {
     if (this.ws) this.ws.close();
   },
   methods: {
     async setup() {
-      if (!this.channelId) return;
+      if (!this.channelId || !this.settings.fcSyncShell) return;
       await this.load();
       this.connect();
     },
     async load() {
+      if (!this.settings.fcSyncShell) return;
       try {
         const res = await fetch(`/api/messages/${this.channelId}`);
         if (res.ok) {
@@ -41,6 +44,7 @@ export default {
       }
     },
     connect() {
+      if (!this.settings.fcSyncShell) return;
       if (this.ws) {
         this.ws.close();
         this.ws = null;

--- a/ui/pages/Templates.vue
+++ b/ui/pages/Templates.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="templates">
+  <div v-if="settings.templates" class="templates">
     <h2>Templates</h2>
     <div v-for="t in templates" :key="t.id" class="template">
       <h3>{{ t.name }}</h3>
@@ -7,18 +7,21 @@
       <button @click="remove(t.id)">Delete</button>
     </div>
   </div>
+  <p v-else>Feature disabled</p>
 </template>
 
 <script>
 import EmbedRenderer from '../components/EmbedRenderer.vue';
+import settings from '../utils/settings';
 
 export default {
   name: 'TemplatesPage',
   components: { EmbedRenderer },
   data() {
-    return { templates: [], ws: null };
+    return { templates: [], ws: null, settings };
   },
   async created() {
+    if (!this.settings.templates) return;
     await this.load();
     this.connect();
   },
@@ -27,6 +30,7 @@ export default {
   },
   methods: {
     async load() {
+      if (!this.settings.templates) return;
       try {
         const res = await fetch('/api/templates');
         if (res.ok) {
@@ -37,6 +41,7 @@ export default {
       }
     },
     connect() {
+      if (!this.settings.templates) return;
       const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
       const url = `${proto}://${window.location.host}/ws/templates`;
       this.ws = new WebSocket(url);
@@ -64,10 +69,12 @@ export default {
       };
     },
     async post(id) {
-      await fetch(`/api/templates/${id}/post`, { method: 'POST' });
+      if (this.settings.templates)
+        await fetch(`/api/templates/${id}/post`, { method: 'POST' });
     },
     async remove(id) {
-      await fetch(`/api/templates/${id}`, { method: 'DELETE' });
+      if (this.settings.templates)
+        await fetch(`/api/templates/${id}`, { method: 'DELETE' });
     }
   }
 };

--- a/ui/utils/settings.js
+++ b/ui/utils/settings.js
@@ -1,0 +1,19 @@
+import { reactive } from 'vue';
+
+const defaults = {
+  syncedChat: true,
+  events: true,
+  templates: true,
+  requests: true,
+  officer: true,
+  fcSyncShell: false
+};
+
+const settings = reactive({ ...defaults });
+
+fetch('/api/settings')
+  .then(r => r.json())
+  .then(data => Object.assign(settings, data))
+  .catch(() => {});
+
+export default settings;


### PR DESCRIPTION
## Summary
- add per-feature flags with defaults
- skip SyncShell background work when disabled
- expose `/api/settings` and read flags in web UI
- cover defaults with new tests

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest` *(collection errors: ModuleNotFoundError: demibot)*

------
https://chatgpt.com/codex/tasks/task_e_68bc57379828832882e2aa1ba0678f85