### PR TITLE
Track per-channel cursor in TrimMessages

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1266,6 +1266,7 @@ public class ChatWindow : IDisposable
         }
         if (_messages.Count > 0 && long.TryParse(_messages[^1].Id, out var last))
         {
+            var channelId = CurrentChannelId;
             _config.ChatCursors[channelId] = last;
         }
     }


### PR DESCRIPTION
## Summary
- update TrimMessages to track cursor for the active channel

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 62 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c7082cc810832897a92a8e24721c2c