### PR TITLE
feat: restrict role mentions to configured roles

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -822,7 +822,7 @@ public class ChatWindow : IDisposable
         try
         {
             var presences = _presence?.Presences ?? new List<PresenceDto>();
-            var content = MentionResolver.Resolve(_input, presences, RoleCache.Roles);
+            var content = MentionResolver.Resolve(_input, presences, RoleCache.Roles, _config.MentionRoleIds);
             logContent = content;
 
             HttpRequestMessage request;

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -40,6 +40,8 @@ public class Config : IPluginConfiguration
     public bool FCSyncShell { get; set; } = false;
     public bool UseCharacterName { get; set; } = false;
     public List<string> Roles { get; set; } = new();
+    [JsonPropertyName("mentionRoleIds")]
+    public List<string> MentionRoleIds { get; set; } = new();
     public List<RoleDto> GuildRoles { get; set; } = new();
     [JsonPropertyName("templates")]
     public List<Template> TemplateData { get; set; } = new();

--- a/DemiCatPlugin/MentionResolver.cs
+++ b/DemiCatPlugin/MentionResolver.cs
@@ -10,7 +10,11 @@ public static class MentionResolver
 
     private static string Normalize(string name) => name.Trim().ToLowerInvariant();
 
-    public static string Resolve(string content, IEnumerable<PresenceDto> presences, IEnumerable<RoleDto> roles)
+    public static string Resolve(
+        string content,
+        IEnumerable<PresenceDto> presences,
+        IEnumerable<RoleDto> roles,
+        IEnumerable<string>? allowedRoleIds = null)
     {
         var lookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -19,9 +23,14 @@ public static class MentionResolver
             lookup[Normalize(u.Name)] = $"<@{u.Id}>";
         }
 
+        HashSet<string>? allowed = null;
+        if (allowedRoleIds != null)
+            allowed = new HashSet<string>(allowedRoleIds);
+
         foreach (var r in roles)
         {
-            lookup[Normalize(r.Name)] = $"<@&{r.Id}>";
+            if (allowed == null || allowed.Contains(r.Id))
+                lookup[Normalize(r.Name)] = $"<@&{r.Id}>";
         }
 
         // Discord special mentions

--- a/tests/ChatWindowTests.cs
+++ b/tests/ChatWindowTests.cs
@@ -1,5 +1,6 @@
 using DemiCatPlugin;
 using Xunit;
+using System;
 
 public class ChatWindowTests
 {
@@ -53,5 +54,18 @@ public class ChatWindowTests
         var result = MentionResolver.Resolve(input, presences, roles);
 
         Assert.Equal("<@1> <@&2> @​Unknown <@everyone> <@here> test@​example.com", result);
+    }
+
+    [Fact]
+    public void MentionResolver_SkipsUnallowedRoleMentions()
+    {
+        var presences = Array.Empty<PresenceDto>();
+        var roles = new[] { new RoleDto { Id = "2", Name = "Admin" } };
+        var allowed = new[] { "3" };
+        var input = "Hello @Admin";
+
+        var result = MentionResolver.Resolve(input, presences, roles, allowed);
+
+        Assert.Equal("Hello @​Admin", result);
     }
 }


### PR DESCRIPTION
## Summary
- allow MentionResolver to filter role mentions by allowed IDs
- wire ChatWindow to pass wizard-configured role IDs
- test skipping of unapproved role mentions

## Testing
- `dotnet test` *(fails: Dalamud installation not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68c7749cfb648328ba983a386d9963f3