### PR TITLE
Gate event operations on valid token

### DIFF
--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -155,6 +155,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     private async Task LoadPresences()
     {
+        if (!TokenManager.Instance!.IsReady()) return;
         if (_presenceLoadAttempted) return;
         _presenceLoadAttempted = true;
         if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
@@ -440,6 +441,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     public async Task RefreshEmbeds()
     {
+        if (!TokenManager.Instance!.IsReady()) return;
         if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
 
         try
@@ -474,7 +476,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     public void Draw()
     {
-        if (TokenManager.Instance?.IsReady() != true)
+        if (!TokenManager.Instance!.IsReady())
         {
             ImGui.TextUnformatted("Link DemiCat to view events");
             return;
@@ -539,6 +541,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     private async Task FetchChannels(bool refreshed = false)
     {
+        if (!TokenManager.Instance!.IsReady()) return;
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
             PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");


### PR DESCRIPTION
## Summary
- Ensure the events UI checks for a valid token before drawing
- Only fetch presences, channels, or embeds when the token is verified

## Testing
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `dotnet test` *(not run: dotnet missing)*
- `pytest -q` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bcab7f0b3c8328b1b52e5f182919d1