### PR TITLE
Handle missing template button tags in payload generation

### DIFF
--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -61,4 +61,23 @@ public class TemplateButtonRoundTripTests
         Assert.Null(btn.width);
         Assert.Null(btn.height);
     }
+
+    [Fact]
+    public void BuildButtonsPayload_IgnoresEmptyTemplateTags()
+    {
+        var rows = new ButtonRows(new() { new() { new ButtonData { Label = "Join" } } });
+        var window = CreateWindow(rows);
+
+        var tmpl = new Template
+        {
+            Buttons = new List<Template.TemplateButton>
+            {
+                new Template.TemplateButton { Label = "Join", Tag = string.Empty }
+            }
+        };
+
+        var payload = window.BuildButtonsPayload(tmpl);
+        var btn = Assert.Single(payload);
+        Assert.Equal("Join", btn.label);
+    }
 }


### PR DESCRIPTION
## Summary
- Persist GUID tags for template buttons that lack them during UI initialization
- Skip blank tags when building button metadata payloads
- Add regression test for templates missing button tags

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08946705c8328adc0b006fd26c77b