### PR TITLE
Gate Syncshell feature by configuration

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -142,9 +142,9 @@ public class MainWindow : IDisposable
                 ImGui.EndTabItem();
             }
 
-            if (_config.FCSyncShell && _syncshell != null)
+            if (!linked)
             {
-                if (!linked)
+                if (_config.FCSyncShell)
                 {
                     ImGui.BeginDisabled();
                     ImGui.TabItemButton("Syncshell");
@@ -152,11 +152,11 @@ public class MainWindow : IDisposable
                     if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
                         ImGui.SetTooltip("Link DemiCat to use syncshell.");
                 }
-                else if (ImGui.BeginTabItem("Syncshell"))
-                {
-                    _syncshell.Draw();
-                    ImGui.EndTabItem();
-                }
+            }
+            else if (_config.FCSyncShell && _syncshell != null && ImGui.BeginTabItem("Syncshell"))
+            {
+                _syncshell.Draw();
+                ImGui.EndTabItem();
             }
 
             if (_chat != null)

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -47,12 +47,11 @@ public class SyncshellWindow : IDisposable
 
     public SyncshellWindow(Config config, HttpClient httpClient)
     {
+        if (!config.FCSyncShell)
+            throw new InvalidOperationException("Syncshell disabled");
+
         _config = config;
         _httpClient = httpClient;
-        if (!_config.FCSyncShell)
-        {
-            return;
-        }
 
         if (!_config.Categories.TryGetValue("syncshell", out var state))
         {

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using DemiCatPlugin;
 using Xunit;
@@ -21,7 +22,7 @@ public class ConfigDefaultsTests
     {
         SyncshellWindow.Instance?.Dispose();
         var cfg = new Config { FCSyncShell = false };
-        var window = new SyncshellWindow(cfg, new HttpClient());
+        Assert.Throws<InvalidOperationException>(() => new SyncshellWindow(cfg, new HttpClient()));
         Assert.Null(SyncshellWindow.Instance);
     }
 }


### PR DESCRIPTION
## Summary
- Skip Syncshell tab rendering when feature disabled
- Disallow creating SyncshellWindow unless Syncshell is enabled
- Adjust tests for Syncshell gating

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alembic')*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd509814c83289c56c259ffc947f7