### PR TITLE
Handle missing template button tags in payload generation

### DIFF
--- a/DemiCatPlugin/EmojiPopup.cs
+++ b/DemiCatPlugin/EmojiPopup.cs
@@ -41,11 +41,17 @@ public class EmojiPopup
                 DrawUnicode();
                 ImGui.EndTabItem();
             }
-            if (ImGui.BeginTabItem("Guild"))
+            var guildEnabled = !string.IsNullOrWhiteSpace(_config.GuildId);
+            if (!guildEnabled) ImGui.BeginDisabled();
+            var guildTab = ImGui.BeginTabItem("Guild");
+            if (!guildEnabled && ImGui.IsItemHovered())
+                ImGui.SetTooltip("Set GuildId in config to enable guild emojis");
+            if (guildTab)
             {
                 DrawGuild();
                 ImGui.EndTabItem();
             }
+            if (!guildEnabled) ImGui.EndDisabled();
             ImGui.EndTabBar();
         }
         ImGui.EndPopup();

--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -61,4 +61,40 @@ public class TemplateButtonRoundTripTests
         Assert.Null(btn.width);
         Assert.Null(btn.height);
     }
+
+    [Fact]
+    public void BuildButtonsPayload_IgnoresEmptyTemplateTags()
+    {
+        var rows = new ButtonRows(new() { new() { new ButtonData { Label = "Join" } } });
+        var window = CreateWindow(rows);
+
+        var tmpl = new Template
+        {
+            Buttons = new List<Template.TemplateButton>
+            {
+                new Template.TemplateButton { Label = "Join", Tag = string.Empty }
+            }
+        };
+
+        var payload = window.BuildButtonsPayload(tmpl);
+        var btn = Assert.Single(payload);
+        Assert.Equal("Join", btn.label);
+    }
+
+    [Fact]
+    public void BuildButtonsPayload_AssignsDistinctIdsForDuplicateLabels()
+    {
+        var rows = new ButtonRows(new()
+        {
+            new() { new ButtonData { Label = "Join" }, new ButtonData { Label = "Join" } },
+            new() { new ButtonData { Label = "Join" } }
+        });
+        var window = CreateWindow(rows);
+
+        var payload = window.BuildButtonsPayload(new Template());
+        Assert.Equal(3, payload.Count);
+        Assert.NotEqual(payload[0].customId, payload[1].customId);
+        Assert.NotEqual(payload[0].customId, payload[2].customId);
+        Assert.NotEqual(payload[1].customId, payload[2].customId);
+    }
 }


### PR DESCRIPTION
## Summary
- Persist GUID tags for template buttons that lack them during UI initialization
- Skip blank tags when building button metadata payloads
- Normalize custom emoji markup for animated guild emojis
- Enforce URL/customId rules for link vs non-link buttons on backend
- Disable guild emoji tab until a GuildId is configured
- Add regression tests for missing tags and customId uniqueness

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: compatible .NET SDK 9.0.100 not found)*
- `pytest` *(fails: missing dependencies like fastapi, discord, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68c08946705c8328adc0b006fd26c77b