### PR TITLE
Validate channel configuration before saving messages

### DIFF
--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -15,7 +15,7 @@ from ._messages_common import (
     delete_message as delete_message_common,
 )
 from ..discord_client import discord_client
-from ...db.models import Message
+from ...db.models import Message, ChannelKind
 
 router = APIRouter(prefix="/api")
 
@@ -40,7 +40,7 @@ async def post_message(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    return await save_message(body, ctx, db, is_officer=False)
+    return await save_message(body, ctx, db, channel_kind=ChannelKind.FC_CHAT)
 
 
 @router.post("/channels/{channel_id}/messages")
@@ -65,7 +65,7 @@ async def post_message_with_attachments(
         use_character_name=useCharacterName,
         message_reference=ref,
     )
-    return await save_message(body, ctx, db, is_officer=False, files=files)
+    return await save_message(body, ctx, db, channel_kind=ChannelKind.FC_CHAT, files=files)
 
 
 @router.put("/channels/{channel_id}/messages/{message_id}/reactions/{emoji}")

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
 from ._messages_common import PostBody, fetch_messages, save_message
+from ...db.models import ChannelKind
 
 router = APIRouter(prefix="/api")
 
@@ -29,4 +30,4 @@ async def post_officer_message(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    return await save_message(body, ctx, db, is_officer=True)
+    return await save_message(body, ctx, db, channel_kind=ChannelKind.OFFICER_CHAT)


### PR DESCRIPTION
## Summary
- ensure message posting checks GuildChannel kind and permissions
- update message routes to specify channel kinds
- adjust webhook handling and expand tests for channel config

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py`

------
https://chatgpt.com/codex/tasks/task_e_68c780f400008328861b502d5ac953dd