### PR TITLE
Add vertical padding before settings gear and tab bar

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -95,9 +95,10 @@ public class MainWindow : IDisposable
         }
 
         var padding = ImGui.GetStyle().FramePadding;
+        ImGui.Dummy(new Vector2(0f, padding.Y));
         var buttonSize = ImGui.GetFrameHeight();
         var cursor = ImGui.GetCursorPos();
-        ImGui.SetCursorPos(new Vector2(ImGui.GetWindowContentRegionMax().X - buttonSize - padding.X, padding.Y));
+        ImGui.SetCursorPos(new Vector2(ImGui.GetWindowContentRegionMax().X - buttonSize - padding.X, cursor.Y));
         if (ImGui.Button("\u2699"))
         {
             _settings.IsOpen = true;


### PR DESCRIPTION
## Summary
- add vertical padding before settings button and tab bar

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68c166ba3fe48328b92e3528c50c553f