### PR TITLE
Handle legacy approval states in request flow

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -81,6 +81,14 @@ public class RequestBoardWindow
             ImGui.PushID(req.Id);
             ImGui.TextWrapped(string.IsNullOrEmpty(req.Description) ? req.Title : req.Description);
             ImGui.TextUnformatted($"Created By: {req.CreatedBy}");
+            if (req.Status == RequestStatus.Approved)
+            {
+                ImGui.TextUnformatted("[Legacy Status: Approved]");
+            }
+            else if (req.Status == RequestStatus.Denied)
+            {
+                ImGui.TextUnformatted("[Legacy Status: Denied]");
+            }
             ImGui.Separator();
             ImGui.PopID();
         }
@@ -298,6 +306,8 @@ public class RequestBoardWindow
         RequestStatus.AwaitingConfirm => "awaiting_confirm",
         RequestStatus.Completed => "completed",
         RequestStatus.Cancelled => "cancelled",
+        RequestStatus.Approved => "approved",
+        RequestStatus.Denied => "denied",
         _ => "open"
     };
 
@@ -309,6 +319,8 @@ public class RequestBoardWindow
         "awaiting_confirm" => RequestStatus.AwaitingConfirm,
         "completed" => RequestStatus.Completed,
         "cancelled" => RequestStatus.Cancelled,
+        "approved" => RequestStatus.Approved,
+        "denied" => RequestStatus.Denied,
         _ => RequestStatus.Open
     };
 

--- a/DemiCatPlugin/RequestState.cs
+++ b/DemiCatPlugin/RequestState.cs
@@ -16,7 +16,9 @@ public enum RequestStatus
     InProgress,
     AwaitingConfirm,
     Completed,
-    Cancelled
+    Cancelled,
+    Approved, // legacy
+    Denied // legacy
 }
 
 public enum RequestUrgency

--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -52,7 +52,10 @@ internal static class RequestStateService
             var cutoff = DateTime.UtcNow.AddDays(-14);
             var remove = RequestsMap
                 .Where(kvp =>
-                    (kvp.Value.Status == RequestStatus.Completed || kvp.Value.Status == RequestStatus.Cancelled) &&
+                    (kvp.Value.Status == RequestStatus.Completed ||
+                     kvp.Value.Status == RequestStatus.Cancelled ||
+                     kvp.Value.Status == RequestStatus.Approved ||
+                     kvp.Value.Status == RequestStatus.Denied) &&
                     kvp.Value.CreatedAt < cutoff)
                 .Select(kvp => kvp.Key)
                 .ToList();
@@ -212,6 +215,8 @@ internal static class RequestStateService
         "awaiting_confirm" => RequestStatus.AwaitingConfirm,
         "completed" => RequestStatus.Completed,
         "cancelled" => RequestStatus.Cancelled,
+        "approved" => RequestStatus.Approved,
+        "denied" => RequestStatus.Denied,
         _ => RequestStatus.Open
     };
 

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -155,6 +155,8 @@ public class RequestWatcher : IDisposable
                 "awaiting_confirm" => RequestStatus.AwaitingConfirm,
                 "completed" => RequestStatus.Completed,
                 "cancelled" => RequestStatus.Cancelled,
+                "approved" => RequestStatus.Approved,
+                "denied" => RequestStatus.Denied,
                 _ => RequestStatus.Open
             };
 
@@ -182,6 +184,14 @@ public class RequestWatcher : IDisposable
             else if (status == RequestStatus.Cancelled)
             {
                 PluginServices.Instance?.ToastGui.ShowNormal("Request cancelled");
+            }
+            else if (status == RequestStatus.Approved)
+            {
+                PluginServices.Instance?.ToastGui.ShowNormal("Request approved (legacy)");
+            }
+            else if (status == RequestStatus.Denied)
+            {
+                PluginServices.Instance?.ToastGui.ShowNormal("Request denied (legacy)");
             }
         }
         catch (Exception ex)

--- a/tests/RequestStateServiceTests.cs
+++ b/tests/RequestStateServiceTests.cs
@@ -33,7 +33,23 @@ public class RequestStateServiceTests
             Status = RequestStatus.Completed,
             CreatedAt = DateTime.UtcNow.AddDays(-30)
         });
+        RequestStateService.Upsert(new RequestState
+        {
+            Id = "oldApproved",
+            Title = "OldApproved",
+            Status = RequestStatus.Approved,
+            CreatedAt = DateTime.UtcNow.AddDays(-30)
+        });
+        RequestStateService.Upsert(new RequestState
+        {
+            Id = "oldDenied",
+            Title = "OldDenied",
+            Status = RequestStatus.Denied,
+            CreatedAt = DateTime.UtcNow.AddDays(-30)
+        });
         RequestStateService.Prune();
         Assert.DoesNotContain(RequestStateService.All, r => r.Id == "old");
+        Assert.DoesNotContain(RequestStateService.All, r => r.Id == "oldApproved");
+        Assert.DoesNotContain(RequestStateService.All, r => r.Id == "oldDenied");
     }
 }


### PR DESCRIPTION
## Summary
- support `Approved` and `Denied` request statuses
- mark legacy requests and surface approval/denial notifications

## Testing
- `~/dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: missing dependencies during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c03d9f06248328a2a53a2f8b32bdb4