### PR TITLE
refactor: guard event UI with token and defer fetches

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -61,29 +61,27 @@ public class EventCreateWindow
 
     public void StartNetworking()
     {
-        if (_config.Events)
+        if (!_config.Events || TokenManager.Instance?.IsReady() != true)
         {
-            _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
+            return;
         }
+
+        _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
+        _ = RefreshChannels();
     }
 
     public void Draw()
     {
-        if (!_config.Events)
-        {
-            ImGui.TextUnformatted("Feature disabled");
-            return;
-        }
-
         if (TokenManager.Instance?.IsReady() != true)
         {
             ImGui.TextUnformatted("Link DemiCat to create events");
             return;
         }
 
-        if (!_channelsLoaded)
+        if (!_config.Events)
         {
-            _ = FetchChannels();
+            ImGui.TextUnformatted("Feature disabled");
+            return;
         }
         if (_channels.Count > 0)
         {

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -100,6 +100,8 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         }
 
         StartPolling();
+        await RefreshChannels();
+        await LoadPresences();
         await ConnectWebSocket();
     }
 
@@ -472,20 +474,18 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     public void Draw()
     {
+        if (TokenManager.Instance?.IsReady() != true)
+        {
+            ImGui.TextUnformatted("Link DemiCat to view events");
+            return;
+        }
+
         if (!_config.Events)
         {
             ImGui.TextUnformatted("Feature disabled");
             return;
         }
 
-        if (!_presenceLoaded)
-        {
-            _ = LoadPresences();
-        }
-        if (!_channelsLoaded)
-        {
-            _ = FetchChannels();
-        }
         if (_channels.Count > 0)
         {
             var channelNames = _channels.Select(c => c.Name).ToArray();
@@ -494,7 +494,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 _channelId = _channels[_selectedIndex].Id;
                 _config.EventChannelId = _channelId;
                 SaveConfig();
-                _ = FetchChannels();
+                _ = RefreshChannels();
                 _ = RefreshEmbeds();
             }
         }


### PR DESCRIPTION
## Summary
- add token gate to UiRenderer and defer channel/presence fetches to networking start
- validate token before drawing event creation UI and fetch channels/presets only after networking

## Testing
- `pytest` *(fails: 51 errors during collection)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9dc5feec8328bfa43e16c91b453f