### PR TITLE
Fix request tombstone migration column types

### DIFF
--- a/demibot/demibot/db/migrations/versions/0038_add_request_tombstones_table.py
+++ b/demibot/demibot/db/migrations/versions/0038_add_request_tombstones_table.py
@@ -9,15 +9,41 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
-        'request_tombstones',
-        sa.Column('request_id', BIGINT(unsigned=True), primary_key=True),
-        sa.Column('guild_id', BIGINT(unsigned=True), sa.ForeignKey('guilds.id'), nullable=False),
-        sa.Column('version', sa.Integer(), nullable=False),
-        sa.Column('deleted_at', sa.DateTime(), nullable=True),
+        "request_tombstones",
+        sa.Column(
+            "request_id",
+            BIGINT(unsigned=True),
+            primary_key=True,
+            autoincrement=False,
+        ),
+        sa.Column(
+            "guild_id",
+            sa.Integer(),
+            sa.ForeignKey("guilds.id"),
+            nullable=False,
+        ),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
     )
-    op.create_index('ix_request_tombstones_deleted_at', 'request_tombstones', ['deleted_at'])
+    op.create_index(
+        "ix_request_tombstones_deleted_at",
+        "request_tombstones",
+        ["deleted_at"],
+    )
+    op.create_index(
+        "ix_request_tombstones_guild_id",
+        "request_tombstones",
+        ["guild_id"],
+    )
 
 
 def downgrade() -> None:
-    op.drop_index('ix_request_tombstones_deleted_at', table_name='request_tombstones')
-    op.drop_table('request_tombstones')
+    op.drop_index(
+        "ix_request_tombstones_guild_id",
+        table_name="request_tombstones",
+    )
+    op.drop_index(
+        "ix_request_tombstones_deleted_at",
+        table_name="request_tombstones",
+    )
+    op.drop_table("request_tombstones")


### PR DESCRIPTION
## Summary
- Correct request_tombstones migration to use integer guild_id and non-auto-incrementing request_id
- Add indexes on deleted_at and guild_id for request_tombstones

## Testing
- `pytest tests/test_requests_delta.py -q`
- `pytest -q` *(fails: UNIQUE constraint failed, runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf241a5cb883288e3422d0abe264eb