### PR TITLE
Delay preset loading until token ready

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -57,6 +57,10 @@ public class EventCreateWindow
         _httpClient = httpClient;
         _channelId = config.EventChannelId;
         ResetDefaultButtons();
+    }
+
+    public void StartNetworking()
+    {
         if (_config.Events)
         {
             _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
@@ -70,6 +74,13 @@ public class EventCreateWindow
             ImGui.TextUnformatted("Feature disabled");
             return;
         }
+
+        if (TokenManager.Instance?.IsReady() != true)
+        {
+            ImGui.TextUnformatted("Link DemiCat to create events");
+            return;
+        }
+
         if (!_channelsLoaded)
         {
             _ = FetchChannels();

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -140,6 +140,7 @@ public class Plugin : IDalamudPlugin
         if (_config.Events)
         {
             _ = _ui.StartNetworking();
+            _mainWindow.EventCreateWindow.StartNetworking();
         }
     }
 

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -41,6 +41,13 @@ public class TemplatesWindow
             ImGui.TextUnformatted("Feature disabled");
             return;
         }
+
+        if (TokenManager.Instance?.IsReady() != true)
+        {
+            ImGui.TextUnformatted("Link DemiCat to manage templates");
+            return;
+        }
+
         if (!_channelsLoaded)
         {
             _ = FetchChannels();
@@ -60,7 +67,6 @@ public class TemplatesWindow
             ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
         }
 
-        _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
         ImGui.BeginChild("TemplateList", new Vector2(150, 0), true);
         var filteredTemplates = _config.TemplateData.Where(t => t.Type == TemplateType.Event).ToList();
         for (var i = 0; i < filteredTemplates.Count; i++)


### PR DESCRIPTION
## Summary
- defer signup preset loading until after token/link verification
- guard template and event creation UIs when token is missing
- start event creation networking after token is ready

## Testing
- `dotnet test` *(fails: SDK 9.0.100 missing)*
- `pytest` *(fails: missing modules such as discord and fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8e6c7ecc8328be112c9635be75cc