### PR TITLE
Include templates window in channel refresh flow

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -15,6 +15,7 @@ public class ChannelWatcher : IDisposable
     private readonly HttpClient _httpClient;
     private readonly UiRenderer _ui;
     private readonly EventCreateWindow _eventCreateWindow;
+    private readonly TemplatesWindow _templatesWindow;
     private readonly ChatWindow _chatWindow;
     private readonly OfficerChatWindow _officerChatWindow;
     private readonly TokenManager _tokenManager;
@@ -24,11 +25,12 @@ public class ChannelWatcher : IDisposable
     private DateTime _lastRefresh = DateTime.MinValue;
     private readonly TimeSpan _refreshCooldown = TimeSpan.FromSeconds(2);
 
-    public ChannelWatcher(Config config, UiRenderer ui, EventCreateWindow eventCreateWindow, ChatWindow chatWindow, OfficerChatWindow officerChatWindow, TokenManager tokenManager, HttpClient httpClient)
+    public ChannelWatcher(Config config, UiRenderer ui, EventCreateWindow eventCreateWindow, TemplatesWindow templatesWindow, ChatWindow chatWindow, OfficerChatWindow officerChatWindow, TokenManager tokenManager, HttpClient httpClient)
     {
         _config = config;
         _ui = ui;
         _eventCreateWindow = eventCreateWindow;
+        _templatesWindow = templatesWindow;
         _chatWindow = chatWindow;
         _officerChatWindow = officerChatWindow;
         _tokenManager = tokenManager;
@@ -204,6 +206,7 @@ public class ChannelWatcher : IDisposable
 
         _ = SafeRefresh(_ui.RefreshChannels);
         _ = SafeRefresh(_eventCreateWindow.RefreshChannels);
+        _ = SafeRefresh(_templatesWindow.RefreshChannels);
         if (_config.SyncedChat && _config.EnableFcChat)
             _ = SafeRefresh(_chatWindow.RefreshChannels);
         if (_config.Roles.Contains("officer"))

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -87,7 +87,7 @@ public class Plugin : IDalamudPlugin
             () => RefreshRoles(_services.Log)
         );
 
-        _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _chatWindow, _officerChatWindow, _tokenManager, _httpClient);
+        _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _mainWindow.TemplatesWindow, _chatWindow, _officerChatWindow, _tokenManager, _httpClient);
         _requestWatcher = new RequestWatcher(_config, _httpClient, _tokenManager);
 
         _settings.MainWindow = _mainWindow;


### PR DESCRIPTION
## Summary
- accept TemplatesWindow in ChannelWatcher and refresh it when channels change
- wire ChannelWatcher up with the templates window in the plugin

## Testing
- `dotnet test` *(fails: command not found – .NET SDK 9 not installed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*


------
https://chatgpt.com/codex/tasks/task_e_68c6fc1d1ecc8328beb226786175df92