### PR TITLE
Add emoji font and DB-backed emoji list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ latest.zip
 .venv/
 .dotnet/
 DemiCatPlugin/packages.lock.json
+DemiCatPlugin/NotoColorEmoji.ttf
 
 # DemiBot configuration
 demibot/demibot/config.json

--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -39,6 +39,10 @@
   <ItemGroup>
     <EmbeddedResource Include="icon.png" />
   </ItemGroup>
+
+  <ItemGroup Condition="Exists('NotoColorEmoji.ttf')">
+    <None Include="NotoColorEmoji.ttf" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../DemiCat.UI/DemiCat.UI.csproj" />
   </ItemGroup>

--- a/DemiCatPlugin/EmojiUtils.cs
+++ b/DemiCatPlugin/EmojiUtils.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace DemiCatPlugin;
+
+public static class EmojiUtils
+{
+    public static string? Normalize(string? emoji)
+    {
+        if (string.IsNullOrWhiteSpace(emoji)) return null;
+        if (emoji.StartsWith("custom:", StringComparison.OrdinalIgnoreCase))
+        {
+            var id = emoji.Substring("custom:".Length);
+            var name = EmojiPopup.LookupGuildName(id) ?? "emoji";
+            var animated = EmojiPopup.IsGuildEmojiAnimated(id);
+            return $"<{(animated ? "a" : string.Empty)}:{name}:{id}>";
+        }
+        return emoji;
+    }
+}

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -448,7 +448,7 @@ public class EventCreateWindow
                     Tag = b.Tag,
                     Include = b.Include,
                     Label = b.Label,
-                    Emoji = b.Emoji,
+                    Emoji = EmojiUtils.Normalize(b.Emoji),
                     Style = b.Style,
                     MaxSignups = b.MaxSignups,
                     Width = b.Width
@@ -586,7 +586,7 @@ public class EventCreateWindow
                     Tag = b.Tag,
                     Include = b.Include,
                     Label = b.Label,
-                    Emoji = b.Emoji,
+                    Emoji = EmojiUtils.Normalize(b.Emoji),
                     Style = b.Style,
                     MaxSignups = b.MaxSignups,
                     Width = b.Width
@@ -724,7 +724,7 @@ public class EventCreateWindow
                 Tag = b.Tag,
                 Include = b.Include,
                 Label = b.Label,
-                Emoji = b.Emoji,
+                Emoji = EmojiUtils.Normalize(b.Emoji),
                 Style = b.Style,
                 MaxSignups = b.MaxSignups,
                 Width = b.Width

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -491,26 +491,12 @@ public class TemplatesWindow
                     MakeCustomId(label, x.RowIndex, x.ColIndex),
                     x.RowIndex,
                     (int)(b?.Style ?? x.Data.Style),
-                    NormalizeEmoji(b?.Emoji ?? x.Data.Emoji),
+                    EmojiUtils.Normalize(b?.Emoji ?? x.Data.Emoji),
                     b?.MaxSignups ?? x.Data.MaxSignups,
                     Math.Min(b?.Width ?? x.Data.Width ?? ButtonSizeHelper.ComputeWidth(label), ButtonSizeHelper.Max));
             })
             .ToList();
     }
-
-    private static string? NormalizeEmoji(string? emoji)
-    {
-        if (string.IsNullOrWhiteSpace(emoji)) return null;
-        if (emoji.StartsWith("custom:", StringComparison.OrdinalIgnoreCase))
-        {
-            var id = emoji.Substring("custom:".Length);
-            var name = EmojiPopup.LookupGuildName(id) ?? "emoji";
-            var animated = EmojiPopup.IsGuildEmojiAnimated(id);
-            return $"<{(animated ? "a" : string.Empty)}:{name}:{id}>";
-        }
-        return emoji;
-    }
-
 
     internal EmbedDto ToEmbedDto(Template tmpl)
     {

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ DemiCat/
 - A database (SQLite by default, MySQL optional)
 - A Discord bot token and Apollo-managed channels
 - FFXIV with the [Dalamud](https://github.com/goatcorp/Dalamud) plugin framework
+- [Noto Color Emoji](https://github.com/googlefonts/noto-emoji/releases) font placed at `DemiCatPlugin/NotoColorEmoji.ttf`
 
 Optional tools for automated setup:
 - [uv](https://github.com/astral-sh/uv) or [Homebrew](https://brew.sh/) for installing Python/.NET if missing
@@ -134,6 +135,9 @@ cd DemiCatPlugin
 dotnet build
 ```
 The build output `DemiCatPlugin.dll` can be found under `bin/Debug/net9.0/`. Copy it into your Dalamud plugins folder and enable it.
+
+#### Emoji Font
+Download the [Noto Color Emoji](https://github.com/googlefonts/noto-emoji/releases) font and save it as `DemiCatPlugin/NotoColorEmoji.ttf` before building. The file is ignored by git but will be copied into the build output and loaded at runtime if present. Without it, the plugin will fall back to monochrome emoji glyphs.
 
 WebSocket communication now streams data in 1 KB chunks and continues reading until the end of each message, allowing the plugin to handle payloads larger than the previous 16-byte limit.
 

--- a/demibot/demibot/db/migrations/versions/0041_add_unicode_emojis_table.py
+++ b/demibot/demibot/db/migrations/versions/0041_add_unicode_emojis_table.py
@@ -1,0 +1,47 @@
+"""add unicode emojis table"""
+
+from pathlib import Path
+import json
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+
+# revision identifiers, used by Alembic.
+revision = "0041_add_unicode_emojis_table"
+down_revision = "0040_store_request_type_values"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "unicode_emojis",
+        sa.Column("emoji", sa.String(length=16), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("image_url", sa.String(length=255), nullable=False),
+    )
+
+    data_path = Path(__file__).resolve().parents[2] / "data" / "unicode_emojis.json"
+    try:
+        with data_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        emoji_table = table(
+            "unicode_emojis",
+            column("emoji", sa.String),
+            column("name", sa.String),
+            column("image_url", sa.String),
+        )
+        op.bulk_insert(
+            emoji_table,
+            [
+                {"emoji": e.get("emoji"), "name": e.get("name"), "image_url": e.get("imageUrl")}
+                for e in data
+            ],
+        )
+    except Exception:
+        pass
+
+
+def downgrade() -> None:
+    op.drop_table("unicode_emojis")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -357,6 +357,14 @@ class EventButton(Base):
     max_signups: Mapped[Optional[int]] = mapped_column(Integer)
 
 
+class UnicodeEmoji(Base):
+    __tablename__ = "unicode_emojis"
+
+    emoji: Mapped[str] = mapped_column(String(16), primary_key=True)
+    name: Mapped[str] = mapped_column(String(255))
+    image_url: Mapped[str] = mapped_column(String(255))
+
+
 class Request(Base):
     __tablename__ = "requests"
     __table_args__ = (

--- a/tests/test_unicode_emojis.py
+++ b/tests/test_unicode_emojis.py
@@ -1,14 +1,26 @@
 import sys
 from pathlib import Path
-import asyncio
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
 
 root = Path(__file__).resolve().parents[1] / 'demibot'
 sys.path.append(str(root))
 
+from demibot.db.base import Base
+from demibot.db.models import UnicodeEmoji
 from demibot.http.routes import emojis
 
 
-def test_get_unicode_emojis():
-    res = asyncio.run(emojis.get_unicode_emojis())
-    assert isinstance(res, list)
-    assert any(e.get('emoji') == '😀' for e in res)
+@pytest.mark.asyncio
+async def test_get_unicode_emojis():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with Session() as session:
+        session.add(UnicodeEmoji(emoji="😀", name="grinning face", image_url="url"))
+        await session.commit()
+        res = await emojis.get_unicode_emojis(session)
+        assert isinstance(res, list)
+        assert any(e.get('emoji') == '😀' for e in res)


### PR DESCRIPTION
## Summary
- load Noto Color Emoji font into ImGui when `DemiCatPlugin/NotoColorEmoji.ttf` is present
- normalize custom emoji codes before sending embeds and templates
- store unicode emoji metadata in a database table and serve it from an API endpoint

## Testing
- `dotnet test` *(command not found: dotnet)*
- `pytest` *(59 errors during collection)*
- `pytest tests/test_unicode_emojis.py`


------
https://chatgpt.com/codex/tasks/task_e_68c41279359c83288a426153a71b994b