### PR TITLE
Load guild emoji textures in EmojiPopup

### DIFF
--- a/DemiCatPlugin/EmojiAssets.cs
+++ b/DemiCatPlugin/EmojiAssets.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace DemiCatPlugin;
+
+public static class EmojiAssets
+{
+    private static readonly Dictionary<string, (string Name, bool IsAnimated)> _guildInfos = new();
+    private static readonly Dictionary<string, string> _unicodeUrls = new();
+
+    public static void SetGuildEmoji(string id, string name, bool isAnimated) => _guildInfos[id] = (name, isAnimated);
+    public static string? LookupGuildName(string id) => _guildInfos.TryGetValue(id, out var v) ? v.Name : null;
+    public static bool IsGuildEmojiAnimated(string id) => _guildInfos.TryGetValue(id, out var v) && v.IsAnimated;
+
+    public static void SetUnicodeEmoji(string emoji, string url) => _unicodeUrls[emoji] = url;
+    public static string? LookupUnicodeUrl(string emoji) => _unicodeUrls.TryGetValue(emoji, out var v) ? v : null;
+
+    public static void Clear()
+    {
+        _guildInfos.Clear();
+        _unicodeUrls.Clear();
+    }
+}
+

--- a/DemiCatPlugin/EmojiPopup.cs
+++ b/DemiCatPlugin/EmojiPopup.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Numerics;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
@@ -11,13 +13,16 @@ public class EmojiPopup
 {
     private readonly Config _config;
     private readonly HttpClient _httpClient;
+
     private readonly List<UnicodeEmoji> _unicode = new();
     private readonly List<GuildEmoji> _guild = new();
     private bool _unicodeLoaded;
     private bool _guildLoaded;
+
     private Action<string>? _onSelected;
 
     private const string PopupId = "PickEmoji";
+    private string _search = string.Empty;
 
     public EmojiPopup(Config config, HttpClient httpClient)
     {
@@ -34,117 +39,209 @@ public class EmojiPopup
     public void Draw()
     {
         if (!ImGui.BeginPopup(PopupId)) return;
+
+        ImGui.SetNextItemWidth(240);
+        ImGui.InputText("Search", ref _search, 64);
+
         if (ImGui.BeginTabBar("emoji-tabs"))
         {
-            if (ImGui.BeginTabItem("Unicode"))
+            if (ImGui.BeginTabItem("Emoji"))
             {
-                DrawUnicode();
+                DrawUnicodeGrid();
                 ImGui.EndTabItem();
             }
+
             var guildEnabled = !string.IsNullOrWhiteSpace(_config.GuildId);
             if (!guildEnabled) ImGui.BeginDisabled();
-            var guildTab = ImGui.BeginTabItem("Guild");
+            var guildTab = ImGui.BeginTabItem("Server");
             if (!guildEnabled && ImGui.IsItemHovered())
-                ImGui.SetTooltip("Set GuildId in config to enable guild emojis");
+                ImGui.SetTooltip("Set GuildId in config to enable server emojis");
             if (guildTab)
             {
-                DrawGuild();
+                DrawGuildGrid();
                 ImGui.EndTabItem();
             }
             if (!guildEnabled) ImGui.EndDisabled();
+
             ImGui.EndTabBar();
         }
+
         ImGui.EndPopup();
     }
 
-    private void DrawUnicode()
+    private void DrawUnicodeGrid()
     {
         if (!_unicodeLoaded) _ = FetchUnicode();
-        foreach (var e in _unicode)
-        {
-            if (ImGui.Button($"{e.Emoji}##u{e.Emoji}"))
-            {
-                _onSelected?.Invoke(e.Emoji);
-                ImGui.CloseCurrentPopup();
-            }
-            ImGui.SameLine();
-        }
-        ImGui.NewLine();
+
+        var items = string.IsNullOrWhiteSpace(_search)
+            ? _unicode
+            : _unicode.Where(u =>
+                   u.Name.Contains(_search, StringComparison.OrdinalIgnoreCase) ||
+                   u.Emoji.Contains(_search, StringComparison.OrdinalIgnoreCase)
+               ).ToList();
+
+        DrawGrid(
+            items.Count,
+            i => items[i].ImageUrl,
+            i => items[i].Name,
+            i => items[i].Emoji,
+            _ => false
+        );
     }
 
-    private void DrawGuild()
+    private void DrawGuildGrid()
     {
         if (!_guildLoaded) _ = FetchGuild();
-        foreach (var e in _guild)
+
+        var items = string.IsNullOrWhiteSpace(_search)
+            ? _guild
+            : _guild.Where(g => g.Name.Contains(_search, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        DrawGrid(
+            items.Count,
+            i => items[i].ImageUrl,
+            i => items[i].Name,
+            i => $"custom:{items[i].Id}",
+            i => items[i].IsAnimated
+        );
+    }
+
+    private void DrawGrid(
+        int count,
+        Func<int, string> getUrl,
+        Func<int, string> getName,
+        Func<int, string> getReturnValue,
+        Func<int, bool> isDisabled,
+        int columns = 8,
+        float cellSize = 28f)
+    {
+        int col = 0;
+
+        for (int i = 0; i < count; i++)
         {
-            if (ImGui.Button($":{e.Name}:##g{e.Id}"))
+            if (col == 0) ImGui.BeginGroup();
+
+            var url = getUrl(i);
+            var name = getName(i);
+            var disabled = isDisabled(i);
+
+            if (disabled) ImGui.BeginDisabled();
+
+            WebTextureCache.Get(url, tex =>
             {
-                GuildEmojiInfos[e.Id] = (e.Name, e.IsAnimated);
-                _onSelected?.Invoke($"custom:{e.Id}");
-                ImGui.CloseCurrentPopup();
-            }
+                if (tex != null)
+                {
+                    ImGui.PushID(i);
+                    var ret = getReturnValue(i);
+
+                    if (ImGui.ImageButton(tex.GetWrapOrEmpty().Handle, new Vector2(cellSize, cellSize)))
+                    {
+                        if (!disabled)
+                        {
+                            var markerPrefix = "custom:";
+                            if (ret.StartsWith(markerPrefix, StringComparison.OrdinalIgnoreCase))
+                            {
+                                var id = ret.Substring(markerPrefix.Length);
+                                EmojiAssets.SetGuildEmoji(id, name, false);
+                            }
+                            else
+                            {
+                                if (EmojiAssets.LookupUnicodeUrl(ret) == null)
+                                    EmojiAssets.SetUnicodeEmoji(ret, url);
+                            }
+
+                            _onSelected?.Invoke(ret);
+                            ImGui.CloseCurrentPopup();
+                        }
+                    }
+
+                    if (ImGui.IsItemHovered())
+                        ImGui.SetTooltip(name);
+
+                    ImGui.PopID();
+                }
+            });
+
+            if (disabled) ImGui.EndDisabled();
+
             ImGui.SameLine();
+
+            col++;
+            if (col >= columns)
+            {
+                ImGui.NewLine();
+                ImGui.EndGroup();
+                col = 0;
+            }
         }
-        ImGui.NewLine();
+
+        if (col != 0) { ImGui.NewLine(); ImGui.EndGroup(); }
+    }
+
+    // For tests to load textures without UI
+    internal void PreloadGuildTextures()
+    {
+        foreach (var g in _guild)
+        {
+            WebTextureCache.Get(g.ImageUrl, _ => { });
+        }
     }
 
     private async Task FetchUnicode()
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
+
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis/unicode");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
-            var response = await _httpClient.SendAsync(request);
-            if (!response.IsSuccessStatusCode) return;
-            var stream = await response.Content.ReadAsStreamAsync();
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis/unicode");
+            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
+            var res = await _httpClient.SendAsync(req);
+            if (!res.IsSuccessStatusCode) return;
+
+            var stream = await res.Content.ReadAsStreamAsync();
             var list = await JsonSerializer.DeserializeAsync<List<UnicodeEmoji>>(stream) ?? new();
+
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _unicode.Clear();
                 _unicode.AddRange(list);
+
+                foreach (var u in list) EmojiAssets.SetUnicodeEmoji(u.Emoji, u.ImageUrl);
+
                 _unicodeLoaded = true;
             });
         }
-        catch
-        {
-            // ignore
-        }
+        catch { }
     }
 
     private async Task FetchGuild()
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrWhiteSpace(_config.GuildId)) return;
+
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis/guilds/{_config.GuildId}");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
-            var response = await _httpClient.SendAsync(request);
-            if (!response.IsSuccessStatusCode) return;
-            var stream = await response.Content.ReadAsStreamAsync();
+            var req = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/emojis/guilds/{_config.GuildId}");
+            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
+            var res = await _httpClient.SendAsync(req);
+            if (!res.IsSuccessStatusCode) return;
+
+            var stream = await res.Content.ReadAsStreamAsync();
             var list = await JsonSerializer.DeserializeAsync<List<GuildEmoji>>(stream) ?? new();
+
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _guild.Clear();
                 _guild.AddRange(list);
-                foreach (var g in list)
-                    GuildEmojiInfos[g.Id] = (g.Name, g.IsAnimated);
+                foreach (var g in list) EmojiAssets.SetGuildEmoji(g.Id, g.Name, g.IsAnimated);
                 _guildLoaded = true;
             });
         }
-        catch
-        {
-            // ignore
-        }
+        catch { }
     }
 
-    public static string? LookupGuildName(string id) =>
-        GuildEmojiInfos.TryGetValue(id, out var info) ? info.Name : null;
-
-    public static bool IsGuildEmojiAnimated(string id) =>
-        GuildEmojiInfos.TryGetValue(id, out var info) && info.IsAnimated;
-
-    private static readonly Dictionary<string, (string Name, bool IsAnimated)> GuildEmojiInfos = new();
+    // Static lookups used elsewhere
+    public static string? LookupGuildName(string id) => EmojiAssets.LookupGuildName(id);
+    public static bool IsGuildEmojiAnimated(string id) => EmojiAssets.IsGuildEmojiAnimated(id);
 
     public class UnicodeEmoji
     {
@@ -161,3 +258,4 @@ public class EmojiPopup
         public string ImageUrl { get; set; } = string.Empty;
     }
 }
+

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -56,6 +56,30 @@ public class SignupOptionEditor
             {
                 _emojiPopup.Open(e => _working.Emoji = e);
             }
+
+            if (!string.IsNullOrWhiteSpace(_working.Emoji))
+            {
+                if (_working.Emoji.StartsWith("custom:", StringComparison.OrdinalIgnoreCase))
+                {
+                    var id = _working.Emoji.Substring("custom:".Length);
+                    var ext = EmojiPopup.IsGuildEmojiAnimated(id) ? "gif" : "png"; // we won’t animate but PNG works for most
+                    var url = $"https://cdn.discordapp.com/emojis/{id}.{ext}";
+                    WebTextureCache.Get(url, tex =>
+                    {
+                        if (tex != null)
+                        {
+                            var wrap = tex.GetWrapOrEmpty();
+                            ImGui.Image(wrap.Handle, new Vector2(20, 20));
+                            ImGui.SameLine();
+                        }
+                    });
+                }
+                else
+                {
+                    ImGui.TextUnformatted(_working.Emoji);
+                    ImGui.SameLine();
+                }
+            }
             var max = _working.MaxSignups ?? 0;
             if (ImGui.InputInt("Max Signups", ref max))
             {

--- a/DemiCatPlugin/WebTextureCache.cs
+++ b/DemiCatPlugin/WebTextureCache.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Dalamud.Interface.Textures;
+using Dalamud.Interface.Textures.TextureWraps;
+
+namespace DemiCatPlugin;
+
+// Simple cache around Dalamud web textures.
+// You already call t.GetWrapOrEmpty() elsewhere; we stick to that pattern.
+public static class WebTextureCache
+{
+    private static readonly Dictionary<string, ISharedImmediateTexture> _map = new();
+
+    // Allow tests to override texture fetching behaviour
+    public static Func<string, Action<ISharedImmediateTexture?>, object?>? FetchOverride { get; set; }
+
+    public static void Get(string url, Action<ISharedImmediateTexture?> onReady)
+    {
+        if (FetchOverride != null)
+        {
+            FetchOverride(url, onReady);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(url))
+        {
+            onReady(null);
+            return;
+        }
+
+        if (_map.TryGetValue(url, out var tex))
+        {
+            onReady(tex);
+            return;
+        }
+
+        try
+        {
+            PluginServices.Instance!.TextureProvider.GetFromUrl(new Uri(url), tex =>
+            {
+                if (tex != null) _map[url] = tex;
+                onReady(tex);
+            });
+        }
+        catch
+        {
+            onReady(null);
+        }
+    }
+
+    public static void DrawImageButton(string id, ISharedImmediateTexture? tex, Vector2 size, Action onClick)
+    {
+        if (tex == null) return;
+        var wrap = tex.GetWrapOrEmpty();
+        if (ImGui.ImageButton(id, wrap.Handle, size))
+            onClick();
+    }
+}
+

--- a/tests/DemiCatPlugin.Tests.csproj
+++ b/tests/DemiCatPlugin.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="xunit" Version="2.5.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.69" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../DemiCatPlugin/MarkdownFormatter.cs" Link="MarkdownFormatter.cs" />

--- a/tests/EmojiPopupGuildTests.cs
+++ b/tests/EmojiPopupGuildTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using DemiCatPlugin;
+using Dalamud.Interface.Textures;
+using Moq;
+using Xunit;
+
+public class EmojiPopupGuildTests
+{
+    private class StubHandler : HttpMessageHandler
+    {
+        private readonly string _response;
+        public StubHandler(string response) => _response = response;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_response)
+            });
+    }
+
+    private class TestFramework : Dalamud.Plugin.Services.IFramework
+    {
+        public event Dalamud.Plugin.Services.FrameworkUpdateDelegate? Update { add { } remove { } }
+        public Dalamud.Plugin.Services.FrameworkUpdateType CurrentUpdateType => Dalamud.Plugin.Services.FrameworkUpdateType.None;
+        public void RunOnTick(System.Action action, Dalamud.Plugin.Services.FrameworkUpdatePriority priority = Dalamud.Plugin.Services.FrameworkUpdatePriority.Normal) => action();
+    }
+
+    private class TestLog : Dalamud.Plugin.Services.IPluginLog
+    {
+        public void Verbose(string message) { }
+        public void Verbose(string message, System.Exception exception) { }
+        public void Debug(string message) { }
+        public void Debug(string message, System.Exception exception) { }
+        public void Info(string message) { }
+        public void Info(string message, System.Exception exception) { }
+        public void Warning(string message) { }
+        public void Warning(string message, System.Exception exception) { }
+        public void Error(string message) { }
+        public void Error(System.Exception exception, string message) { }
+        public void Fatal(string message) { }
+        public void Fatal(System.Exception exception, string message) { }
+    }
+
+    [Fact]
+    public async Task FetchGuild_CachesTextures()
+    {
+        var json = "[{\"id\":\"1\",\"name\":\"foo\",\"isAnimated\":false,\"imageUrl\":\"http://image\"}]";
+        var config = new Config { ApiBaseUrl = "http://host", GuildId = "1" };
+        var http = new HttpClient(new StubHandler(json));
+        var popup = new EmojiPopup(config, http);
+
+        var ps = new PluginServices();
+        var framework = new TestFramework();
+        var log = new TestLog();
+        typeof(PluginServices).GetProperty("Framework", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.SetValue(ps, framework);
+        typeof(PluginServices).GetProperty("Log", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.SetValue(ps, log);
+
+        var urls = new List<string>();
+        WebTextureCache.FetchOverride = (url, cb) =>
+        {
+            if (url != null) urls.Add(url);
+            cb(new Mock<ISharedImmediateTexture>().Object);
+            return null;
+        };
+
+        var fetch = typeof(EmojiPopup).GetMethod("FetchGuild", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        await (Task)fetch!.Invoke(popup, null)!;
+
+        popup.PreloadGuildTextures();
+
+        Assert.Equal(new[] { "http://image" }, urls);
+        Assert.Equal("foo", EmojiPopup.LookupGuildName("1"));
+        WebTextureCache.FetchOverride = null;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add web texture cache for emojis
- revamp emoji picker with image grid, search, and texture reuse
- preview selected emoji textures in signup option editor
- test guild emoji texture loading using cache

## Testing
- `pytest tests/test_emojis.py::test_get_emojis -q`
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c12023708328a10239437d947992