### PR TITLE
Handle malformed discord components gracefully

### DIFF
--- a/demibot/demibot/http/discord_helpers.py
+++ b/demibot/demibot/http/discord_helpers.py
@@ -222,7 +222,7 @@ def extract_embed_buttons(message: discord.Message) -> List[EmbedButtonDto]:
                         row_index=row_index,
                     )
                 )
-    except Exception:
+    except (AttributeError, TypeError):
         logging.exception(
             "Button extraction failed for channel %s message %s",
             getattr(getattr(message, "channel", None), "id", None),
@@ -267,7 +267,7 @@ def serialize_message(
         for emb in message.embeds:
             try:
                 embeds_list.append(embed_to_dto(message, emb, buttons or None))
-            except Exception:
+            except (AttributeError, TypeError):
                 continue
         embeds = embeds_list or None
         if embeds:
@@ -289,7 +289,7 @@ def serialize_message(
     if getattr(message, "components", None):
         try:
             components = components_to_dtos(message)
-        except Exception:
+        except (AttributeError, TypeError):
             components = None
         if components:
             components_json = json.dumps(


### PR DESCRIPTION
## Summary
- avoid swallowing unexpected errors when extracting embed buttons
- limit exception handling during message serialization to AttributeError/TypeError
- test message serialization against malformed component structures

## Testing
- `pytest tests/test_message_components.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c64cc6f97083289c79b00a3df7ac79