### PR TITLE
Rename attendance table to event_signups

### DIFF
--- a/demibot/demibot/db/migrations/versions/0034_add_event_signup_timestamp.py
+++ b/demibot/demibot/db/migrations/versions/0034_add_event_signup_timestamp.py
@@ -1,35 +1,15 @@
-import sqlalchemy as sa
-from alembic import op
-from datetime import datetime
+# No longer needed; event_signups table includes timestamp in 0035_rename_attendance_event_signups
 
 # revision identifiers, used by Alembic.
 revision = "0034_add_event_signup_timestamp"
-down_revision = "0033_add_event_templates"
+down_revision = "0035_rename_attendance_event_signups"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "event_signups",
-        sa.Column("created_at", sa.DateTime(), nullable=True),
-    )
-    op.create_index(
-        "ix_event_signups_discord_message_id_choice",
-        "event_signups",
-        ["message_id", "tag"],
-    )
-    conn = op.get_bind()
-    conn.execute(
-        sa.text("UPDATE event_signups SET created_at = :now WHERE created_at IS NULL"),
-        {"now": datetime.utcnow()},
-    )
-    op.alter_column("event_signups", "created_at", nullable=False)
+    pass
 
 
 def downgrade() -> None:
-    op.drop_index(
-        "ix_event_signups_discord_message_id_choice",
-        table_name="event_signups",
-    )
-    op.drop_column("event_signups", "created_at")
+    pass

--- a/demibot/demibot/db/migrations/versions/0035_rename_attendance_event_signups.py
+++ b/demibot/demibot/db/migrations/versions/0035_rename_attendance_event_signups.py
@@ -1,0 +1,108 @@
+import sqlalchemy as sa
+from alembic import op
+from datetime import datetime
+
+# revision identifiers, used by Alembic.
+revision = "0035_rename_attendance_event_signups"
+down_revision = "0033_add_event_templates"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if "attendance" in insp.get_table_names():
+        op.rename_table("attendance", "attendance_old")
+
+        op.create_table(
+            "event_signups",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("message_id", sa.BigInteger(), nullable=False),
+            sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("users.id"), nullable=False),
+            sa.Column("tag", sa.String(length=50), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.UniqueConstraint("message_id", "user_id", name="uq_event_signups_message_user"),
+        )
+        op.create_index(
+            "ix_event_signups_discord_message_id_choice",
+            "event_signups",
+            ["message_id", "tag"],
+        )
+
+        rows = bind.execute(
+            sa.text(
+                "SELECT discord_message_id AS message_id, user_id, choice AS tag FROM attendance_old"
+            )
+        ).fetchall()
+        now = datetime.utcnow()
+        if rows:
+            bind.execute(
+                sa.text(
+                    "INSERT INTO event_signups (message_id, user_id, tag, created_at) VALUES (:message_id, :user_id, :tag, :created_at)"
+                ),
+                [
+                    {
+                        "message_id": r.message_id if hasattr(r, "message_id") else r[0],
+                        "user_id": r.user_id if hasattr(r, "user_id") else r[1],
+                        "tag": r.tag if hasattr(r, "tag") else r[2],
+                        "created_at": now,
+                    }
+                    for r in rows
+                ],
+            )
+        op.drop_table("attendance_old")
+    else:
+        op.create_table(
+            "event_signups",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("message_id", sa.BigInteger(), nullable=False),
+            sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("users.id"), nullable=False),
+            sa.Column("tag", sa.String(length=50), nullable=False),
+            sa.Column("created_at", sa.DateTime(), nullable=False),
+            sa.UniqueConstraint("message_id", "user_id", name="uq_event_signups_message_user"),
+        )
+        op.create_index(
+            "ix_event_signups_discord_message_id_choice",
+            "event_signups",
+            ["message_id", "tag"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if "event_signups" in insp.get_table_names():
+        op.rename_table("event_signups", "event_signups_old")
+
+        op.create_table(
+            "attendance",
+            sa.Column("discord_message_id", sa.BigInteger(), nullable=False),
+            sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("users.id"), nullable=False),
+            sa.Column("choice", sa.String(length=10), nullable=False),
+            sa.PrimaryKeyConstraint("discord_message_id", "user_id"),
+        )
+        rows = bind.execute(
+            sa.text(
+                "SELECT message_id AS discord_message_id, user_id, tag AS choice FROM event_signups_old"
+            )
+        ).fetchall()
+        if rows:
+            bind.execute(
+                sa.text(
+                    "INSERT INTO attendance (discord_message_id, user_id, choice) VALUES (:discord_message_id, :user_id, :choice)"
+                ),
+                [
+                    {
+                        "discord_message_id": r.discord_message_id if hasattr(r, "discord_message_id") else r[0],
+                        "user_id": r.user_id if hasattr(r, "user_id") else r[1],
+                        "choice": r.choice if hasattr(r, "choice") else r[2],
+                    }
+                    for r in rows
+                ],
+            )
+        op.drop_table("event_signups_old")
+    else:
+        op.drop_table("attendance")


### PR DESCRIPTION
## Summary
- migrate legacy attendance entries into new event_signups table with timestamp, unique constraint, and index
- adjust no-op timestamp migration to depend on new event_signups table

## Testing
- `PYTHONPATH=demibot python - <<'PY'
import asyncio
from demibot.db.session import init_db
asyncio.run(init_db('sqlite+aiosqlite:///:memory:'))
print('init_db done')
PY`
- `PYTHONPATH=demibot pytest tests/test_migration_event_signup_index.py tests/test_rsvp_timestamp_index.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcf2e4611883288b570b03f5bc6779