### PR TITLE
Surface webhook errors in message responses

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -332,7 +332,7 @@ async def _send_via_webhook(
             for a in sent.attachments
         ]
 
-    return discord_msg_id, attachments, []
+    return discord_msg_id, attachments, errors
 
 
 class PostBody(BaseModel):


### PR DESCRIPTION
## Summary
- propagate webhook send errors to API responses
- cover error propagation with tests

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_webhook_errors_returned -q`
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_save_message_webhook_failure -q`


------
https://chatgpt.com/codex/tasks/task_e_68c624c8b33c83289429bbef0d87d99b