### PR TITLE
test: ensure event signup index exists after migrations

### DIFF
--- a/tests/test_migration_event_signup_index.py
+++ b/tests/test_migration_event_signup_index.py
@@ -1,0 +1,29 @@
+import asyncio
+from pathlib import Path
+from sqlalchemy import text
+import sys, types
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+from demibot.db.session import init_db, get_session
+
+
+async def _run_test():
+    db_path = Path("test_migration_index.db")
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    async with get_session() as db:
+        idx_rows = await db.execute(text("PRAGMA index_list('event_signups')"))
+        index_names = [r[1] for r in idx_rows]
+        assert "ix_event_signups_discord_message_id_choice" in index_names
+
+
+def test_event_signup_index_exists():
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary
- add migration smoke test verifying ix_event_signups_discord_message_id_choice exists

## Testing
- `black tests/test_migration_event_signup_index.py`
- `pytest tests/test_migration_event_signup_index.py tests/test_rsvp_timestamp_index.py`
- `python - <<'PY'
import sys, types
from pathlib import Path
root = Path('demibot')
sys.path.append(str(root))
demibot_pkg = types.ModuleType('demibot')
demibot_pkg.__path__ = [str(root/'demibot')]
sys.modules.setdefault('demibot', demibot_pkg)
from demibot.http.api import create_app
from fastapi.testclient import TestClient
print(TestClient(create_app()).get('/health').json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bc78cb8ba083289907f2f0e163a616