### PR TITLE
Group presence sidebar by role and reposition left

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -1,19 +1,24 @@
 using System;
-using System.Collections.Generic;
 using System.Net.Http;
-using System.Numerics;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
-using Dalamud.Interface.Textures;
+using System.Numerics;
 
 namespace DemiCatPlugin;
 
 public class FcChatWindow : ChatWindow
 {
+    private readonly PresenceSidebar? _presenceSidebar;
+    private float _presenceWidth = 150f;
+
     public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager)
         : base(config, httpClient, presence, tokenManager)
     {
         _channelId = config.FcChannelId;
+        if (presence != null)
+        {
+            _presenceSidebar = new PresenceSidebar(presence) { TextureLoader = LoadTexture };
+        }
     }
 
     public override void StartNetworking()
@@ -43,63 +48,14 @@ public class FcChatWindow : ChatWindow
 
         _ = RoleCache.EnsureLoaded(_httpClient, _config);
 
-        ImGui.BeginChild("##fcChat", new Vector2(-150, 0), false);
+        if (_presenceSidebar != null)
+        {
+            _presenceSidebar.Draw(ref _presenceWidth);
+            ImGui.SameLine();
+        }
+
+        ImGui.BeginChild("##fcChat", ImGui.GetContentRegionAvail(), false);
         base.Draw();
-        ImGui.EndChild();
-
-        ImGui.SameLine();
-        ImGui.BeginChild("##userList", new Vector2(150, -30), true);
-
-        var presences = _presence?.Presences ?? new List<PresenceDto>();
-        foreach (var user in presences)
-        {
-            var color = user.Status == "online"
-                ? new Vector4(0f, 1f, 0f, 1f)
-                : new Vector4(0.5f, 0.5f, 0.5f, 1f);
-            ImGui.PushStyleColor(ImGuiCol.Text, color);
-            ImGui.TextUnformatted("●");
-            ImGui.PopStyleColor();
-            ImGui.SameLine();
-            if (!string.IsNullOrEmpty(user.AvatarUrl) && user.AvatarTexture == null)
-            {
-                LoadTexture(user.AvatarUrl, t => user.AvatarTexture = t);
-            }
-            if (user.AvatarTexture != null)
-            {
-                var wrap = user.AvatarTexture.GetWrapOrEmpty();
-                ImGui.Image(wrap.Handle, new Vector2(24, 24));
-            }
-            else
-            {
-                ImGui.Dummy(new Vector2(24, 24));
-            }
-            ImGui.SameLine();
-            var label = user.Name;
-            foreach (var roleId in user.Roles)
-            {
-                foreach (var role in RoleCache.Roles)
-                {
-                    if (role.Id == roleId)
-                    {
-                        label += $" [{role.Name}]";
-                        break;
-                    }
-                }
-            }
-            if (ImGui.Selectable(label))
-            {
-                _input += $"@{user.Name} ";
-            }
-        }
-
-        foreach (var role in RoleCache.Roles)
-        {
-            if (ImGui.Selectable($"@{role.Name}"))
-            {
-                _input += $"@{role.Name} ";
-            }
-        }
-
         ImGui.EndChild();
 
         if (_config.ChatChannelId != originalChatChannel || _config.FcChannelId != _channelId)


### PR DESCRIPTION
## Summary
- Group online presences by guild role and show separate No Role/Offline sections
- Anchor presence sidebar on left of FC chat window with resizable width

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3ba30648832899e8ebd2edf7d4e7