### PR TITLE
Restore selection tracking in chat input

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -517,8 +517,13 @@ public class ChatWindow : IDisposable
             FormatContent(preview);
         }
 
-        var inputBuf = MakeUtf8Buffer(_input, 512);
-        var send = ImGui.InputText("##chatInput", inputBuf, ImGuiInputTextFlags.EnterReturnsTrue);
+        var inputBuf = MakeUtf8Buffer(_input, 2048);
+        var send = ImGui.InputText(
+            "##chatInput",
+            inputBuf,
+            ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
+            new ImGui.ImGuiInputTextCallbackDelegate(OnInputEdited)
+        );
         _input = ReadUtf8Buffer(inputBuf);
 
         ImGui.SameLine();
@@ -702,6 +707,14 @@ public class ChatWindow : IDisposable
         text = Regex.Replace(text, "\\[/(?:B|I|U)\\]", "");
         text = Regex.Replace(text, "\\[LINK=([^\\]]+)\\](.+?)\\[/LINK\\]", "$2 ($1)");
         ImGui.TextUnformatted(text);
+    }
+
+    private unsafe nint OnInputEdited(ImGuiInputTextCallbackData* data)
+    {
+        if (data == null) return 0;
+        _selectionStart = data->SelectionStart;
+        _selectionEnd = data->SelectionEnd;
+        return 0;
     }
 
     private void WrapSelection(string prefix, string suffix)


### PR DESCRIPTION
## Summary
- Track chat input selection to enable formatting actions
- Expand chat and edit buffers to 2048 bytes to avoid truncation
- Guard the selection callback against null pointers
- Fix input callback return type to match ImGui delegate

## Testing
- `bash /tmp/dotnet-install.sh --channel 9.0 --quality preview` *(fails: Failed to locate the latest version in the channel '9.0' with 'preview' quality for 'dotnet-sdk')*
- `~/.dotnet/dotnet test` *(fails: No such file or directory)*
- `pip install fastapi sqlalchemy discord.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'alembic', etc.; RuntimeError: starlette.testclient requires httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f2bacfbc8328a8e094a6e1202d5b