### PR TITLE
Restore selection tracking in chat input

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -518,7 +518,12 @@ public class ChatWindow : IDisposable
         }
 
         var inputBuf = MakeUtf8Buffer(_input, 512);
-        var send = ImGui.InputText("##chatInput", inputBuf, ImGuiInputTextFlags.EnterReturnsTrue);
+        var send = ImGui.InputText(
+            "##chatInput",
+            inputBuf,
+            ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
+            new ImGui.ImGuiInputTextCallbackDelegate(OnInputEdited)
+        );
         _input = ReadUtf8Buffer(inputBuf);
 
         ImGui.SameLine();
@@ -702,6 +707,13 @@ public class ChatWindow : IDisposable
         text = Regex.Replace(text, "\\[/(?:B|I|U)\\]", "");
         text = Regex.Replace(text, "\\[LINK=([^\\]]+)\\](.+?)\\[/LINK\\]", "$2 ($1)");
         ImGui.TextUnformatted(text);
+    }
+
+    private unsafe int OnInputEdited(ImGuiInputTextCallbackData* data)
+    {
+        _selectionStart = data->SelectionStart;
+        _selectionEnd = data->SelectionEnd;
+        return 0;
     }
 
     private void WrapSelection(string prefix, string suffix)


### PR DESCRIPTION
## Summary
- Track chat input selection to enable formatting actions

## Testing
- `dotnet test` *(fails: command not found)*
- `bash /tmp/dotnet-install.sh --channel 9.0 --quality preview` *(fails: failed to locate 9.0 preview)*
- `pytest` *(fails: 54 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f2bacfbc8328a8e094a6e1202d5b