### PR TITLE
Move template management to API with real-time sync

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -169,6 +169,7 @@ public class Plugin : IDalamudPlugin
         {
             _ = _ui.StartNetworking();
             _mainWindow.EventCreateWindow.StartNetworking();
+            _mainWindow.TemplatesWindow.StartNetworking();
         }
     }
 
@@ -179,6 +180,7 @@ public class Plugin : IDalamudPlugin
         _chatWindow.StopNetworking();
         _officerChatWindow.StopNetworking();
         _ui.StopNetworking();
+        _mainWindow.TemplatesWindow.StopNetworking();
     }
 
     private async Task<bool> RefreshRoles(IPluginLog log)

--- a/tests/TemplatesWindowPreviewTests.cs
+++ b/tests/TemplatesWindowPreviewTests.cs
@@ -32,13 +32,10 @@ public class TemplatesWindowPreviewTests
     public void Preview_Reopens_After_Close_And_Selection_Disposes()
     {
         var config = new Config();
-        config.TemplateData.Add(new Template { Name = "One", Title = "T1", Description = "D1" });
-        config.TemplateData.Add(new Template { Name = "Two", Title = "T2", Description = "D2" });
-
         var http = new HttpClient(new StubHandler());
         var window = new TemplatesWindow(config, http);
 
-        var firstTmpl = config.TemplateData[0];
+        var firstTmpl = new Template { Name = "One", Title = "T1", Description = "D1" };
         window.SelectTemplate(0, firstTmpl);
         window.OpenPreview(firstTmpl);
         var first = GetPreviewEvent(window);
@@ -52,7 +49,7 @@ public class TemplatesWindowPreviewTests
         Assert.NotNull(second);
         Assert.NotSame(first, second);
 
-        var secondTmpl = config.TemplateData[1];
+        var secondTmpl = new Template { Name = "Two", Title = "T2", Description = "D2" };
         window.SelectTemplate(1, secondTmpl);
         Assert.False(GetShowPreview(window));
         Assert.Null(GetPreviewEvent(window));

--- a/tests/test_templates_sync.py
+++ b/tests/test_templates_sync.py
@@ -1,0 +1,101 @@
+import types
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+# Setup module paths
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+# Package stubs
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+# Stubs for RequestContext
+deps_pkg = types.ModuleType("demibot.http.deps")
+class RequestContext:
+    def __init__(self, guild, roles):
+        self.guild = guild
+        self.roles = roles
+async def api_key_auth(*args, **kwargs):
+    pass
+deps_pkg.RequestContext = RequestContext
+deps_pkg.api_key_auth = api_key_auth
+sys.modules.setdefault("demibot.http.deps", deps_pkg)
+
+# Minimal discord/fastapi stubs
+sys.modules.setdefault("discord", types.ModuleType("discord"))
+fastapi_stub = types.ModuleType("fastapi")
+fastapi_stub.WebSocket = type("WebSocket", (), {})
+fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (Exception,), {})
+sys.modules.setdefault("fastapi", fastapi_stub)
+
+from demibot.http.ws import ConnectionManager
+from demibot.http.routes import templates
+from demibot.db.models import Guild, GuildChannel, ChannelKind
+from demibot.db.session import init_db, get_session
+from demibot.http.schemas import TemplatePayload
+
+class StubWebSocket:
+    def __init__(self, path: str):
+        self.scope = {"path": path}
+        self.sent: list[str] = []
+
+    async def accept(self):
+        pass
+
+    async def send_text(self, message: str):
+        self.sent.append(message)
+
+    async def ping(self):
+        return None
+
+class StubContext:
+    def __init__(self, guild_id: int, roles):
+        self.guild = types.SimpleNamespace(id=guild_id)
+        self.roles = roles
+
+def test_template_create_delete_sync(monkeypatch):
+    async def _run():
+        mgr = ConnectionManager()
+        monkeypatch.setattr(templates, "manager", mgr)
+
+        ws1 = StubWebSocket("/ws/templates")
+        ws2 = StubWebSocket("/ws/templates")
+        ctx1 = StubContext(1, [])
+        ctx2 = StubContext(1, [])
+        await mgr.connect(ws1, ctx1)
+        await mgr.connect(ws2, ctx2)
+
+        db_path = Path("test_templates_sync.db")
+        if db_path.exists():
+            db_path.unlink()
+        await init_db(f"sqlite+aiosqlite:///{db_path}")
+        async with get_session() as db:
+            guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
+            db.add(guild)
+            db.add(GuildChannel(guild_id=guild.id, channel_id=123, kind=ChannelKind.EVENT))
+            await db.commit()
+
+        payload = TemplatePayload(channelId="123", title="Test", time="2024-01-01T00:00:00Z", description="desc")
+        body = templates.TemplateCreateBody(name="Raid", description="templ", payload=payload)
+        ctx = StubContext(1, [])
+        async with get_session() as db:
+            dto = await templates.create_template(body=body, ctx=ctx, db=db)
+            msg1 = json.loads(ws1.sent[0])
+            msg2 = json.loads(ws2.sent[0])
+            assert msg1 == msg2
+            assert msg1["topic"] == "templates.updated"
+            assert msg1["payload"]["id"] == dto.id
+            ws1.sent.clear(); ws2.sent.clear()
+            await templates.delete_template(template_id=dto.id, ctx=ctx, db=db)
+            msg1 = json.loads(ws1.sent[0])
+            msg2 = json.loads(ws2.sent[0])
+            assert msg1 == msg2
+            assert msg1["payload"] == {"id": dto.id, "deleted": True}
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Load and manage templates via `/api/templates` instead of local config
- Allow deleting templates and sync updates through `templates.updated` websocket
- Save templates through API and add end-to-end tests for template sync

## Testing
- ⚠️ `dotnet test` *(command not found)*
- ⚠️ `pytest` *(54 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e7cff61883289fc54d1f66e9cc47