### PR TITLE
Use uint for emoji ranges

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -38,7 +38,7 @@ public class Plugin : IDalamudPlugin
     private readonly TokenManager _tokenManager;
     private readonly Action<string?> _unlinkedHandler;
 
-    private static readonly ushort[] EmojiRanges =
+    private static readonly uint[] EmojiRanges =
     {
         0x1F300, 0x1F5FF,
         0x1F600, 0x1F64F,
@@ -319,7 +319,7 @@ public class Plugin : IDalamudPlugin
             var io = ImGui.GetIO();
             var cfg = ImGuiNative.ImFontConfig_ImFontConfig();
             cfg.MergeMode = true;
-            fixed (ushort* ranges = EmojiRanges)
+            fixed (uint* ranges = EmojiRanges)
             {
                 io.Fonts.AddFontFromFileTTF(fontPath, io.Fonts.Fonts[0]?.FontSize ?? 16f, cfg, (IntPtr)ranges);
             }


### PR DESCRIPTION
## Summary
- switch emoji range array to uint and pin as uint*

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: package not found)*
- `pytest` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c590a8ec6883288cdef72e28ed0165