### PR TITLE
Use ChannelSelectionService to centralize channel selection

### DIFF
--- a/DemiCatPlugin/ChannelSelectionService.cs
+++ b/DemiCatPlugin/ChannelSelectionService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace DemiCatPlugin;
+
+public class ChannelSelectionService
+{
+    private readonly Config _config;
+    private readonly Dictionary<string, string> _channels = new();
+
+    public ChannelSelectionService(Config config)
+    {
+        _config = config;
+        _channels[ChannelKind.Event] = config.EventChannelId;
+        _channels[ChannelKind.FcChat] = config.FcChannelId;
+        _channels[ChannelKind.OfficerChat] = config.OfficerChannelId;
+    }
+
+    public event Action<string, string, string>? ChannelChanged;
+
+    public string GetChannel(string kind)
+        => _channels.TryGetValue(kind, out var id) ? id : string.Empty;
+
+    public void SetChannel(string kind, string id)
+    {
+        var old = GetChannel(kind);
+        if (old == id) return;
+        _channels[kind] = id;
+        switch (kind)
+        {
+            case ChannelKind.Event:
+                _config.EventChannelId = id;
+                break;
+            case ChannelKind.FcChat:
+                _config.FcChannelId = id;
+                break;
+            case ChannelKind.OfficerChat:
+                _config.OfficerChannelId = id;
+                break;
+        }
+        PluginServices.Instance?.PluginInterface.SavePluginConfig(_config);
+        ChannelChanged?.Invoke(kind, old, id);
+    }
+}
+

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -14,10 +14,9 @@ public class FcChatWindow : ChatWindow
     private readonly Emoji.EmojiPicker _emojiPicker;
     private string _chatInput = string.Empty;
 
-    public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService)
-        : base(config, httpClient, presence, tokenManager, channelService)
+    public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService, ChannelSelectionService channelSelection)
+        : base(config, httpClient, presence, tokenManager, channelService, channelSelection, ChannelKind.FcChat)
     {
-        _channelId = config.FcChannelId;
         if (presence != null)
         {
             _presenceSidebar = new PresenceSidebar(presence) { TextureLoader = LoadTexture };
@@ -50,8 +49,6 @@ public class FcChatWindow : ChatWindow
             return;
         }
 
-        var originalChatChannel = _config.ChatChannelId;
-
         _ = RoleCache.EnsureLoaded(_httpClient, _config);
 
         if (_presenceSidebar != null)
@@ -76,17 +73,6 @@ public class FcChatWindow : ChatWindow
             ImGui.EndPopup();
         }
         _input = _chatInput;
-
-        if (_config.ChatChannelId != originalChatChannel || _config.FcChannelId != _channelId)
-        {
-            _config.ChatChannelId = originalChatChannel;
-            _config.FcChannelId = _channelId;
-            SaveConfig();
-        }
-        else
-        {
-            _config.ChatChannelId = originalChatChannel;
-        }
     }
 
     public override Task RefreshMessages()

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -29,7 +29,7 @@ public class MainWindow : IDisposable
     public EventCreateWindow EventCreateWindow => _create;
     public TemplatesWindow TemplatesWindow => _templates;
 
-    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient, ChannelService channelService, Func<Task<bool>> refreshRoles)
+    public MainWindow(Config config, UiRenderer ui, ChatWindow? chat, OfficerChatWindow officer, SettingsWindow settings, HttpClient httpClient, ChannelService channelService, ChannelSelectionService channelSelection, Func<Task<bool>> refreshRoles)
     {
         _config = config;
         _ui = ui;
@@ -38,8 +38,8 @@ public class MainWindow : IDisposable
         _settings = settings;
         _httpClient = httpClient;
         _refreshRoles = refreshRoles;
-        _create = new EventCreateWindow(config, httpClient, channelService);
-        _templates = new TemplatesWindow(config, httpClient);
+        _create = new EventCreateWindow(config, httpClient, channelService, channelSelection);
+        _templates = new TemplatesWindow(config, httpClient, channelSelection);
         _requestBoard = new RequestBoardWindow(config, httpClient);
         _syncshellEnabled = config.FCSyncShell;
         _syncshell = _syncshellEnabled ? new SyncshellWindow(config, httpClient) : null;

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -28,6 +28,7 @@ public class Plugin : IDalamudPlugin
     private readonly MainWindow _mainWindow;
     private readonly ChannelWatcher _channelWatcher;
     private readonly RequestWatcher _requestWatcher;
+    private readonly ChannelSelectionService _channelSelection;
 
     private Config _config = null!;
     private readonly HttpClient _httpClient;
@@ -63,7 +64,8 @@ public class Plugin : IDalamudPlugin
         };
         _httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
 
-        _ui = new UiRenderer(_config, _httpClient);
+        _channelSelection = new ChannelSelectionService(_config);
+        _ui = new UiRenderer(_config, _httpClient, _channelSelection);
         _settings = new SettingsWindow(_config, _tokenManager, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
 
         _presenceService = _config.SyncedChat && _config.EnableFcChat
@@ -71,8 +73,8 @@ public class Plugin : IDalamudPlugin
             : null;
 
         _channelService = new ChannelService(_config, _httpClient, _tokenManager);
-        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService);
-        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService);
+        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection);
+        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection);
 
         _presenceService?.Reset();
 
@@ -84,6 +86,7 @@ public class Plugin : IDalamudPlugin
             _settings,
             _httpClient,
             _channelService,
+            _channelSelection,
             () => RefreshRoles(_services.Log)
         );
 

--- a/tests/ColorConversionTests.cs
+++ b/tests/ColorConversionTests.cs
@@ -70,7 +70,8 @@ public class ColorConversionTests
         var config = new Config();
         var http = new HttpClient(new StubHandler());
         var channelService = new ChannelService(config, http, new TokenManager());
-        var window = new EventCreateWindow(config, http, channelService);
+        var selection = new ChannelSelectionService(config);
+        var window = new EventCreateWindow(config, http, channelService, selection);
         typeof(EventCreateWindow).GetField("_color", BindingFlags.NonPublic | BindingFlags.Instance)!
             .SetValue(window, ColorUtils.RgbToImGui(rgb));
         var preview = (EmbedDto)typeof(EventCreateWindow).GetMethod("BuildPreview", BindingFlags.NonPublic | BindingFlags.Instance)!

--- a/tests/EventButtonWidthTests.cs
+++ b/tests/EventButtonWidthTests.cs
@@ -22,7 +22,8 @@ public class EventButtonWidthTests
         var config = new Config();
         var http = new HttpClient(new StubHandler());
         var channelService = new ChannelService(config, http, new TokenManager());
-        var window = new EventCreateWindow(config, http, channelService);
+        var selection = new ChannelSelectionService(config);
+        var window = new EventCreateWindow(config, http, channelService, selection);
         var buttonsField = typeof(EventCreateWindow).GetField("_buttons", BindingFlags.NonPublic | BindingFlags.Instance)!;
         buttonsField.SetValue(window, new List<Template.TemplateButton>
         {

--- a/tests/SyncshellTabToggleTests.cs
+++ b/tests/SyncshellTabToggleTests.cs
@@ -14,10 +14,11 @@ public class SyncshellTabToggleTests
         var http = new HttpClient();
         var token = new TokenManager();
         var channelService = new ChannelService(cfg, http, token);
-        var ui = new UiRenderer(cfg, http);
-        var officer = new OfficerChatWindow(cfg, http, null, token, channelService);
+        var selection = new ChannelSelectionService(cfg);
+        var ui = new UiRenderer(cfg, http, selection);
+        var officer = new OfficerChatWindow(cfg, http, null, token, channelService, selection);
         var settings = (SettingsWindow)FormatterServices.GetUninitializedObject(typeof(SettingsWindow));
-        var main = new MainWindow(cfg, ui, null, officer, settings, http, channelService, () => Task.FromResult(true));
+        var main = new MainWindow(cfg, ui, null, officer, settings, http, channelService, selection, () => Task.FromResult(true));
 
         Assert.Null(SyncshellWindow.Instance);
 


### PR DESCRIPTION
## Summary
- add ChannelSelectionService to track selected channels and publish change events
- refactor chat, event, template, and UI windows to read selection from the service
- wire up plugin and tests to use centralized channel selection

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found)*
- `pytest` *(fails: Interrupted: 62 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ff5f4bf883289a53aedd3aeebdda