### PR TITLE
Handle null pointer in OnInputEdited callback

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -688,8 +688,9 @@ public class ChatWindow : IDisposable
 
     private unsafe int OnInputEdited(ImGuiInputTextCallbackData* data)
     {
+        if (data == null) return 0;
         _selectionStart = data->SelectionStart;
-        _selectionEnd = data->SelectionEnd;
+        _selectionEnd   = data->SelectionEnd;
         return 0;
     }
 


### PR DESCRIPTION
## Summary
- Handle potential null ImGui callback data in `OnInputEdited`

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: PluginService and IDalamudPluginInterface not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e5ed4ee08328a6116d2d85084c37