### PR TITLE
Ensure auth headers before HTTP requests and log failures

### DIFF
--- a/DemiCatPlugin/ChannelNameResolver.cs
+++ b/DemiCatPlugin/ChannelNameResolver.cs
@@ -36,9 +36,12 @@ internal static class ChannelNameResolver
             {
                 var refreshReq = new HttpRequestMessage(HttpMethod.Post,
                     $"{config.ApiBaseUrl.TrimEnd('/')}/api/channels/refresh");
-                if (TokenManager.Instance != null)
-                    ApiHelpers.AddAuthHeader(refreshReq, TokenManager.Instance!);
-                await httpClient.SendAsync(refreshReq);
+                ApiHelpers.AddAuthHeader(refreshReq, TokenManager.Instance!);
+                var resp = await httpClient.SendAsync(refreshReq);
+                if (!resp.IsSuccessStatusCode)
+                {
+                    PluginServices.Instance!.Log.Warning($"Failed to refresh channel names. URL: {refreshReq.RequestUri}, Status: {resp.StatusCode}");
+                }
             }
             catch (Exception ex)
             {

--- a/DemiCatPlugin/RoleCache.cs
+++ b/DemiCatPlugin/RoleCache.cs
@@ -41,11 +41,11 @@ internal static class RoleCache
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/guild-roles");
-            if (TokenManager.Instance != null)
-                ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
+                PluginServices.Instance!.Log.Warning($"Failed to refresh guild roles. URL: {request.RequestUri}, Status: {response.StatusCode}");
                 _loaded = true;
                 return;
             }

--- a/DemiCatPlugin/SignupPresetService.cs
+++ b/DemiCatPlugin/SignupPresetService.cs
@@ -35,8 +35,7 @@ internal static class SignupPresetService
         {
             var url = $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets";
             var req = new HttpRequestMessage(HttpMethod.Get, url);
-            if (TokenManager.Instance != null)
-                ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
             {
@@ -68,8 +67,7 @@ internal static class SignupPresetService
         {
             var url = $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets";
             var req = new HttpRequestMessage(HttpMethod.Post, url);
-            if (TokenManager.Instance != null)
-                ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
             req.Content = new StringContent(JsonSerializer.Serialize(preset), Encoding.UTF8, "application/json");
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
@@ -99,8 +97,7 @@ internal static class SignupPresetService
         {
             var url = $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets/{id}";
             var req = new HttpRequestMessage(HttpMethod.Delete, url);
-            if (TokenManager.Instance != null)
-                ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
             {


### PR DESCRIPTION
## Summary
- Always add auth header before sending HTTP requests in RoleCache, SignupPresetService, ChannelNameResolver, and RequestStateService
- Log warnings with URL and status code when HTTP responses fail

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest tests/test_guild_roles.py tests/test_signup_presets.py` *(fails: UNIQUE constraint in test_signup_presets)*

------
https://chatgpt.com/codex/tasks/task_e_68bf19c4cf788328a6c1bb42f1f51214