### PR TITLE
feat: render emoji icons in signup options

### DIFF
--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -125,8 +125,13 @@ public static class EmbedPreviewRenderer
                         ImGui.SameLine();
                     }
 
+                    if (!string.IsNullOrEmpty(button.Emoji))
+                    {
+                        EmojiUtils.DrawEmoji(button.Emoji);
+                        ImGui.SameLine();
+                    }
+
                     var id = button.CustomId ?? button.Label;
-                    var text = string.IsNullOrEmpty(button.Emoji) ? button.Label : $"{button.Emoji} {button.Label}";
                     var styled = button.Style.HasValue && button.Style.Value != ButtonStyle.Link;
                     if (styled)
                     {
@@ -137,7 +142,7 @@ public static class EmbedPreviewRenderer
                     }
 
                     var w = button.Width ?? -1;
-                    if (ImGui.Button($"{text}##{id}{dto.Id}", new Vector2(w, 0)))
+                    if (ImGui.Button($"{button.Label}##{id}{dto.Id}", new Vector2(w, 0)))
                     {
                         if (!string.IsNullOrEmpty(button.Url))
                         {

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -95,8 +95,13 @@ public static class EmbedRenderer
                         ImGui.SameLine();
                     }
 
+                    if (!string.IsNullOrEmpty(button.Emoji))
+                    {
+                        EmojiUtils.DrawEmoji(button.Emoji);
+                        ImGui.SameLine();
+                    }
+
                     var id = button.CustomId ?? button.Label;
-                    var text = string.IsNullOrEmpty(button.Emoji) ? button.Label : $"{button.Emoji} {button.Label}";
                     var styled = button.Style.HasValue && button.Style.Value != ButtonStyle.Link;
                     if (styled)
                     {
@@ -107,7 +112,7 @@ public static class EmbedRenderer
                     }
 
                     var w = button.Width ?? -1;
-                    if (ImGui.Button($"{text}##{id}{dto.Id}", new Vector2(w, 0)))
+                    if (ImGui.Button($"{button.Label}##{id}{dto.Id}", new Vector2(w, 0)))
                     {
                         if (!string.IsNullOrEmpty(button.Url))
                         {

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -14,12 +14,15 @@ namespace DemiCatPlugin.Emoji
 
         public void Draw(ref string targetText, float buttonSize = 28f)
         {
+            var prev = _tabIndex;
             if (ImGui.BeginTabBar("##dc_emoji_tabs"))
             {
                 if (ImGui.BeginTabItem("Standard")) { _tabIndex = 0; DrawStandard(ref targetText, buttonSize); ImGui.EndTabItem(); }
                 if (ImGui.BeginTabItem("Custom"))   { _tabIndex = 1; DrawCustom(ref targetText, buttonSize);   ImGui.EndTabItem(); }
                 ImGui.EndTabBar();
             }
+            if (prev != _tabIndex)
+                _search = string.Empty;
         }
 
         private void DrawStandard(ref string targetText, float size)

--- a/DemiCatPlugin/EmojiUtils.cs
+++ b/DemiCatPlugin/EmojiUtils.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
 
@@ -16,4 +18,28 @@ public static class EmojiUtils
         }
         return emoji;
     }
+
+    public static void DrawEmoji(string? emoji, float size = 20f)
+    {
+        if (string.IsNullOrWhiteSpace(emoji)) return;
+        if (emoji.StartsWith("custom:", StringComparison.OrdinalIgnoreCase))
+        {
+            var id = emoji.Substring("custom:".Length);
+            var ext = EmojiAssets.IsGuildEmojiAnimated(id) ? "gif" : "png";
+            var url = $"https://cdn.discordapp.com/emojis/{id}.{ext}";
+            WebTextureCache.Get(url, tex =>
+            {
+                if (tex != null)
+                {
+                    var wrap = tex.GetWrapOrEmpty();
+                    ImGui.Image(wrap.Handle, new Vector2(size, size));
+                }
+            });
+        }
+        else
+        {
+            ImGui.TextUnformatted(emoji);
+        }
+    }
 }
+

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -177,6 +177,11 @@ public class EventCreateWindow
             if (ImGui.Checkbox("Include", ref include))
                 button.Include = include;
             ImGui.SameLine();
+            if (!string.IsNullOrWhiteSpace(button.Emoji))
+            {
+                EmojiUtils.DrawEmoji(button.Emoji);
+                ImGui.SameLine();
+            }
             ImGui.TextUnformatted($"{button.Label} ({button.Tag})");
             ImGui.SameLine();
             if (ImGui.Button("Edit"))

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -214,9 +214,14 @@ public class EventView : IDisposable
                 var buttons = row.ToList();
                 for (var i = 0; i < buttons.Count; i++)
                 {
+                    if (i > 0) ImGui.SameLine();
                     var button = buttons[i];
+                    if (!string.IsNullOrEmpty(button.Emoji))
+                    {
+                        EmojiUtils.DrawEmoji(button.Emoji);
+                        ImGui.SameLine();
+                    }
                     var id = button.CustomId ?? button.Label;
-                    var text = string.IsNullOrEmpty(button.Emoji) ? button.Label : $"{button.Emoji} {button.Label}";
                     var styled = button.Style.HasValue && button.Style.Value != ButtonStyle.Link;
                     if (styled)
                     {
@@ -227,7 +232,7 @@ public class EventView : IDisposable
                     }
 
                     var w = button.Width ?? -1;
-                    if (ImGui.Button($"{text}##{id}{_dto.Id}", new Vector2(w, 0)))
+                    if (ImGui.Button($"{button.Label}##{id}{_dto.Id}", new Vector2(w, 0)))
                     {
                         if (!string.IsNullOrEmpty(button.Url))
                         {
@@ -242,11 +247,6 @@ public class EventView : IDisposable
                     if (styled)
                     {
                         ImGui.PopStyleColor(3);
-                    }
-
-                    if (i < buttons.Count - 1)
-                    {
-                        ImGui.SameLine();
                     }
                 }
             }

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -59,26 +59,8 @@ public class SignupOptionEditor
 
             if (!string.IsNullOrWhiteSpace(_working.Emoji))
             {
-                if (_working.Emoji.StartsWith("custom:", StringComparison.OrdinalIgnoreCase))
-                {
-                    var id = _working.Emoji.Substring("custom:".Length);
-                    var ext = EmojiPopup.IsGuildEmojiAnimated(id) ? "gif" : "png"; // we won’t animate but PNG works for most
-                    var url = $"https://cdn.discordapp.com/emojis/{id}.{ext}";
-                    WebTextureCache.Get(url, tex =>
-                    {
-                        if (tex != null)
-                        {
-                            var wrap = tex.GetWrapOrEmpty();
-                            ImGui.Image(wrap.Handle, new Vector2(20, 20));
-                            ImGui.SameLine();
-                        }
-                    });
-                }
-                else
-                {
-                    ImGui.TextUnformatted(_working.Emoji);
-                    ImGui.SameLine();
-                }
+                EmojiUtils.DrawEmoji(_working.Emoji);
+                ImGui.SameLine();
             }
             var max = _working.MaxSignups ?? 0;
             if (ImGui.InputInt("Max Signups", ref max))


### PR DESCRIPTION
## Summary
- render emoji icons using utility
- show emoji icons for signup options and event buttons
- reset emoji picker search when switching tabs

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release` *(fails: Dalamud installation not found)*
- `pytest tests/test_emojis.py -q` *(fails: No module named 'alembic')*

------
https://chatgpt.com/codex/tasks/task_e_68c607ea84948328896c3ebec2071a32