### PR TITLE
Handle role and channel mentions

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -607,13 +607,7 @@ public class ChatWindow : IDisposable
     {
         EnsureEmojiCatalog();
         var text = msg.Content ?? string.Empty;
-        if (msg.Mentions != null)
-        {
-            foreach (var m in msg.Mentions)
-            {
-                text = text.Replace($"<@{m.Id}>", $"@{m.Name}");
-            }
-        }
+        text = ReplaceMentionTokens(text, msg.Mentions);
         text = MarkdownFormatter.Format(text);
         var parts = Regex.Split(text, "(<a?:[a-zA-Z0-9_]+:\\d+>|:[a-zA-Z0-9_]+:)");
         ImGui.PushTextWrapPos();
@@ -696,6 +690,31 @@ public class ChatWindow : IDisposable
             first = false;
         }
         ImGui.PopTextWrapPos();
+    }
+
+    internal static string ReplaceMentionTokens(string text, List<DiscordMentionDto>? mentions)
+    {
+        if (mentions == null)
+            return text;
+
+        foreach (var m in mentions)
+        {
+            switch (m.Type)
+            {
+                case "user":
+                    text = text.Replace($"<@{m.Id}>", $"@{m.Name}");
+                    text = text.Replace($"<@!{m.Id}>", $"@{m.Name}");
+                    break;
+                case "role":
+                    text = text.Replace($"<@&{m.Id}>", $"@{m.Name}");
+                    break;
+                case "channel":
+                    text = text.Replace($"<#{m.Id}>", $"#{m.Name}");
+                    break;
+            }
+        }
+
+        return text;
     }
 
     private void RenderMarkdown(string text)

--- a/DemiCatPlugin/DiscordMessageDto.cs
+++ b/DemiCatPlugin/DiscordMessageDto.cs
@@ -34,6 +34,7 @@ public class DiscordMentionDto
 {
     public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
 }
 
 public class DiscordAttachmentDto

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -70,6 +70,7 @@ class EmbedDto(CamelModel):
 class Mention(CamelModel):
     id: str
     name: str
+    type: str
 
 
 class AttachmentDto(CamelModel):

--- a/tests/ChatWindowMentionTests.cs
+++ b/tests/ChatWindowMentionTests.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using DemiCatPlugin;
+using Xunit;
+
+public class ChatWindowMentionTests
+{
+    [Fact]
+    public void ReplaceMentionTokens_ReplacesAllMentionTypes()
+    {
+        var mentions = new List<DiscordMentionDto>
+        {
+            new() { Id = "1", Name = "Alice", Type = "user" },
+            new() { Id = "2", Name = "Admins", Type = "role" },
+            new() { Id = "3", Name = "general", Type = "channel" }
+        };
+        var text = "<@1> <@&2> <#3>";
+        var result = ChatWindow.ReplaceMentionTokens(text, mentions);
+        Assert.Equal("@Alice @Admins #general", result);
+    }
+}

--- a/tests/test_mentions_roundtrip.py
+++ b/tests/test_mentions_roundtrip.py
@@ -1,0 +1,94 @@
+import types
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+# Ensure packages are importable
+pkg = types.ModuleType("demibot")
+pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", pkg)
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+# Stub discord module with minimal classes
+discord = types.ModuleType("discord")
+abc = types.ModuleType("discord.abc")
+
+class Snowflake:
+    def __init__(self, id):
+        self.id = id
+
+class User(Snowflake):
+    def __init__(self, id, name):
+        super().__init__(id)
+        self.display_name = name
+        self.name = name
+        self.bot = False
+
+class Role(Snowflake):
+    def __init__(self, id, name):
+        super().__init__(id)
+        self.name = name
+
+class GuildChannel(Snowflake):
+    def __init__(self, id, name):
+        super().__init__(id)
+        self.name = name
+
+discord.User = User
+discord.Member = User
+discord.Role = Role
+abc.GuildChannel = GuildChannel
+discord.abc = abc
+
+sys.modules.setdefault("discord", discord)
+sys.modules.setdefault("discord.abc", abc)
+
+from demibot.http.discord_helpers import message_to_chat_message
+
+
+class DummyUser(User):
+    def __init__(self):
+        super().__init__(1, "User")
+
+
+class DummyRole(Role):
+    def __init__(self):
+        super().__init__(2, "Role")
+
+
+class DummyChannel(GuildChannel):
+    def __init__(self):
+        super().__init__(3, "general")
+
+
+class DummyMessage:
+    def __init__(self):
+        self.mentions = [DummyUser()]
+        self.role_mentions = [DummyRole()]
+        self.channel_mentions = [DummyChannel()]
+        self.attachments = []
+        self.embeds = []
+        self.reference = None
+        self.components = []
+        self.reactions = []
+        self.author = DummyUser()
+        self.channel = types.SimpleNamespace(id=123)
+        self.id = 42
+        self.content = "<@1> <@&2> <#3>"
+        self.created_at = None
+        self.edited_at = None
+
+
+def test_message_mentions_roundtrip():
+    msg = DummyMessage()
+    dto = message_to_chat_message(msg)
+    assert dto.mentions is not None
+    assert {m.type for m in dto.mentions} == {"user", "role", "channel"}
+    mapping = {m.type: m for m in dto.mentions}
+    assert mapping["user"].id == "1"
+    assert mapping["role"].id == "2"
+    assert mapping["channel"].id == "3"


### PR DESCRIPTION
## Summary
- Capture role and channel mentions when serializing Discord messages and expose mention type
- Display role and channel mentions in chat window via new mention token replacement helper
- Test round-trip of role and channel mentions and replacement logic

## Testing
- `pytest tests/test_mentions_roundtrip.py -q`
- `dotnet test tests/DemiCatPlugin.Tests.csproj --filter ChatWindowMentionTests -v minimal` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c216ad849883288fc3b75abac697d8