### PR TITLE
Auto-refresh officer role

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -37,7 +37,7 @@ public class ChannelWatcher : IDisposable
 
     public async Task Start()
     {
-        if (!_config.Events && !_config.SyncedChat && !_config.Officer)
+        if (!_config.Events && !_config.SyncedChat && !_config.Roles.Contains("officer"))
         {
             return;
         }
@@ -208,7 +208,7 @@ public class ChannelWatcher : IDisposable
         _ = SafeRefresh(_eventCreateWindow.RefreshChannels);
         if (_config.SyncedChat && _config.EnableFcChat)
             _ = SafeRefresh(_chatWindow.RefreshChannels);
-        if (_config.Officer && _config.Roles.Contains("officer"))
+        if (_config.Roles.Contains("officer"))
             _ = SafeRefresh(_officerChatWindow.RefreshChannels);
 
         _lastRefresh = DateTime.UtcNow;

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -24,7 +24,7 @@ public class OfficerChatWindow : ChatWindow
     public override void StartNetworking()
     {
         _bridge.Start();
-        if (_config.Officer && _config.Roles.Contains("officer"))
+        if (_config.Roles.Contains("officer"))
         {
             _bridge.Subscribe(_channelId);
             _presence?.Reset();
@@ -34,7 +34,7 @@ public class OfficerChatWindow : ChatWindow
 
     public override void Draw()
     {
-        if (!_config.Officer || !_config.Roles.Contains("officer"))
+        if (!_config.Roles.Contains("officer"))
         {
             return;
         }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -74,7 +74,15 @@ public class Plugin : IDalamudPlugin
         _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService);
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService);
         _presenceService?.Reset();
-        _mainWindow = new MainWindow(_config, _ui, _chatWindow, _officerChatWindow, _settings, _httpClient, _channelService);
+        _mainWindow = new MainWindow(
+            _config,
+            _ui,
+            _chatWindow,
+            _officerChatWindow,
+            _settings,
+            _httpClient,
+            _channelService,
+            () => RefreshRoles(_services.Log));
         _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _chatWindow, _officerChatWindow, _tokenManager, _httpClient);
         _requestWatcher = new RequestWatcher(_config, _httpClient, _tokenManager);
         _settings.MainWindow = _mainWindow;
@@ -153,7 +161,7 @@ public class Plugin : IDalamudPlugin
             _requestWatcher.Start();
         }
         var hasOfficerRole = _config.Roles.Contains("officer");
-        if (_config.Events || _config.SyncedChat || (_config.Officer && hasOfficerRole))
+        if (_config.Events || _config.SyncedChat || hasOfficerRole)
         {
             _ = _channelWatcher.Start();
         }
@@ -161,7 +169,7 @@ public class Plugin : IDalamudPlugin
         {
             _chatWindow.StartNetworking();
         }
-        if (_config.Officer && hasOfficerRole)
+        if (hasOfficerRole)
         {
             _officerChatWindow.StartNetworking();
         }

--- a/tests/SyncshellTabToggleTests.cs
+++ b/tests/SyncshellTabToggleTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 using DemiCatPlugin;
 using Xunit;
 
@@ -16,7 +17,7 @@ public class SyncshellTabToggleTests
         var ui = new UiRenderer(cfg, http);
         var officer = new OfficerChatWindow(cfg, http, null, token, channelService);
         var settings = (SettingsWindow)FormatterServices.GetUninitializedObject(typeof(SettingsWindow));
-        var main = new MainWindow(cfg, ui, null, officer, settings, http, channelService);
+        var main = new MainWindow(cfg, ui, null, officer, settings, http, channelService, () => Task.FromResult(true));
 
         Assert.Null(SyncshellWindow.Instance);
 


### PR DESCRIPTION
## Summary
- Check user roles whenever Officer tab opens and hide tab if role removed
- Allow Officer channel watcher and window to run solely based on role presence
- Update constructor and tests for refresh callback

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `pytest` *(fails: 56 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c175404c1c8328a49a2b12283d9131