### PR TITLE
Handle template conflicts and inline editing

### DIFF
--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -157,3 +157,4 @@ class TemplateDto(CamelModel):
     name: str
     description: str | None = None
     payload: TemplatePayload
+    updated_at: datetime = Field(alias="updatedAt")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import types
 import asyncio
 from types import SimpleNamespace
+import json
 
 root = Path(__file__).resolve().parents[1] / "demibot"
 sys.path.append(str(root))
@@ -59,6 +60,9 @@ async def _run_test() -> None:
     ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
     async with get_session() as db:
         dto = await create_template(body=body, ctx=ctx, db=db)
+        dup = await create_template(body=body, ctx=ctx, db=db)
+        assert dup.status_code == 409
+        assert json.loads(dup.body.decode()) == {"error": "duplicate"}
         tid = dto.id
         lst = await list_templates(ctx=ctx, db=db)
         assert len(lst) == 1 and lst[0].id == tid


### PR DESCRIPTION
## Summary
- prevent duplicate template names with 409 error
- expose template update time and keep listing sorted
- add inline template editing UI with debounced PATCH
- test template name conflicts

## Testing
- `pytest tests/test_templates.py tests/test_template_ws.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc6bbc42288328a171ee47153fcc0d