### PR TITLE
Add detailed request and WebSocket logging

### DIFF
--- a/DemiCatPlugin/ApiHelpers.cs
+++ b/DemiCatPlugin/ApiHelpers.cs
@@ -54,6 +54,19 @@ internal static class ApiHelpers
                 PluginServices.Instance!.Log.Debug($"HTTP {request.Method} {request.RequestUri} attempt {attempt}/{maxAttempts}");
                 var response = await httpClient.SendAsync(request);
                 PluginServices.Instance!.Log.Debug($"HTTP {request.Method} {request.RequestUri} responded {(int)response.StatusCode}");
+
+                if (response.IsSuccessStatusCode)
+                {
+                    // Successful communications are logged at info so they are visible in Dalamud's log file.
+                    PluginServices.Instance!.Log.Information($"HTTP {request.Method} {request.RequestUri} succeeded");
+                }
+                else
+                {
+                    // If the server returns an error status code, capture the body so the reason is clear to the user.
+                    var body = await response.Content.ReadAsStringAsync();
+                    PluginServices.Instance!.Log.Warning($"HTTP {request.Method} {request.RequestUri} failed with {(int)response.StatusCode} {response.ReasonPhrase}. Body: {body}");
+                }
+
                 return response;
             }
             catch (Exception ex)

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -298,7 +298,11 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 var wsUrl = new Uri(($"{baseUrl}/ws/embeds")
                     .Replace("http://", "ws://")
                     .Replace("https://", "wss://"));
+
+                PluginServices.Instance!.Log.Information($"Connecting WebSocket to {wsUrl}");
                 await _webSocket.ConnectAsync(wsUrl, CancellationToken.None);
+                PluginServices.Instance!.Log.Information("WebSocket connected successfully");
+
                 StopPolling();
                 await ReceiveLoop();
             }


### PR DESCRIPTION
## Summary
- log each HTTP request and whether it succeeds or fails
- report HTTP success or failure with response details in ApiHelpers
- emit explicit connection diagnostics for plugin WebSocket

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'discord')
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` (fails: compatible .NET SDK not found; requires 9.0.100)


------
https://chatgpt.com/codex/tasks/task_e_68c58ee2ff788328bb207642f38db44f