### PR TITLE
Remove default button emojis and disallow height customization

### DIFF
--- a/DemiCatPlugin/ButtonRowsImGui.cs
+++ b/DemiCatPlugin/ButtonRowsImGui.cs
@@ -35,12 +35,6 @@ public static class ButtonRowsImGui
                 var autoW = ButtonSizeHelper.ComputeWidth(state.Rows[r][c].Label);
                 ImGui.Text($"Auto: {autoW}");
 
-                var height = state.Rows[r][c].Height ?? 0;
-                if (ImGui.InputInt("Height", ref height))
-                    state.Rows[r][c].Height = height > 0 ? Math.Min(height, ButtonSizeHelper.Max) : null;
-                ImGui.SameLine();
-                ImGui.Text($"Auto: {ButtonSizeHelper.DefaultHeight}");
-
                 ImGui.SameLine();
                 if (ImGui.Button("Remove"))
                 {

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -708,21 +708,18 @@ public class EventCreateWindow
         {
             Tag = "yes",
             Label = "Yes",
-            Emoji = "✅",
             Style = ButtonStyle.Success
         });
         _buttons.Add(new Template.TemplateButton
         {
             Tag = "maybe",
             Label = "Maybe",
-            Emoji = "❔",
             Style = ButtonStyle.Secondary
         });
         _buttons.Add(new Template.TemplateButton
         {
             Tag = "no",
             Label = "No",
-            Emoji = "❌",
             Style = ButtonStyle.Danger
         });
     }

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -29,8 +29,7 @@ public class SignupOptionEditor
             Emoji = button.Emoji,
             Style = button.Style,
             MaxSignups = button.MaxSignups,
-            Width = button.Width,
-            Height = button.Height
+            Width = button.Width
         };
         _onSave = onSave;
         _open = true;
@@ -93,13 +92,6 @@ public class SignupOptionEditor
             }
             ImGui.SameLine();
             ImGui.Text($"Auto: {ButtonSizeHelper.ComputeWidth(_working.Label)}");
-            var height = _working.Height ?? 0;
-            if (ImGui.InputInt("Height", ref height))
-            {
-                _working.Height = height > 0 ? Math.Min(height, ButtonSizeHelper.Max) : null;
-            }
-            ImGui.SameLine();
-            ImGui.Text($"Auto: {ButtonSizeHelper.DefaultHeight}");
             var style = _working.Style.ToString();
             if (ImGui.BeginCombo("Style", style))
             {
@@ -125,7 +117,7 @@ public class SignupOptionEditor
                     Style = _working.Style,
                     MaxSignups = _working.MaxSignups,
                     Width = _working.Width ?? ButtonSizeHelper.ComputeWidth(_working.Label),
-                    Height = _working.Height ?? ButtonSizeHelper.DefaultHeight
+                    Height = ButtonSizeHelper.DefaultHeight
                 });
                 _open = false;
                 ImGui.CloseCurrentPopup();


### PR DESCRIPTION
## Summary
- Stop adding emoji text to default RSVP buttons
- Remove button height customization from sign-up editor and button row editor

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest` *(fails: 54 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c160cc7fe48328bf2f4bcbe0aee831