### PR TITLE
Fix discord emojis route import path

### DIFF
--- a/demibot/demibot/http/routes/discord_emojis.py
+++ b/demibot/demibot/http/routes/discord_emojis.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from ..deps import RequestContext, api_key_auth
-from ...ws.client import discord_client
+from ..discord_client import discord_client
 
 router = APIRouter(prefix="/api/discord", tags=["discord"])
 


### PR DESCRIPTION
## Summary
- fix Discord emoji route import path to reference local client module

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68c605dd66e08328bfdd0865864755ee