### PR TITLE
Use discord_guild_id for Discord emoji route

### DIFF
--- a/demibot/demibot/http/routes/discord_emojis.py
+++ b/demibot/demibot/http/routes/discord_emojis.py
@@ -8,7 +8,7 @@ router = APIRouter(prefix="/api/discord", tags=["discord"])
 async def list_emojis(ctx: RequestContext = Depends(api_key_auth)):
     if not discord_client:
         raise HTTPException(503, "discord not connected")
-    guild = discord_client.get_guild(ctx.guild.id)
+    guild = discord_client.get_guild(ctx.guild.discord_guild_id)
     if not guild:
         raise HTTPException(404, "guild not found")
 


### PR DESCRIPTION
## Summary
- fix discord emoji route to use `discord_guild_id` for guild lookup

## Testing
- `pytest` *(fails: Interrupted: 59 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c606bba6648328bcd874839ba9b98f