### PR TITLE
Expand wrapping to current word when no text selected

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -679,6 +679,18 @@ public class ChatWindow : IDisposable
         var start = Math.Min(s, e);
         var end = Math.Max(s, e);
 
+        if (start == end)
+        {
+            while (start > 0 && char.IsLetterOrDigit(_input[start - 1]))
+            {
+                start--;
+            }
+            while (end < len && char.IsLetterOrDigit(_input[end]))
+            {
+                end++;
+            }
+        }
+
         var selected = _input.Substring(start, end - start);
         _input = _input[..start] + prefix + selected + suffix + _input[end..];
 

--- a/tests/ChatWindowFormattingTests.cs
+++ b/tests/ChatWindowFormattingTests.cs
@@ -54,6 +54,51 @@ public class ChatWindowFormattingTests
         Assert.Equal("[click](url)", GetInput(window));
     }
 
+    [Fact]
+    public void BoldButton_WrapsWord_WhenNoSelection()
+    {
+        var window = CreateWindow();
+        SetInput(window, "hello world", 8, 8);
+        InvokeWrap(window, "**", "**");
+        Assert.Equal("hello **world**", GetInput(window));
+    }
+
+    [Fact]
+    public void ItalicButton_WrapsWord_WhenNoSelection()
+    {
+        var window = CreateWindow();
+        SetInput(window, "hello world", 2, 2);
+        InvokeWrap(window, "*", "*");
+        Assert.Equal("*hello* world", GetInput(window));
+    }
+
+    [Fact]
+    public void CodeButton_WrapsWord_WhenNoSelection()
+    {
+        var window = CreateWindow();
+        SetInput(window, "test", 2, 2);
+        InvokeWrap(window, "`", "`");
+        Assert.Equal("`test`", GetInput(window));
+    }
+
+    [Fact]
+    public void SpoilerButton_WrapsWord_WhenNoSelection()
+    {
+        var window = CreateWindow();
+        SetInput(window, "secret", 3, 3);
+        InvokeWrap(window, "||", "||");
+        Assert.Equal("||secret||", GetInput(window));
+    }
+
+    [Fact]
+    public void LinkButton_WrapsWord_WhenNoSelection()
+    {
+        var window = CreateWindow();
+        SetInput(window, "click", 2, 2);
+        InvokeWrap(window, "[", "](url)");
+        Assert.Equal("[click](url)", GetInput(window));
+    }
+
     private static ChatWindow CreateWindow()
     {
         SetupServices();


### PR DESCRIPTION
## Summary
- expand `WrapSelection` to grow a zero-length selection to surrounding word boundaries before applying the prefix/suffix
- add formatting tests for when the cursor is inside a word without a selection

## Testing
- `MSBUILDTERMINALLOGGER=false /root/.dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj -c Release` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e6f8c1a083289758fad3752ab3a5