### PR TITLE
Guard officer tab role checks and keep presence roles

### DIFF
--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -194,6 +194,8 @@ public class DiscordPresenceService : IDisposable
                                 var existing = _presences[idx];
                                 dto.AvatarUrl ??= existing.AvatarUrl;
                                 dto.AvatarTexture = existing.AvatarTexture;
+                                if (dto.Roles.Count == 0)
+                                    dto.Roles = existing.Roles;
                                 _presences[idx] = dto;
                             }
                             else


### PR DESCRIPTION
## Summary
- avoid repeated officer role refreshes and revalidate once when tab is opened
- retain previous roles when presence updates omit role data

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: structlog has no attribute get_logger)*

------
https://chatgpt.com/codex/tasks/task_e_68c6018853dc8328bde0dc89640096e7