### PR TITLE
Guard officer chat features by role

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -102,7 +102,8 @@ public class ChannelWatcher : IDisposable
                             _ = SafeRefresh(_eventCreateWindow.RefreshChannels);
                             if (_config.SyncedChat && _config.EnableFcChat)
                                 _ = SafeRefresh(_chatWindow.RefreshChannels);
-                            _ = SafeRefresh(_officerChatWindow.RefreshChannels);
+                            if (_config.Officer && _config.Roles.Contains("officer"))
+                                _ = SafeRefresh(_officerChatWindow.RefreshChannels);
                         });
                     }
                 }
@@ -139,7 +140,8 @@ public class ChannelWatcher : IDisposable
                     _ = SafeRefresh(_eventCreateWindow.RefreshChannels);
                     if (_config.SyncedChat && _config.EnableFcChat)
                         _ = SafeRefresh(_chatWindow.RefreshChannels);
-                    _ = SafeRefresh(_officerChatWindow.RefreshChannels);
+                    if (_config.Officer && _config.Roles.Contains("officer"))
+                        _ = SafeRefresh(_officerChatWindow.RefreshChannels);
                 });
             }
             try { await Task.Delay(delay, token); } catch { }

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -17,7 +17,7 @@ public class OfficerChatWindow : ChatWindow
 
     public override void StartNetworking()
     {
-        if (!_config.Officer)
+        if (!_config.Officer || !_config.Roles.Contains("officer"))
         {
             return;
         }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -125,7 +125,8 @@ public class Plugin : IDalamudPlugin
         {
             _requestWatcher.Start();
         }
-        if (_config.Events || _config.SyncedChat || _config.Officer)
+        var hasOfficerRole = _config.Roles.Contains("officer");
+        if (_config.Events || _config.SyncedChat || (_config.Officer && hasOfficerRole))
         {
             _ = _channelWatcher.Start();
         }
@@ -133,7 +134,7 @@ public class Plugin : IDalamudPlugin
         {
             _chatWindow.StartNetworking();
         }
-        if (_config.Officer)
+        if (_config.Officer && hasOfficerRole)
         {
             _officerChatWindow.StartNetworking();
         }


### PR DESCRIPTION
## Summary
- Require the officer role before starting officer chat networking
- Only refresh officer channels when the officer role is present
- Prevent officer chat window from starting without the officer role

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest -q` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bce3e997408328992c88f26e4a3491