### PR TITLE
fix migration header and add template

### DIFF
--- a/demibot/demibot/db/migrations/script.py.mako
+++ b/demibot/demibot/db/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/demibot/demibot/db/migrations/versions/0027_add_message_metadata_fields.py
+++ b/demibot/demibot/db/migrations/versions/0027_add_message_metadata_fields.py
@@ -2,33 +2,36 @@
 
 Revision ID: 0027_add_message_metadata_fields
 Revises: 0026_add_attachments_json_to_messages
-Create Date: 2024-09-20 00:00:00.000000"""
+Create Date: 2024-09-20 00:00:00.000000
+"""
 
 from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision = '0027_add_message_metadata_fields'
-down_revision = '0026_add_attachments_json_to_messages'
+revision = "0027_add_message_metadata_fields"
+down_revision = "0026_add_attachments_json_to_messages"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column('messages', sa.Column('content', sa.Text(), nullable=True))
-    op.add_column('messages', sa.Column('author_json', sa.Text(), nullable=True))
-    op.add_column('messages', sa.Column('embeds_json', sa.Text(), nullable=True))
-    op.add_column('messages', sa.Column('mentions_json', sa.Text(), nullable=True))
-    op.add_column('messages', sa.Column('reference_json', sa.Text(), nullable=True))
-    op.add_column('messages', sa.Column('components_json', sa.Text(), nullable=True))
-    op.add_column('messages', sa.Column('edited_timestamp', sa.DateTime(), nullable=True))
+    op.add_column("messages", sa.Column("content", sa.Text(), nullable=True))
+    op.add_column("messages", sa.Column("author_json", sa.Text(), nullable=True))
+    op.add_column("messages", sa.Column("embeds_json", sa.Text(), nullable=True))
+    op.add_column("messages", sa.Column("mentions_json", sa.Text(), nullable=True))
+    op.add_column("messages", sa.Column("reference_json", sa.Text(), nullable=True))
+    op.add_column("messages", sa.Column("components_json", sa.Text(), nullable=True))
+    op.add_column(
+        "messages", sa.Column("edited_timestamp", sa.DateTime(), nullable=True)
+    )
 
 
 def downgrade() -> None:
-    op.drop_column('messages', 'edited_timestamp')
-    op.drop_column('messages', 'components_json')
-    op.drop_column('messages', 'reference_json')
-    op.drop_column('messages', 'mentions_json')
-    op.drop_column('messages', 'embeds_json')
-    op.drop_column('messages', 'author_json')
-    op.drop_column('messages', 'content')
+    op.drop_column("messages", "edited_timestamp")
+    op.drop_column("messages", "components_json")
+    op.drop_column("messages", "reference_json")
+    op.drop_column("messages", "mentions_json")
+    op.drop_column("messages", "embeds_json")
+    op.drop_column("messages", "author_json")
+    op.drop_column("messages", "content")


### PR DESCRIPTION
## Summary
- fix triple-quoted header in migration 0027
- add Alembic migration template with conventional header layout

## Testing
- `black demibot/db/migrations/versions/0027_add_message_metadata_fields.py`
- `black demibot/db/migrations/script.py.mako` *(fails: Cannot parse for target version Python 3.13: 12:0: ${imports if imports else ""})*
- `pytest -q` *(fails: Module 'discord.ext.commands' has no attribute 'Cog')*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c03da2c980832899ce951cf82a29cb