### PR TITLE
Make syncshell optional and tidy flags

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -46,12 +46,6 @@ public class EventCreateWindow
     private string _channelId = string.Empty;
     private EmbedDto? _preview;
 
-    public bool ChannelsLoaded
-    {
-        get => _channelsLoaded;
-        set => _channelsLoaded = value;
-    }
-
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -16,7 +16,7 @@ public class MainWindow : IDisposable
     private readonly EventCreateWindow _create;
     private readonly TemplatesWindow _templates;
     private readonly RequestBoardWindow _requestBoard;
-    private readonly SyncshellWindow _syncshell;
+    private readonly SyncshellWindow? _syncshell;
     private readonly HttpClient _httpClient;
 
     public bool IsOpen;

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -56,12 +56,6 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         set => _channelId = value;
     }
 
-    public bool ChannelsLoaded
-    {
-        get => _channelsLoaded;
-        set => _channelsLoaded = value;
-    }
-
     private void StartPolling()
     {
         if (_pollCts != null)


### PR DESCRIPTION
## Summary
- mark Syncshell window reference as nullable to avoid accessing when disabled
- remove unused ChannelsLoaded properties from event windows to keep flags internal

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release` *(fails: A compatible .NET SDK was not found; requires 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8699d7208328bcbf93c67760d40f