### PR TITLE
Clarify SyncShell purpose in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ DemiCat/
 - **Create** – Draft new events without leaving the game.
 - **Templates** – Save and reuse preset event layouts.
 - **Request Board** – Track signup requests and interest.
-- **Syncshell** – Cross-world chat integration powered by Discord (see `DemiCatPlugin/SyncshellWindow.cs`).
-- **Chat** – Mirror Discord conversations directly in game.
+- **SyncShell** – Work-in-progress replacement for the Mare Synchronos mod-sharing plugin. Syncs Penumbra mod lists to replicate player appearances and is disabled by default while under development (see `DemiCatPlugin/SyncshellWindow.cs`).
+- **FC Chat** – Mirror Discord conversations directly in game.
 - **Officer** – Administrative tools for event staff and moderators.
 
 ### DemiBot Services


### PR DESCRIPTION
## Summary
- Clarify that the SyncShell tab is a WIP Mare Synchronos replacement for syncing Penumbra mods, not a chat feature
- Rename Chat tab to FC Chat in README

## Testing
- `pytest` *(fails: 51 errors during collection)*
- `PATH=/root/.dotnet:$PATH dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8a702bf48328b2c0f23dd3084876