### PR TITLE
Store request type enum values

### DIFF
--- a/demibot/demibot/db/migrations/versions/0040_store_request_type_values.py
+++ b/demibot/demibot/db/migrations/versions/0040_store_request_type_values.py
@@ -1,0 +1,37 @@
+"""store request type values
+
+Revision ID: 0040_store_request_type_values
+Revises: 0039_add_officer_role_ids
+Create Date: 2025-02-16
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+revision = "0040_store_request_type_values"
+down_revision = "0039_add_officer_role_ids"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "requests",
+        "type",
+        existing_type=mysql.ENUM("ITEM", "RUN", "EVENT", name="request_type"),
+        type_=mysql.ENUM("item", "run", "event", name="request_type"),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "requests",
+        "type",
+        existing_type=mysql.ENUM("item", "run", "event", name="request_type"),
+        type_=mysql.ENUM("ITEM", "RUN", "EVENT", name="request_type"),
+        nullable=False,
+    )
+

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -376,7 +376,14 @@ class Request(Base):
     )
     title: Mapped[str] = mapped_column(String(255))
     description: Mapped[Optional[str]] = mapped_column(Text)
-    type: Mapped[RequestType] = mapped_column(SAEnum(RequestType))
+    type: Mapped[RequestType] = mapped_column(
+        SAEnum(
+            RequestType,
+            name="request_type",
+            values_callable=lambda e: [v.value for v in e],
+            native_enum=False,
+        )
+    )
     status: Mapped[RequestStatus] = mapped_column(SAEnum(RequestStatus))
     urgency: Mapped[Urgency] = mapped_column(SAEnum(Urgency))
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/tests/test_request_type_lowercase.py
+++ b/tests/test_request_type_lowercase.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from demibot.http.api import create_app
+from demibot.http.deps import RequestContext, api_key_auth
+from demibot.db.session import init_db, get_session
+from demibot.db.models import Guild, Request as DbRequest, User
+
+
+def test_create_request_accepts_lowercase_types(monkeypatch):
+    user = User(id=1, discord_user_id=1)
+    guild = Guild(id=1, discord_guild_id=1, name="G")
+
+    async def _setup():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            db.add_all([user, guild])
+            await db.commit()
+
+    asyncio.run(_setup())
+
+    app = create_app()
+    app.dependency_overrides[api_key_auth] = lambda: RequestContext(
+        user=user, guild=guild, key=None, roles=[]
+    )
+
+    async def _noop(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr("demibot.http.routes.requests._notify", _noop)
+    monkeypatch.setattr("demibot.http.routes.requests._dto", lambda req: {"id": str(req.id)})
+
+    client = TestClient(app)
+
+    for kind in ["item", "run", "event"]:
+        resp = client.post(
+            "/api/requests", json={"title": "t", "type": kind, "urgency": "low"}
+        )
+        assert resp.status_code == 200
+
+    async def _types():
+        async with get_session() as db:
+            rows = await db.execute(select(DbRequest.type))
+            return [t.value for (t,) in rows.all()]
+
+    types = asyncio.run(_types())
+    assert set(types) == {"item", "run", "event"}
+


### PR DESCRIPTION
## Summary
- store request type enum values rather than names
- add migration to update requests.type enum values
- allow POST /api/requests with lowercase type strings

## Testing
- `PYTHONPATH=demibot pytest tests/test_request_type_lowercase.py::test_create_request_accepts_lowercase_types -vv`
- `PYTHONPATH=demibot DEMIBOT_FORCED_URL=sqlite:///migration.db alembic -c alembic.ini upgrade head` *(fails: No support for ALTER of constraints in SQLite dialect)*

------
https://chatgpt.com/codex/tasks/task_e_68c40f46e64483289e6452a81369fecb