### PR TITLE
Add events table migration

### DIFF
--- a/demibot/demibot/db/__init__.py
+++ b/demibot/demibot/db/__init__.py
@@ -12,5 +12,6 @@ from .base import Base
 # are not re-exported but the import has the desired side effect of registering
 # all models with ``Base.metadata``.
 from . import models  # noqa: F401
+from models import event as _event  # noqa: F401
 
 __all__ = ["Base"]

--- a/demibot/demibot/db/migrations/versions/0043_add_events_table.py
+++ b/demibot/demibot/db/migrations/versions/0043_add_events_table.py
@@ -1,0 +1,38 @@
+"""add events table
+
+Revision ID: 0043_add_events_table
+Revises: 0042_add_mention_role_ids
+Create Date: 2025-01-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision: str = "0043_add_events_table"
+down_revision: str = "0042_add_mention_role_ids"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "events",
+        sa.Column(
+            "discord_message_id",
+            mysql.BIGINT(unsigned=True),
+            primary_key=True,
+        ),
+        sa.Column("channel_id", mysql.BIGINT(unsigned=True), nullable=False),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column("embeds", sa.JSON(), nullable=True),
+        sa.Column("attachments", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_events_channel_id", "events", ["channel_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_events_channel_id", table_name="events")
+    op.drop_table("events")


### PR DESCRIPTION
## Summary
- add Alembic migration creating events table
- import event model in db package so Base metadata includes table

## Testing
- `pytest tests/test_event_api_errors.py tests/test_event_emit_event.py tests/test_event_update.py -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'roles'; IntegrityError: UNIQUE constraint failed: guilds.id)*

------
https://chatgpt.com/codex/tasks/task_e_68c6213912408328bd26f5a7f60e0064