### PR TITLE
Log config wizard save failures

### DIFF
--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -686,9 +686,10 @@ class ConfigWizard(discord.ui.View):
                         )
                     )
                 await db.commit()
-        except Exception:
+        except Exception as exc:
+            logging.exception("Failed to save settings")
             await interaction.response.send_message(
-                "Failed to save settings", ephemeral=True
+                f"Failed to save settings: {exc}", ephemeral=True
             )
             return
         summary = (


### PR DESCRIPTION
## Summary
- log admin setup wizard errors and surface details in response

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*


------
https://chatgpt.com/codex/tasks/task_e_68c64576a6cc8328b7e574d81750e81b