### PR TITLE
Handle webhook rate limits and surface Discord errors

### DIFF
--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -262,7 +262,10 @@ def test_message_too_long(monkeypatch):
             with pytest.raises(HTTPException) as exc:
                 await mc.save_message(body, ctx, db, is_officer=False)
             assert exc.value.status_code == 400
-            assert exc.value.detail == "message too long"
+            assert (
+                exc.value.detail
+                == "Message too long (max 2000 characters)."
+            )
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary
- retry webhook sends on Discord rate limits and clarify message length errors
- show Discord send failures in plugin UI

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_message_too_long`
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: structlog.get_logger missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c60a8372b08328add3282563bb257d