### PR TITLE
Add health endpoint fallback for watchers

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -72,15 +72,13 @@ public class ChannelWatcher : IDisposable
             }
             try
             {
-                var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/ping";
-                var ping = new HttpRequestMessage(HttpMethod.Head, url);
-                ApiHelpers.AddAuthHeader(ping, _tokenManager);
-                var pingResponse = await _httpClient.SendAsync(ping, token);
-                if (!pingResponse.IsSuccessStatusCode)
+                var pingResponse = await ApiHelpers.PingAsync(_httpClient, _config, _tokenManager, token);
+                if (pingResponse?.IsSuccessStatusCode != true)
                 {
-                    var responseBody = await pingResponse.Content.ReadAsStringAsync();
-                    PluginServices.Instance!.Log.Warning($"Channel watcher ping failed. URL: {url}, Status: {pingResponse.StatusCode}. Response Body: {responseBody}");
-                    if (pingResponse.StatusCode == HttpStatusCode.Unauthorized || pingResponse.StatusCode == HttpStatusCode.Forbidden)
+                    var responseBody = pingResponse == null ? string.Empty : await pingResponse.Content.ReadAsStringAsync();
+                    var status = pingResponse?.StatusCode;
+                    PluginServices.Instance!.Log.Warning($"Channel watcher ping failed. Status: {status}. Response Body: {responseBody}");
+                    if (status == HttpStatusCode.Unauthorized || status == HttpStatusCode.Forbidden)
                     {
                         PluginServices.Instance?.ToastGui.ShowError("Channel watcher auth failed");
                     }

--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -320,17 +320,8 @@ public class ChatBridge : IDisposable
 
     private async Task<bool> ValidateToken(CancellationToken token)
     {
-        try
-        {
-            var request = new HttpRequestMessage(HttpMethod.Head, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/ping");
-            ApiHelpers.AddAuthHeader(request, _tokenManager);
-            var response = await _httpClient.SendAsync(request, token);
-            return response.IsSuccessStatusCode;
-        }
-        catch
-        {
-            return false;
-        }
+        var response = await ApiHelpers.PingAsync(_httpClient, _config, _tokenManager, token);
+        return response?.IsSuccessStatusCode ?? false;
     }
 
     private async Task DelayWithJitter(int seconds, CancellationToken token)

--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -128,10 +128,8 @@ public class DiscordPresenceService : IDisposable
 
             try
             {
-                var ping = new HttpRequestMessage(HttpMethod.Head, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/ping");
-                ApiHelpers.AddAuthHeader(ping, TokenManager.Instance!);
-                var pingResponse = await _httpClient.SendAsync(ping, token);
-                if (!pingResponse.IsSuccessStatusCode)
+                var pingResponse = await ApiHelpers.PingAsync(_httpClient, _config, TokenManager.Instance!, token);
+                if (pingResponse?.IsSuccessStatusCode != true)
                 {
                     try { await Task.Delay(TimeSpan.FromSeconds(5), token); } catch { }
                     continue;

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -58,10 +58,8 @@ public class RequestWatcher : IDisposable
             }
             try
             {
-                var ping = new HttpRequestMessage(HttpMethod.Head, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/ping");
-                ApiHelpers.AddAuthHeader(ping, _tokenManager);
-                var pingResponse = await _httpClient.SendAsync(ping, token);
-                if (!pingResponse.IsSuccessStatusCode)
+                var pingResponse = await ApiHelpers.PingAsync(_httpClient, _config, _tokenManager, token);
+                if (pingResponse?.IsSuccessStatusCode != true)
                 {
                     try { await Task.Delay(delay, token); } catch { }
                     delay = TimeSpan.FromSeconds(5);

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -281,10 +281,8 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
             try
             {
-                var ping = new HttpRequestMessage(HttpMethod.Head, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/ping");
-                ApiHelpers.AddAuthHeader(ping, TokenManager.Instance!);
-                var pingResponse = await _httpClient.SendAsync(ping);
-                if (!pingResponse.IsSuccessStatusCode)
+                var pingResponse = await ApiHelpers.PingAsync(_httpClient, _config, TokenManager.Instance!, CancellationToken.None);
+                if (pingResponse?.IsSuccessStatusCode != true)
                 {
                     StartPolling();
                     return;


### PR DESCRIPTION
## Summary
- add ApiHelpers.PingAsync to retry `/health` when `/api/ping` returns 404
- update network watchers to use ping fallback instead of failing immediately
- cover health fallback with new ChatWindowWebSocket test

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bec02f28d883288253018a443c8736