### PR TITLE
feat: add file dialog for chat attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ DemiCat/
 - **Request Board** – Track signup requests and interest.
 - **SyncShell** – Work-in-progress replacement for the Mare Synchronos mod-sharing plugin. Syncs Penumbra mod lists to replicate player appearances and is disabled by default while under development (see `DemiCatPlugin/SyncshellWindow.cs`).
 - **FC Chat** – Mirror Discord conversations directly in game.
+  - Use **Attach** to open a file picker and add attachments. Selected files appear below the input with remove buttons, and invalid files display an error tooltip.
 - **Officer** – Administrative tools for event staff and moderators.
   - Officer chat window now includes a padded area beneath the input box reserved for future features.
 


### PR DESCRIPTION
## Summary
- allow browsing for attachments with Dalamud file dialog
- warn when attachments can't be opened
- document new attachment workflow

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: command not found)*
- `pytest` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b691a37483288d18a44ee78f909f