### PR TITLE
feat: improve mention resolving logic

### DIFF
--- a/DemiCatPlugin/MentionResolver.cs
+++ b/DemiCatPlugin/MentionResolver.cs
@@ -1,20 +1,71 @@
+using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
+using System.Text;
 
 namespace DemiCatPlugin;
 
 public static class MentionResolver
 {
+    private static readonly char[] TrimChars = ['!', '.', ',', '?', ';', ':', ')', ']', '}', '>', '\'', '"'];
+
+    private static string Normalize(string name) => name.Trim().ToLowerInvariant();
+
     public static string Resolve(string content, IEnumerable<PresenceDto> presences, IEnumerable<RoleDto> roles)
     {
+        var lookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var u in presences)
         {
-            content = Regex.Replace(content, $"@{Regex.Escape(u.Name)}\\b", $"<@{u.Id}>");
+            lookup[Normalize(u.Name)] = $"<@{u.Id}>";
         }
+
         foreach (var r in roles)
         {
-            content = Regex.Replace(content, $"@{Regex.Escape(r.Name)}\\b", $"<@&{r.Id}>");
+            lookup[Normalize(r.Name)] = $"<@&{r.Id}>";
         }
-        return content;
+
+        // Discord special mentions
+        lookup[Normalize("everyone")] = "<@everyone>";
+        lookup[Normalize("here")] = "<@here>";
+
+        var sb = new StringBuilder(content.Length);
+
+        for (var i = 0; i < content.Length;)
+        {
+            if (content[i] == '@')
+            {
+                var start = i + 1;
+                var j = start;
+                while (j < content.Length && !char.IsWhiteSpace(content[j]))
+                {
+                    j++;
+                }
+
+                var token = content.Substring(start, j - start);
+                var name = token.TrimEnd(TrimChars);
+                var suffix = token.Substring(name.Length);
+                var key = Normalize(name);
+
+                if (lookup.TryGetValue(key, out var replacement))
+                {
+                    sb.Append(replacement);
+                    sb.Append(suffix);
+                }
+                else
+                {
+                    sb.Append("@\u200B");
+                    sb.Append(token);
+                }
+
+                i = j;
+            }
+            else
+            {
+                sb.Append(content[i]);
+                i++;
+            }
+        }
+
+        return sb.ToString();
     }
 }

--- a/tests/ChatWindowTests.cs
+++ b/tests/ChatWindowTests.cs
@@ -25,4 +25,16 @@ public class ChatWindowTests
 
         Assert.Equal("Hello <@1> and <@&2>", result);
     }
+
+    [Fact]
+    public void MentionResolver_HandlesSpecialCaseInsensitiveAndEscapes()
+    {
+        var presences = new[] { new PresenceDto { Id = "1", Name = "Alice" } };
+        var roles = new[] { new RoleDto { Id = "2", Name = "Admin" } };
+        var input = "@ALICE @admin @Unknown @everyone @Here test@example.com";
+
+        var result = MentionResolver.Resolve(input, presences, roles);
+
+        Assert.Equal("<@1> <@&2> @​Unknown <@everyone> <@here> test@​example.com", result);
+    }
 }


### PR DESCRIPTION
## Summary
- switch MentionResolver to dictionary-based mention lookup to prevent partial matches
- support @everyone and @here with explicit IDs and case-insensitive matching
- escape stray @ characters to avoid accidental pings

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Requested SDK version 9.0.100 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf57b7b760832896a7b87e686a1ca2