### PR TITLE
Support multiple officer roles in DemiBot

### DIFF
--- a/demibot/demibot/db/migrations/versions/0039_add_officer_role_ids.py
+++ b/demibot/demibot/db/migrations/versions/0039_add_officer_role_ids.py
@@ -1,0 +1,37 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.mysql import BIGINT
+
+
+revision = "0039_add_officer_role_ids"
+down_revision = "0038_add_request_tombstones_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("guild_config", sa.Column("officer_role_ids", sa.Text(), nullable=True))
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE guild_config SET officer_role_ids = CAST(officer_role_id AS CHAR) "
+            "WHERE officer_role_id IS NOT NULL"
+        )
+    )
+    op.drop_column("guild_config", "officer_role_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "guild_config",
+        sa.Column("officer_role_id", BIGINT(unsigned=True), nullable=True),
+    )
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE guild_config SET officer_role_id = CAST(SUBSTRING_INDEX(officer_role_ids, ',', 1) AS UNSIGNED) "
+            "WHERE officer_role_ids IS NOT NULL AND officer_role_ids != ''"
+        )
+    )
+    op.drop_column("guild_config", "officer_role_ids")
+

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -92,7 +92,7 @@ class GuildConfig(Base):
     officer_visible_channel_id: Mapped[Optional[int]] = mapped_column(
         BIGINT(unsigned=True)
     )
-    officer_role_id: Mapped[Optional[int]] = mapped_column(BIGINT(unsigned=True))
+    officer_role_ids: Mapped[Optional[str]] = mapped_column(Text)
 
     guild: Mapped[Guild] = relationship(back_populates="config")
 

--- a/demibot/docs/multiple_officer_roles.md
+++ b/demibot/docs/multiple_officer_roles.md
@@ -1,0 +1,7 @@
+# Manual Test: Multiple Officer Roles
+
+1. Run the `/setup` or `/settings` command to open the configuration wizard.
+2. When prompted for officer roles, select multiple roles from the multi-select and finish the wizard.
+   * Verify that the summary lists all selected officer roles.
+3. Assign one of the chosen officer roles to a user and execute `/key`.
+   * The command should succeed and the role should be marked as an officer role in the database.


### PR DESCRIPTION
## Summary
- Allow configuration of multiple officer roles with a new RoleSelect UI
- Persist selected officer roles in guild config and update Role records
- Update key generation to recognize any configured officer role

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68c238d3fff88328a6a9812cfdf56fbc