### PR TITLE
Handle missing discord types in mention_to_dto

### DIFF
--- a/demibot/demibot/http/discord_helpers.py
+++ b/demibot/demibot/http/discord_helpers.py
@@ -47,12 +47,17 @@ def mention_to_dto(obj: discord.abc.Snowflake) -> Mention:
     # First, attempt to use the ``discord`` types directly.  This is the
     # typical code path when running inside the real application where the
     # ``discord.py`` library is available.
-    if isinstance(obj, (discord.User, getattr(discord, "Member", object))):
+
+    member_cls = getattr(discord, "Member", None)
+    role_cls = getattr(discord, "Role", None)
+    channel_cls = getattr(discord.abc, "GuildChannel", None)
+
+    if isinstance(obj, discord.User) or (member_cls and isinstance(obj, member_cls)):
         mention_type = "user"
         name = getattr(obj, "display_name", None) or getattr(obj, "name", "")
-    elif isinstance(obj, getattr(discord, "Role", object)):
+    elif role_cls and isinstance(obj, role_cls):
         mention_type = "role"
-    elif isinstance(obj, getattr(discord.abc, "GuildChannel", object)):
+    elif channel_cls and isinstance(obj, channel_cls):
         mention_type = "channel"
     else:
         # In the test environment the full ``discord`` module might not be


### PR DESCRIPTION
## Summary
- Safely obtain `Member`, `Role`, and `GuildChannel` classes using `getattr` with `None` default
- Guard `isinstance` checks in `mention_to_dto` so they run only when discord classes are available

## Testing
- `pytest tests/test_mentions_roundtrip.py::test_message_mentions_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_68c575cbecf483288c37444775492521