### PR TITLE
Use MediaTypeHeaderValue for JSON requests

### DIFF
--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -504,7 +504,8 @@ public class TemplatesWindow
             };
             var id = _templates[_selectedIndex].Id;
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates/{id}/post");
-            var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, new MediaTypeHeaderValue("application/json"));
+            var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
             request.Content = content;
             ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await ApiHelpers.SendWithRetries(request, _httpClient);

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Numerics;
 using System.Threading;
@@ -502,7 +504,8 @@ public class TemplatesWindow
             };
             var id = _templates[_selectedIndex].Id;
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates/{id}/post");
-            request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+            var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, new MediaTypeHeaderValue("application/json"));
+            request.Content = content;
             ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await ApiHelpers.SendWithRetries(request, _httpClient);
             if (response?.IsSuccessStatusCode == true)


### PR DESCRIPTION
## Summary
- import System.Text and System.Net.Http.Headers in TemplatesWindow
- use MediaTypeHeaderValue with StringContent for template posts

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found)*
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 62 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c70aa854fc8328a7de00d32d47030f