### PR TITLE
Refresh event channels on draw

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -46,6 +46,12 @@ public class EventCreateWindow
     private string _channelId = string.Empty;
     private EmbedDto? _preview;
 
+    public bool ChannelsLoaded
+    {
+        get => _channelsLoaded;
+        set => _channelsLoaded = value;
+    }
+
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -83,6 +89,10 @@ public class EventCreateWindow
         {
             ImGui.TextUnformatted("Feature disabled");
             return;
+        }
+        if (!_channelsLoaded)
+        {
+            _ = RefreshChannels();
         }
         if (_channels.Count > 0)
         {


### PR DESCRIPTION
## Summary
- Refresh event channel list on draw when not loaded
- Expose `ChannelsLoaded` property for external resets

## Testing
- `/usr/share/dotnet/dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud.NET.Sdk: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd844e60988328b5201db65d02037c