### PR TITLE
Remove unused presence sidebar from chat views

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -12,27 +12,24 @@ public class MainWindow : IDisposable
     private readonly ChatWindow? _chat;
     private readonly OfficerChatWindow _officer;
     private readonly SettingsWindow _settings;
-    private readonly PresenceSidebar? _presenceSidebar;
     private readonly EventCreateWindow _create;
     private readonly TemplatesWindow _templates;
     private readonly RequestBoardWindow _requestBoard;
     private readonly SyncshellWindow? _syncshell;
     private readonly HttpClient _httpClient;
-    private float _presenceWidth = 150f;
 
     public bool IsOpen;
     public bool HasOfficerRole { get; set; }
     public UiRenderer Ui => _ui;
     public EventCreateWindow EventCreateWindow => _create;
 
-    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, PresenceSidebar? presenceSidebar, HttpClient httpClient)
+    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient)
     {
         _config = config;
         _ui = ui;
         _chat = chat;
         _officer = officer;
         _settings = settings;
-        _presenceSidebar = presenceSidebar;
         _httpClient = httpClient;
         _create = new EventCreateWindow(config, httpClient);
         _templates = new TemplatesWindow(config, httpClient);
@@ -96,11 +93,6 @@ public class MainWindow : IDisposable
             }
             else if (ImGui.BeginTabItem("Events"))
             {
-                if (_config.SyncedChat && _presenceSidebar != null)
-                {
-                    _presenceSidebar.Draw(ref _presenceWidth);
-                    ImGui.SameLine();
-                }
                 ImGui.BeginChild("##eventsArea", ImGui.GetContentRegionAvail(), false);
                 _ui.Draw();
                 ImGui.EndChild();
@@ -178,11 +170,6 @@ public class MainWindow : IDisposable
                 }
                 else if (ImGui.BeginTabItem("Chat"))
                 {
-                    if (_config.SyncedChat && _presenceSidebar != null)
-                    {
-                        _presenceSidebar.Draw(ref _presenceWidth);
-                        ImGui.SameLine();
-                    }
                     ImGui.BeginChild("##chatArea", ImGui.GetContentRegionAvail(), false);
                     _chat.Draw();
                     ImGui.EndChild();
@@ -202,11 +189,6 @@ public class MainWindow : IDisposable
                 }
                 else if (ImGui.BeginTabItem("Officer"))
                 {
-                    if (_config.SyncedChat && _presenceSidebar != null)
-                    {
-                        _presenceSidebar.Draw(ref _presenceWidth);
-                        ImGui.SameLine();
-                    }
                     ImGui.BeginChild("##officerChatArea", ImGui.GetContentRegionAvail(), false);
                     _officer.Draw();
                     ImGui.EndChild();

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -23,7 +23,6 @@ public class Plugin : IDalamudPlugin
     private readonly ChatWindow _chatWindow;
     private readonly OfficerChatWindow _officerChatWindow;
     private readonly DiscordPresenceService? _presenceService;
-    private readonly PresenceSidebar? _presenceSidebar;
     private readonly MainWindow _mainWindow;
     private readonly ChannelWatcher _channelWatcher;
     private readonly RequestWatcher _requestWatcher;
@@ -60,13 +59,8 @@ public class Plugin : IDalamudPlugin
             : null;
         _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager);
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager);
-        _presenceSidebar = _presenceService != null ? new PresenceSidebar(_presenceService) : null;
-        if (_config.SyncedChat && _presenceSidebar != null)
-        {
-            _presenceSidebar.TextureLoader = _chatWindow.TextureLoader;
-        }
         _presenceService?.Reset();
-        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _presenceSidebar, _httpClient);
+        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);
         _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _chatWindow, _officerChatWindow, _tokenManager, _httpClient);
         _requestWatcher = new RequestWatcher(_config, _httpClient, _tokenManager);
         _settings.MainWindow = _mainWindow;
@@ -107,7 +101,6 @@ public class Plugin : IDalamudPlugin
 
         _channelWatcher.Dispose();
         _requestWatcher.Dispose();
-        _presenceSidebar?.Dispose();
         _presenceService?.Dispose();
         _chatWindow.Dispose();
         _officerChatWindow.Dispose();
@@ -223,7 +216,6 @@ public class Plugin : IDalamudPlugin
                 if (!_config.EnableFcChat)
                 {
                     _chatWindow.StopNetworking();
-                    _presenceSidebar?.Dispose();
                     _presenceService?.Dispose();
                 }
                 _services.PluginInterface.SavePluginConfig(_config);


### PR DESCRIPTION
## Summary
- drop presence sidebar from main window tabs
- simplify plugin bootstrap to stop creating the sidebar

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf306b69988328aed9b0a3b3b9d24f