### PR TITLE
Clamp selection indices in WrapSelection

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -672,10 +672,16 @@ public class ChatWindow : IDisposable
 
     private void WrapSelection(string prefix, string suffix)
     {
-        var start = Math.Min(_selectionStart, _selectionEnd);
-        var end = Math.Max(_selectionStart, _selectionEnd);
+        _input ??= string.Empty;
+        var len = _input.Length;
+        var s = Math.Clamp(_selectionStart, 0, len);
+        var e = Math.Clamp(_selectionEnd, 0, len);
+        var start = Math.Min(s, e);
+        var end = Math.Max(s, e);
+
         var selected = _input.Substring(start, end - start);
         _input = _input[..start] + prefix + selected + suffix + _input[end..];
+
         var cursor = start + prefix.Length + selected.Length + suffix.Length;
         _selectionStart = _selectionEnd = cursor;
     }


### PR DESCRIPTION
## Summary
- Clamp selection range and guard against null input when wrapping text selections

## Testing
- ❌ `dotnet test tests/DemiCatPlugin.Tests.csproj` *(Dalamud.NET.Sdk: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e56042a08328b4054ed5ecd6afe6