### PR TITLE
Pass WebSocket request context for authentication

### DIFF
--- a/tests/test_chat_ws.py
+++ b/tests/test_chat_ws.py
@@ -63,7 +63,8 @@ def test_chat_ws_role_access(monkeypatch):
         async def fake_get_session():
             yield DummySession()
 
-        async def fake_auth(x_api_key, x_discord_id, db):
+        async def fake_auth(request, x_api_key, x_discord_id, db):
+            assert request.method == "WS"
             return ctx
 
         manager = ws_chat.ChatConnectionManager()
@@ -90,7 +91,8 @@ def test_chat_ws_invalid_token(monkeypatch):
         async def fake_get_session():
             yield DummySession()
 
-        async def fake_auth(x_api_key, x_discord_id, db):
+        async def fake_auth(request, x_api_key, x_discord_id, db):
+            assert request.method == "WS"
             raise HTTPException(status_code=401, detail="bad")
 
         monkeypatch.setattr(ws_chat, "get_session", fake_get_session)

--- a/tests/test_config_wizard_channel_filter.py
+++ b/tests/test_config_wizard_channel_filter.py
@@ -5,7 +5,9 @@ import sys
 import types
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "demibot"))
-sys.modules.setdefault("structlog", types.ModuleType("structlog"))
+structlog_stub = types.ModuleType("structlog")
+structlog_stub.get_logger = lambda *a, **k: None
+sys.modules.setdefault("structlog", structlog_stub)
 alembic_stub = types.ModuleType("alembic")
 alembic_stub.command = types.SimpleNamespace()
 alembic_config_stub = types.ModuleType("alembic.config")

--- a/tests/test_config_wizard_role_union.py
+++ b/tests/test_config_wizard_role_union.py
@@ -5,7 +5,9 @@ import types
 
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "demibot"))
-sys.modules.setdefault("structlog", types.ModuleType("structlog"))
+structlog_stub = types.ModuleType("structlog")
+structlog_stub.get_logger = lambda *a, **k: None
+sys.modules.setdefault("structlog", structlog_stub)
 alembic_stub = types.ModuleType("alembic")
 alembic_stub.command = types.SimpleNamespace()
 alembic_config_stub = types.ModuleType("alembic.config")

--- a/tests/test_officer_ws.py
+++ b/tests/test_officer_ws.py
@@ -103,8 +103,9 @@ def test_officer_path_requires_role(monkeypatch):
             finally:
                 await session.close()
 
-        async def fake_api_key_auth(x_api_key, x_discord_id, db):
+        async def fake_api_key_auth(request, x_api_key, x_discord_id, db):
             assert x_discord_id is None
+            assert request.method == "WS"
             return ctx
 
         connected = False

--- a/tests/test_syncshell.py
+++ b/tests/test_syncshell.py
@@ -18,6 +18,7 @@ structlog_stub = types.SimpleNamespace(
     make_filtering_bound_logger=lambda *a, **k: None,
     stdlib=types.SimpleNamespace(LoggerFactory=lambda: None),
     configure=lambda *a, **k: None,
+    get_logger=lambda *a, **k: None,
 )
 sys.modules.setdefault("structlog", structlog_stub)
 

--- a/tests/test_template_ws.py
+++ b/tests/test_template_ws.py
@@ -15,7 +15,9 @@ http_pkg = types.ModuleType("demibot.http")
 http_pkg.__path__ = [str(root / "demibot/http")]
 sys.modules.setdefault("demibot.http", http_pkg)
 
-sys.modules.setdefault("structlog", types.ModuleType("structlog"))
+structlog_stub = types.ModuleType("structlog")
+structlog_stub.get_logger = lambda *a, **k: None
+sys.modules.setdefault("structlog", structlog_stub)
 
 db_pkg = types.ModuleType("demibot.db")
 db_pkg.__path__ = [str(root / "demibot/db")]

--- a/tests/test_ws_api_key.py
+++ b/tests/test_ws_api_key.py
@@ -52,8 +52,9 @@ def test_websocket_auth_success(monkeypatch):
         finally:
             await session.close()
 
-    async def fake_api_key_auth(x_api_key, x_discord_id, db):
+    async def fake_api_key_auth(request, x_api_key, x_discord_id, db):
         assert x_discord_id is None
+        assert request.method == "WS"
         return ctx
 
     connected = False
@@ -85,8 +86,9 @@ def test_websocket_auth_failure(monkeypatch):
         finally:
             await session.close()
 
-    async def fake_api_key_auth(x_api_key, x_discord_id, db):
+    async def fake_api_key_auth(request, x_api_key, x_discord_id, db):
         assert x_discord_id is None
+        assert request.method == "WS"
         raise HTTPException(status_code=401, detail="bad token")
 
     monkeypatch.setattr(ws_module, "get_session", fake_get_session)


### PR DESCRIPTION
## Summary
- build lightweight Request objects from WebSocket connections
- supply WebSocket method/path and client to `api_key_auth`
- adjust tests for new auth call signature and structlog stubs

## Testing
- `PYTHONPATH=demibot pytest tests/test_ws_api_key.py tests/test_officer_ws.py tests/test_chat_ws.py -q`
- `PYTHONPATH=demibot pytest tests/test_installations.py::test_installations_flow -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_68c6f47beee4832897758c8a61c79914