### PR TITLE
Remove button height from embed buttons

### DIFF
--- a/DemiCat.UI/ButtonData.cs
+++ b/DemiCat.UI/ButtonData.cs
@@ -11,5 +11,4 @@ public class ButtonData
     public string? Emoji { get; set; }
     public int? MaxSignups { get; set; }
     public int? Width { get; set; }
-    public int? Height { get; set; }
 }

--- a/DemiCatPlugin/EmbedDto.cs
+++ b/DemiCatPlugin/EmbedDto.cs
@@ -45,7 +45,6 @@ public class EmbedButtonDto
     public ButtonStyle? Style { get; set; }
     public int? MaxSignups { get; set; }
     public int? Width { get; set; }
-    public int? Height { get; set; }
     public int? RowIndex { get; set; }
 }
 

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -137,8 +137,7 @@ public static class EmbedPreviewRenderer
                     }
 
                     var w = button.Width ?? -1;
-                    var h = button.Height ?? 0;
-                    if (ImGui.Button($"{text}##{id}{dto.Id}", new Vector2(w, h)))
+                    if (ImGui.Button($"{text}##{id}{dto.Id}", new Vector2(w, 0)))
                     {
                         if (!string.IsNullOrEmpty(button.Url))
                         {

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -107,8 +107,7 @@ public static class EmbedRenderer
                     }
 
                     var w = button.Width ?? -1;
-                    var h = button.Height ?? 0;
-                    if (ImGui.Button($"{text}##{id}{dto.Id}", new Vector2(w, h)))
+                    if (ImGui.Button($"{text}##{id}{dto.Id}", new Vector2(w, 0)))
                     {
                         if (!string.IsNullOrEmpty(button.Url))
                         {

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -426,8 +426,7 @@ public class EventCreateWindow
                     Emoji = b.Emoji,
                     Style = b.Style,
                     MaxSignups = b.MaxSignups,
-                    Width = b.Width,
-                    Height = b.Height
+                    Width = b.Width
                 });
             }
         }
@@ -459,7 +458,7 @@ public class EventCreateWindow
                 thumbnailUrl = dto.ThumbnailUrl,
                 color = dto.Color,
                 fields = dto.Fields?.Select(f => new { name = f.Name, value = f.Value, inline = f.Inline }).ToList(),
-                buttons = buttons.Select(b => new { label = b.Label, customId = b.CustomId, style = b.Style.HasValue ? (int?)b.Style : null, emoji = b.Emoji, maxSignups = b.MaxSignups, width = b.Width, height = b.Height, rowIndex = b.RowIndex }).ToList(),
+                buttons = buttons.Select(b => new { label = b.Label, customId = b.CustomId, style = b.Style.HasValue ? (int?)b.Style : null, emoji = b.Emoji, maxSignups = b.MaxSignups, width = b.Width, rowIndex = b.RowIndex }).ToList(),
                 mentions = _mentions.Count > 0 ? _mentions.ToList() : null
             };
             var body = new
@@ -510,7 +509,7 @@ public class EventCreateWindow
                 thumbnailUrl = dto.ThumbnailUrl,
                 color = dto.Color,
                 fields = dto.Fields?.Select(f => new { name = f.Name, value = f.Value, inline = f.Inline }).ToList(),
-                buttons = buttons.Select(b => new { label = b.Label, customId = b.CustomId, url = b.Url, emoji = b.Emoji, style = b.Style.HasValue ? (int)b.Style : (int?)null, maxSignups = b.MaxSignups, width = b.Width, height = b.Height }).ToList(),
+                buttons = buttons.Select(b => new { label = b.Label, customId = b.CustomId, url = b.Url, emoji = b.Emoji, style = b.Style.HasValue ? (int)b.Style : (int?)null, maxSignups = b.MaxSignups, width = b.Width }).ToList(),
                 mentions = _mentions.Count > 0 ? _mentions.Select(ulong.Parse).ToList() : null,
                 repeat = _repeat == RepeatOption.None ? null : _repeat.ToString().ToLowerInvariant()
             };
@@ -533,19 +532,18 @@ public class EventCreateWindow
         _buttons.Clear();
         foreach (var b in preset.Buttons)
         {
-            _buttons.Add(new Template.TemplateButton
-            {
-                Tag = b.Tag,
-                Include = b.Include,
-                Label = b.Label,
-                Emoji = b.Emoji,
-                Style = b.Style,
-                MaxSignups = b.MaxSignups,
-                Width = b.Width,
-                Height = b.Height
-            });
+                _buttons.Add(new Template.TemplateButton
+                {
+                    Tag = b.Tag,
+                    Include = b.Include,
+                    Label = b.Label,
+                    Emoji = b.Emoji,
+                    Style = b.Style,
+                    MaxSignups = b.MaxSignups,
+                    Width = b.Width
+                });
+            }
         }
-    }
 
     private void SaveConfig()
     {
@@ -577,7 +575,6 @@ public class EventCreateWindow
                     Style = b.Style,
                     MaxSignups = b.MaxSignups,
                     Width = Math.Min(b.Width ?? ButtonSizeHelper.ComputeWidth(b.Label), ButtonSizeHelper.Max),
-                    Height = Math.Min(b.Height ?? ButtonSizeHelper.DefaultHeight, ButtonSizeHelper.Max),
                     RowIndex = i / 5
                 })
                 .ToList()
@@ -681,8 +678,7 @@ public class EventCreateWindow
                 Emoji = b.Emoji,
                 Style = b.Style,
                 MaxSignups = b.MaxSignups,
-                Width = b.Width,
-                Height = b.Height
+                Width = b.Width
             }).ToList()
         };
         _ = SignupPresetService.Create(preset, _httpClient, _config);

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -116,8 +116,7 @@ public class SignupOptionEditor
                     Emoji = _working.Emoji,
                     Style = _working.Style,
                     MaxSignups = _working.MaxSignups,
-                    Width = _working.Width ?? ButtonSizeHelper.ComputeWidth(_working.Label),
-                    Height = ButtonSizeHelper.DefaultHeight
+                    Width = _working.Width ?? ButtonSizeHelper.ComputeWidth(_working.Label)
                 });
                 _open = false;
                 ImGui.CloseCurrentPopup();

--- a/DemiCatPlugin/Template.cs
+++ b/DemiCatPlugin/Template.cs
@@ -38,7 +38,6 @@ public class Template
         public ButtonStyle Style { get; set; } = ButtonStyle.Secondary;
         public int? MaxSignups { get; set; }
         public int? Width { get; set; }
-        public int? Height { get; set; }
     }
 }
 

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -265,8 +265,7 @@ public class TemplatesWindow
                 Style = b.Style,
                 Emoji = string.IsNullOrWhiteSpace(b.Emoji) ? null : b.Emoji,
                 MaxSignups = b.MaxSignups,
-                Width = b.Width,
-                Height = b.Height
+                Width = b.Width
             }).ToList())
             .ToList();
 
@@ -465,8 +464,7 @@ public class TemplatesWindow
         int style,
         string? emoji,
         int? maxSignups,
-        int? width,
-        int? height);
+        int? width);
 
     internal List<ButtonPayload> BuildButtonsPayload(Template tmpl)
     {
@@ -485,8 +483,7 @@ public class TemplatesWindow
                     (int)(b?.Style ?? x.Data.Style),
                     NormalizeEmoji(b?.Emoji ?? x.Data.Emoji),
                     b?.MaxSignups ?? x.Data.MaxSignups,
-                    Math.Min(b?.Width ?? x.Data.Width ?? ButtonSizeHelper.ComputeWidth(label), ButtonSizeHelper.Max),
-                    Math.Min(b?.Height ?? x.Data.Height ?? ButtonSizeHelper.DefaultHeight, ButtonSizeHelper.Max));
+                    Math.Min(b?.Width ?? x.Data.Width ?? ButtonSizeHelper.ComputeWidth(label), ButtonSizeHelper.Max));
             })
             .ToList();
     }
@@ -522,7 +519,6 @@ public class TemplatesWindow
                 Emoji = b.emoji,
                 MaxSignups = b.maxSignups,
                 Width = b.width,
-                Height = b.height,
                 RowIndex = b.rowIndex
             })
             .ToList();
@@ -683,8 +679,7 @@ public class TemplatesWindow
                 Emoji = b.Emoji ?? string.Empty,
                 Style = b.Style ?? ButtonStyle.Secondary,
                 MaxSignups = b.MaxSignups,
-                Width = b.Width,
-                Height = b.Height
+                Width = b.Width
             }).ToList() ?? new List<Template.TemplateButton>(),
             Mentions = payload.Mentions?.Select(ulong.Parse).ToList() ?? new List<ulong>()
         };

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -33,7 +33,6 @@ class EmbedButtonDto(CamelModel):
     style: Optional[ButtonStyle] = None
     max_signups: Optional[int] = Field(default=None, alias="maxSignups")
     width: Optional[int] = None
-    height: Optional[int] = None
     row_index: Optional[int] = Field(default=None, alias="rowIndex")
 
 

--- a/demibot/demibot/http/validation.py
+++ b/demibot/demibot/http/validation.py
@@ -15,7 +15,6 @@ TOTAL_CHAR_LIMIT = 6000
 BUTTON_LABEL_LIMIT = 80
 BUTTON_COUNT_LIMIT = 25
 BUTTON_WIDTH_LIMIT = 5
-BUTTON_HEIGHT_LIMIT = 5
 
 
 def _check_url(name: str, url: str | None) -> None:
@@ -100,14 +99,10 @@ def validate_embed_payload(dto: EmbedDto, buttons: List[EmbedButtonDto]) -> None
                 raise HTTPException(422, detail="Button label too long")
             _check_url("button url", btn.url)
             width = btn.width or 1
-            height = btn.height or 1
             if width < 1 or width > BUTTON_WIDTH_LIMIT:
                 logging.warning("Button width %d out of range", width)
                 raise HTTPException(422, detail="Invalid button width")
-            if height < 1 or height > BUTTON_HEIGHT_LIMIT:
-                logging.warning("Button height %d out of range", height)
-                raise HTTPException(422, detail="Invalid button height")
-            total_slots += width * height
+            total_slots += width
         if total_slots > BUTTON_COUNT_LIMIT:
             logging.warning(
                 "Embed has %d button slots, limit is %d", total_slots, BUTTON_COUNT_LIMIT

--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -41,7 +41,6 @@ public class TemplateButtonRoundTripTests
         Assert.Null(btn.Emoji);
         Assert.Null(btn.MaxSignups);
         Assert.Equal(ButtonSizeHelper.ComputeWidth("Signup"), btn.Width);
-        Assert.Equal(ButtonSizeHelper.DefaultHeight, btn.Height);
     }
 
     [Fact]
@@ -59,7 +58,6 @@ public class TemplateButtonRoundTripTests
         Assert.Null(btn.emoji);
         Assert.Null(btn.maxSignups);
         Assert.Equal(ButtonSizeHelper.ComputeWidth("Join"), btn.width);
-        Assert.Equal(ButtonSizeHelper.DefaultHeight, btn.height);
     }
 
     [Fact]

--- a/tests/test_embed_validation.py
+++ b/tests/test_embed_validation.py
@@ -33,17 +33,17 @@ def test_button_limit():
         validate_embed_payload(dto, buttons)
 
 
-def test_button_width_height_limits():
+def test_button_width_limit():
     dto = EmbedDto(id="1", title="t", description="d")
     buttons = [EmbedButtonDto(label="b", custom_id="1", width=6)]
     with pytest.raises(HTTPException):
         validate_embed_payload(dto, buttons)
 
 
-def test_button_area_limit():
+def test_button_total_width_limit():
     dto = EmbedDto(id="1", title="t", description="d")
     buttons = [
-        EmbedButtonDto(label="b1", custom_id="1", width=5, height=5),
+        EmbedButtonDto(label="b1", custom_id="1", width=25),
         EmbedButtonDto(label="b2", custom_id="2")
     ]
     with pytest.raises(HTTPException):


### PR DESCRIPTION
## Summary
- stop assigning button height in event preview and signup option editor
- drop `Height` from templates, DTOs and server validation; adjust tests

## Testing
- `dotnet test` *(fails: SDK 9.0.100 not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68c16f73a3cc83289ecf56d383911394