### PR TITLE
Add Open Settings button for unlinked DemiCat users

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -64,6 +64,11 @@ public class MainWindow : IDisposable
         if (!linked)
         {
             ImGui.TextColored(new Vector4(1f, 0.85f, 0f, 1f), "Link DemiCat: run `/demibot embed` in Discord and paste the key.");
+            ImGui.SameLine();
+            if (ImGui.Button("Open Settings"))
+            {
+                _settings.IsOpen = true;
+            }
             ImGui.Separator();
         }
 


### PR DESCRIPTION
## Summary
- Add prominent `Open Settings` button beside link instructions for new users

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bce75175d88328a66e76c135635992