### PR TITLE
feat: add discord emoji support

### DIFF
--- a/DemiCatPlugin/Emoji/EmojiInsert.cs
+++ b/DemiCatPlugin/Emoji/EmojiInsert.cs
@@ -1,0 +1,11 @@
+namespace DemiCatPlugin.Emoji
+{
+    public static class EmojiInsert
+    {
+        public static void InsertUnicode(ref string input, string unicodeEmoji)
+            => input += unicodeEmoji;
+
+        public static void InsertCustom(ref string input, CustomEmoji e)
+            => input += e.Animated ? $"<a:{e.Name}:{e.Id}>" : $"<:{e.Name}:{e.Id}>";
+    }
+}

--- a/DemiCatPlugin/Emoji/EmojiModels.cs
+++ b/DemiCatPlugin/Emoji/EmojiModels.cs
@@ -1,0 +1,17 @@
+namespace DemiCatPlugin.Emoji
+{
+    public record CustomEmoji(string Id, string Name, bool Animated);
+    public record EmojiRefUnicode(string Emoji);
+    public record EmojiRefCustom(string Id, string Name, bool Animated);
+
+    public static class EmojiStrings
+    {
+        public static readonly (string Emoji, string Label)[] Popular =
+        {
+            ("😀","grinning"),("😁","beaming"),("😂","tears"),("🤣","rofl"),
+            ("😊","smile"),("😎","cool"),("😍","heart eyes"),("😅","sweat"),
+            ("👍","thumbs up"),("🎉","tada"),("🔥","fire"),("❤️","heart"),
+            ("🤔","thinking")
+        };
+    }
+}

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using Dalamud.Bindings.ImGui;
+
+namespace DemiCatPlugin.Emoji
+{
+    public sealed class EmojiPicker
+    {
+        private readonly EmojiService _svc;
+        private int _tabIndex; // 0=Standard, 1=Custom
+        private string _search = "";
+
+        public EmojiPicker(EmojiService svc) => _svc = svc;
+
+        public void Draw(ref string targetText, float buttonSize = 28f)
+        {
+            if (ImGui.BeginTabBar("##dc_emoji_tabs"))
+            {
+                if (ImGui.BeginTabItem("Standard")) { _tabIndex = 0; DrawStandard(ref targetText, buttonSize); ImGui.EndTabItem(); }
+                if (ImGui.BeginTabItem("Custom"))   { _tabIndex = 1; DrawCustom(ref targetText, buttonSize);   ImGui.EndTabItem(); }
+                ImGui.EndTabBar();
+            }
+        }
+
+        private void DrawStandard(ref string targetText, float size)
+        {
+            ImGui.InputTextWithHint("##search_std", "Search…", ref _search, 64);
+            ImGui.Separator();
+
+            var items = string.IsNullOrWhiteSpace(_search)
+                ? EmojiStrings.Popular
+                : EmojiStrings.Popular.Where(p => p.Label.Contains(_search, StringComparison.OrdinalIgnoreCase)
+                                               || p.Emoji.Contains(_search, StringComparison.OrdinalIgnoreCase)).ToArray();
+
+            int col = 0;
+            foreach (var (emoji, label) in items)
+            {
+                if (ImGui.Button(emoji, new(size, size)))
+                { EmojiInsert.InsertUnicode(ref targetText, emoji); }
+                if (++col % 10 != 0) ImGui.SameLine();
+            }
+        }
+
+        private void DrawCustom(ref string targetText, float size)
+        {
+            ImGui.InputTextWithHint("##search_cus", "Search :name:", ref _search, 64);
+            ImGui.SameLine();
+            if (ImGui.Button("Refresh")) _ = _svc.RefreshAsync();
+
+            ImGui.Separator();
+
+            var items = string.IsNullOrWhiteSpace(_search)
+                ? _svc.Custom
+                : _svc.Custom.Where(c => c.Name.Contains(_search, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            int col = 0;
+            foreach (var e in items)
+            {
+                var label = e.Animated ? $":{e.Name}: (gif)" : $":{e.Name}:";
+                if (ImGui.Button(label, new(size * 3.2f, size)))
+                { EmojiInsert.InsertCustom(ref targetText, e); }
+                if (++col % 3 != 0) ImGui.SameLine();
+            }
+        }
+    }
+}

--- a/DemiCatPlugin/Emoji/EmojiService.cs
+++ b/DemiCatPlugin/Emoji/EmojiService.cs
@@ -1,0 +1,47 @@
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace DemiCatPlugin.Emoji
+{
+    public sealed class EmojiService
+    {
+        private readonly HttpClient _http;
+        private readonly TokenManager _tokens;
+        private readonly Config _config;
+
+        public List<CustomEmoji> Custom { get; private set; } = new();
+
+        public EmojiService(HttpClient http, TokenManager tokens, Config config)
+        { _http = http; _tokens = tokens; _config = config; }
+
+        public async Task RefreshAsync(CancellationToken ct = default)
+        {
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/discord/emojis";
+            var req = new HttpRequestMessage(HttpMethod.Get, url);
+            ApiHelpers.AddAuthHeader(req, _tokens);
+
+            using var res = await _http.SendAsync(req, ct);
+            res.EnsureSuccessStatusCode();
+            using var stream = await res.Content.ReadAsStreamAsync(ct);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+
+            var list = new List<CustomEmoji>();
+            if (doc.RootElement.TryGetProperty("emojis", out var arr))
+            {
+                foreach (var e in arr.EnumerateArray())
+                {
+                    var id = e.GetProperty("id").GetString()!;
+                    var name = e.GetProperty("name").GetString()!;
+                    var animated = e.GetProperty("animated").GetBoolean();
+                    var available = e.TryGetProperty("available", out var a) ? a.GetBoolean() : true;
+                    if (available)
+                        list.Add(new CustomEmoji(id, name, animated));
+                }
+            }
+            Custom = list;
+        }
+    }
+}

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -10,6 +10,9 @@ public class FcChatWindow : ChatWindow
 {
     private readonly PresenceSidebar? _presenceSidebar;
     private float _presenceWidth = 150f;
+    private readonly Emoji.EmojiService _emojiService;
+    private readonly Emoji.EmojiPicker _emojiPicker;
+    private string _chatInput = string.Empty;
 
     public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService)
         : base(config, httpClient, presence, tokenManager, channelService)
@@ -19,6 +22,9 @@ public class FcChatWindow : ChatWindow
         {
             _presenceSidebar = new PresenceSidebar(presence) { TextureLoader = LoadTexture };
         }
+        _emojiService = new Emoji.EmojiService(httpClient, tokenManager, config);
+        _emojiPicker = new Emoji.EmojiPicker(_emojiService);
+        _ = _emojiService.RefreshAsync();
     }
 
     public override void StartNetworking()
@@ -57,6 +63,19 @@ public class FcChatWindow : ChatWindow
         ImGui.BeginChild("##fcChat", ImGui.GetContentRegionAvail(), false);
         base.Draw();
         ImGui.EndChild();
+
+        _chatInput = _input;
+        ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X - 36f);
+        ImGui.InputText("##chat_input", ref _chatInput, 2000);
+        ImGui.PopItemWidth();
+        ImGui.SameLine();
+        if (ImGui.Button("😊")) ImGui.OpenPopup("##dc_emoji_picker");
+        if (ImGui.BeginPopup("##dc_emoji_picker"))
+        {
+            _emojiPicker.Draw(ref _chatInput);
+            ImGui.EndPopup();
+        }
+        _input = _chatInput;
 
         if (_config.ChatChannelId != originalChatChannel || _config.FcChannelId != _channelId)
         {

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -17,6 +17,9 @@ public class OfficerChatWindow : ChatWindow
 {
     private DateTime _lastRolesRefresh = DateTime.MinValue;
     private bool _subscribed;
+    private readonly Emoji.EmojiService _emojiService;
+    private readonly Emoji.EmojiPicker _emojiPicker;
+    private string _chatInput = string.Empty;
 
     public OfficerChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService)
         : base(config, httpClient, presence, tokenManager, channelService)
@@ -29,6 +32,9 @@ public class OfficerChatWindow : ChatWindow
                 TryRefreshRoles();
             }
         };
+        _emojiService = new Emoji.EmojiService(httpClient, tokenManager, config);
+        _emojiPicker = new Emoji.EmojiPicker(_emojiService);
+        _ = _emojiService.RefreshAsync();
     }
 
     public override void StartNetworking()
@@ -80,6 +86,19 @@ public class OfficerChatWindow : ChatWindow
 
         var originalChatChannel = _config.ChatChannelId;
         base.Draw();
+
+        _chatInput = _input;
+        ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X - 36f);
+        ImGui.InputText("##chat_input", ref _chatInput, 2000);
+        ImGui.PopItemWidth();
+        ImGui.SameLine();
+        if (ImGui.Button("😊")) ImGui.OpenPopup("##dc_emoji_picker");
+        if (ImGui.BeginPopup("##dc_emoji_picker"))
+        {
+            _emojiPicker.Draw(ref _chatInput);
+            ImGui.EndPopup();
+        }
+        _input = _chatInput;
 
         // Reserved padded area beneath the standard chat input for upcoming officer tools.
         ImGui.Dummy(new Vector2(0, ImGui.GetFrameHeightWithSpacing()));

--- a/demibot/demibot/http/routes/__init__.py
+++ b/demibot/demibot/http/routes/__init__.py
@@ -11,6 +11,7 @@ from . import (
     requests,
     user_settings,
     installations,
+    discord_emojis,
 )
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "requests",
     "user_settings",
     "installations",
+    "discord_emojis",
 ]

--- a/demibot/demibot/http/routes/discord_emojis.py
+++ b/demibot/demibot/http/routes/discord_emojis.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends, HTTPException
+from ..auth import with_context, RequestContext
+from ...ws.client import discord_client
+
+router = APIRouter(prefix="/api/discord", tags=["discord"])
+
+@router.get("/emojis")
+async def list_emojis(ctx: RequestContext = Depends(with_context)):
+    if not discord_client:
+        raise HTTPException(503, "discord not connected")
+    guild = discord_client.get_guild(ctx.guild.id)
+    if not guild:
+        raise HTTPException(404, "guild not found")
+
+    out = []
+    for e in guild.emojis:
+        out.append({
+            "id": str(e.id),
+            "name": e.name,
+            "animated": bool(getattr(e, "animated", False)),
+            "available": bool(getattr(e, "available", True)),
+        })
+    return {"ok": True, "emojis": out}

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
+import re
 import discord
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
@@ -209,12 +210,23 @@ async def create_event(
                             if b.style is not None
                             else discord.ButtonStyle.secondary
                         )
+                        emoji_obj = None
+                        if b.emoji:
+                            match = re.match(r"<(a?):([^:>]+):(\d+)>", b.emoji)
+                            if match:
+                                emoji_obj = discord.PartialEmoji(
+                                    name=match.group(2),
+                                    id=int(match.group(3)),
+                                    animated=match.group(1) == "a",
+                                )
+                            else:
+                                emoji_obj = discord.PartialEmoji(name=b.emoji)
                         if b.url:
                             view.add_item(
                                 discord.ui.Button(
                                     label=b.label,
                                     url=b.url,
-                                    emoji=b.emoji,
+                                    emoji=emoji_obj,
                                     style=style,
                                     row=row_index,
                                 )
@@ -224,7 +236,7 @@ async def create_event(
                                 discord.ui.Button(
                                     label=b.label,
                                     custom_id=b.custom_id,
-                                    emoji=b.emoji,
+                                    emoji=emoji_obj,
                                     style=style,
                                     row=row_index,
                                 )


### PR DESCRIPTION
## Summary
- expose guild emoji list via `/api/discord/emojis`
- send proper emoji objects when building event buttons
- add plugin emoji picker and wire to chat windows

## Testing
- `dotnet test` *(fails: command not found)*
- `pytest` *(errors: 59 during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ff18b118832883a18bf10bbb1406