### PR TITLE
Add request tombstones table

### DIFF
--- a/demibot/demibot/db/migrations/versions/0038_add_request_tombstones_table.py
+++ b/demibot/demibot/db/migrations/versions/0038_add_request_tombstones_table.py
@@ -1,0 +1,23 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.mysql import BIGINT
+
+revision = '0038_add_request_tombstones_table'
+down_revision = '0037_add_reactions_json_to_messages'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'request_tombstones',
+        sa.Column('request_id', BIGINT(unsigned=True), primary_key=True),
+        sa.Column('guild_id', BIGINT(unsigned=True), sa.ForeignKey('guilds.id'), nullable=False),
+        sa.Column('version', sa.Integer(), nullable=False),
+        sa.Column('deleted_at', sa.DateTime(), nullable=True),
+    )
+    op.create_index('ix_request_tombstones_deleted_at', 'request_tombstones', ['deleted_at'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_request_tombstones_deleted_at', table_name='request_tombstones')
+    op.drop_table('request_tombstones')


### PR DESCRIPTION
## Summary
- add migration for request_tombstones table

## Testing
- `PYTHONPATH=demibot python - <<'PY'
import asyncio
from db.session import init_db
asyncio.run(init_db('sqlite+aiosqlite:///dev.db'))
PY`
- `PYTHONPATH=demibot python - <<'PY'
import asyncio
from db.session import init_db
asyncio.run(init_db('sqlite+aiosqlite:///ci.db'))
PY`
- `PYTHONPATH=demibot pytest` *(fails: TypeError: test_multipart_message.<locals>._run.<locals>.fake_..., more)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2b16425c83288e74601b82cde2fe