### PR TITLE
Validate event channels and support thread webhooks

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -139,6 +139,8 @@ async def _send_via_webhook(
     username: str,
     avatar: str | None,
     files: list[discord.File] | None,
+    embed: discord.Embed | None = None,
+    view: discord.ui.View | None = None,
     db: AsyncSession,
     thread: discord.abc.Snowflake | None = None,
 ) -> tuple[int | None, list[AttachmentDto] | None, list[str]]:
@@ -148,8 +150,9 @@ async def _send_via_webhook(
     provided, the message will be sent to that thread using the parent
     channel's webhook.
 
-    Returns the Discord message id and attachments on success, otherwise
-    a list of error messages describing the failure.
+    ``embed`` and ``view`` are optional and allow rich messages to be sent via
+    the webhook.  Returns the Discord message id and attachments on success,
+    otherwise a list of error messages describing the failure.
     """
 
     errors: list[str] = []
@@ -226,6 +229,8 @@ async def _send_via_webhook(
             files=files,
             wait=True,
             allowed_mentions=ALLOWED_MENTIONS,
+            embeds=[embed] if embed else None,
+            view=view,
             thread=thread,
         )
     except discord.HTTPException as e:  # pragma: no cover - network errors
@@ -243,6 +248,8 @@ async def _send_via_webhook(
                     files=files,
                     wait=True,
                     allowed_mentions=ALLOWED_MENTIONS,
+                    embeds=[embed] if embed else None,
+                    view=view,
                     thread=thread,
                 )
             except Exception as e2:  # pragma: no cover - network errors
@@ -290,6 +297,8 @@ async def _send_via_webhook(
                 files=files,
                 wait=True,
                 allowed_mentions=ALLOWED_MENTIONS,
+                embeds=[embed] if embed else None,
+                view=view,
                 thread=thread,
             )
             webhook = created

--- a/tests/test_event_channel_validation.py
+++ b/tests/test_event_channel_validation.py
@@ -1,0 +1,114 @@
+import asyncio
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import discord
+import pytest
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.db.models import Guild, GuildChannel, ChannelKind
+from demibot.db.session import init_db, get_session
+from demibot.http.routes.events import create_event, CreateEventBody
+from fastapi import HTTPException
+
+
+async def _setup_db(path: str, *, kind: ChannelKind | None) -> None:
+    db_path = Path(path)
+    if db_path.exists():
+        db_path.unlink()
+    url = f"sqlite+aiosqlite:///{db_path}"
+    await init_db(url)
+    async with get_session() as db:
+        guild = Guild(id=1, discord_guild_id=1, name="G")
+        db.add(guild)
+        if kind is not None:
+            db.add(GuildChannel(guild_id=1, channel_id=456, kind=kind))
+        await db.commit()
+
+
+async def _call_create(body: CreateEventBody):
+    ctx = SimpleNamespace(guild=SimpleNamespace(id=1), roles=[])
+    async with get_session() as db:
+        original_dumps = json.dumps
+        with patch(
+            "demibot.http.routes.events.json.dumps",
+            lambda obj, *a, **k: original_dumps(obj, default=str, *a, **k),
+        ):
+            return await create_event(body=body, ctx=ctx, db=db)
+
+
+def test_create_event_requires_event_channel() -> None:
+    async def run() -> None:
+        await _setup_db("test_event_invalid_kind.db", kind=ChannelKind.CHAT)
+        body = CreateEventBody(channelId="456", title="T", description="d")
+        with pytest.raises(HTTPException):
+            await _call_create(body)
+    asyncio.run(run())
+
+
+class DummyTextChannel(discord.abc.Messageable):
+    def __init__(self) -> None:
+        self.id = 123
+
+    async def send(self, *args, **kwargs):  # pragma: no cover - should not be called
+        return SimpleNamespace(id=999, embeds=[], attachments=[])
+
+    async def _get_channel(self):  # pragma: no cover - required by Messageable
+        return self
+
+
+class DummyThread(discord.abc.Messageable):
+    def __init__(self, parent: DummyTextChannel) -> None:
+        self.parent = parent
+        self.id = 456
+
+    async def _get_channel(self):  # pragma: no cover - required by Messageable
+        return self
+
+
+def test_create_event_thread_uses_webhook() -> None:
+    async def run() -> None:
+        await _setup_db("test_event_thread.db", kind=ChannelKind.EVENT)
+        parent = DummyTextChannel()
+        thread = DummyThread(parent)
+        client = SimpleNamespace(get_channel=lambda cid: thread)
+        captured: dict[str, object] = {}
+
+        async def fake_webhook(**kwargs):
+            captured.update(kwargs)
+            return 123, None, []
+
+        body = CreateEventBody(channelId="456", title="T", description="d")
+        ctx = SimpleNamespace(guild=SimpleNamespace(id=1), roles=[])
+        async with get_session() as db:
+            original_dumps = json.dumps
+            with patch(
+                "demibot.http.routes.events.json.dumps",
+                lambda obj, *a, **k: original_dumps(obj, default=str, *a, **k),
+            ), patch(
+                "demibot.http.routes.events._send_via_webhook", fake_webhook
+            ), patch(
+                "demibot.http.routes.events.discord_client", client
+            ), patch(
+                "demibot.http.routes.events.discord.Thread", DummyThread
+            ), patch(
+                "demibot.http.routes.events.discord.TextChannel", DummyTextChannel
+            ):
+                await create_event(body=body, ctx=ctx, db=db)
+        assert captured["channel"] is parent
+        assert captured["thread"] is thread
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Require events to target channels configured as ChannelKind.EVENT
- Reject non-text channels and support sending events into threads via webhooks
- Extend webhook helper to send embeds and add tests for channel validation and thread routing

## Testing
- `pytest -q` *(fails: 48 failed, 76 passed, 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c788ee53b88328ae494708de55dba8