### PR TITLE
Handle websocket disconnect message

### DIFF
--- a/demibot/demibot/http/ws.py
+++ b/demibot/demibot/http/ws.py
@@ -157,6 +157,10 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     )
     try:
         while True:
-            await websocket.receive()
-    except WebSocketDisconnect:
+            result = await websocket.receive()
+            if result["type"] == "websocket.disconnect":
+                break
+    except (WebSocketDisconnect, RuntimeError):
         manager.disconnect(websocket)
+        return
+    manager.disconnect(websocket)


### PR DESCRIPTION
## Summary
- Break out of websocket loop when a disconnect message is received
- Cleanly disconnect websocket clients on WebSocketDisconnect or RuntimeError

## Testing
- `pytest` *(fails: TypeError, IntegrityError)*

------
https://chatgpt.com/codex/tasks/task_e_68bed00c48b083289cb0f9d598d10172