### PR TITLE
Preserve template button metadata

### DIFF
--- a/DemiCat.UI/ButtonRowEditor.cs
+++ b/DemiCat.UI/ButtonRowEditor.cs
@@ -10,17 +10,36 @@ public sealed class ButtonRowEditor
     private const int MaxPerRow = 5;
     private const int MaxTotal  = 25;
 
-    // Represents a row of button labels (or IDs) the plugin will later map to actual actions.
-    private readonly List<List<string>> _rows;
-
-    public ButtonRowEditor(List<List<string>> initial)
+    public class ButtonData
     {
-        _rows = initial ?? new List<List<string>>();
-        if (_rows.Count == 0) _rows.Add(new List<string>());
+        public string Label { get; set; } = string.Empty;
+        public ButtonStyle Style { get; set; } = ButtonStyle.Secondary;
+        public string Emoji { get; set; } = string.Empty;
+        public int? MaxSignups { get; set; }
+        public int? Width { get; set; }
+        public int? Height { get; set; }
+    }
+
+    public enum ButtonStyle
+    {
+        Primary = 1,
+        Secondary = 2,
+        Success = 3,
+        Danger = 4,
+        Link = 5,
+    }
+
+    // Represents a row of buttons with metadata the plugin will later map to actual actions.
+    private readonly List<List<ButtonData>> _rows;
+
+    public ButtonRowEditor(List<List<ButtonData>> initial)
+    {
+        _rows = initial ?? new List<List<ButtonData>>();
+        if (_rows.Count == 0) _rows.Add(new List<ButtonData>());
         Normalize();
     }
 
-    public IReadOnlyList<IReadOnlyList<string>> Value => _rows;
+    public IReadOnlyList<IReadOnlyList<ButtonData>> Value => _rows;
 
     public void Draw(string id)
     {
@@ -39,17 +58,17 @@ public sealed class ButtonRowEditor
             ImGui.SameLine();
             if (CanAddAny() && _rows[r].Count < MaxPerRow && ImGui.Button("+ Add"))
             {
-                _rows[r].Add("New Button");
+                _rows[r].Add(new ButtonData { Label = "New Button" });
             }
 
             // Render each button as an editable input
             for (int i = 0; i < _rows[r].Count; i++)
             {
                 ImGui.PushID(i);
-                var label = _rows[r][i];
-                var buf = label;
+                var button = _rows[r][i];
+                var buf = button.Label;
                 if (ImGui.InputText("##label", ref buf, 128))
-                    _rows[r][i] = buf;
+                    button.Label = buf;
 
                 ImGui.SameLine();
                 if (ImGui.Button("Remove"))
@@ -73,7 +92,7 @@ public sealed class ButtonRowEditor
             ImGui.SameLine();
             if (_rows.Count < MaxRows && CanAddAny() && ImGui.Button("Add Row"))
             {
-                _rows.Insert(r + 1, new List<string>());
+                _rows.Insert(r + 1, new List<ButtonData>());
             }
 
             ImGui.PopID();
@@ -95,7 +114,7 @@ public sealed class ButtonRowEditor
     private void Normalize()
     {
         // Ensure at least one row, and each row <= MaxPerRow, total <= MaxTotal.
-        if (_rows.Count == 0) _rows.Add(new List<string>());
+        if (_rows.Count == 0) _rows.Add(new List<ButtonData>());
 
         // Cap total rows
         if (_rows.Count > MaxRows)

--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using DemiCatPlugin;
+using DemiCat.UI;
+using DiscordHelper;
+using Xunit;
+
+public class TemplateButtonRoundTripTests
+{
+    private class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+    }
+
+    private static TemplatesWindow CreateWindow(ButtonRowEditor editor)
+    {
+        var config = new Config();
+        var http = new HttpClient(new StubHandler());
+        var window = new TemplatesWindow(config, http);
+        var field = typeof(TemplatesWindow).GetField("_buttonRows", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        field!.SetValue(window, editor);
+        return window;
+    }
+
+    [Fact]
+    public void ToEmbedDto_UsesButtonMetadata()
+    {
+        var button = new ButtonRowEditor.ButtonData
+        {
+            Label = "Join",
+            Style = ButtonRowEditor.ButtonStyle.Success,
+            Emoji = "🔥",
+            MaxSignups = 3,
+            Width = 2,
+            Height = 1
+        };
+        var editor = new ButtonRowEditor(new()
+        {
+            new List<ButtonRowEditor.ButtonData> { button }
+        });
+        // Simulate user editing label
+        editor.Value[0][0].Label = "Signup";
+
+        var window = CreateWindow(editor);
+        var tmpl = new Template { Title = "T", Description = "D" };
+
+        var embed = window.ToEmbedDto(tmpl);
+        var btn = Assert.Single(embed.Buttons!);
+        Assert.Equal("Signup", btn.Label);
+        Assert.Equal(ButtonStyle.Success, btn.Style);
+        Assert.Equal("🔥", btn.Emoji);
+        Assert.Equal(3, btn.MaxSignups);
+        Assert.Equal(2, btn.Width);
+        Assert.Equal(1, btn.Height);
+    }
+
+    [Fact]
+    public void BuildButtonsPayload_ProducesFullMetadata()
+    {
+        var button = new ButtonRowEditor.ButtonData
+        {
+            Label = "Join",
+            Style = ButtonRowEditor.ButtonStyle.Danger,
+            Emoji = "💥",
+            MaxSignups = 5,
+            Width = 3,
+            Height = 2
+        };
+        var editor = new ButtonRowEditor(new()
+        {
+            new List<ButtonRowEditor.ButtonData> { button }
+        });
+        var window = CreateWindow(editor);
+
+        var payload = window.BuildButtonsPayload();
+        var btn = Assert.Single(payload);
+        Assert.Equal("Join", btn.label);
+        Assert.Equal((int)ButtonRowEditor.ButtonStyle.Danger, btn.style);
+        Assert.Equal("💥", btn.emoji);
+        Assert.Equal(5, btn.maxSignups);
+        Assert.Equal(3, btn.width);
+        Assert.Equal(2, btn.height);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace string-based button rows with structured metadata in ButtonRowEditor
- Forward button style, emoji, size and signup limits through TemplatesWindow to embed and API payloads
- Add tests verifying button metadata survives round-trip editing

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found; ImGui.NET missing)*
- `pytest tests/test_event_button_limit.py` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68c05680c9808328b60c9f0e17fd9677