### PR TITLE
Fix button ID collisions and animated emoji handling

### DIFF
--- a/DemiCat.UI/ButtonData.cs
+++ b/DemiCat.UI/ButtonData.cs
@@ -1,9 +1,11 @@
+using System;
 using DiscordHelper;
 
 namespace DemiCat.UI;
 
 public class ButtonData
 {
+    public string Tag { get; set; } = Guid.NewGuid().ToString();
     public string Label { get; set; } = string.Empty;
     public ButtonStyle Style { get; set; } = ButtonStyle.Primary;
     public string? Emoji { get; set; }

--- a/DemiCatPlugin/EmojiPopup.cs
+++ b/DemiCatPlugin/EmojiPopup.cs
@@ -73,7 +73,7 @@ public class EmojiPopup
         {
             if (ImGui.Button($":{e.Name}:##g{e.Id}"))
             {
-                GuildEmojiNames[e.Id] = e.Name;
+                GuildEmojiInfos[e.Id] = (e.Name, e.IsAnimated);
                 _onSelected?.Invoke($"custom:{e.Id}");
                 ImGui.CloseCurrentPopup();
             }
@@ -122,7 +122,7 @@ public class EmojiPopup
                 _guild.Clear();
                 _guild.AddRange(list);
                 foreach (var g in list)
-                    GuildEmojiNames[g.Id] = g.Name;
+                    GuildEmojiInfos[g.Id] = (g.Name, g.IsAnimated);
                 _guildLoaded = true;
             });
         }
@@ -132,12 +132,13 @@ public class EmojiPopup
         }
     }
 
-    public static string? LookupGuildName(string id)
-    {
-        return GuildEmojiNames.TryGetValue(id, out var name) ? name : null;
-    }
+    public static string? LookupGuildName(string id) =>
+        GuildEmojiInfos.TryGetValue(id, out var info) ? info.Name : null;
 
-    private static readonly Dictionary<string, string> GuildEmojiNames = new();
+    public static bool IsGuildEmojiAnimated(string id) =>
+        GuildEmojiInfos.TryGetValue(id, out var info) && info.IsAnimated;
+
+    private static readonly Dictionary<string, (string Name, bool IsAnimated)> GuildEmojiInfos = new();
 
     public class UnicodeEmoji
     {

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -107,6 +107,7 @@ public class TemplatesWindow
                     .Chunk(5)
                     .Select(chunk => chunk.Select(b => new ButtonData
                     {
+                        Tag = string.IsNullOrWhiteSpace(b.Tag) ? Guid.NewGuid().ToString() : b.Tag,
                         Label = b.Label,
                         Style = b.Style,
                         Emoji = string.IsNullOrWhiteSpace(b.Emoji) ? null : b.Emoji,
@@ -388,12 +389,12 @@ public class TemplatesWindow
     {
         var srcButtons = (tmpl.Buttons ?? new List<Template.TemplateButton>())
             .Where(b => !string.IsNullOrWhiteSpace(b.Label))
-            .ToDictionary(b => b.Label);
+            .ToDictionary(b => b.Tag);
         return _buttonRows.FlattenNonEmpty()
             .Select(x =>
             {
                 var label = x.Data.Label.Trim();
-                srcButtons.TryGetValue(label, out var b);
+                srcButtons.TryGetValue(x.Data.Tag, out var b);
                 return new ButtonPayload(
                     Truncate(label, 80),
                     MakeCustomId(label, x.RowIndex, x.ColIndex),
@@ -414,7 +415,8 @@ public class TemplatesWindow
         {
             var id = emoji.Substring("custom:".Length);
             var name = EmojiPopup.LookupGuildName(id) ?? "emoji";
-            return $"<:{name}:{id}>";
+            var animated = EmojiPopup.IsGuildEmojiAnimated(id);
+            return $"<{(animated ? "a" : string.Empty)}:{name}:{id}>";
         }
         return emoji;
     }

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -164,6 +164,8 @@ async def create_event(
 
             view: discord.ui.View | None = None
             if buttons:
+                if len(buttons) > 25:
+                    raise HTTPException(422, "Too many buttons (max 25)")
                 view = discord.ui.View()
                 rows: Dict[int, List[EmbedButtonDto]] = {}
                 for b in buttons:

--- a/tests/ButtonRowsHelperTests.cs
+++ b/tests/ButtonRowsHelperTests.cs
@@ -29,4 +29,16 @@ public class ButtonRowsHelperTests
         Assert.True(id2.Length <= 100);
         Assert.NotEqual(id1, id2);
     }
+
+    [Fact]
+    public void MakeCustomId_IncludesRowAndColInHash()
+    {
+        var label = "Click";
+        var id1 = IdHelpers.MakeCustomId(label, 0, 0);
+        var id2 = IdHelpers.MakeCustomId(label, 0, 1);
+        var id3 = IdHelpers.MakeCustomId(label, 1, 0);
+        Assert.NotEqual(id1, id2);
+        Assert.NotEqual(id1, id3);
+        Assert.NotEqual(id2, id3);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure custom IDs incorporate row/column and cap at 100 characters
- track stable tags for template buttons and normalize animated custom emojis
- validate total button count on backend

## Testing
- `pytest tests/test_event_button_limit.py tests/test_emojis.py`
- `dotnet test` *(fails: Requested SDK version 9.0.100 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c07fef1eb4832887c26fb4ad43470d