### PR TITLE
Add emoji catalog endpoints and picker

### DIFF
--- a/DemiCatPlugin/EmojiPopup.cs
+++ b/DemiCatPlugin/EmojiPopup.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Dalamud.Bindings.ImGui;
+
+namespace DemiCatPlugin;
+
+public class EmojiPopup
+{
+    private readonly Config _config;
+    private readonly HttpClient _httpClient;
+    private readonly List<UnicodeEmoji> _unicode = new();
+    private readonly List<GuildEmoji> _guild = new();
+    private bool _unicodeLoaded;
+    private bool _guildLoaded;
+    private Action<string>? _onSelected;
+
+    private const string PopupId = "PickEmoji";
+
+    public EmojiPopup(Config config, HttpClient httpClient)
+    {
+        _config = config;
+        _httpClient = httpClient;
+    }
+
+    public void Open(Action<string> onSelected)
+    {
+        _onSelected = onSelected;
+        ImGui.OpenPopup(PopupId);
+    }
+
+    public void Draw()
+    {
+        if (!ImGui.BeginPopup(PopupId)) return;
+        if (ImGui.BeginTabBar("emoji-tabs"))
+        {
+            if (ImGui.BeginTabItem("Unicode"))
+            {
+                DrawUnicode();
+                ImGui.EndTabItem();
+            }
+            if (ImGui.BeginTabItem("Guild"))
+            {
+                DrawGuild();
+                ImGui.EndTabItem();
+            }
+            ImGui.EndTabBar();
+        }
+        ImGui.EndPopup();
+    }
+
+    private void DrawUnicode()
+    {
+        if (!_unicodeLoaded) _ = FetchUnicode();
+        foreach (var e in _unicode)
+        {
+            if (ImGui.Button($"{e.Emoji}##u{e.Emoji}"))
+            {
+                _onSelected?.Invoke(e.Emoji);
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine();
+        }
+        ImGui.NewLine();
+    }
+
+    private void DrawGuild()
+    {
+        if (!_guildLoaded) _ = FetchGuild();
+        foreach (var e in _guild)
+        {
+            if (ImGui.Button($":{e.Name}:##g{e.Id}"))
+            {
+                GuildEmojiNames[e.Id] = e.Name;
+                _onSelected?.Invoke($"custom:{e.Id}");
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine();
+        }
+        ImGui.NewLine();
+    }
+
+    private async Task FetchUnicode()
+    {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis/unicode");
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode) return;
+            var stream = await response.Content.ReadAsStreamAsync();
+            var list = await JsonSerializer.DeserializeAsync<List<UnicodeEmoji>>(stream) ?? new();
+            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+            {
+                _unicode.Clear();
+                _unicode.AddRange(list);
+                _unicodeLoaded = true;
+            });
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    private async Task FetchGuild()
+    {
+        if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis/guilds/0");
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode) return;
+            var stream = await response.Content.ReadAsStreamAsync();
+            var list = await JsonSerializer.DeserializeAsync<List<GuildEmoji>>(stream) ?? new();
+            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+            {
+                _guild.Clear();
+                _guild.AddRange(list);
+                foreach (var g in list)
+                    GuildEmojiNames[g.Id] = g.Name;
+                _guildLoaded = true;
+            });
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    public static string? LookupGuildName(string id)
+    {
+        return GuildEmojiNames.TryGetValue(id, out var name) ? name : null;
+    }
+
+    private static readonly Dictionary<string, string> GuildEmojiNames = new();
+
+    public class UnicodeEmoji
+    {
+        public string Emoji { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string ImageUrl { get; set; } = string.Empty;
+    }
+
+    public class GuildEmoji
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public bool IsAnimated { get; set; }
+        public string ImageUrl { get; set; } = string.Empty;
+    }
+}

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -31,7 +31,7 @@ public class EventCreateWindow
     private readonly List<Field> _fields = new();
     private string? _lastResult;
     private readonly List<Template.TemplateButton> _buttons = new();
-    private readonly SignupOptionEditor _optionEditor = new();
+    private readonly SignupOptionEditor _optionEditor;
     private int _editingButtonIndex = -1;
     private int _selectedPreset = -1;
     private string _presetName = string.Empty;
@@ -62,6 +62,7 @@ public class EventCreateWindow
         _httpClient = httpClient;
         _channelService = channelService;
         _channelId = config.EventChannelId;
+        _optionEditor = new SignupOptionEditor(config, httpClient);
         ResetDefaultButtons();
     }
 

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -2,6 +2,7 @@ using System;
 using Dalamud.Bindings.ImGui;
 using DiscordHelper;
 using System.Numerics;
+using System.Net.Http;
 
 namespace DemiCatPlugin;
 
@@ -10,6 +11,12 @@ public class SignupOptionEditor
     private bool _open;
     private Template.TemplateButton _working = new();
     private Action<Template.TemplateButton>? _onSave;
+    private readonly EmojiPopup _emojiPopup;
+
+    public SignupOptionEditor(Config config, HttpClient httpClient)
+    {
+        _emojiPopup = new EmojiPopup(config, httpClient);
+    }
 
     public void Open(Template.TemplateButton button, Action<Template.TemplateButton> onSave)
     {
@@ -44,6 +51,11 @@ public class SignupOptionEditor
             var emoji = _working.Emoji;
             if (ImGui.InputText("Emoji", ref emoji, 16))
                 _working.Emoji = emoji;
+            ImGui.SameLine();
+            if (ImGui.Button("Pick"))
+            {
+                _emojiPopup.Open(e => _working.Emoji = e);
+            }
             var max = _working.MaxSignups ?? 0;
             if (ImGui.InputInt("Max Signups", ref max))
             {
@@ -71,6 +83,8 @@ public class SignupOptionEditor
                 }
                 ImGui.EndCombo();
             }
+            _emojiPopup.Draw();
+
             if (ImGui.Button("Save"))
             {
                 _onSave?.Invoke(new Template.TemplateButton

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -376,19 +376,38 @@ public class TemplatesWindow
         int? width,
         int? height);
 
-    internal List<ButtonPayload> BuildButtonsPayload()
+    internal List<ButtonPayload> BuildButtonsPayload(Template tmpl)
     {
+        var srcButtons = (tmpl.Buttons ?? new List<Template.TemplateButton>())
+            .Where(b => !string.IsNullOrWhiteSpace(b.Label))
+            .ToDictionary(b => b.Label);
         return _buttonRows.FlattenNonEmpty()
-            .Select(x => new ButtonPayload(
-                Truncate(x.Label.Trim(), 80),
-                MakeCustomId(x.Label.Trim(), x.RowIndex, x.ColIndex),
-                x.RowIndex,
-                (int)ButtonStyle.Primary,
-                null,
-                null,
-                null,
-                null))
+            .Select(x =>
+            {
+                srcButtons.TryGetValue(x.Label, out var b);
+                return new ButtonPayload(
+                    Truncate(x.Label.Trim(), 80),
+                    MakeCustomId(x.Label.Trim(), x.RowIndex, x.ColIndex),
+                    x.RowIndex,
+                    (int)(b?.Style ?? ButtonStyle.Primary),
+                    NormalizeEmoji(b?.Emoji),
+                    b?.MaxSignups,
+                    b?.Width,
+                    b?.Height);
+            })
             .ToList();
+    }
+
+    private static string? NormalizeEmoji(string? emoji)
+    {
+        if (string.IsNullOrWhiteSpace(emoji)) return null;
+        if (emoji.StartsWith("custom:", StringComparison.OrdinalIgnoreCase))
+        {
+            var id = emoji.Substring("custom:".Length);
+            var name = EmojiPopup.LookupGuildName(id) ?? "emoji";
+            return $"<:{name}:{id}>";
+        }
+        return emoji;
     }
 
 
@@ -400,7 +419,7 @@ public class TemplatesWindow
             ts = parsed;
         }
 
-        var buttons = BuildButtonsPayload()
+        var buttons = BuildButtonsPayload(tmpl)
             .Select(b => new EmbedButtonDto
             {
                 Label = b.label,
@@ -452,7 +471,7 @@ public class TemplatesWindow
         try
         {
 
-            var buttonsFlat = BuildButtonsPayload();
+            var buttonsFlat = BuildButtonsPayload(tmpl);
             if (buttonsFlat.Count == 0)
             {
                 _lastResult = "Add at least one button";

--- a/demibot/demibot/data/unicode_emojis.json
+++ b/demibot/demibot/data/unicode_emojis.json
@@ -1,0 +1,5 @@
+[
+  {"emoji": "😀", "name": "grinning face", "imageUrl": "https://cdn.jsdelivr.net/gh/twitter/twemoji@v14.0.2/assets/72x72/1f600.png"},
+  {"emoji": "😃", "name": "grinning face with big eyes", "imageUrl": "https://cdn.jsdelivr.net/gh/twitter/twemoji@v14.0.2/assets/72x72/1f603.png"},
+  {"emoji": "😄", "name": "grinning face with smiling eyes", "imageUrl": "https://cdn.jsdelivr.net/gh/twitter/twemoji@v14.0.2/assets/72x72/1f604.png"}
+]

--- a/demibot/demibot/http/routes/emojis.py
+++ b/demibot/demibot/http/routes/emojis.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from time import monotonic
 from typing import Dict, List, Tuple
+import json
+from pathlib import Path
 
 from fastapi import APIRouter, Depends
 
@@ -12,6 +14,7 @@ router = APIRouter(prefix="/api")
 
 _CACHE_TTL = 600  # seconds
 _emoji_cache: Dict[int, Tuple[List[dict], float]] = {}
+_unicode_cache: Tuple[List[dict], float] | None = None
 
 
 @router.get("/emojis")
@@ -36,3 +39,46 @@ async def get_emojis(ctx: RequestContext = Depends(api_key_auth)) -> List[dict]:
             _emoji_cache[ctx.guild.id] = (data, monotonic())
             return data
     return []
+
+
+@router.get("/emojis/guilds/{guild_id}")
+async def get_guild_emojis(
+    guild_id: int, ctx: RequestContext = Depends(api_key_auth)
+) -> List[dict]:
+    cache_entry = _emoji_cache.get(guild_id)
+    if cache_entry:
+        data, ts = cache_entry
+        if monotonic() - ts < _CACHE_TTL:
+            return data
+    if discord_client:
+        guild = discord_client.get_guild(guild_id)
+        if guild is not None:
+            data = [
+                {
+                    "id": str(e.id),
+                    "name": e.name,
+                    "isAnimated": bool(getattr(e, "animated", False)),
+                    "imageUrl": str(e.url),
+                }
+                for e in guild.emojis
+            ]
+            _emoji_cache[guild_id] = (data, monotonic())
+            return data
+    return []
+
+
+@router.get("/emojis/unicode")
+async def get_unicode_emojis() -> List[dict]:
+    global _unicode_cache
+    if _unicode_cache:
+        data, ts = _unicode_cache
+        if monotonic() - ts < _CACHE_TTL:
+            return data
+    data_path = Path(__file__).resolve().parents[1] / "data" / "unicode_emojis.json"
+    try:
+        with data_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        data = []
+    _unicode_cache = (data, monotonic())
+    return data

--- a/tests/test_emojis.py
+++ b/tests/test_emojis.py
@@ -59,6 +59,11 @@ async def _run_test():
     res2 = await emojis.get_emojis(ctx=ctx)
     assert res2 == res1
 
+    emojis._emoji_cache.clear()
+    emojis.discord_client = DummyClient(guild)
+    res3 = await emojis.get_guild_emojis(100, ctx=ctx)
+    assert res3 == res1
+
 
 def test_get_emojis():
     asyncio.run(_run_test())

--- a/tests/test_unicode_emojis.py
+++ b/tests/test_unicode_emojis.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+import asyncio
+
+root = Path(__file__).resolve().parents[1] / 'demibot'
+sys.path.append(str(root))
+
+from demibot.http.routes import emojis
+
+
+def test_get_unicode_emojis():
+    res = asyncio.run(emojis.get_unicode_emojis())
+    assert isinstance(res, list)
+    assert any(e.get('emoji') == '😀' for e in res)


### PR DESCRIPTION
## Summary
- serve Unicode emoji catalog and guild emoji lists from HTTP API
- add ImGui popup to pick Unicode or guild emojis and store selection tokens
- normalize button emojis when building template payloads

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*
- `pytest` *(fails: missing dependencies such as fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68c06a77b8688328a365f5f1662cc05a