### PR TITLE
Restart watchers when roles update

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -281,6 +281,8 @@ public class Plugin : IDalamudPlugin
                     _presenceService?.Dispose();
                 }
                 _services.PluginInterface.SavePluginConfig(_config);
+                StopWatchers();
+                StartWatchers();
             });
 
             await RoleCache.Refresh(_httpClient, _config);


### PR DESCRIPTION
## Summary
- Reinitialize services after role refresh by stopping and restarting watchers once roles and config are saved

## Testing
- `~/.dotnet/dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord', 'fastapi', 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68c6141cc4088328b01051adcdeee8f5