### PR TITLE
Reserve officer chat input area for future features

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
+using System.Numerics;
 
 namespace DemiCatPlugin;
 
@@ -41,6 +42,9 @@ public class OfficerChatWindow : ChatWindow
 
         var originalChatChannel = _config.ChatChannelId;
         base.Draw();
+
+        // Reserved padded area beneath the standard chat input for upcoming officer tools.
+        ImGui.Dummy(new Vector2(0, ImGui.GetFrameHeightWithSpacing()));
 
         if (_config.ChatChannelId != originalChatChannel || _config.OfficerChannelId != _channelId)
         {

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ DemiCat/
 - **SyncShell** – Work-in-progress replacement for the Mare Synchronos mod-sharing plugin. Syncs Penumbra mod lists to replicate player appearances and is disabled by default while under development (see `DemiCatPlugin/SyncshellWindow.cs`).
 - **FC Chat** – Mirror Discord conversations directly in game.
 - **Officer** – Administrative tools for event staff and moderators.
+  - Officer chat window now includes a padded area beneath the input box reserved for future features.
 
 ### DemiBot Services
 


### PR DESCRIPTION
## Summary
- reserve padded area beneath officer chat input for upcoming tools
- document officer chat reserved region in README
- import System.Numerics for Vector2 padding call

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: compatible .NET SDK 9.0.100 not installed)*
- `pytest` *(fails: missing modules such as discord, fastapi, pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3f96e9c48328a1047c026ffd8507