### PR TITLE
feat: expand markdown formatting

### DIFF
--- a/DemiCatPlugin/MarkdownFormatter.cs
+++ b/DemiCatPlugin/MarkdownFormatter.cs
@@ -6,6 +6,11 @@ public static class MarkdownFormatter
 {
     public static string Format(string text)
     {
+        text = Regex.Replace(text, "```([\n\s\S]+?)```", m => $"[CODEBLOCK]{m.Groups[1].Value}[/CODEBLOCK]");
+        text = Regex.Replace(text, "`([^`]+?)`", m => $"[CODE]{m.Groups[1].Value}[/CODE]");
+        text = Regex.Replace(text, "^>\\s?(.*)$", m => $"[QUOTE]{m.Groups[1].Value}[/QUOTE]", RegexOptions.Multiline);
+        text = Regex.Replace(text, "\\|\\|(.+?)\\|\\|", m => $"[SPOILER]{m.Groups[1].Value}[/SPOILER]");
+        text = Regex.Replace(text, "~~(.+?)~~", m => $"[S]{m.Groups[1].Value}[/S]");
         text = Regex.Replace(text, "\\[(.+?)\\]\\((.+?)\\)", m => $"[LINK={m.Groups[2].Value}]{m.Groups[1].Value}[/LINK]");
         text = Regex.Replace(text, "\\*\\*(.+?)\\*\\*", m => $"[B]{m.Groups[1].Value}[/B]");
         text = Regex.Replace(text, "\\*(.+?)\\*", m => $"[I]{m.Groups[1].Value}[/I]");

--- a/tests/ChatWindowTests.cs
+++ b/tests/ChatWindowTests.cs
@@ -15,6 +15,23 @@ public class ChatWindowTests
     }
 
     [Fact]
+    public void FormatContent_HandlesExtendedMarkdown()
+    {
+        var input = "~~strike~~ `code`" +
+                    "\n```\nblock\n```" +
+                    "\n> quote" +
+                    "\n||secret||";
+        var expected = "[S]strike[/S] [CODE]code[/CODE]\n" +
+                        "[CODEBLOCK]\nblock\n[/CODEBLOCK]\n" +
+                        "[QUOTE]quote[/QUOTE]\n" +
+                        "[SPOILER]secret[/SPOILER]";
+
+        var result = MarkdownFormatter.Format(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
     public void MentionResolver_ReplacesUserAndRoleMentions()
     {
         var presences = new[] { new PresenceDto { Id = "1", Name = "Alice" } };


### PR DESCRIPTION
## Summary
- support parsing strike, code, code blocks, quotes and spoilers in MarkdownFormatter
- render extended markdown tags in chat content
- test additional markdown cases

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5937c1588328a2b42ffb2ecdc3f0