### PR TITLE
Disable Syncshell checkbox when not linked

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -116,11 +116,19 @@ public class SettingsWindow : IDisposable
                 }
 
                 var syncEnabled = _config.FCSyncShell;
+                if (!linked)
+                    ImGui.BeginDisabled();
                 if (ImGui.Checkbox("Enable Sync", ref syncEnabled))
                 {
                     _config.FCSyncShell = syncEnabled;
                     SaveConfig();
                     _ = Task.Run(PushSettings);
+                }
+                if (!linked)
+                {
+                    ImGui.EndDisabled();
+                    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                        ImGui.SetTooltip("Link DemiCat to enable Syncshell.");
                 }
 
                 var paused = !_config.Enabled;


### PR DESCRIPTION
## Summary
- Disable Syncshell checkbox unless DemiCat is linked
- Show tooltip guiding users to link DemiCat to enable Syncshell

## Testing
- `dotnet build` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*
- `pytest` *(fails: Interrupted: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bce67302348328a9991b0efb208dca