### PR TITLE
Introduce channel fetch service with retry

### DIFF
--- a/DemiCatPlugin/ChannelService.cs
+++ b/DemiCatPlugin/ChannelService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DemiCatPlugin;
+
+public class ChannelService
+{
+    private readonly Config _config;
+    private readonly HttpClient _httpClient;
+    private readonly TokenManager _tokenManager;
+
+    public ChannelService(Config config, HttpClient httpClient, TokenManager tokenManager)
+    {
+        _config = config;
+        _httpClient = httpClient;
+        _tokenManager = tokenManager;
+    }
+
+    public async Task<IReadOnlyList<ChannelDto>> FetchAsync(string kind, CancellationToken ct)
+    {
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels?kind={kind}";
+        var delay = TimeSpan.FromMilliseconds(500);
+
+        for (var attempt = 0; ; attempt++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            linkedCts.CancelAfter(TimeSpan.FromSeconds(10));
+            try
+            {
+                var response = await _httpClient.SendAsync(request, linkedCts.Token);
+                response.EnsureSuccessStatusCode();
+                var stream = await response.Content.ReadAsStreamAsync(linkedCts.Token);
+                var channels = await JsonSerializer.DeserializeAsync<List<ChannelDto>>(stream, cancellationToken: linkedCts.Token) ?? new List<ChannelDto>();
+                return channels;
+            }
+            catch (HttpRequestException) when (attempt < 2)
+            {
+                await Task.Delay(delay, ct);
+                delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 2);
+            }
+            catch (TaskCanceledException) when (attempt < 2)
+            {
+                await Task.Delay(delay, ct);
+                delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 2);
+            }
+        }
+    }
+}
+

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -11,8 +11,8 @@ public class FcChatWindow : ChatWindow
     private readonly PresenceSidebar? _presenceSidebar;
     private float _presenceWidth = 150f;
 
-    public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager)
-        : base(config, httpClient, presence, tokenManager)
+    public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService)
+        : base(config, httpClient, presence, tokenManager, channelService)
     {
         _channelId = config.FcChannelId;
         if (presence != null)

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -23,7 +23,7 @@ public class MainWindow : IDisposable
     public UiRenderer Ui => _ui;
     public EventCreateWindow EventCreateWindow => _create;
 
-    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient)
+    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient, ChannelService channelService)
     {
         _config = config;
         _ui = ui;
@@ -31,7 +31,7 @@ public class MainWindow : IDisposable
         _officer = officer;
         _settings = settings;
         _httpClient = httpClient;
-        _create = new EventCreateWindow(config, httpClient);
+        _create = new EventCreateWindow(config, httpClient, channelService);
         _templates = new TemplatesWindow(config, httpClient);
         _requestBoard = new RequestBoardWindow(config, httpClient);
         _syncshell = config.FCSyncShell ? new SyncshellWindow(config, httpClient) : null;

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -28,6 +28,7 @@ public class Plugin : IDalamudPlugin
     private readonly RequestWatcher _requestWatcher;
     private Config _config;
     private readonly HttpClient _httpClient = new();
+    private readonly ChannelService _channelService;
     private readonly Action _openMainUi;
     private readonly Action _openConfigUi;
     private readonly TokenManager _tokenManager;
@@ -57,10 +58,11 @@ public class Plugin : IDalamudPlugin
         _presenceService = _config.SyncedChat && _config.EnableFcChat
             ? new DiscordPresenceService(_config, _httpClient)
             : null;
-        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager);
-        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager);
+        _channelService = new ChannelService(_config, _httpClient, _tokenManager);
+        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService);
+        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService);
         _presenceService?.Reset();
-        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient);
+        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient, _channelService);
         _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _chatWindow, _officerChatWindow, _tokenManager, _httpClient);
         _requestWatcher = new RequestWatcher(_config, _httpClient, _tokenManager);
         _settings.MainWindow = _mainWindow;


### PR DESCRIPTION
## Summary
- centralize channel API requests into ChannelService with timeout and retry logic
- use ChannelService in chat and event windows
- wire up ChannelService through plugin initialization

## Testing
- `dotnet test` *(fails: Requested SDK version 9.0.100 not installed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68bf4f5161c083288bdc6b5139ddebad