### PR TITLE
Fix Alembic multiple heads

### DIFF
--- a/demibot/demibot/db/migrations/versions/0036_add_membership_guild_user_unique.py
+++ b/demibot/demibot/db/migrations/versions/0036_add_membership_guild_user_unique.py
@@ -2,7 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = '0036_add_membership_guild_user_unique'
-down_revision = '0035_rename_attendance_event_signups'
+down_revision = '0034_add_event_signup_timestamp'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- ensure migration 0036 depends on 0034 to avoid multiple Alembic heads

## Testing
- `pytest` *(fails: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd931ae0f08328b5810fcaea6a8b10