### PR TITLE
Handle missing tokens and unauthorized responses in EmojiService

### DIFF
--- a/DemiCatPlugin/Emoji/EmojiService.cs
+++ b/DemiCatPlugin/Emoji/EmojiService.cs
@@ -20,8 +20,9 @@ namespace DemiCatPlugin.Emoji
 
         public async Task RefreshAsync(CancellationToken ct = default)
         {
-            if (!_tokens.IsReady())
+            if (!_tokens.IsReady() || string.IsNullOrEmpty(_tokens.Token))
             {
+                PluginServices.Instance?.ToastGui.ShowError("Emoji auth failed");
                 Custom = new();
                 return;
             }
@@ -33,6 +34,7 @@ namespace DemiCatPlugin.Emoji
             using var res = await _http.SendAsync(req, ct);
             if (res.StatusCode == HttpStatusCode.Unauthorized)
             {
+                PluginServices.Instance?.ToastGui.ShowError("Emoji auth failed");
                 _tokens.Clear("Authentication failed");
                 Custom = new();
                 return;


### PR DESCRIPTION
## Summary
- Skip emoji refresh when token manager isn't ready or token is missing
- Clear token and alert user if the emoji endpoint returns 401

## Testing
- `dotnet test` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 62 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c779acfe8c8328a8b11ed69926e7c2