### PR TITLE
Use cross-platform token storage

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="StbImageSharp" Version="2.30.15" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DemiCatPlugin/TokenManager.cs
+++ b/DemiCatPlugin/TokenManager.cs
@@ -55,10 +55,13 @@ public class TokenManager
                 _token = null;
                 return;
             }
-
+#if WINDOWS
             var encrypted = File.ReadAllBytes(path);
             var bytes = ProtectedData.Unprotect(encrypted, null, DataProtectionScope.CurrentUser);
             _token = Encoding.UTF8.GetString(bytes);
+#else
+            _token = File.ReadAllText(path);
+#endif
             State = string.IsNullOrEmpty(_token) ? LinkState.Unlinked : LinkState.Linked;
         }
         catch
@@ -73,9 +76,13 @@ public class TokenManager
         try
         {
             var path = Path.Combine(_pluginInterface.ConfigDirectory.FullName, TokenFileName);
+#if WINDOWS
             var bytes = Encoding.UTF8.GetBytes(token);
             var encrypted = ProtectedData.Protect(bytes, null, DataProtectionScope.CurrentUser);
             File.WriteAllBytes(path, encrypted);
+#else
+            File.WriteAllText(path, token);
+#endif
             _token = token;
             State = LinkState.Linked;
             OnLinked?.Invoke();


### PR DESCRIPTION
## Summary
- add ProtectedData NuGet package
- support plain-text token persistence on non-Windows builds

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7438b3088328849bdcddff4915ef