### PR TITLE
Fix MarkdownFormatter regex for code blocks

### DIFF
--- a/DemiCatPlugin/MarkdownFormatter.cs
+++ b/DemiCatPlugin/MarkdownFormatter.cs
@@ -6,7 +6,7 @@ public static class MarkdownFormatter
 {
     public static string Format(string text)
     {
-        text = Regex.Replace(text, "```([\n\s\S]+?)```", m => $"[CODEBLOCK]{m.Groups[1].Value}[/CODEBLOCK]");
+        text = Regex.Replace(text, @"```([\s\S]+?)```", m => $"[CODEBLOCK]{m.Groups[1].Value}[/CODEBLOCK]");
         text = Regex.Replace(text, "`([^`]+?)`", m => $"[CODE]{m.Groups[1].Value}[/CODE]");
         text = Regex.Replace(text, "^>\\s?(.*)$", m => $"[QUOTE]{m.Groups[1].Value}[/QUOTE]", RegexOptions.Multiline);
         text = Regex.Replace(text, "\\|\\|(.+?)\\|\\|", m => $"[SPOILER]{m.Groups[1].Value}[/SPOILER]");


### PR DESCRIPTION
## Summary
- fix escape sequences in MarkdownFormatter's code block regex

## Testing
- `dotnet build -c Release` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68bf54dcf9308328b0704c6b51a2ad51