### PR TITLE
Add reactions_json column to messages table

### DIFF
--- a/demibot/demibot/db/migrations/versions/0037_add_reactions_json_to_messages.py
+++ b/demibot/demibot/db/migrations/versions/0037_add_reactions_json_to_messages.py
@@ -1,0 +1,14 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0037_add_reactions_json_to_messages'
+down_revision = '0036_add_membership_guild_user_unique'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.add_column('messages', sa.Column('reactions_json', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('messages', 'reactions_json')


### PR DESCRIPTION
## Summary
- add `reactions_json` column to messages table

## Testing
- `python - <<'PY'
from pathlib import Path
import sqlalchemy as sa
from alembic import command
from alembic.config import Config
import sys
sys.path.insert(0, str(Path('demibot')))

migrations = Path('demibot/demibot/db/migrations')

urls = ['sqlite:///dev.db', 'sqlite:///test.db']
for url in urls:
    print('Preparing database', url)
    engine = sa.create_engine(url)
    metadata = sa.MetaData()
    sa.Table('messages', metadata,
             sa.Column('discord_message_id', sa.Integer, primary_key=True),
             )
    metadata.create_all(engine)
    cfg = Config()
    cfg.set_main_option('script_location', str(migrations))
    cfg.set_main_option('sqlalchemy.url', url)
    command.stamp(cfg, '0036_add_membership_guild_user_unique')
    command.upgrade(cfg, 'head')
    # verify column exists
    insp = sa.inspect(engine)
    cols = [c['name'] for c in insp.get_columns('messages')]
    print('Columns after upgrade for', url, ':', cols)
PY`
- `pytest` *(fails: IntegrityError and missing parameters)*

------
https://chatgpt.com/codex/tasks/task_e_68bf28f2c97483289e1528e07f9156c5