### PR TITLE
Add configurable mentionable roles

### DIFF
--- a/demibot/demibot/db/migrations/versions/0042_add_mention_role_ids.py
+++ b/demibot/demibot/db/migrations/versions/0042_add_mention_role_ids.py
@@ -1,0 +1,16 @@
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0042_add_mention_role_ids"
+down_revision = "0041_add_unicode_emojis_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("guild_config", sa.Column("mention_role_ids", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("guild_config", "mention_role_ids")
+

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -93,6 +93,7 @@ class GuildConfig(Base):
         BIGINT(unsigned=True)
     )
     officer_role_ids: Mapped[Optional[str]] = mapped_column(Text)
+    mention_role_ids: Mapped[Optional[str]] = mapped_column(Text)
 
     guild: Mapped[Guild] = relationship(back_populates="config")
 

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -28,6 +28,7 @@ from ...db.models import (
     ChannelKind,
     EventSignup,
     User,
+    GuildConfig,
 )
 from models.event import Event
 
@@ -126,6 +127,14 @@ async def create_event(
         ts = datetime.now(timezone.utc)
 
     mention_ids = [int(m) for m in body.mentions or []]
+    if "officer" not in ctx.roles:
+        cfg = await db.scalar(
+            select(GuildConfig).where(GuildConfig.guild_id == ctx.guild.id)
+        )
+        allowed = {
+            int(r) for r in (cfg.mention_role_ids or "").split(",") if r
+        } if cfg else set()
+        mention_ids = [m for m in mention_ids if m in allowed]
 
     dto = EmbedDto(
         id=eid,

--- a/demibot/demibot/http/routes/guild_roles.py
+++ b/demibot/demibot/http/routes/guild_roles.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
 from ..discord_client import discord_client
-from ...db.models import Role
+from ...db.models import Role, GuildConfig
 
 router = APIRouter(prefix="/api")
 
@@ -16,9 +16,24 @@ async def get_guild_roles(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    result = await db.execute(
-        select(Role.discord_role_id, Role.name).where(Role.guild_id == ctx.guild.id)
+    mention_ids: set[int] | None = None
+    if "officer" not in ctx.roles:
+        cfg = await db.scalar(
+            select(GuildConfig).where(GuildConfig.guild_id == ctx.guild.id)
+        )
+        if cfg and cfg.mention_role_ids:
+            mention_ids = {
+                int(r) for r in cfg.mention_role_ids.split(",") if r
+            }
+        else:
+            return []
+
+    stmt = select(Role.discord_role_id, Role.name).where(
+        Role.guild_id == ctx.guild.id
     )
+    if mention_ids is not None:
+        stmt = stmt.where(Role.discord_role_id.in_(mention_ids))
+    result = await db.execute(stmt)
     rows = result.all()
     if rows:
         return [{"id": str(rid), "name": name} for rid, name in rows]
@@ -30,6 +45,8 @@ async def get_guild_roles(
             existing = set()
             for r in guild.roles:
                 if r.name == "@everyone":
+                    continue
+                if mention_ids is not None and r.id not in mention_ids:
                     continue
                 roles_out.append({"id": str(r.id), "name": r.name})
                 existing.add(r.id)

--- a/tests/test_guild_roles_filter.py
+++ b/tests/test_guild_roles_filter.py
@@ -1,0 +1,65 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+# Create package stubs so relative imports work
+pkg = types.ModuleType("demibot")
+pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", pkg)
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+routes_pkg = types.ModuleType("demibot.http.routes")
+routes_pkg.__path__ = [str(root / "demibot/http/routes")]
+sys.modules.setdefault("demibot.http.routes", routes_pkg)
+
+spec = importlib.util.spec_from_file_location(
+    "demibot.http.routes.guild_roles", root / "demibot/http/routes/guild_roles.py"
+)
+guild_roles = importlib.util.module_from_spec(spec)
+sys.modules["demibot.http.routes.guild_roles"] = guild_roles
+spec.loader.exec_module(guild_roles)
+
+from demibot.http.deps import RequestContext
+from demibot.db.models import Guild, GuildConfig, Role
+from demibot.db.session import init_db, get_session
+
+class StubContext(RequestContext):
+    def __init__(self, guild_id: int, roles: list[str]):
+        self.guild = types.SimpleNamespace(id=guild_id, discord_guild_id=guild_id)
+        self.roles = roles
+        self.key = None
+        self.user = None
+
+def test_guild_roles_filter():
+    async def _run():
+        db_path = Path("test_guild_roles.db")
+        if db_path.exists():
+            db_path.unlink()
+        await init_db(f"sqlite+aiosqlite:///{db_path}")
+        async with get_session() as db:
+            guild = Guild(id=1, discord_guild_id=1, name="Test")
+            db.add(guild)
+            db.add(GuildConfig(guild_id=1, mention_role_ids="1,2"))
+            db.add_all(
+                [
+                    Role(guild_id=1, discord_role_id=1, name="One"),
+                    Role(guild_id=1, discord_role_id=2, name="Two"),
+                    Role(guild_id=1, discord_role_id=3, name="Three"),
+                ]
+            )
+            await db.commit()
+        ctx = StubContext(1, [])
+        async with get_session() as db:
+            roles = await guild_roles.get_guild_roles(ctx=ctx, db=db)
+            assert {r["id"] for r in roles} == {"1", "2"}
+        ctx_off = StubContext(1, ["officer"])
+        async with get_session() as db:
+            roles = await guild_roles.get_guild_roles(ctx=ctx_off, db=db)
+            assert {r["id"] for r in roles} == {"1", "2", "3"}
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- allow admins to pick mentionable roles during setup wizard
- store mentionable role IDs in guild config
- enforce mentionable role filtering for event creation and role listing

## Testing
- `pytest tests/test_guild_roles_filter.py tests/test_config_wizard_channel_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_68c619a9ce188328af9e5cd4351e9bd9