### PR TITLE
Watch syncshell setting

### DIFF
--- a/tests/SyncshellTabToggleTests.cs
+++ b/tests/SyncshellTabToggleTests.cs
@@ -1,0 +1,31 @@
+using System.Net.Http;
+using System.Runtime.Serialization;
+using DemiCatPlugin;
+using Xunit;
+
+public class SyncshellTabToggleTests
+{
+    [Fact]
+    public void SyncshellWindow_TogglesWithConfig()
+    {
+        SyncshellWindow.Instance?.Dispose();
+        var cfg = new Config { FCSyncShell = false };
+        var http = new HttpClient();
+        var token = new TokenManager();
+        var channelService = new ChannelService(cfg, http, token);
+        var ui = new UiRenderer(cfg, http);
+        var officer = new OfficerChatWindow(cfg, http, null, token, channelService);
+        var settings = (SettingsWindow)FormatterServices.GetUninitializedObject(typeof(SettingsWindow));
+        var main = new MainWindow(cfg, ui, null, officer, settings, http, channelService);
+
+        Assert.Null(SyncshellWindow.Instance);
+
+        cfg.FCSyncShell = true;
+        main.UpdateSyncshell();
+        Assert.NotNull(SyncshellWindow.Instance);
+
+        cfg.FCSyncShell = false;
+        main.UpdateSyncshell();
+        Assert.Null(SyncshellWindow.Instance);
+    }
+}


### PR DESCRIPTION
## Summary
- Watch Syncshell setting in `MainWindow` and create/dispose Syncshell window on config changes
- Safely skip drawing Syncshell tab when the window is absent
- Add test ensuring Syncshell window updates when setting toggles

## Testing
- `./.dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj -c Release` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b9f8f4588328807f0f5204e32325