### PR TITLE
Add ImGui binding using

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -1,3 +1,4 @@
+using Dalamud.Bindings.ImGui;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;


### PR DESCRIPTION
## Summary
- import ImGui binding in OfficerChatWindow

## Testing
- `dotnet --version` *(fails: .NET SDK 9.0.100 required, 8.0 installed)*
- `pytest` *(fails: 48 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bd71e8c9288328b66d440ad1965e09