### PR TITLE
feat: support button row index

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -269,7 +269,8 @@ public class ChatWindow : IDisposable
                     CustomId = c.CustomId,
                     Url = c.Url,
                     Emoji = c.Emoji,
-                    Style = c.Style
+                    Style = c.Style,
+                    RowIndex = c.RowIndex
                 }).ToList();
                 var pseudo = new EmbedDto { Id = msg.Id + "_components", Buttons = buttons };
                 EmbedRenderer.Draw(pseudo, LoadTexture, cid => _ = Interact(msg.Id, msg.ChannelId, cid));

--- a/DemiCatPlugin/DiscordMessageDto.cs
+++ b/DemiCatPlugin/DiscordMessageDto.cs
@@ -68,4 +68,5 @@ public class ButtonComponentDto
     public string? Url { get; set; }
     public ButtonStyle Style { get; set; } = ButtonStyle.Primary;
     public string? Emoji { get; set; }
+    public int? RowIndex { get; set; }
 }

--- a/DemiCatPlugin/EmbedDto.cs
+++ b/DemiCatPlugin/EmbedDto.cs
@@ -46,6 +46,7 @@ public class EmbedButtonDto
     public int? MaxSignups { get; set; }
     public int? Width { get; set; }
     public int? Height { get; set; }
+    public int? RowIndex { get; set; }
 }
 
 public class EmbedAuthorDto

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -575,7 +575,8 @@ public class EventCreateWindow
                     Style = b.Style,
                     MaxSignups = b.MaxSignups,
                     Width = b.Width,
-                    Height = b.Height
+                    Height = b.Height,
+                    RowIndex = b.RowIndex
                 })
                 .ToList()
         };

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -409,7 +409,8 @@ public class TemplatesWindow
                 Emoji = b.emoji,
                 MaxSignups = b.maxSignups,
                 Width = b.width,
-                Height = b.height
+                Height = b.height,
+                RowIndex = b.row
             })
             .ToList();
 

--- a/demibot/demibot/http/discord_helpers.py
+++ b/demibot/demibot/http/discord_helpers.py
@@ -138,7 +138,7 @@ def components_to_dtos(message: discord.Message) -> List[ButtonComponentDto] | N
     """
 
     components: list[ButtonComponentDto] = []
-    for row in getattr(message, "components", []) or []:
+    for row_index, row in enumerate(getattr(message, "components", []) or []):
         children = getattr(row, "children", None) or getattr(row, "components", [])
         for comp in children or []:
             if getattr(comp, "type", None) != 2:  # 2 == button
@@ -154,6 +154,7 @@ def components_to_dtos(message: discord.Message) -> List[ButtonComponentDto] | N
                     url=getattr(comp, "url", None),
                     style=style_val,
                     emoji=emoji_str,
+                    row_index=row_index,
                 )
             )
     return components or None
@@ -170,7 +171,7 @@ def extract_embed_buttons(message: discord.Message) -> List[EmbedButtonDto]:
 
     buttons: list[EmbedButtonDto] = []
     try:
-        for row in getattr(message, "components", []) or []:
+        for row_index, row in enumerate(getattr(message, "components", []) or []):
             children = getattr(row, "children", None) or getattr(row, "components", [])
             for comp in children or []:
                 if getattr(comp, "type", None) != 2:  # 2 == button
@@ -186,6 +187,7 @@ def extract_embed_buttons(message: discord.Message) -> List[EmbedButtonDto]:
                         style=style_val,
                         emoji=emoji_str,
                         url=getattr(comp, "url", None),
+                        row_index=row_index,
                     )
                 )
     except Exception:

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -34,6 +34,7 @@ class EmbedButtonDto(CamelModel):
     max_signups: Optional[int] = Field(default=None, alias="maxSignups")
     width: Optional[int] = None
     height: Optional[int] = None
+    row_index: Optional[int] = Field(default=None, alias="rowIndex")
 
 
 class EmbedAuthorDto(CamelModel):
@@ -84,6 +85,7 @@ class ButtonComponentDto(CamelModel):
     url: Optional[str] = None
     style: ButtonStyle
     emoji: Optional[str] = None
+    row_index: Optional[int] = Field(default=None, alias="rowIndex")
 
 
 class MessageAuthor(CamelModel):


### PR DESCRIPTION
## Summary
- allow specifying rowIndex on buttons
- group buttons by rowIndex when sending Discord messages
- propagate rowIndex through DTO helpers and plugin classes

## Testing
- `pytest tests/test_event_button_limit.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68c06a88660c8328a832d2f09644c789