### PR TITLE
Maintain chat input visibility with dynamic scroll height

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -201,7 +201,10 @@ public class ChatWindow : IDisposable
             SaveConfig();
         }
 
-        var scrollRegionHeight = -ImGui.GetFrameHeightWithSpacing() * 2;
+        // Calculate available space and reserve room for the input section so it remains visible
+        var availableHeight = ImGui.GetContentRegionAvail().Y;
+        var inputSectionHeight = ImGui.GetFrameHeightWithSpacing() * 8;
+        var scrollRegionHeight = MathF.Max(1f, availableHeight - inputSectionHeight);
         ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), true);
         var clipper = new ImGuiListClipper();
         clipper.Begin(_messages.Count);


### PR DESCRIPTION
## Summary
- reserve room for the input area when calculating chat scroll height

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: No module named 'discord', 'fastapi', 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68c1645368e4832880e5b8707fff7c37