### PR TITLE
Allow resizing presence sidebar and render only once

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -18,6 +18,7 @@ public class MainWindow : IDisposable
     private readonly RequestBoardWindow _requestBoard;
     private readonly SyncshellWindow? _syncshell;
     private readonly HttpClient _httpClient;
+    private float _presenceWidth = 150f;
 
     public bool IsOpen;
     public bool HasOfficerRole { get; set; }
@@ -97,7 +98,7 @@ public class MainWindow : IDisposable
             {
                 if (_config.SyncedChat && _presenceSidebar != null)
                 {
-                    _presenceSidebar.Draw();
+                    _presenceSidebar.Draw(ref _presenceWidth);
                     ImGui.SameLine();
                 }
                 ImGui.BeginChild("##eventsArea", ImGui.GetContentRegionAvail(), false);
@@ -179,7 +180,7 @@ public class MainWindow : IDisposable
                 {
                     if (_config.SyncedChat && _presenceSidebar != null)
                     {
-                        _presenceSidebar.Draw();
+                        _presenceSidebar.Draw(ref _presenceWidth);
                         ImGui.SameLine();
                     }
                     ImGui.BeginChild("##chatArea", ImGui.GetContentRegionAvail(), false);
@@ -203,7 +204,7 @@ public class MainWindow : IDisposable
                 {
                     if (_config.SyncedChat && _presenceSidebar != null)
                     {
-                        _presenceSidebar.Draw();
+                        _presenceSidebar.Draw(ref _presenceWidth);
                         ImGui.SameLine();
                     }
                     ImGui.BeginChild("##officerChatArea", ImGui.GetContentRegionAvail(), false);

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -22,9 +22,10 @@ public class PresenceSidebar : IDisposable
         _service = service;
     }
 
-    public void Draw()
+    public void Draw(ref float width)
     {
-        ImGui.BeginChild("##presence", new Vector2(150, 0), true);
+        // Main presence list
+        ImGui.BeginChild("##presence", new Vector2(width, 0), true);
 
         if (!_service.Loaded)
         {
@@ -55,6 +56,15 @@ public class PresenceSidebar : IDisposable
         }
 
         ImGui.EndChild();
+
+        // Draw a draggable handle to allow the sidebar to be resized
+        ImGui.SameLine();
+        ImGui.InvisibleButton("##presence_resize", new Vector2(4, -1));
+        if (ImGui.IsItemActive())
+        {
+            width += ImGui.GetIO().MouseDelta.X;
+            if (width < 100) width = 100; // minimum width
+        }
     }
 
     private void DrawPresence(PresenceDto p)


### PR DESCRIPTION
## Summary
- ensure presence sidebar draws only once per tab on the left side
- add drag handle to resize presence sidebar width for full names

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf184b2b10832893929d7c308ed82d