### PR TITLE
Auto-size template buttons and wrap rows

### DIFF
--- a/DemiCat.UI/ButtonRows.cs
+++ b/DemiCat.UI/ButtonRows.cs
@@ -49,6 +49,10 @@ public sealed class ButtonRows
     {
         if (!CanAddToRow(row)) return;
         _rows[row].Add(data ?? new ButtonData { Label = "New Button" });
+
+        if (_rows[row].Count == MaxPerRow && _rows.Count < MaxRows && TotalCount < MaxTotal)
+            _rows.Insert(row + 1, new());
+
         Normalize();
     }
 

--- a/DemiCat.UI/ButtonSizeHelper.cs
+++ b/DemiCat.UI/ButtonSizeHelper.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace DemiCat.UI;
+
+public static class ButtonSizeHelper
+{
+    public const int Max = 200;
+    public const int DefaultHeight = 40;
+
+    public static int ComputeWidth(string label)
+    {
+        if (string.IsNullOrWhiteSpace(label)) return 0;
+        // Approximate width: 8px per character plus padding.
+        var width = label.Length * 8 + 24;
+        return Math.Min(width, Max);
+    }
+}

--- a/DemiCatPlugin/ButtonRowsImGui.cs
+++ b/DemiCatPlugin/ButtonRowsImGui.cs
@@ -28,6 +28,19 @@ public static class ButtonRowsImGui
                 if (ImGui.InputText("##label", ref buf, 128))
                     state.SetLabel(r, c, buf);
 
+                var width = state.Rows[r][c].Width ?? 0;
+                if (ImGui.InputInt("Width", ref width))
+                    state.Rows[r][c].Width = width > 0 ? Math.Min(width, ButtonSizeHelper.Max) : null;
+                ImGui.SameLine();
+                var autoW = ButtonSizeHelper.ComputeWidth(state.Rows[r][c].Label);
+                ImGui.Text($"Auto: {autoW}");
+
+                var height = state.Rows[r][c].Height ?? 0;
+                if (ImGui.InputInt("Height", ref height))
+                    state.Rows[r][c].Height = height > 0 ? Math.Min(height, ButtonSizeHelper.Max) : null;
+                ImGui.SameLine();
+                ImGui.Text($"Auto: {ButtonSizeHelper.DefaultHeight}");
+
                 ImGui.SameLine();
                 if (ImGui.Button("Remove"))
                 {

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Globalization;
 using Dalamud.Bindings.ImGui;
 using DiscordHelper;
+using DemiCat.UI;
 
 namespace DemiCatPlugin;
 
@@ -580,8 +581,8 @@ public class EventCreateWindow
                     Emoji = string.IsNullOrWhiteSpace(b.Emoji) ? null : b.Emoji,
                     Style = b.Style,
                     MaxSignups = b.MaxSignups,
-                    Width = b.Width,
-                    Height = b.Height,
+                    Width = Math.Min(b.Width ?? ButtonSizeHelper.ComputeWidth(b.Label), ButtonSizeHelper.Max),
+                    Height = Math.Min(b.Height ?? ButtonSizeHelper.DefaultHeight, ButtonSizeHelper.Max),
                     RowIndex = i / 5
                 })
                 .ToList()

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -3,6 +3,7 @@ using Dalamud.Bindings.ImGui;
 using DiscordHelper;
 using System.Numerics;
 using System.Net.Http;
+using DemiCat.UI;
 
 namespace DemiCatPlugin;
 
@@ -88,13 +89,17 @@ public class SignupOptionEditor
             var width = _working.Width ?? 0;
             if (ImGui.InputInt("Width", ref width))
             {
-                _working.Width = width > 0 ? width : null;
+                _working.Width = width > 0 ? Math.Min(width, ButtonSizeHelper.Max) : null;
             }
+            ImGui.SameLine();
+            ImGui.Text($"Auto: {ButtonSizeHelper.ComputeWidth(_working.Label)}");
             var height = _working.Height ?? 0;
             if (ImGui.InputInt("Height", ref height))
             {
-                _working.Height = height > 0 ? height : null;
+                _working.Height = height > 0 ? Math.Min(height, ButtonSizeHelper.Max) : null;
             }
+            ImGui.SameLine();
+            ImGui.Text($"Auto: {ButtonSizeHelper.DefaultHeight}");
             var style = _working.Style.ToString();
             if (ImGui.BeginCombo("Style", style))
             {
@@ -119,8 +124,8 @@ public class SignupOptionEditor
                     Emoji = _working.Emoji,
                     Style = _working.Style,
                     MaxSignups = _working.MaxSignups,
-                    Width = _working.Width,
-                    Height = _working.Height
+                    Width = _working.Width ?? ButtonSizeHelper.ComputeWidth(_working.Label),
+                    Height = _working.Height ?? ButtonSizeHelper.DefaultHeight
                 });
                 _open = false;
                 ImGui.CloseCurrentPopup();

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -485,8 +485,8 @@ public class TemplatesWindow
                     (int)(b?.Style ?? x.Data.Style),
                     NormalizeEmoji(b?.Emoji ?? x.Data.Emoji),
                     b?.MaxSignups ?? x.Data.MaxSignups,
-                    b?.Width ?? x.Data.Width,
-                    b?.Height ?? x.Data.Height);
+                    Math.Min(b?.Width ?? x.Data.Width ?? ButtonSizeHelper.ComputeWidth(label), ButtonSizeHelper.Max),
+                    Math.Min(b?.Height ?? x.Data.Height ?? ButtonSizeHelper.DefaultHeight, ButtonSizeHelper.Max));
             })
             .ToList();
     }

--- a/tests/ButtonRowsHelperTests.cs
+++ b/tests/ButtonRowsHelperTests.cs
@@ -41,4 +41,16 @@ public class ButtonRowsHelperTests
         Assert.NotEqual(id1, id3);
         Assert.NotEqual(id2, id3);
     }
+
+    [Fact]
+    public void ButtonsWrapAfterFive()
+    {
+        var rows = new ButtonRows(new() { new() });
+        for (var i = 0; i < 6; i++)
+            rows.AddButton(rows.Rows.Count - 1, new ButtonData { Label = i.ToString() });
+
+        Assert.Equal(2, rows.Rows.Count);
+        Assert.Equal(5, rows.Rows[0].Count);
+        Assert.Single(rows.Rows[1]);
+    }
 }

--- a/tests/EventButtonWidthTests.cs
+++ b/tests/EventButtonWidthTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DemiCatPlugin;
+using DemiCat.UI;
+using DiscordHelper;
+using Xunit;
+
+public class EventButtonWidthTests
+{
+    private class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+    }
+
+    [Fact]
+    public void BuildPreview_ComputesButtonWidth()
+    {
+        var config = new Config();
+        var http = new HttpClient(new StubHandler());
+        var channelService = new ChannelService(config, http, new TokenManager());
+        var window = new EventCreateWindow(config, http, channelService);
+        var buttonsField = typeof(EventCreateWindow).GetField("_buttons", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        buttonsField.SetValue(window, new List<Template.TemplateButton>
+        {
+            new() { Tag = "s", Label = "Short", Include = true },
+            new() { Tag = "l", Label = "A much longer label", Include = true }
+        });
+
+        var preview = (EmbedDto)typeof(EventCreateWindow)
+            .GetMethod("BuildPreview", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(window, System.Array.Empty<object>())!;
+        var btns = preview.Buttons!;
+        Assert.Equal(ButtonSizeHelper.ComputeWidth("Short"), btns[0].Width);
+        Assert.Equal(ButtonSizeHelper.ComputeWidth("A much longer label"), btns[1].Width);
+        Assert.True(btns[1].Width > btns[0].Width);
+    }
+}

--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -40,8 +40,8 @@ public class TemplateButtonRoundTripTests
         Assert.Equal(ButtonStyle.Primary, btn.Style);
         Assert.Null(btn.Emoji);
         Assert.Null(btn.MaxSignups);
-        Assert.Null(btn.Width);
-        Assert.Null(btn.Height);
+        Assert.Equal(ButtonSizeHelper.ComputeWidth("Signup"), btn.Width);
+        Assert.Equal(ButtonSizeHelper.DefaultHeight, btn.Height);
     }
 
     [Fact]
@@ -58,8 +58,8 @@ public class TemplateButtonRoundTripTests
 
         Assert.Null(btn.emoji);
         Assert.Null(btn.maxSignups);
-        Assert.Null(btn.width);
-        Assert.Null(btn.height);
+        Assert.Equal(ButtonSizeHelper.ComputeWidth("Join"), btn.width);
+        Assert.Equal(ButtonSizeHelper.DefaultHeight, btn.height);
     }
 
     [Fact]
@@ -96,5 +96,17 @@ public class TemplateButtonRoundTripTests
         Assert.NotEqual(payload[0].customId, payload[1].customId);
         Assert.NotEqual(payload[0].customId, payload[2].customId);
         Assert.NotEqual(payload[1].customId, payload[2].customId);
+    }
+
+    [Fact]
+    public void BuildButtonsPayload_ComputesWidthFromLabel()
+    {
+        var rows = new ButtonRows(new() { new() { new ButtonData { Label = "Short" }, new ButtonData { Label = "Much Longer Label" } } });
+        var window = CreateWindow(rows);
+
+        var payload = window.BuildButtonsPayload(new Template());
+        Assert.Equal(ButtonSizeHelper.ComputeWidth("Short"), payload[0].width);
+        Assert.Equal(ButtonSizeHelper.ComputeWidth("Much Longer Label"), payload[1].width);
+        Assert.True(payload[1].width > payload[0].width);
     }
 }


### PR DESCRIPTION
## Summary
- auto-add a new button row when one fills up
- preview button width/height and clamp to maximum size
- compute button width from label text when no custom size

## Testing
- `dotnet test` *(fails: .NET SDK 9.0.100 not installed)*
- `pytest` *(fails: missing modules discord, fastapi, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e9ab1108832890787953bd7f5c51