### PR TITLE
Show bridge status messages and refresh roles

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -167,10 +167,13 @@ public class ChatWindow : IDisposable
         _fileDialog.Draw();
         if (!_bridge.IsReady())
         {
-            ImGui.TextUnformatted("Link DemiCat…");
             if (!string.IsNullOrEmpty(_statusMessage))
             {
                 ImGui.TextUnformatted(_statusMessage);
+            }
+            else
+            {
+                ImGui.TextUnformatted("Link DemiCat…");
             }
             return;
         }


### PR DESCRIPTION
## Summary
- Show status message when chat bridge isn't ready, falling back to link prompt
- Relay officer chat bridge status and auto-refresh roles on forbidden errors

## Testing
- `~/.dotnet/dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 57 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bd7163948328854a3173cc67dfe9