### PR TITLE
Centralize RGB↔ABGR conversions for preview rendering

### DIFF
--- a/DemiCatPlugin/ColorUtils.cs
+++ b/DemiCatPlugin/ColorUtils.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace DemiCatPlugin;
 
 public static class ColorUtils
@@ -17,4 +19,17 @@ public static class ColorUtils
         var b = (abgr >> 16) & 0xFF;
         return (r << 16) | (g << 8) | b;
     }
+
+    public static uint RgbToImGui(uint rgb)
+        => RgbToAbgr(rgb) | 0xFF000000;
+
+    public static uint ImGuiToRgb(uint color)
+        => AbgrToRgb(color & 0xFFFFFF);
+
+    public static Vector3 ImGuiToVector(uint color)
+        => new((color & 0xFF) / 255f, ((color >> 8) & 0xFF) / 255f, ((color >> 16) & 0xFF) / 255f);
+
+    public static uint VectorToImGui(Vector3 color)
+        => ((uint)(color.X * 255)) | ((uint)(color.Y * 255) << 8) | ((uint)(color.Z * 255) << 16) | 0xFF000000;
 }
+

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -149,7 +149,8 @@ public static class EmbedPreviewRenderer
         {
             var min = ImGui.GetItemRectMin();
             var max = ImGui.GetItemRectMax();
-            ImGui.GetWindowDrawList().AddRectFilled(min, new Vector2(min.X + stripeWidth, max.Y), dto.Color.Value | 0xFF000000);
+            var color = ColorUtils.RgbToImGui(dto.Color.Value);
+            ImGui.GetWindowDrawList().AddRectFilled(min, new Vector2(min.X + stripeWidth, max.Y), color);
         }
     }
 

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -134,15 +134,10 @@ public class EventCreateWindow
         ImGui.InputText("URL", ref _url, 260);
         ImGui.InputText("Image URL", ref _imageUrl, 260);
         ImGui.InputText("Thumbnail URL", ref _thumbnailUrl, 260);
-        var colorVec = new Vector3(
-            (_color & 0xFF) / 255f,
-            ((_color >> 8) & 0xFF) / 255f,
-            ((_color >> 16) & 0xFF) / 255f);
+        var colorVec = ColorUtils.ImGuiToVector(_color);
         if (ImGui.ColorEdit3("Color", ref colorVec))
         {
-            _color = ((uint)(colorVec.X * 255)) |
-                     ((uint)(colorVec.Y * 255) << 8) |
-                     ((uint)(colorVec.Z * 255) << 16);
+            _color = ColorUtils.VectorToImGui(colorVec);
         }
 
         if (!_rolesLoaded)
@@ -399,7 +394,7 @@ public class EventCreateWindow
         _url = template.Url;
         _imageUrl = template.ImageUrl;
         _thumbnailUrl = template.ThumbnailUrl;
-        _color = ColorUtils.RgbToAbgr(template.Color);
+        _color = ColorUtils.RgbToImGui(template.Color);
         _mentions.Clear();
         if (template.Mentions != null)
         {
@@ -566,7 +561,7 @@ public class EventCreateWindow
             Url = string.IsNullOrWhiteSpace(_url) ? null : _url,
             ImageUrl = string.IsNullOrWhiteSpace(_imageUrl) ? null : _imageUrl,
             ThumbnailUrl = string.IsNullOrWhiteSpace(_thumbnailUrl) ? null : _thumbnailUrl,
-            Color = _color > 0 ? (uint?)ColorUtils.AbgrToRgb(_color) : null,
+            Color = _color > 0 ? (uint?)ColorUtils.ImGuiToRgb(_color) : null,
             Timestamp = DateTime.TryParse(_time, null, DateTimeStyles.AdjustToUniversal, out var ts) ? ts : (DateTimeOffset?)null,
             Fields = _fields
                 .Where(f => !string.IsNullOrWhiteSpace(f.Name) && !string.IsNullOrWhiteSpace(f.Value))

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -71,7 +71,7 @@ public class EventView : IDisposable
 
         if (dto.Color.HasValue)
         {
-            var color = ColorUtils.RgbToAbgr(dto.Color.Value) | 0xFF000000;
+            var color = ColorUtils.RgbToImGui(dto.Color.Value);
             var dl = ImGui.GetWindowDrawList();
             var p = ImGui.GetCursorScreenPos();
             var end = new Vector2(p.X + 4, p.Y + ImGui.GetTextLineHeightWithSpacing() * 3);

--- a/tests/ColorConversionTests.cs
+++ b/tests/ColorConversionTests.cs
@@ -40,6 +40,20 @@ public class ColorConversionTests
         Assert.Equal(rgb, back);
     }
 
+    [Theory]
+    [InlineData(0xFF0000)]
+    [InlineData(0x00FF00)]
+    [InlineData(0x0000FF)]
+    [InlineData(0x123456)]
+    [InlineData(0xABCDEF)]
+    public void ImGuiVectorRoundTrip(uint rgb)
+    {
+        var imGui = ColorUtils.RgbToImGui(rgb);
+        var vec = ColorUtils.ImGuiToVector(imGui);
+        var back = ColorUtils.ImGuiToRgb(ColorUtils.VectorToImGui(vec));
+        Assert.Equal(rgb, back);
+    }
+
     private class StubHandler : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -58,7 +72,7 @@ public class ColorConversionTests
         var channelService = new ChannelService(config, http, new TokenManager());
         var window = new EventCreateWindow(config, http, channelService);
         typeof(EventCreateWindow).GetField("_color", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .SetValue(window, ColorUtils.RgbToAbgr(rgb));
+            .SetValue(window, ColorUtils.RgbToImGui(rgb));
         var preview = (EmbedDto)typeof(EventCreateWindow).GetMethod("BuildPreview", BindingFlags.NonPublic | BindingFlags.Instance)!
             .Invoke(window, Array.Empty<object>())!;
         Assert.Equal(rgb, preview.Color);


### PR DESCRIPTION
## Summary
- centralize RGB<->ABGR conversions with new ColorUtils helpers
- use helpers in event color picker and preview rendering
- add unit tests for color round-tripping

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord' and other missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68c16ab71a38832883447d63ba220c20