### PR TITLE
Refactor ButtonRows to use ButtonData and unify payload generation

### DIFF
--- a/DemiCat.UI/ButtonData.cs
+++ b/DemiCat.UI/ButtonData.cs
@@ -1,0 +1,13 @@
+using DiscordHelper;
+
+namespace DemiCat.UI;
+
+public class ButtonData
+{
+    public string Label { get; set; } = string.Empty;
+    public ButtonStyle Style { get; set; } = ButtonStyle.Primary;
+    public string? Emoji { get; set; }
+    public int? MaxSignups { get; set; }
+    public int? Width { get; set; }
+    public int? Height { get; set; }
+}

--- a/DemiCat.UI/ButtonRows.cs
+++ b/DemiCat.UI/ButtonRows.cs
@@ -10,16 +10,16 @@ public sealed class ButtonRows
     public const int MaxPerRow = 5;
     public const int MaxTotal  = 25;
 
-    private readonly List<List<string>> _rows;
+    private readonly List<List<ButtonData>> _rows;
 
-    public ButtonRows(List<List<string>> initial)
+    public ButtonRows(List<List<ButtonData>> initial)
     {
         _rows = initial ?? new();
         if (_rows.Count == 0) _rows.Add(new());
         Normalize();
     }
 
-    public IReadOnlyList<IReadOnlyList<string>> Rows => _rows;
+    public IReadOnlyList<IReadOnlyList<ButtonData>> Rows => _rows;
 
     public int TotalCount => _rows.Sum(r => r.Count);
 
@@ -45,10 +45,10 @@ public sealed class ButtonRows
         Normalize();
     }
 
-    public void AddButton(int row, string label = "New Button")
+    public void AddButton(int row, ButtonData? data = null)
     {
         if (!CanAddToRow(row)) return;
-        _rows[row].Add(label);
+        _rows[row].Add(data ?? new ButtonData { Label = "New Button" });
         Normalize();
     }
 
@@ -64,13 +64,13 @@ public sealed class ButtonRows
     {
         if (row < 0 || row >= _rows.Count) return;
         if (col < 0 || col >= _rows[row].Count) return;
-        _rows[row][col] = newLabel ?? string.Empty;
+        _rows[row][col].Label = newLabel ?? string.Empty;
     }
 
-    public IEnumerable<(int RowIndex, int ColIndex, string Label)> FlattenNonEmpty() =>
+    public IEnumerable<(int RowIndex, int ColIndex, ButtonData Data)> FlattenNonEmpty() =>
         _rows.SelectMany((row, r) => row
-            .Select((label, c) => (RowIndex: r, ColIndex: c, Label: label))
-            .Where(x => !string.IsNullOrWhiteSpace(x.Label)));
+            .Select((data, c) => (RowIndex: r, ColIndex: c, Data: data))
+            .Where(x => !string.IsNullOrWhiteSpace(x.Data.Label)));
 
     private void Normalize()
     {

--- a/DemiCat.UI/ButtonStyle.cs
+++ b/DemiCat.UI/ButtonStyle.cs
@@ -1,0 +1,10 @@
+namespace DiscordHelper;
+
+public enum ButtonStyle
+{
+    Primary = 1,
+    Secondary = 2,
+    Success = 3,
+    Danger = 4,
+    Link = 5,
+}

--- a/DemiCat.UI/IdHelpers.cs
+++ b/DemiCat.UI/IdHelpers.cs
@@ -1,50 +1,32 @@
-using System;
-using System.Globalization;
 using System.Linq;
 
 namespace DemiCat.UI;
 
 public static class IdHelpers
 {
-    public static string Truncate(string s, int max)
-    {
-        if (string.IsNullOrEmpty(s) || s.Length <= max) return s;
-        var e = StringInfo.GetTextElementEnumerator(s);
-        int consumed = 0;
-        int count = 0;
-        while (e.MoveNext())
-        {
-            var element = e.GetTextElement();
-            consumed += element.Length;
-            count++;
-            if (count == max)
-                return s.Substring(0, consumed);
-        }
-        return s;
-    }
+    public static string Truncate(string s, int max) =>
+        string.IsNullOrEmpty(s) || s.Length <= max ? s : s.Substring(0, max);
+
+    public static string Sanitize(string s) =>
+        new string((s ?? "").ToLowerInvariant()
+            .Where(ch => char.IsLetterOrDigit(ch) || ch == '-' || ch == '_')
+            .ToArray());
 
     public static string MakeCustomId(string label, int row, int col)
     {
         var slug = Sanitize(label);
         if (string.IsNullOrWhiteSpace(slug)) slug = $"btn-{row}-{col}";
-        var hash = Hash8(label);
-        var maxSlug = 100 - ("rsvp:".Length + 1 + hash.Length);
-        if (maxSlug < 0) maxSlug = 0;
-        slug = Truncate(slug, maxSlug);
-        return $"rsvp:{slug}:{hash}";
+        var h = Hash8(label);
+        var id = $"rsvp:{slug}:{h}";
+        return Truncate(id, 100); // Discord custom_id limit
     }
 
-    public static string Sanitize(string s) =>
-        new string(s.ToLowerInvariant()
-            .Where(ch => char.IsLetterOrDigit(ch) || ch == '-' || ch == '_')
-            .ToArray());
-
-    public static string Hash8(string s)
+    private static string Hash8(string s)
     {
         unchecked
         {
             uint hash = 2166136261;
-            foreach (var ch in s)
+            foreach (var ch in s ?? "")
                 hash = (hash ^ ch) * 16777619;
             return hash.ToString("x8");
         }

--- a/DemiCatPlugin/ButtonRowsImGui.cs
+++ b/DemiCatPlugin/ButtonRowsImGui.cs
@@ -1,5 +1,4 @@
 using ImGuiNET;
-using System.Linq;
 using DemiCat.UI;
 
 namespace DemiCatPlugin;
@@ -25,7 +24,7 @@ public static class ButtonRowsImGui
             for (int c = 0; c < state.Rows[r].Count; c++)
             {
                 ImGui.PushID(c);
-                var buf = state.Rows[r][c];
+                var buf = state.Rows[r][c].Label;
                 if (ImGui.InputText("##label", ref buf, 128))
                     state.SetLabel(r, c, buf);
 

--- a/DemiCatPlugin/EmbedDto.cs
+++ b/DemiCatPlugin/EmbedDto.cs
@@ -55,12 +55,3 @@ public class EmbedAuthorDto
     public string? Url { get; set; }
     public string? IconUrl { get; set; }
 }
-
-public enum ButtonStyle
-{
-    Primary = 1,
-    Secondary = 2,
-    Success = 3,
-    Danger = 4,
-    Link = 5,
-}

--- a/tests/ButtonRowsHelperTests.cs
+++ b/tests/ButtonRowsHelperTests.cs
@@ -9,7 +9,7 @@ public class ButtonRowsHelperTests
     public void NormalizesMaxPerRowAndTotal()
     {
         var data = Enumerable.Range(0, 10)
-            .Select(_ => Enumerable.Range(0, 10).Select(i => $"Btn {i}").ToList())
+            .Select(_ => Enumerable.Range(0, 10).Select(i => new ButtonData { Label = $"Btn {i}" }).ToList())
             .ToList();
         var rows = new ButtonRows(data);
         Assert.Equal(ButtonRows.MaxRows, rows.Rows.Count);

--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -28,7 +28,7 @@ public class TemplateButtonRoundTripTests
     [Fact]
     public void ToEmbedDto_UsesButtonLabels()
     {
-        var rows = new ButtonRows(new() { new() { "Join" } });
+        var rows = new ButtonRows(new() { new() { new ButtonData { Label = "Join" } } });
         rows.SetLabel(0, 0, "Signup");
 
         var window = CreateWindow(rows);
@@ -47,13 +47,14 @@ public class TemplateButtonRoundTripTests
     [Fact]
     public void BuildButtonsPayload_ProducesMetadata()
     {
-        var rows = new ButtonRows(new() { new() { "Join" } });
+        var rows = new ButtonRows(new() { new() { new ButtonData { Label = "Join" } } });
         var window = CreateWindow(rows);
 
-        var payload = window.BuildButtonsPayload();
+        var payload = window.BuildButtonsPayload(new Template());
         var btn = Assert.Single(payload);
         Assert.Equal("Join", btn.label);
         Assert.Equal((int)ButtonStyle.Primary, btn.style);
+        Assert.Equal(0, btn.rowIndex);
 
         Assert.Null(btn.emoji);
         Assert.Null(btn.maxSignups);


### PR DESCRIPTION
## Summary
- model buttons with ButtonData and share ButtonStyle enum
- update ButtonRows, UI, and TemplatesWindow to work with ButtonData
- centralize ID helpers and normalize button payload building

## Testing
- `DOTNET`: :x: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev
- `pytest`: :x: 53 errors during collection


------
https://chatgpt.com/codex/tasks/task_e_68c0773d29ac8328963ae355a799d984