### PR TITLE
Group event buttons by row

### DIFF
--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -180,7 +180,7 @@ public static class EmbedPreviewRenderer
         return tex;
     }
 
-    private static Vector4 GetStyleColor(ButtonStyle style) => style switch
+    internal static Vector4 GetStyleColor(ButtonStyle style) => style switch
     {
         ButtonStyle.Primary => new Vector4(0.345f, 0.396f, 0.949f, 1f),
         ButtonStyle.Secondary => new Vector4(0.31f, 0.329f, 0.361f, 1f),
@@ -189,7 +189,7 @@ public static class EmbedPreviewRenderer
         _ => new Vector4(0.345f, 0.396f, 0.949f, 1f),
     };
 
-    private static Vector4 Lighten(Vector4 color, float amount)
+    internal static Vector4 Lighten(Vector4 color, float amount)
         => new(MathF.Min(color.X * amount, 1f), MathF.Min(color.Y * amount, 1f), MathF.Min(color.Z * amount, 1f), color.W);
 
     public static void ClearCache()


### PR DESCRIPTION
## Summary
- Render Discord-style button rows in event view by grouping by row index, honoring explicit widths, and spacing with `SameLine`
- Expose preview renderer color helpers and reuse them for consistent button styling

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(failed: Dalamud.NET.Sdk: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c221af3cd0832897e774b87365b7e5