### PR TITLE
Handle missing status details in ChannelWatcher logs

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -80,7 +80,7 @@ public class ChannelWatcher : IDisposable
                 {
                     var responseBody = pingResponse == null ? string.Empty : await pingResponse.Content.ReadAsStringAsync();
                     var status = pingResponse?.StatusCode;
-                    PluginServices.Instance!.Log.Warning("Channel watcher ping failed. Status: {Status}. Response Body: {ResponseBody}", status, responseBody);
+                    PluginServices.Instance!.Log.Warning("Channel watcher ping failed. Status: {Status}. Response Body: {ResponseBody}", status?.ToString() ?? "unknown", responseBody ?? "");
                     if (status == HttpStatusCode.NotFound)
                     {
                         PluginServices.Instance!.Log.Error("Backend ping endpoints missing. Please update or restart the backend.");
@@ -141,10 +141,8 @@ public class ChannelWatcher : IDisposable
             {
                 var status = _ws?.CloseStatus;
                 var description = _ws?.CloseStatusDescription;
-                if (status != null)
-                {
-                    PluginServices.Instance!.Log.Information("Channel watcher disconnected. Status: {Status}, Description: {Description}", status, description);
-                }
+                PluginServices.Instance!.Log.Information("Channel watcher disconnected. Status: {Status}, Description: {Description}",
+                    status?.ToString() ?? "unknown", description ?? "");
                 _ws?.Dispose();
                 _ws = null;
             }


### PR DESCRIPTION
## Summary
- Ensure channel watcher ping warning logs "unknown" status and empty body when fields are null
- Report disconnect status and description with fallbacks when closing the WebSocket

## Testing
- `dotnet build` *(fails: A compatible .NET SDK was not found. Requested SDK version 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_68c230e090808328b5eb530aac89de71