### PR TITLE
Add unique guild-user constraint for memberships

### DIFF
--- a/demibot/demibot/db/migrations/versions/0036_add_membership_guild_user_unique.py
+++ b/demibot/demibot/db/migrations/versions/0036_add_membership_guild_user_unique.py
@@ -1,0 +1,20 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0036_add_membership_guild_user_unique'
+down_revision = '0035_rename_attendance_event_signups'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        'uq_memberships_guild_user',
+        'memberships',
+        ['guild_id', 'user_id'],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('uq_memberships_guild_user', table_name='memberships')

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -160,6 +160,10 @@ class UserKey(Base):
 class Membership(Base):
     __tablename__ = "memberships"
 
+    __table_args__ = (
+        UniqueConstraint("guild_id", "user_id", name="uq_memberships_guild_user"),
+    )
+
     id: Mapped[int] = mapped_column(primary_key=True)
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
     user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), ForeignKey("users.id"))


### PR DESCRIPTION
## Summary
- ensure Memberships are unique per guild/user pair by adding a unique constraint
- add Alembic migration creating a unique index on memberships.guild_id and memberships.user_id

## Testing
- `PYTHONPATH=demibot python - <<'PY'
from alembic.config import Config
from alembic import command
from pathlib import Path
config = Config(); config.set_main_option('script_location', str(Path('demibot/demibot/db/migrations').resolve())); config.set_main_option('sqlalchemy.url', 'sqlite:///test.db'); command.stamp(config, '0035_rename_attendance_event_signups'); command.upgrade(config, '0036_add_membership_guild_user_unique')
PY`
- `sqlite3 test.db 'PRAGMA index_list("memberships");'`
- `pytest` *(fails: module 'discord.ext.commands' has no attribute 'Cog')*

------
https://chatgpt.com/codex/tasks/task_e_68bd8690843083288e26274218191a54