### PR TITLE
Add auth header to delta token request

### DIFF
--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -109,7 +109,9 @@ internal static class RequestStateService
             string? newToken = null;
             try
             {
-                var tokenResp = await httpClient.GetAsync($"{config.ApiBaseUrl.TrimEnd('/')}/api/delta-token");
+                var tokenMsg = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/delta-token");
+                ApiHelpers.AddAuthHeader(tokenMsg, TokenManager.Instance!);
+                var tokenResp = await httpClient.SendAsync(tokenMsg);
                 if (tokenResp.IsSuccessStatusCode)
                 {
                     var tokenStream = await tokenResp.Content.ReadAsStreamAsync();


### PR DESCRIPTION
## Summary
- use HttpRequestMessage with auth header for delta-token request

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest tests/test_requests_delta.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68bed02a4ec88328829d8290feb19ec8