### PR TITLE
Use window-specific channel kind when fetching channels

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1366,7 +1366,7 @@ public class ChatWindow : IDisposable
 
         try
         {
-            var channels = (await _channelService.FetchAsync(ChannelKind.FcChat, CancellationToken.None)).ToList();
+            var channels = (await _channelService.FetchAsync(_channelKind, CancellationToken.None)).ToList();
             if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true))) return;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {


### PR DESCRIPTION
## Summary
- use the window's `_channelKind` when fetching channels
- ensure chat windows supply the proper `ChannelKind`

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest tests/test_config_wizard_channel_filter.py`
- `pytest tests/test_config_wizard_role_union.py`


------
https://chatgpt.com/codex/tasks/task_e_68c711b98a448328898040416f70dd84