### PR TITLE
Use TokenManager for auth headers

### DIFF
--- a/DemiCatPlugin/ChannelNameResolver.cs
+++ b/DemiCatPlugin/ChannelNameResolver.cs
@@ -36,7 +36,8 @@ internal static class ChannelNameResolver
             {
                 var refreshReq = new HttpRequestMessage(HttpMethod.Post,
                     $"{config.ApiBaseUrl.TrimEnd('/')}/api/channels/refresh");
-                ApiHelpers.AddAuthHeader(refreshReq, config);
+                if (TokenManager.Instance != null)
+                    ApiHelpers.AddAuthHeader(refreshReq, TokenManager.Instance!);
                 await httpClient.SendAsync(refreshReq);
             }
             catch (Exception ex)

--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -127,7 +127,8 @@ internal static class RequestStateService
                 ? $"{baseUrl}/api/requests"
                 : $"{baseUrl}/api/requests/delta?since={Uri.EscapeDataString(config.RequestsDeltaToken)}";
             var msg = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(msg, config);
+            if (TokenManager.Instance != null)
+                ApiHelpers.AddAuthHeader(msg, TokenManager.Instance!);
             var resp = await httpClient.SendAsync(msg);
             if (!resp.IsSuccessStatusCode) return;
             var stream = await resp.Content.ReadAsStreamAsync();

--- a/DemiCatPlugin/RoleCache.cs
+++ b/DemiCatPlugin/RoleCache.cs
@@ -41,7 +41,8 @@ internal static class RoleCache
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/guild-roles");
-            ApiHelpers.AddAuthHeader(request, config);
+            if (TokenManager.Instance != null)
+                ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/SignupPresetService.cs
+++ b/DemiCatPlugin/SignupPresetService.cs
@@ -33,7 +33,8 @@ internal static class SignupPresetService
         try
         {
             var req = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets");
-            ApiHelpers.AddAuthHeader(req, config);
+            if (TokenManager.Instance != null)
+                ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
             {
@@ -55,7 +56,8 @@ internal static class SignupPresetService
         try
         {
             var req = new HttpRequestMessage(HttpMethod.Post, $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets");
-            ApiHelpers.AddAuthHeader(req, config);
+            if (TokenManager.Instance != null)
+                ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
             req.Content = new StringContent(JsonSerializer.Serialize(preset), Encoding.UTF8, "application/json");
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
@@ -75,7 +77,8 @@ internal static class SignupPresetService
         try
         {
             var req = new HttpRequestMessage(HttpMethod.Delete, $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets/{id}");
-            ApiHelpers.AddAuthHeader(req, config);
+            if (TokenManager.Instance != null)
+                ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
             {


### PR DESCRIPTION
## Summary
- use TokenManager for API auth headers instead of Config
- skip auth header if no token is available

## Testing
- `/root/dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: multiple ModuleNotFoundError for missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbc4cb25c8328ba2151bc7207589f