### PR TITLE
Use ChannelService for TemplatesWindow channels

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -39,7 +39,7 @@ public class MainWindow : IDisposable
         _httpClient = httpClient;
         _refreshRoles = refreshRoles;
         _create = new EventCreateWindow(config, httpClient, channelService, channelSelection);
-        _templates = new TemplatesWindow(config, httpClient, channelSelection);
+        _templates = new TemplatesWindow(config, httpClient, channelService, channelSelection);
         _requestBoard = new RequestBoardWindow(config, httpClient);
         _syncshellEnabled = config.FCSyncShell;
         _syncshell = _syncshellEnabled ? new SyncshellWindow(config, httpClient) : null;

--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -19,7 +19,9 @@ public class TemplateButtonRoundTripTests
     {
         var config = new Config();
         var http = new HttpClient(new StubHandler());
-        var window = new TemplatesWindow(config, http);
+        var channelService = new ChannelService(config, http, new TokenManager());
+        var selection = new ChannelSelectionService(config);
+        var window = new TemplatesWindow(config, http, channelService, selection);
         var field = typeof(TemplatesWindow).GetField("_buttonRows", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         field!.SetValue(window, state);
         return window;

--- a/tests/TemplatesWindowPreviewTests.cs
+++ b/tests/TemplatesWindowPreviewTests.cs
@@ -33,7 +33,9 @@ public class TemplatesWindowPreviewTests
     {
         var config = new Config();
         var http = new HttpClient(new StubHandler());
-        var window = new TemplatesWindow(config, http);
+        var channelService = new ChannelService(config, http, new TokenManager());
+        var selection = new ChannelSelectionService(config);
+        var window = new TemplatesWindow(config, http, channelService, selection);
 
         var firstTmpl = new Template { Name = "One", Title = "T1", Description = "D1" };
         window.SelectTemplate(0, firstTmpl);


### PR DESCRIPTION
## Summary
- inject ChannelService into TemplatesWindow and consume it for channel loading
- rely on ChannelService retry logic instead of custom HTTP/error handling
- pass ChannelService when creating TemplatesWindow

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7040bd2708328a954c8f4cb339248