### PR TITLE
Remove unused presence loaded flag

### DIFF
--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -40,7 +40,6 @@ public class UiRenderer : IAsyncDisposable, IDisposable
     };
 
     private readonly Dictionary<string, PresenceDto> _presences = new();
-    private bool _presenceLoaded;
     private bool _presenceLoadAttempted;
     private static readonly Regex MentionRegex = new("<@!?([0-9]+)>", RegexOptions.Compiled);
 
@@ -174,7 +173,6 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 {
                     _presences[p.Id] = p;
                 }
-                _presenceLoaded = true;
                 AnnotateEmbedsWithPresence();
             });
         }


### PR DESCRIPTION
## Summary
- remove unused `_presenceLoaded` field from UiRenderer, relying solely on `_presenceLoadAttempted`

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68bd844f548c83288f55e77fe5af8412