### PR TITLE
Handle invalid port input in config profile prompt

### DIFF
--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -128,8 +128,15 @@ async def ensure_config(force_reconfigure: bool = False) -> AppConfig:
         """Prompt for basic connection details for a profile."""
 
         profile.host = input(f"{name} host [{profile.host}]: ") or profile.host
-        port = input(f"{name} port [{profile.port}]: ") or profile.port
-        profile.port = int(port)
+        while True:
+            port_input = input(f"{name} port [{profile.port}]: ")
+            if not port_input:
+                break
+            try:
+                profile.port = int(port_input)
+                break
+            except ValueError:
+                print("Invalid port. Please enter a number.")
         profile.database = (
             input(f"{name} database [{profile.database}]: ") or profile.database
         )

--- a/tests/test_prompt_profile.py
+++ b/tests/test_prompt_profile.py
@@ -1,0 +1,40 @@
+import types
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "demibot"))
+import demibot.config as config  # type: ignore
+
+
+def get_prompt_profile():
+    code = [c for c in config.ensure_config.__code__.co_consts if isinstance(c, types.CodeType) and c.co_name == '_prompt_profile'][0]
+    return types.FunctionType(code, config.__dict__)
+
+
+def test_prompt_profile_valid_port(monkeypatch):
+    _prompt_profile = get_prompt_profile()
+    profile = config.DBProfile()
+    inputs = iter(["", "1234", ""])
+    monkeypatch.setattr(config, "input", lambda _: next(inputs), raising=False)
+    _prompt_profile("Test", profile)
+    assert profile.port == 1234
+
+
+def test_prompt_profile_invalid_then_valid_port(monkeypatch, capsys):
+    _prompt_profile = get_prompt_profile()
+    profile = config.DBProfile()
+    inputs = iter(["", "abc", "2345", ""])
+    monkeypatch.setattr(config, "input", lambda _: next(inputs), raising=False)
+    _prompt_profile("Test", profile)
+    assert profile.port == 2345
+    captured = capsys.readouterr()
+    assert "Invalid port" in captured.out
+
+
+def test_prompt_profile_empty_port(monkeypatch):
+    _prompt_profile = get_prompt_profile()
+    profile = config.DBProfile()
+    inputs = iter(["", "", ""])
+    monkeypatch.setattr(config, "input", lambda _: next(inputs), raising=False)
+    _prompt_profile("Test", profile)
+    assert profile.port == 3306


### PR DESCRIPTION
## Summary
- make database profile prompts robust against invalid port entries
- add tests for valid, invalid, and empty port inputs

## Testing
- `pytest tests/test_prompt_profile.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c64b6b99688328bc90bc348d73db33