### PR TITLE
Centralize emoji button in ChatWindow

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -547,13 +547,23 @@ public class ChatWindow : IDisposable
         }
 
         var inputBuf = MakeUtf8Buffer(_input, 2048);
+        ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X - 72f);
         var send = ImGui.InputText(
             "##chatInput",
             inputBuf,
             ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
             new ImGui.ImGuiInputTextCallbackDelegate(OnInputEdited)
         );
+        ImGui.PopItemWidth();
         _input = ReadUtf8Buffer(inputBuf);
+
+        ImGui.SameLine();
+        if (ImGui.Button("😊")) ImGui.OpenPopup("##dc_emoji_picker");
+        if (ImGui.BeginPopup("##dc_emoji_picker"))
+        {
+            _emojiPicker.Draw(selection => _input += selection);
+            ImGui.EndPopup();
+        }
 
         ImGui.SameLine();
         if (ImGui.Button("Send") || send)

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -10,9 +10,6 @@ public class FcChatWindow : ChatWindow
 {
     private readonly PresenceSidebar? _presenceSidebar;
     private float _presenceWidth = 150f;
-    private readonly Emoji.EmojiService _emojiService;
-    private readonly Emoji.EmojiPicker _emojiPicker;
-    private string _chatInput = string.Empty;
 
     public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService, ChannelSelectionService channelSelection)
         : base(config, httpClient, presence, tokenManager, channelService, channelSelection, ChannelKind.FcChat)
@@ -21,9 +18,6 @@ public class FcChatWindow : ChatWindow
         {
             _presenceSidebar = new PresenceSidebar(presence) { TextureLoader = LoadTexture };
         }
-        _emojiService = new Emoji.EmojiService(httpClient, tokenManager, config);
-        _emojiPicker = new Emoji.EmojiPicker(_emojiService);
-        _ = _emojiService.RefreshAsync();
     }
 
     public override void StartNetworking()
@@ -60,19 +54,6 @@ public class FcChatWindow : ChatWindow
         ImGui.BeginChild("##fcChat", ImGui.GetContentRegionAvail(), false);
         base.Draw();
         ImGui.EndChild();
-
-        _chatInput = _input;
-        ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X - 36f);
-        ImGui.InputText("##chat_input", ref _chatInput, 2000);
-        ImGui.PopItemWidth();
-        ImGui.SameLine();
-        if (ImGui.Button("😊")) ImGui.OpenPopup("##dc_emoji_picker");
-        if (ImGui.BeginPopup("##dc_emoji_picker"))
-        {
-            _emojiPicker.Draw(ref _chatInput);
-            ImGui.EndPopup();
-        }
-        _input = _chatInput;
     }
 
     public override Task RefreshMessages()

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -17,9 +17,6 @@ public class OfficerChatWindow : ChatWindow
 {
     private DateTime _lastRolesRefresh = DateTime.MinValue;
     private bool _subscribed;
-    private readonly Emoji.EmojiService _emojiService;
-    private readonly Emoji.EmojiPicker _emojiPicker;
-    private string _chatInput = string.Empty;
 
     public OfficerChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService, ChannelSelectionService channelSelection)
         : base(config, httpClient, presence, tokenManager, channelService, channelSelection, ChannelKind.OfficerChat)
@@ -31,9 +28,6 @@ public class OfficerChatWindow : ChatWindow
                 TryRefreshRoles();
             }
         };
-        _emojiService = new Emoji.EmojiService(httpClient, tokenManager, config);
-        _emojiPicker = new Emoji.EmojiPicker(_emojiService);
-        _ = _emojiService.RefreshAsync();
     }
 
     public override void StartNetworking()
@@ -84,19 +78,6 @@ public class OfficerChatWindow : ChatWindow
         }
 
         base.Draw();
-
-        _chatInput = _input;
-        ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X - 36f);
-        ImGui.InputText("##chat_input", ref _chatInput, 2000);
-        ImGui.PopItemWidth();
-        ImGui.SameLine();
-        if (ImGui.Button("😊")) ImGui.OpenPopup("##dc_emoji_picker");
-        if (ImGui.BeginPopup("##dc_emoji_picker"))
-        {
-            _emojiPicker.Draw(ref _chatInput);
-            ImGui.EndPopup();
-        }
-        _input = _chatInput;
 
         // Reserved padded area beneath the standard chat input for upcoming officer tools.
         ImGui.Dummy(new Vector2(0, ImGui.GetFrameHeightWithSpacing()));


### PR DESCRIPTION
## Summary
- add emoji popup and button to `ChatWindow.Draw` using the existing `_emojiPicker`
- rely on base `ChatWindow` input for FC and officer chat windows

## Testing
- `dotnet test` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c71050235483288c93ae306820426c