### PR TITLE
Use empty string fallback for emoji normalization

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -448,7 +448,7 @@ public class EventCreateWindow
                     Tag = b.Tag,
                     Include = b.Include,
                     Label = b.Label,
-                    Emoji = EmojiUtils.Normalize(b.Emoji),
+                    Emoji = EmojiUtils.Normalize(b.Emoji) ?? string.Empty,
                     Style = b.Style,
                     MaxSignups = b.MaxSignups,
                     Width = b.Width
@@ -586,7 +586,7 @@ public class EventCreateWindow
                     Tag = b.Tag,
                     Include = b.Include,
                     Label = b.Label,
-                    Emoji = EmojiUtils.Normalize(b.Emoji),
+                    Emoji = EmojiUtils.Normalize(b.Emoji) ?? string.Empty,
                     Style = b.Style,
                     MaxSignups = b.MaxSignups,
                     Width = b.Width
@@ -724,7 +724,7 @@ public class EventCreateWindow
                 Tag = b.Tag,
                 Include = b.Include,
                 Label = b.Label,
-                Emoji = EmojiUtils.Normalize(b.Emoji),
+                Emoji = EmojiUtils.Normalize(b.Emoji) ?? string.Empty,
                 Style = b.Style,
                 MaxSignups = b.MaxSignups,
                 Width = b.Width


### PR DESCRIPTION
## Summary
- ensure button emoji strings default to empty when normalization returns null

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68c59a91e3ac83289ca407d75fb2347e