### PR TITLE
Require at least one button for template posting

### DIFF
--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -453,6 +453,11 @@ public class TemplatesWindow
         {
 
             var buttonsFlat = BuildButtonsPayload();
+            if (buttonsFlat.Count == 0)
+            {
+                _lastResult = "Add at least one button";
+                return;
+            }
 
             var body = new
             {
@@ -469,7 +474,7 @@ public class TemplatesWindow
                                  .Select(f => new { name = f.Name, value = f.Value, inline = f.Inline })
                                  .ToList()
                     : null,
-                buttons = buttonsFlat.Count > 0 ? buttonsFlat : null,
+                buttons = buttonsFlat,
                 mentions = _mentions.Count > 0 ? _mentions.Select(ulong.Parse).ToList() : null
             };
 


### PR DESCRIPTION
## Summary
- ensure template posting includes at least one button and return informative message otherwise

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0695e54a48328b912c6bad7aa8d42