### PR TITLE
Implement websocket channel unsubscribe support

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -80,6 +80,16 @@ public class ChatBridge : IDisposable
         _ = SendSubscriptions();
     }
 
+    public void Unsubscribe(string channel)
+    {
+        if (string.IsNullOrEmpty(channel)) return;
+        if (_subs.Remove(channel))
+        {
+            PluginServices.Instance?.Log.Info($"chat.ws unsubscribe channel={channel}");
+            _ = SendSubscriptions();
+        }
+    }
+
     public void Ack(string channel)
     {
         _ = AckAsync(channel);

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -127,6 +127,7 @@ public class ChatWindow : IDisposable
     public virtual void StartNetworking()
     {
         _bridge.Start();
+        _bridge.Unsubscribe(_channelId);
         _bridge.Subscribe(_channelId);
         _presence?.Reset();
     }
@@ -189,10 +190,12 @@ public class ChatWindow : IDisposable
             var channelNames = _channels.Select(c => c.Name).ToArray();
             if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
             {
+                var oldChannel = _channelId;
                 _channelId = _channels[_selectedIndex].Id;
                 _config.ChatChannelId = _channelId;
                 ClearTextureCache();
                 SaveConfig();
+                _bridge.Unsubscribe(oldChannel);
                 _bridge.Subscribe(_channelId);
                 _ = RefreshMessages();
             }
@@ -1429,6 +1432,7 @@ public class ChatWindow : IDisposable
     {
         _presence?.Reload();
         _ = _presence?.Refresh();
+        _bridge.Unsubscribe(_channelId);
         _bridge.Subscribe(_channelId);
     }
 

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -265,6 +265,7 @@ public class OfficerChatWindow : ChatWindow
 
     private void Subscribe()
     {
+        _bridge.Unsubscribe(_channelId);
         _bridge.Subscribe(_channelId);
         _presence?.Reset();
         _ = RefreshMessages();

--- a/demibot/demibot/http/ws_chat.py
+++ b/demibot/demibot/http/ws_chat.py
@@ -134,6 +134,8 @@ class ChatConnectionManager:
         if info is None:
             return
         channels = data.get("channels", [])
+        old_channels = set(info.channels)
+        new_channels: Set[str] = set()
         for ch in channels:
             channel_id: str
             is_officer = False
@@ -145,7 +147,13 @@ class ChatConnectionManager:
             if is_officer and "officer" not in info.ctx.roles:
                 # Skip officer-only channels for non-officers.
                 continue
-            info.channels.add(channel_id)
+            new_channels.add(channel_id)
+        removed = old_channels - new_channels
+        for ch in removed:
+            info.cursors.pop(ch, None)
+        added = new_channels - old_channels
+        info.channels = new_channels
+        for channel_id in added:
             self._sub_count += 1
             logger.info(
                 "chat.ws subscribe channel=%s count=%s",


### PR DESCRIPTION
## Summary
- add ability to unsubscribe channels in `ChatBridge`
- ensure windows unsubscribe from old channel before subscribing
- replace websocket subscription set on server side

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 62 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f8fdce708328b4dc36acc5f6517b