### PR TITLE
Deliver API key via ephemeral embed

### DIFF
--- a/demibot/demibot/discordbot/cogs/keygen.py
+++ b/demibot/demibot/discordbot/cogs/keygen.py
@@ -136,13 +136,14 @@ async def key_command(interaction: discord.Interaction) -> None:
         )
         return
 
+    embed = discord.Embed(title="Your API key", description=token)
     try:
-        await interaction.user.send(f"Your API key: {token}")
-        await interaction.response.send_message(
-            "Sent you a DM with your key", ephemeral=True
-        )
-    except discord.Forbidden:
-        await interaction.response.send_message("Unable to send DM", ephemeral=True)
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+    except Exception:
+        if interaction.response.is_done():
+            await interaction.followup.send("Failed to generate key", ephemeral=True)
+        else:
+            await interaction.response.send_message("Failed to generate key", ephemeral=True)
 
 
 @app_commands.command(name="generatekey", description="Generate an API key")

--- a/tests/test_key_command_ephemeral.py
+++ b/tests/test_key_command_ephemeral.py
@@ -1,0 +1,96 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+import types
+
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+discordbot_pkg = types.ModuleType("demibot.discordbot")
+discordbot_pkg.__path__ = [str(root / "demibot/discordbot")]
+sys.modules.setdefault("demibot.discordbot", discordbot_pkg)
+
+
+from demibot.discordbot.cogs import keygen as keygen_module
+from contextlib import asynccontextmanager
+
+
+class DummyResponse:
+    def __init__(self) -> None:
+        self.kwargs: dict | None = None
+
+    async def send_message(self, *args, **kwargs) -> None:
+        self.kwargs = kwargs
+
+
+class DummyUser:
+    def __init__(self) -> None:
+        self.id = 1
+        self.global_name = "Member"
+        self.discriminator = "0001"
+        self.roles = []
+        self.dm_called = False
+
+    async def send(self, *args, **kwargs) -> None:
+        self.dm_called = True
+
+
+class DummyDB:
+    async def execute(self, *args, **kwargs):
+        class DummyScalar:
+            def first(self):
+                return None
+
+            def all(self):
+                return []
+
+            def __iter__(self):
+                return iter([])
+
+        class DummyResult:
+            def scalars(self):
+                return DummyScalar()
+
+        return DummyResult()
+
+    def add(self, *args, **kwargs):
+        pass
+
+    async def flush(self):
+        pass
+
+    async def commit(self):
+        pass
+
+
+@asynccontextmanager
+async def dummy_get_session():
+    yield DummyDB()
+
+
+class DummyInteraction:
+    def __init__(self) -> None:
+        self.guild = SimpleNamespace(id=1, name="Test Guild")
+        self.user = DummyUser()
+        self.response = DummyResponse()
+
+
+async def _run() -> DummyInteraction:
+    keygen_module.get_session = dummy_get_session
+    inter = DummyInteraction()
+    await keygen_module.key_command.callback(inter)
+    return inter
+
+
+def test_key_sent_ephemeral_and_no_dm():
+    inter = asyncio.run(_run())
+    assert inter.user.dm_called is False
+    assert inter.response.kwargs is not None
+    assert inter.response.kwargs.get("embed") is not None
+    assert inter.response.kwargs.get("ephemeral") is True


### PR DESCRIPTION
## Summary
- send generated API key in an ephemeral embed instead of DM
- handle interaction response errors with fallback messages
- test that key generation responds ephemerally without DM

## Testing
- `pytest tests/test_key_command_ephemeral.py -q`
- `pytest tests/test_key_generation_roles.py -q` *(fails: fastapi.exceptions.HTTPException: 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c21ae6b0248328a1bde1db6bd2b2e3