### PR TITLE
Register emoji font via UiBuilder

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -111,8 +111,8 @@ public class Plugin : IDalamudPlugin
 
         _ = RoleCache.EnsureLoaded(_httpClient, _config);
 
-        _services.PluginInterface.UiBuilder.BuildFonts += AddEmojiFont;
-        _services.PluginInterface.UiBuilder.RebuildFontAtlas();
+        PluginInterface.UiBuilder.BuildFonts += AddEmojiFont;
+        PluginInterface.UiBuilder.RebuildFonts();
 
         _services.PluginInterface.UiBuilder.Draw += _mainWindow.Draw;
         _services.PluginInterface.UiBuilder.Draw += _settings.Draw;
@@ -141,7 +141,7 @@ public class Plugin : IDalamudPlugin
         // Unsubscribe UI open handlers
         _services.PluginInterface.UiBuilder.OpenMainUi -= _openMainUi;
         _services.PluginInterface.UiBuilder.OpenConfigUi -= _openConfigUi;
-        _services.PluginInterface.UiBuilder.BuildFonts -= AddEmojiFont;
+        PluginInterface.UiBuilder.BuildFonts -= AddEmojiFont;
 
         _tokenManager.OnLinked -= StartWatchers;
         _tokenManager.OnUnlinked -= _unlinkedHandler;


### PR DESCRIPTION
## Summary
- subscribe AddEmojiFont to UiBuilder.BuildFonts and rebuild fonts
- dispose font builder subscription on shutdown

## Testing
- `dotnet build` *(fails: A compatible .NET SDK was not found; requires 9.0.100)*
- `pytest tests/test_apollo_embed.py -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68c59b89a0a483288a730eec5a44d2ef