### PR TITLE
Fallback to legacy /health ping endpoint

### DIFF
--- a/DemiCatPlugin/ApiHelpers.cs
+++ b/DemiCatPlugin/ApiHelpers.cs
@@ -50,14 +50,19 @@ internal static class ApiHelpers
             var ping = new HttpRequestMessage(HttpMethod.Head, $"{baseUrl}/api/ping");
             AddAuthHeader(ping, tokenManager);
             var response = await httpClient.SendAsync(ping, token);
-            if (response.StatusCode != HttpStatusCode.NotFound || response.IsSuccessStatusCode)
+            if (response.StatusCode != HttpStatusCode.NotFound)
             {
                 return response;
             }
 
             var health = new HttpRequestMessage(HttpMethod.Head, $"{baseUrl}/health");
             AddAuthHeader(health, tokenManager);
-            return await httpClient.SendAsync(health, token);
+            var healthResponse = await httpClient.SendAsync(health, token);
+            if (healthResponse.StatusCode == HttpStatusCode.NotFound)
+            {
+                PluginServices.Instance?.Log.Error("Backend missing /api/ping and /health endpoints. Please update or restart the backend.");
+            }
+            return healthResponse;
         }
         catch
         {

--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -78,6 +78,10 @@ public class ChannelWatcher : IDisposable
                     var responseBody = pingResponse == null ? string.Empty : await pingResponse.Content.ReadAsStringAsync();
                     var status = pingResponse?.StatusCode;
                     PluginServices.Instance!.Log.Warning($"Channel watcher ping failed. Status: {status}. Response Body: {responseBody}");
+                    if (status == HttpStatusCode.NotFound)
+                    {
+                        PluginServices.Instance!.Log.Error("Backend ping endpoints missing. Please update or restart the backend.");
+                    }
                     if (status == HttpStatusCode.Unauthorized || status == HttpStatusCode.Forbidden)
                     {
                         PluginServices.Instance?.ToastGui.ShowError("Channel watcher auth failed");

--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -321,6 +321,10 @@ public class ChatBridge : IDisposable
     private async Task<bool> ValidateToken(CancellationToken token)
     {
         var response = await ApiHelpers.PingAsync(_httpClient, _config, _tokenManager, token);
+        if (response?.StatusCode == HttpStatusCode.NotFound)
+        {
+            PluginServices.Instance?.Log.Error("Backend ping endpoints missing. Please update or restart the backend.");
+        }
         return response?.IsSuccessStatusCode ?? false;
     }
 

--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.WebSockets;
 using System.Text;
@@ -131,6 +132,10 @@ public class DiscordPresenceService : IDisposable
                 var pingResponse = await ApiHelpers.PingAsync(_httpClient, _config, TokenManager.Instance!, token);
                 if (pingResponse?.IsSuccessStatusCode != true)
                 {
+                    if (pingResponse?.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        PluginServices.Instance!.Log.Error("Backend ping endpoints missing. Please update or restart the backend.");
+                    }
                     try { await Task.Delay(TimeSpan.FromSeconds(5), token); } catch { }
                     continue;
                 }

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Net.WebSockets;
 using System.Text.Json;
@@ -61,6 +62,10 @@ public class RequestWatcher : IDisposable
                 var pingResponse = await ApiHelpers.PingAsync(_httpClient, _config, _tokenManager, token);
                 if (pingResponse?.IsSuccessStatusCode != true)
                 {
+                    if (pingResponse?.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        PluginServices.Instance!.Log.Error("Backend ping endpoints missing. Please update or restart the backend.");
+                    }
                     try { await Task.Delay(delay, token); } catch { }
                     delay = TimeSpan.FromSeconds(5);
                     continue;

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -284,6 +285,10 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 var pingResponse = await ApiHelpers.PingAsync(_httpClient, _config, TokenManager.Instance!, CancellationToken.None);
                 if (pingResponse?.IsSuccessStatusCode != true)
                 {
+                    if (pingResponse?.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        PluginServices.Instance!.Log.Error("Backend ping endpoints missing. Please update or restart the backend.");
+                    }
                     StartPolling();
                     return;
                 }


### PR DESCRIPTION
## Summary
- attempt `/api/ping` before `/health` in watcher connectivity checks
- surface clear log when neither endpoint is available

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68bf1dc804208328b4ebab3552960f6c