### PR TITLE
Rename response body variables to avoid shadowing

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -494,8 +494,8 @@ public class EventCreateWindow
             }
             else if (response != null)
             {
-                var body = await response.Content.ReadAsStringAsync();
-                _lastResult = $"Failed to save template: {(int)response.StatusCode} {body}";
+                var responseBody = await response.Content.ReadAsStringAsync();
+                _lastResult = $"Failed to save template: {(int)response.StatusCode} {responseBody}";
             }
             else
             {
@@ -554,8 +554,8 @@ public class EventCreateWindow
             }
             else if (response != null)
             {
-                var body = await response.Content.ReadAsStringAsync();
-                _lastResult = $"Error {(int)response.StatusCode}: {body}";
+                var responseBody = await response.Content.ReadAsStringAsync();
+                _lastResult = $"Error {(int)response.StatusCode}: {responseBody}";
             }
             else
             {


### PR DESCRIPTION
## Summary
- Rename temporary error response variables to `responseBody`
- Update event and template error messages

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 56 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c230c9dc74832881ccb5da38736b89