### PR TITLE
Rename type property variable to avoid duplication

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -187,7 +187,7 @@ public class RequestBoardWindow
                     var id = payload.GetProperty("id").GetString() ?? req.Id;
                     var title = payload.TryGetProperty("title", out var tEl) ? tEl.GetString() ?? req.Title : req.Title;
                     var statusStr = payload.GetProperty("status").GetString() ?? StatusToString(newStatus);
-                    var typeStr = payload.TryGetProperty("type", out var tEl) ? tEl.GetString() ?? TypeToString(req.Type) : TypeToString(req.Type);
+                    var typeStr = payload.TryGetProperty("type", out var typeEl) ? typeEl.GetString() ?? TypeToString(req.Type) : TypeToString(req.Type);
                     var urgencyStr = payload.TryGetProperty("urgency", out var uEl) ? uEl.GetString() ?? UrgencyToString(req.Urgency) : UrgencyToString(req.Urgency);
                     var itemId = payload.TryGetProperty("item_id", out var iEl) ? iEl.GetUInt32() : (uint?)req.ItemId;
                     var dutyId = payload.TryGetProperty("duty_id", out var dEl) ? dEl.GetUInt32() : (uint?)req.DutyId;


### PR DESCRIPTION
## Summary
- Clarify request update parsing by renaming the `type` JSON element variable to `typeEl`

## Testing
- `~/.dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest -q` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6cac3bd48328b97a24b9ea15b47f