### PR TITLE
Restore setup wizard instructions

### DIFF
--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -410,7 +410,16 @@ class ConfigWizard(discord.ui.View):
         followup: bool = False,
     ) -> None:
         self.clear_items()
-        embed = discord.Embed(title=self.title, description=f"Step {self.step + 1} / 4")
+        step_descriptions = [
+            "Select the event channels to be used in the plugin",
+            "Select the FC chat channels to be used in the plugin",
+            "Select the officer chat channels to be used in the plugin",
+            "Select the roles that should be treated as officers",
+        ]
+        embed = discord.Embed(
+            title=self.title,
+            description=f"Step {self.step + 1} / 4\n{step_descriptions[self.step]}",
+        )
         if self.step in (0, 1, 2):
             selected_map = {
                 0: self.event_channel_ids,


### PR DESCRIPTION
## Summary
- Add explicit descriptions for each step of the Discord setup wizard so users know what to select

## Testing
- `pytest` *(fails: TypeError: HTTPException.__init__() missing 2 required positional arguments: 'status_code' and 'detail', sqlite3.IntegrityError UNIQUE constraint failed etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c2ab7c8e488328a833112b5362c7ee