### PR TITLE
Truncate webhook username and add test

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -302,6 +302,7 @@ async def save_message(
                 username = (
                     f"{username_base} / {ctx.user.character_name}@FFXIV FC"
                 )
+            username = username[:80]
             try:
                 sent = await webhook.send(
                     body.content,

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -114,6 +114,66 @@ def test_save_and_fetch_messages(monkeypatch):
     asyncio.run(_run())
 
 
+def test_long_username_truncated(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            await db.execute(text("DELETE FROM messages"))
+            await db.execute(text("DELETE FROM memberships"))
+            await db.execute(text("DELETE FROM users"))
+            await db.execute(text("DELETE FROM guilds"))
+            long_name = "A" * 100
+            db.add(Guild(id=3, discord_guild_id=3, name="Guild"))
+            db.add(User(id=3, discord_user_id=30, global_name="Alice"))
+            db.add(
+                Membership(
+                    guild_id=3,
+                    user_id=3,
+                    nickname=long_name,
+                    avatar_url="http://example.com/avatar.png",
+                )
+            )
+            await db.commit()
+            guild = await db.get(Guild, 3)
+            user = await db.get(User, 3)
+            ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=[])
+
+            async def dummy_broadcast(
+                message: str, guild_id: int, officer_only: bool = False, path: str | None = None
+            ):
+                pass
+
+            monkeypatch.setattr(mc.manager, "broadcast_text", dummy_broadcast)
+
+            captured: dict[str, str] = {}
+
+            class DummyWebhook:
+                url = "http://example.com"
+
+                async def send(self, *args, **kwargs):
+                    captured["username"] = kwargs.get("username")
+                    return types.SimpleNamespace(id=1, attachments=[])
+
+            class DummyChannel:
+                async def create_webhook(self, name: str):
+                    return DummyWebhook()
+
+            class DummyClient:
+                def get_channel(self, cid: int):
+                    return DummyChannel()
+
+            monkeypatch.setattr(mc, "discord_client", DummyClient())
+            monkeypatch.setattr(mc.discord.abc, "Messageable", DummyChannel)
+            monkeypatch.setattr(mc, "_channel_webhooks", {})
+
+            body = mc.PostBody(channelId="123", content="hello")
+            res = await mc.save_message(body, ctx, db, is_officer=False)
+            assert res["ok"] is True
+            assert len(captured["username"]) == 80
+
+    asyncio.run(_run())
+
+
 def test_rest_ws_payload_parity(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")


### PR DESCRIPTION
## Summary
- Limit relay webhook usernames to 80 characters
- Add regression test confirming long nicknames are truncated without errors

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_long_username_truncated -q`


------
https://chatgpt.com/codex/tasks/task_e_68c20a678db88328af0c260baf925189