### PR TITLE
Allow role mentions in messages

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -36,7 +36,10 @@ _channel_webhooks: dict[int, str] = {}
 MAX_ATTACHMENTS = 10
 MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024  # 25MB
 
-ALLOWED_MENTIONS = discord.AllowedMentions(users=True, roles=False, everyone=False)
+# Restrict everyone mentions but allow user and role pings
+ALLOWED_MENTIONS = discord.AllowedMentions(
+    users=True, roles=True, everyone=False
+)
 
 
 def _discord_error(exc: discord.HTTPException) -> str:

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -178,7 +178,7 @@ def test_allowed_mentions(monkeypatch):
             am = captured.get("allowed_mentions")
             assert isinstance(am, mc.discord.AllowedMentions)
             assert am.everyone is False
-            assert am.roles is False
+            assert am.roles is True
             assert am.users is True
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- allow role mentions in message relay and prevent everyone pings
- update tests for mention handling

## Testing
- `PYTHONPATH=demibot pytest -q tests/test_messages_common.py::test_allowed_mentions` *(fails: fastapi.exceptions.HTTPException: 502)*

------
https://chatgpt.com/codex/tasks/task_e_68c580baec148328aaa4d4df65f341fe