### PR TITLE
Handle channels without cursor

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1068,8 +1068,8 @@ public class ChatWindow : IDisposable
             const int PageSize = 50;
             var all = new List<DiscordMessageDto>();
             string? before = null;
-            _config.ChatCursors.TryGetValue(_channelId, out var since);
-            var after = since > 0 ? since.ToString() : null;
+            var hasCursor = _config.ChatCursors.TryGetValue(_channelId, out var since);
+            var after = hasCursor ? since.ToString() : null;
             while (all.Count < MaxMessages)
             {
                 var url = $"{_config.ApiBaseUrl.TrimEnd('/')}{MessagesPath}/{_channelId}?limit={PageSize}";

--- a/tests/ChatWindowMessageLimitTests.cs
+++ b/tests/ChatWindowMessageLimitTests.cs
@@ -49,6 +49,25 @@ public class ChatWindowMessageLimitTests
     }
 
     [Fact]
+    public async Task RefreshMessages_NoCursorRequestsLatest()
+    {
+        SetupServices();
+        var config = new Config { ApiBaseUrl = "http://localhost", ChatChannelId = "1" };
+        var handler = new SequenceHandler();
+        using var client = new HttpClient(handler);
+        var tm = new TokenManager();
+        var channelService = new ChannelService(config, client, tm);
+        var window = new ChatWindow(config, client, null, tm, channelService);
+
+        handler.EnqueueResponse(SerializeMessages(1, 20));
+        await window.RefreshMessages();
+
+        Assert.Single(handler.Requests);
+        Assert.DoesNotContain("after=", handler.Requests[0].Query);
+        Assert.Equal(20, config.ChatCursors["1"]);
+    }
+
+    [Fact]
     public void HandleBridgeMessage_TrimsOldMessages()
     {
         SetupServices();


### PR DESCRIPTION
## Summary
- avoid `after` parameter when refreshing a channel with no cursor yet
- cover no-cursor scenario with unit test

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found; requires Dalamud environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c167d488ec83289feb3b6389236b05