### PR TITLE
Correct event color channel order and add conversion tests

### DIFF
--- a/DemiCatPlugin/ColorUtils.cs
+++ b/DemiCatPlugin/ColorUtils.cs
@@ -1,0 +1,20 @@
+namespace DemiCatPlugin;
+
+public static class ColorUtils
+{
+    public static uint RgbToAbgr(uint rgb)
+    {
+        var r = (rgb >> 16) & 0xFF;
+        var g = (rgb >> 8) & 0xFF;
+        var b = rgb & 0xFF;
+        return r | (g << 8) | (b << 16);
+    }
+
+    public static uint AbgrToRgb(uint abgr)
+    {
+        var r = abgr & 0xFF;
+        var g = (abgr >> 8) & 0xFF;
+        var b = (abgr >> 16) & 0xFF;
+        return (r << 16) | (g << 8) | b;
+    }
+}

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -27,7 +27,7 @@ public class EventCreateWindow
     private string _imageUrl = string.Empty;
     private string _url = string.Empty;
     private string _thumbnailUrl = string.Empty;
-    private int _color;
+    private uint _color;
     private readonly List<Field> _fields = new();
     private string? _lastResult;
     private readonly List<Template.TemplateButton> _buttons = new();
@@ -134,14 +134,14 @@ public class EventCreateWindow
         ImGui.InputText("Image URL", ref _imageUrl, 260);
         ImGui.InputText("Thumbnail URL", ref _thumbnailUrl, 260);
         var colorVec = new Vector3(
-            ((_color >> 16) & 0xFF) / 255f,
+            (_color & 0xFF) / 255f,
             ((_color >> 8) & 0xFF) / 255f,
-            (_color & 0xFF) / 255f);
+            ((_color >> 16) & 0xFF) / 255f);
         if (ImGui.ColorEdit3("Color", ref colorVec))
         {
-            _color = ((int)(colorVec.X * 255) << 16) |
-                     ((int)(colorVec.Y * 255) << 8) |
-                     (int)(colorVec.Z * 255);
+            _color = ((uint)(colorVec.X * 255)) |
+                     ((uint)(colorVec.Y * 255) << 8) |
+                     ((uint)(colorVec.Z * 255) << 16);
         }
 
         if (!_rolesLoaded)
@@ -398,7 +398,7 @@ public class EventCreateWindow
         _url = template.Url;
         _imageUrl = template.ImageUrl;
         _thumbnailUrl = template.ThumbnailUrl;
-        _color = (int)template.Color;
+        _color = ColorUtils.RgbToAbgr(template.Color);
         _mentions.Clear();
         if (template.Mentions != null)
         {
@@ -453,7 +453,7 @@ public class EventCreateWindow
             Url = _url,
             ImageUrl = _imageUrl,
             ThumbnailUrl = _thumbnailUrl,
-            Color = (uint)_color,
+            Color = ColorUtils.AbgrToRgb(_color),
             Fields = _fields.Select(f => new Template.TemplateField
             {
                 Name = f.Name,
@@ -560,7 +560,7 @@ public class EventCreateWindow
             Url = string.IsNullOrWhiteSpace(_url) ? null : _url,
             ImageUrl = string.IsNullOrWhiteSpace(_imageUrl) ? null : _imageUrl,
             ThumbnailUrl = string.IsNullOrWhiteSpace(_thumbnailUrl) ? null : _thumbnailUrl,
-            Color = _color > 0 ? (uint?)_color : null,
+            Color = _color > 0 ? (uint?)ColorUtils.AbgrToRgb(_color) : null,
             Timestamp = DateTime.TryParse(_time, null, DateTimeStyles.AdjustToUniversal, out var ts) ? ts : (DateTimeOffset?)null,
             Fields = _fields
                 .Where(f => !string.IsNullOrWhiteSpace(f.Name) && !string.IsNullOrWhiteSpace(f.Value))

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -71,7 +71,7 @@ public class EventView : IDisposable
 
         if (dto.Color.HasValue)
         {
-            var color = dto.Color.Value | 0xFF000000;
+            var color = ColorUtils.RgbToAbgr(dto.Color.Value) | 0xFF000000;
             var dl = ImGui.GetWindowDrawList();
             var p = ImGui.GetCursorScreenPos();
             var end = new Vector2(p.X + 4, p.Y + ImGui.GetTextLineHeightWithSpacing() * 3);

--- a/tests/ColorConversionTests.cs
+++ b/tests/ColorConversionTests.cs
@@ -1,0 +1,66 @@
+using System.Numerics;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Bindings.ImGui;
+using DemiCatPlugin;
+using DiscordHelper;
+using Xunit;
+
+public class ColorConversionTests
+{
+    [Theory]
+    [InlineData(0xFF0000)]
+    [InlineData(0x00FF00)]
+    [InlineData(0x0000FF)]
+    [InlineData(0x123456)]
+    [InlineData(0xABCDEF)]
+    public void RgbToAbgrMatchesImGui(uint rgb)
+    {
+        var expected = ImGui.ColorConvertFloat4ToU32(new Vector4(
+            ((rgb >> 16) & 0xFF) / 255f,
+            ((rgb >> 8) & 0xFF) / 255f,
+            (rgb & 0xFF) / 255f,
+            1f)) & 0x00FFFFFF;
+        var actual = ColorUtils.RgbToAbgr(rgb);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(0xFF0000)]
+    [InlineData(0x00FF00)]
+    [InlineData(0x0000FF)]
+    [InlineData(0x123456)]
+    [InlineData(0xABCDEF)]
+    public void AbgrToRgbRoundTrip(uint rgb)
+    {
+        var abgr = ColorUtils.RgbToAbgr(rgb);
+        var back = ColorUtils.AbgrToRgb(abgr);
+        Assert.Equal(rgb, back);
+    }
+
+    private class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+    }
+
+    [Theory]
+    [InlineData(0xFF0000)]
+    [InlineData(0x00FF00)]
+    [InlineData(0x0000FF)]
+    [InlineData(0x123456)]
+    public void BuildPreviewUsesRgb(uint rgb)
+    {
+        var config = new Config();
+        var http = new HttpClient(new StubHandler());
+        var channelService = new ChannelService(config, http, new TokenManager());
+        var window = new EventCreateWindow(config, http, channelService);
+        typeof(EventCreateWindow).GetField("_color", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(window, ColorUtils.RgbToAbgr(rgb));
+        var preview = (EmbedDto)typeof(EventCreateWindow).GetMethod("BuildPreview", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, Array.Empty<object>())!;
+        Assert.Equal(rgb, preview.Color);
+    }
+}


### PR DESCRIPTION
## Summary
- keep event creation color in ImGui's ABGR format and convert when saving or previewing
- ensure EventView draws color stripe using correct channel order
- add ColorUtils helper and unit tests for RGB/ABGR conversions

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b9fc1f388328ae045c94660aa534