### PR TITLE
Add channel-loaded flag access and lazy fetch in UiRenderer

### DIFF
--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -57,6 +57,12 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         set => _channelId = value;
     }
 
+    public bool ChannelsLoaded
+    {
+        get => _channelsLoaded;
+        set => _channelsLoaded = value;
+    }
+
     private void StartPolling()
     {
         if (_pollCts != null)
@@ -486,6 +492,11 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         {
             ImGui.TextUnformatted("Feature disabled");
             return;
+        }
+
+        if (!_channelsLoaded)
+        {
+            _ = FetchChannels();
         }
 
         if (_channels.Count > 0)


### PR DESCRIPTION
## Summary
- allow external control of UiRenderer channel state via ChannelsLoaded property
- lazily fetch channels on first UI draw when not yet loaded

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68bd84472fd483289d023ddc70f36771