### PR TITLE
Defer Discord interactions for network requests

### DIFF
--- a/demibot/demibot/discordbot/cogs/events.py
+++ b/demibot/demibot/discordbot/cogs/events.py
@@ -26,6 +26,7 @@ class Events(commands.Cog):
 async def create_event(
     interaction: discord.Interaction, title: str, time: str, description: str
 ) -> None:
+    await interaction.response.defer(ephemeral=True, thinking=True)
     host = interaction.client.cfg.server.host
     if host == "0.0.0.0":
         host = "127.0.0.1"
@@ -33,7 +34,7 @@ async def create_event(
     try:
         validate_embed_payload(EmbedDto(id="0", title=title, description=description), [])
     except HTTPException as exc:
-        await interaction.response.send_message(
+        await interaction.followup.send(
             f"Invalid event: {exc.detail}", ephemeral=True
         )
         return
@@ -53,12 +54,11 @@ async def create_event(
         ) as resp:
             if resp.status != 200:
                 text = await resp.text()
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     f"Failed to create event: {resp.status} {text}", ephemeral=True
                 )
                 return
-
-    await interaction.response.send_message("Event created", ephemeral=True)
+    await interaction.followup.send("Event created", ephemeral=True)
 
 
 @app_commands.command(name="createevent", description="Create a simple event")

--- a/demibot/demibot/discordbot/cogs/requests.py
+++ b/demibot/demibot/discordbot/cogs/requests.py
@@ -33,15 +33,16 @@ async def _create_request(
         "X-Api-Key": interaction.client.cfg.security.api_key,
         "X-Discord-Id": str(interaction.user.id),
     }
+    await interaction.response.defer(ephemeral=True, thinking=True)
     async with aiohttp.ClientSession() as session:
         async with session.post(f"{base_url}/api/requests", json=body, headers=headers) as resp:
             if resp.status != 200:
                 text = await resp.text()
-                await interaction.response.send_message(
+                await interaction.followup.send(
                     f"Failed to create request: {resp.status} {text}", ephemeral=True
                 )
                 return
-    await interaction.response.send_message("Request submitted", ephemeral=True)
+    await interaction.followup.send("Request submitted", ephemeral=True)
 
 request_group = app_commands.Group(name="request", description="Create requests")
 


### PR DESCRIPTION
## Summary
- Defer responses and use follow-up messages when creating requests
- Defer responses and use follow-up messages when creating events

## Testing
- `pytest` *(fails: 54 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c2091437ac8328aa24ab4d20ea9ed7