### PR TITLE
Handle event channel filtering and selection

### DIFF
--- a/ui/pages/Create.vue
+++ b/ui/pages/Create.vue
@@ -4,7 +4,9 @@
     <div class="pane">
       <div class="editor">
         <div>
-          <label>Channel ID: <input v-model="channelId" required /></label>
+          <select v-model="selectedChannel">
+            <option v-for="c in channels" :key="c.id" :value="c.id">{{ c.name }}</option>
+          </select>
         </div>
         <textarea v-model="raw"></textarea>
         <div v-if="error" class="error">{{ error }}</div>
@@ -20,13 +22,17 @@
 <script>
 import EmbedRenderer from '../components/EmbedRenderer.vue';
 import { validateEmbed } from '../utils/embed.js';
+import { useEventChannels } from '../utils/useEventChannels.js';
 
 export default {
   name: 'CreatePage',
   components: { EmbedRenderer },
+  setup() {
+    const { channels, selected } = useEventChannels('create');
+    return { channels, selectedChannel: selected };
+  },
   data() {
     return {
-      channelId: '',
       raw: '{"title":"","description":""}'
     };
   },
@@ -46,7 +52,7 @@ export default {
   methods: {
     async submit() {
       if (this.error) return;
-      const payload = Object.assign({ channelId: this.channelId }, this.preview);
+      const payload = Object.assign({ channelId: this.selectedChannel }, this.preview);
       try {
         await fetch('/api/events', {
           method: 'POST',

--- a/ui/pages/Events.vue
+++ b/ui/pages/Events.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="events">
-    <div v-for="event in events" :key="event.id" class="event">
+    <select v-model="selectedChannel">
+      <option value="">All Channels</option>
+      <option v-for="c in channels" :key="c.id" :value="c.id">{{ c.name }}</option>
+    </select>
+    <div v-for="event in filteredEvents" :key="event.id" class="event">
       <div class="attachments" v-if="event.attachments">
         <div v-for="(att, i) in event.attachments" :key="i">
           <img
@@ -20,10 +24,15 @@
 
 <script>
 import EmbedRenderer from '../components/EmbedRenderer.vue';
+import { useEventChannels } from '../utils/useEventChannels.js';
 
 export default {
   name: 'EventsPage',
   components: { EmbedRenderer },
+  setup() {
+    const { channels, selected } = useEventChannels('events');
+    return { channels, selectedChannel: selected };
+  },
   data() {
     return {
       events: []
@@ -37,6 +46,12 @@ export default {
       }
     } catch (e) {
       console.error('Failed to load events', e);
+    }
+  },
+  computed: {
+    filteredEvents() {
+      if (!this.selectedChannel) return this.events;
+      return this.events.filter(ev => ev.channelId === this.selectedChannel);
     }
   }
 };

--- a/ui/pages/Templates.vue
+++ b/ui/pages/Templates.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="templates">
     <h2>Templates</h2>
+    <select v-model="selectedChannel">
+      <option v-for="c in channels" :key="c.id" :value="c.id">{{ c.name }}</option>
+    </select>
     <div v-for="t in templates" :key="t.id" class="template">
       <h3>{{ t.name }}</h3>
       <button @click="post(t.id)">Post</button>
@@ -11,10 +14,15 @@
 
 <script>
 import EmbedRenderer from '../components/EmbedRenderer.vue';
+import { useEventChannels } from '../utils/useEventChannels.js';
 
 export default {
   name: 'TemplatesPage',
   components: { EmbedRenderer },
+  setup() {
+    const { channels, selected } = useEventChannels('templates');
+    return { channels, selectedChannel: selected };
+  },
   data() {
     return { templates: [], ws: null };
   },
@@ -64,7 +72,18 @@ export default {
       };
     },
     async post(id) {
-      await fetch(`/api/templates/${id}/post`, { method: 'POST' });
+      const tmpl = this.templates.find(t => t.id === id);
+      if (!tmpl) return;
+      const body = Object.assign({}, tmpl.payload, { channelId: this.selectedChannel });
+      try {
+        await fetch('/api/events', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+      } catch (e) {
+        console.error('Failed to post template', e);
+      }
     },
     async remove(id) {
       await fetch(`/api/templates/${id}`, { method: 'DELETE' });

--- a/ui/utils/useEventChannels.js
+++ b/ui/utils/useEventChannels.js
@@ -1,0 +1,30 @@
+import { ref, watch } from 'vue';
+
+const cache = { channels: null };
+
+export function useEventChannels(tab) {
+  const channels = ref([]);
+  const selected = ref(localStorage.getItem(`eventChannel:${tab}`) || '');
+
+  async function load() {
+    if (!cache.channels) {
+      try {
+        const res = await fetch('/api/channels?kind=event');
+        cache.channels = res.ok ? await res.json() : [];
+      } catch (e) {
+        console.error('Failed to load event channels', e);
+        cache.channels = [];
+      }
+    }
+    channels.value = cache.channels;
+  }
+
+  load();
+
+  watch(selected, (val) => {
+    localStorage.setItem(`eventChannel:${tab}`, val);
+  });
+
+  return { channels, selected };
+}
+


### PR DESCRIPTION
## Summary
- support `kind=event` filter for `/api/channels`
- share `useEventChannels` composable across event pages and keep last selection in localStorage
- fetch event channels from new endpoint in `EventCreateWindow`

## Testing
- `PYTHONPATH=demibot pytest tests/test_channels_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc57215f448328a7124367bbc64e6f