### PR TITLE
feat: add button sizing

### DIFF
--- a/DemiCatPlugin/EmbedDto.cs
+++ b/DemiCatPlugin/EmbedDto.cs
@@ -44,6 +44,8 @@ public class EmbedButtonDto
     public string? Emoji { get; set; }
     public ButtonStyle? Style { get; set; }
     public int? MaxSignups { get; set; }
+    public int? Width { get; set; }
+    public int? Height { get; set; }
 }
 
 public class EmbedAuthorDto

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -94,7 +94,9 @@ public static class EmbedRenderer
                     ImGui.PushStyleColor(ImGuiCol.ButtonHovered, Lighten(color, 1.1f));
                     ImGui.PushStyleColor(ImGuiCol.ButtonActive, Lighten(color, 1.2f));
                 }
-                if (ImGui.Button($"{text}##{id}{dto.Id}", new Vector2(-1, 0)))
+                var w = button.Width ?? -1;
+                var h = button.Height ?? 0;
+                if (ImGui.Button($"{text}##{id}{dto.Id}", new Vector2(w, h)))
                 {
                     if (!string.IsNullOrEmpty(button.Url))
                     {

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -428,7 +428,9 @@ public class EventCreateWindow
                     Label = b.Label,
                     Emoji = b.Emoji,
                     Style = b.Style,
-                    MaxSignups = b.MaxSignups
+                    MaxSignups = b.MaxSignups,
+                    Width = b.Width,
+                    Height = b.Height
                 });
             }
         }
@@ -464,7 +466,9 @@ public class EventCreateWindow
                 Label = b.Label,
                 Emoji = b.Emoji,
                 Style = b.Style,
-                MaxSignups = b.MaxSignups
+                MaxSignups = b.MaxSignups,
+                Width = b.Width,
+                Height = b.Height
             }).ToList(),
             Mentions = _mentions.Select(ulong.Parse).ToList()
         };
@@ -504,7 +508,7 @@ public class EventCreateWindow
                 thumbnailUrl = dto.ThumbnailUrl,
                 color = dto.Color,
                 fields = dto.Fields?.Select(f => new { name = f.Name, value = f.Value, inline = f.Inline }).ToList(),
-                buttons = buttons.Select(b => new { label = b.Label, customId = b.CustomId, url = b.Url, emoji = b.Emoji, style = b.Style.HasValue ? (int)b.Style : (int?)null, maxSignups = b.MaxSignups }).ToList(),
+                buttons = buttons.Select(b => new { label = b.Label, customId = b.CustomId, url = b.Url, emoji = b.Emoji, style = b.Style.HasValue ? (int)b.Style : (int?)null, maxSignups = b.MaxSignups, width = b.Width, height = b.Height }).ToList(),
                 mentions = _mentions.Count > 0 ? _mentions.Select(ulong.Parse).ToList() : null,
                 repeat = _repeat == RepeatOption.None ? null : _repeat.ToString().ToLowerInvariant()
             };
@@ -534,7 +538,9 @@ public class EventCreateWindow
                 Label = b.Label,
                 Emoji = b.Emoji,
                 Style = b.Style,
-                MaxSignups = b.MaxSignups
+                MaxSignups = b.MaxSignups,
+                Width = b.Width,
+                Height = b.Height
             });
         }
     }
@@ -567,7 +573,9 @@ public class EventCreateWindow
                     CustomId = $"rsvp:{b.Tag}",
                     Emoji = string.IsNullOrWhiteSpace(b.Emoji) ? null : b.Emoji,
                     Style = b.Style,
-                    MaxSignups = b.MaxSignups
+                    MaxSignups = b.MaxSignups,
+                    Width = b.Width,
+                    Height = b.Height
                 })
                 .ToList()
         };
@@ -669,7 +677,9 @@ public class EventCreateWindow
                 Label = b.Label,
                 Emoji = b.Emoji,
                 Style = b.Style,
-                MaxSignups = b.MaxSignups
+                MaxSignups = b.MaxSignups,
+                Width = b.Width,
+                Height = b.Height
             }).ToList()
         };
         _ = SignupPresetService.Create(preset, _httpClient, _config);

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -20,7 +20,9 @@ public class SignupOptionEditor
             Label = button.Label,
             Emoji = button.Emoji,
             Style = button.Style,
-            MaxSignups = button.MaxSignups
+            MaxSignups = button.MaxSignups,
+            Width = button.Width,
+            Height = button.Height
         };
         _onSave = onSave;
         _open = true;
@@ -47,6 +49,16 @@ public class SignupOptionEditor
             {
                 _working.MaxSignups = max > 0 ? max : null;
             }
+            var width = _working.Width ?? 0;
+            if (ImGui.InputInt("Width", ref width))
+            {
+                _working.Width = width > 0 ? width : null;
+            }
+            var height = _working.Height ?? 0;
+            if (ImGui.InputInt("Height", ref height))
+            {
+                _working.Height = height > 0 ? height : null;
+            }
             var style = _working.Style.ToString();
             if (ImGui.BeginCombo("Style", style))
             {
@@ -68,7 +80,9 @@ public class SignupOptionEditor
                     Label = _working.Label,
                     Emoji = _working.Emoji,
                     Style = _working.Style,
-                    MaxSignups = _working.MaxSignups
+                    MaxSignups = _working.MaxSignups,
+                    Width = _working.Width,
+                    Height = _working.Height
                 });
                 _open = false;
                 ImGui.CloseCurrentPopup();

--- a/DemiCatPlugin/Template.cs
+++ b/DemiCatPlugin/Template.cs
@@ -37,6 +37,8 @@ public class Template
         public string Emoji { get; set; } = string.Empty;
         public ButtonStyle Style { get; set; } = ButtonStyle.Secondary;
         public int? MaxSignups { get; set; }
+        public int? Width { get; set; }
+        public int? Height { get; set; }
     }
 }
 

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -359,7 +359,9 @@ public class TemplatesWindow
                 CustomId = $"rsvp:{b.Tag}",
                 Emoji = string.IsNullOrWhiteSpace(b.Emoji) ? null : b.Emoji,
                 Style = b.Style,
-                MaxSignups = b.MaxSignups
+                MaxSignups = b.MaxSignups,
+                Width = b.Width,
+                Height = b.Height
             }).ToList(),
             Mentions = _mentions.Count > 0 ? _mentions.Select(ulong.Parse).ToList() : null
         };
@@ -390,7 +392,9 @@ public class TemplatesWindow
                     customId = $"rsvp:{b.Tag}",
                     emoji = string.IsNullOrWhiteSpace(b.Emoji) ? null : b.Emoji,
                     style = (int)b.Style,
-                    maxSignups = b.MaxSignups
+                    maxSignups = b.MaxSignups,
+                    width = b.Width,
+                    height = b.Height
                 })
                 .ToList();
 

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -32,6 +32,8 @@ class EmbedButtonDto(CamelModel):
     emoji: Optional[str] = None
     style: Optional[ButtonStyle] = None
     max_signups: Optional[int] = Field(default=None, alias="maxSignups")
+    width: Optional[int] = None
+    height: Optional[int] = None
 
 
 class EmbedAuthorDto(CamelModel):

--- a/demibot/demibot/http/validation.py
+++ b/demibot/demibot/http/validation.py
@@ -14,6 +14,8 @@ AUTHOR_NAME_LIMIT = 256
 TOTAL_CHAR_LIMIT = 6000
 BUTTON_LABEL_LIMIT = 80
 BUTTON_COUNT_LIMIT = 25
+BUTTON_WIDTH_LIMIT = 5
+BUTTON_HEIGHT_LIMIT = 5
 
 
 def _check_url(name: str, url: str | None) -> None:
@@ -88,6 +90,7 @@ def validate_embed_payload(dto: EmbedDto, buttons: List[EmbedButtonDto]) -> None
 
     # Buttons
     if buttons:
+        total_slots = 0
         if len(buttons) > BUTTON_COUNT_LIMIT:
             logging.warning("Embed has %d buttons, limit is %d", len(buttons), BUTTON_COUNT_LIMIT)
             raise HTTPException(422, detail="Too many buttons")
@@ -96,3 +99,17 @@ def validate_embed_payload(dto: EmbedDto, buttons: List[EmbedButtonDto]) -> None
                 logging.warning("Button label exceeds %d characters", BUTTON_LABEL_LIMIT)
                 raise HTTPException(422, detail="Button label too long")
             _check_url("button url", btn.url)
+            width = btn.width or 1
+            height = btn.height or 1
+            if width < 1 or width > BUTTON_WIDTH_LIMIT:
+                logging.warning("Button width %d out of range", width)
+                raise HTTPException(422, detail="Invalid button width")
+            if height < 1 or height > BUTTON_HEIGHT_LIMIT:
+                logging.warning("Button height %d out of range", height)
+                raise HTTPException(422, detail="Invalid button height")
+            total_slots += width * height
+        if total_slots > BUTTON_COUNT_LIMIT:
+            logging.warning(
+                "Embed has %d button slots, limit is %d", total_slots, BUTTON_COUNT_LIMIT
+            )
+            raise HTTPException(422, detail="Too many buttons")

--- a/tests/test_embed_validation.py
+++ b/tests/test_embed_validation.py
@@ -31,3 +31,20 @@ def test_button_limit():
     buttons = [EmbedButtonDto(label=f"b{i}", custom_id=str(i)) for i in range(26)]
     with pytest.raises(HTTPException):
         validate_embed_payload(dto, buttons)
+
+
+def test_button_width_height_limits():
+    dto = EmbedDto(id="1", title="t", description="d")
+    buttons = [EmbedButtonDto(label="b", custom_id="1", width=6)]
+    with pytest.raises(HTTPException):
+        validate_embed_payload(dto, buttons)
+
+
+def test_button_area_limit():
+    dto = EmbedDto(id="1", title="t", description="d")
+    buttons = [
+        EmbedButtonDto(label="b1", custom_id="1", width=5, height=5),
+        EmbedButtonDto(label="b2", custom_id="2")
+    ]
+    with pytest.raises(HTTPException):
+        validate_embed_payload(dto, buttons)


### PR DESCRIPTION
## Summary
- allow template buttons to specify width and height
- edit and persist button dimensions in event creation and templates
- validate button sizes against Discord limits

## Testing
- `pytest -q` *(fails: No module named 'discord')*
- `dotnet build DemiCatPlugin -c Release` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7d1143308328b17eaf8b8be113eb