### PR TITLE
feat: add ping endpoint for health checks

### DIFF
--- a/demibot/demibot/http/routes/ping.py
+++ b/demibot/demibot/http/routes/ping.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Response
+
+router = APIRouter(prefix="/api")
+
+
+@router.head("/ping")
+@router.get("/ping")
+async def ping() -> Response:
+    """Simple endpoint for liveness checks."""
+    return Response(status_code=200)


### PR DESCRIPTION
## Summary
- add `/api/ping` route for basic liveness checks

## Testing
- `curl -I http://127.0.0.1:8000/api/ping`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alembic')*


------
https://chatgpt.com/codex/tasks/task_e_68bebbe7dc0c83288e42a067ad27350b