### PR TITLE
Handle auth errors for role and channel fetch

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1120,9 +1120,11 @@ public class ChatWindow : IDisposable
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channelFetchFailed = true;
-                _channelErrorMessage = ex.StatusCode == HttpStatusCode.Forbidden
-                    ? "Forbidden – check API key/roles"
-                    : "Failed to load channels";
+                _channelErrorMessage = ex.StatusCode == HttpStatusCode.Unauthorized
+                    ? "Authentication failed"
+                    : ex.StatusCode == HttpStatusCode.Forbidden
+                        ? "Forbidden – check API key/roles"
+                        : "Failed to load channels";
                 _channelsLoaded = true;
             });
         }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -22,6 +22,7 @@ public class MainWindow : IDisposable
     public bool HasOfficerRole { get; set; }
     public UiRenderer Ui => _ui;
     public EventCreateWindow EventCreateWindow => _create;
+    public TemplatesWindow TemplatesWindow => _templates;
 
     public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient, ChannelService channelService)
     {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -195,6 +195,13 @@ public class Plugin : IDalamudPlugin
             ApiHelpers.AddAuthHeader(request, _tokenManager);
             log.Info($"Requesting roles from {url}");
             var response = await _httpClient.SendAsync(request);
+            if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                log.Error($"Failed to fetch roles: {response.StatusCode}. Response Body: {responseBody}");
+                _tokenManager.Clear("Authentication failed");
+                return false;
+            }
             if (!response.IsSuccessStatusCode)
             {
                 var responseBody = await response.Content.ReadAsStringAsync();
@@ -212,6 +219,13 @@ public class Plugin : IDalamudPlugin
             try
             {
                 var channelResponse = await _httpClient.SendAsync(channelRequest);
+                if (channelResponse.StatusCode == HttpStatusCode.Unauthorized || channelResponse.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    var responseBody = await channelResponse.Content.ReadAsStringAsync();
+                    log.Error($"Failed to fetch channels: {channelResponse.StatusCode}. Response Body: {responseBody}");
+                    _tokenManager.Clear("Authentication failed");
+                    return false;
+                }
                 if (channelResponse.IsSuccessStatusCode)
                 {
                     var channelStream = await channelResponse.Content.ReadAsStreamAsync();

--- a/DemiCatPlugin/RoleCache.cs
+++ b/DemiCatPlugin/RoleCache.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -9,13 +10,16 @@ internal static class RoleCache
 {
     private static List<RoleDto> _roles = new();
     private static bool _loaded;
+    private static string? _lastErrorMessage;
 
     internal static IReadOnlyList<RoleDto> Roles => _roles;
+    internal static string? LastErrorMessage => _lastErrorMessage;
 
     internal static void Reset()
     {
         _roles = new();
         _loaded = false;
+        _lastErrorMessage = null;
     }
 
     internal static async Task EnsureLoaded(HttpClient httpClient, Config config)
@@ -36,6 +40,7 @@ internal static class RoleCache
         if (!ApiHelpers.ValidateApiBaseUrl(config))
         {
             _loaded = true;
+            _lastErrorMessage = "Invalid API URL";
             return;
         }
         try
@@ -43,15 +48,24 @@ internal static class RoleCache
             var request = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/guild-roles");
             ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await httpClient.SendAsync(request);
+            if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                TokenManager.Instance!.Clear("Authentication failed");
+                _lastErrorMessage = "Authentication failed";
+                _loaded = true;
+                return;
+            }
             if (!response.IsSuccessStatusCode)
             {
                 PluginServices.Instance!.Log.Warning($"Failed to refresh guild roles. URL: {request.RequestUri}, Status: {response.StatusCode}");
+                _lastErrorMessage = "Failed to load roles";
                 _loaded = true;
                 return;
             }
             var stream = await response.Content.ReadAsStreamAsync();
             var roles = await JsonSerializer.DeserializeAsync<List<RoleDto>>(stream) ?? new List<RoleDto>();
             _roles = roles;
+            _lastErrorMessage = null;
             _loaded = true;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
@@ -61,6 +75,7 @@ internal static class RoleCache
         }
         catch
         {
+            _lastErrorMessage = "Failed to load roles";
             _loaded = true;
         }
     }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -503,6 +503,8 @@ public class SettingsWindow : IDisposable
                             _ = ChatWindow?.RefreshChannels();
                         }
                         _ = OfficerChatWindow?.RefreshChannels();
+                        _ = MainWindow?.EventCreateWindow.RefreshChannels();
+                        _ = MainWindow?.TemplatesWindow.RefreshChannels();
                     }
                     catch (Exception ex)
                     {
@@ -526,6 +528,7 @@ public class SettingsWindow : IDisposable
                     {
                         MainWindow?.Ui.ResetChannels();
                         MainWindow?.ResetEventCreateRoles();
+                        MainWindow?.TemplatesWindow.ResetRoles();
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
## Summary
- clear token and surface auth failures when guild role refresh is unauthorized
- show helpful channel/role error messages and allow retries after reauth

## Testing
- `dotnet build` *(fails: compatible .NET SDK 9.0.100 not found)*
- `pytest` *(fails: missing dependencies such as fastapi, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68bf66e7dbdc8328abe82a8874de6161