### PR TITLE
Validate user input for events, templates, and requests

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -449,6 +449,11 @@ public class EventCreateWindow
             }
             return;
         }
+        if (_description.Length > 2000)
+        {
+            _lastResult = "Description exceeds 2000 characters";
+            return;
+        }
         try
         {
             var dto = BuildPreview();

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -23,6 +23,7 @@ public class RequestBoardWindow
     private string _newDescription = string.Empty;
     private RequestType _newType = RequestType.Item;
     private RequestUrgency _newUrgency = RequestUrgency.Low;
+    private string _createStatus = string.Empty;
 
     private enum SortMode
     {
@@ -97,10 +98,16 @@ public class RequestBoardWindow
             var urgLabels = Enum.GetNames<RequestUrgency>();
             if (ImGui.Combo("Urgency", ref urgIdx, urgLabels, urgLabels.Length))
                 _newUrgency = (RequestUrgency)urgIdx;
+            if (!string.IsNullOrEmpty(_createStatus))
+                ImGui.TextUnformatted(_createStatus);
             if (ImGui.Button("Create"))
             {
-                _ = CreateRequest();
-                ImGui.CloseCurrentPopup();
+                if (ValidateNewRequest())
+                {
+                    _ = CreateRequest();
+                    _createStatus = string.Empty;
+                    ImGui.CloseCurrentPopup();
+                }
             }
             ImGui.SameLine();
             if (ImGui.Button("Cancel"))
@@ -336,6 +343,17 @@ public class RequestBoardWindow
         "high" => RequestUrgency.High,
         _ => RequestUrgency.Low
     };
+
+    private bool ValidateNewRequest()
+    {
+        if (_newTitle.Length > 2000 || _newDescription.Length > 2000)
+        {
+            _createStatus = "Title or description exceeds 2000 characters";
+            return false;
+        }
+        _createStatus = string.Empty;
+        return true;
+    }
 
     private async Task CreateRequest()
     {

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -254,6 +254,11 @@ public class TemplatesWindow
             }
             return;
         }
+        if (!string.IsNullOrEmpty(tmpl.Description) && tmpl.Description.Length > 2000)
+        {
+            _lastResult = "Description exceeds 2000 characters";
+            return;
+        }
         try
         {
             var buttons = tmpl.Buttons?


### PR DESCRIPTION
## Summary
- Prevent event creation when description exceeds 2000 characters
- Block template posting with overly long descriptions
- Validate request text length and show an error before submission

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found: dotnet)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68bceb7f6e948328a1f49e1d9d7722d1