### PR TITLE
fix: handle nullable discord error messages

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -951,6 +951,7 @@ public class ChatWindow : IDisposable
                                 parts = discord.EnumerateArray()
                                     .Select(e => e.GetString())
                                     .Where(s => !string.IsNullOrEmpty(s))
+                                    .Select(s => s!)
                                     .ToList();
                             }
                             if (parts.Count > 0)


### PR DESCRIPTION
## Summary
- avoid nullability mismatch when parsing Discord error messages

## Testing
- `dotnet build -c release` *(fails: Dalamud installation not found)*
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60edf5bd08328a1760193fd94064e