### PR TITLE
feat: add channel parent grouping

### DIFF
--- a/DemiCatPlugin/ChannelDto.cs
+++ b/DemiCatPlugin/ChannelDto.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace DemiCatPlugin;
@@ -6,4 +8,30 @@ public class ChannelDto
 {
     [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("parentId")] public string? ParentId { get; set; }
+}
+
+public static class ChannelDtoExtensions
+{
+    public static List<ChannelDto> SortForDisplay(IEnumerable<ChannelDto> channels)
+    {
+        var parents = channels.Where(c => string.IsNullOrEmpty(c.ParentId)).ToList();
+        var lookup = channels.Where(c => !string.IsNullOrEmpty(c.ParentId))
+            .GroupBy(c => c.ParentId!)
+            .ToDictionary(g => g.Key, g => g.ToList());
+        var ordered = new List<ChannelDto>();
+        foreach (var parent in parents)
+        {
+            ordered.Add(parent);
+            if (lookup.TryGetValue(parent.Id, out var children))
+            {
+                ordered.AddRange(children);
+            }
+        }
+        foreach (var ch in channels)
+        {
+            if (!ordered.Contains(ch)) ordered.Add(ch);
+        }
+        return ordered;
+    }
 }

--- a/DemiCatPlugin/ChannelService.cs
+++ b/DemiCatPlugin/ChannelService.cs
@@ -12,6 +12,10 @@ public class ChannelService
     private readonly Config _config;
     private readonly HttpClient _httpClient;
     private readonly TokenManager _tokenManager;
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
 
     public ChannelService(Config config, HttpClient httpClient, TokenManager tokenManager)
     {
@@ -36,8 +40,8 @@ public class ChannelService
                 var response = await _httpClient.SendAsync(request, linkedCts.Token);
                 response.EnsureSuccessStatusCode();
                 var stream = await response.Content.ReadAsStreamAsync(linkedCts.Token);
-                var channels = await JsonSerializer.DeserializeAsync<List<ChannelDto>>(stream, cancellationToken: linkedCts.Token) ?? new List<ChannelDto>();
-                return channels;
+                var channels = await JsonSerializer.DeserializeAsync<List<ChannelDto>>(stream, JsonOpts, linkedCts.Token) ?? new List<ChannelDto>();
+                return ChannelDtoExtensions.SortForDisplay(channels);
             }
             catch (HttpRequestException) when (attempt < 2)
             {

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -225,7 +225,7 @@ public class ChatWindow : IDisposable
 
         if (_channels.Count > 0)
         {
-            var channelNames = _channels.Select(c => c.Name).ToArray();
+            var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
             if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
             {
                 var newId = _channels[_selectedIndex].Id;
@@ -605,7 +605,7 @@ public class ChatWindow : IDisposable
     public void SetChannels(List<ChannelDto> channels)
     {
         _channels.Clear();
-        _channels.AddRange(channels);
+        _channels.AddRange(ChannelDtoExtensions.SortForDisplay(channels));
         var current = CurrentChannelId;
         if (!string.IsNullOrEmpty(current))
         {

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -116,7 +116,7 @@ public class EventCreateWindow
         }
         if (_channels.Count > 0)
         {
-            var channelNames = _channels.Select(c => c.Name).ToArray();
+            var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
             if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
             {
                 var newId = _channels[_selectedIndex].Id;
@@ -687,7 +687,7 @@ public class EventCreateWindow
 
         try
         {
-            var dto = (await _channelService.FetchAsync(ChannelKind.Event, CancellationToken.None)).ToList();
+            var dto = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(ChannelKind.Event, CancellationToken.None)).ToList());
             if (await ChannelNameResolver.Resolve(dto, _httpClient, _config, refreshed, () => FetchChannels(true))) return;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Numerics;
 using System.IO;
+using System.Linq;
 
 namespace DemiCatPlugin;
 
@@ -207,7 +208,7 @@ public class OfficerChatWindow : ChatWindow
 
         try
         {
-            var channels = (await _channelService.FetchAsync(ChannelKind.OfficerChat, CancellationToken.None)).ToList();
+            var channels = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(ChannelKind.OfficerChat, CancellationToken.None)).ToList());
             if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true)))
                 return;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -115,7 +115,7 @@ public class TemplatesWindow
         }
         if (_channels.Count > 0)
         {
-            var channelNames = _channels.Select(c => c.Name).ToArray();
+            var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
             if (ImGui.Combo("Channel", ref _channelIndex, channelNames, channelNames.Length))
             {
                 var newId = _channels[_channelIndex].Id;
@@ -335,7 +335,7 @@ public class TemplatesWindow
 
         try
         {
-            var channels = (await _channelService.FetchAsync(ChannelKind.Event, CancellationToken.None)).ToList();
+            var channels = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(ChannelKind.Event, CancellationToken.None)).ToList());
             if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true))) return;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
@@ -360,7 +360,7 @@ public class TemplatesWindow
     private void SetChannels(List<ChannelDto> channels)
     {
         _channels.Clear();
-        _channels.AddRange(channels);
+        _channels.AddRange(ChannelDtoExtensions.SortForDisplay(channels));
         var current = ChannelId;
         if (!string.IsNullOrEmpty(current))
         {


### PR DESCRIPTION
## Summary
- include optional parent thread reference in channel DTO
- load and sort channels with parent/child relationships
- indent thread names in channel dropdowns across plugin windows

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 63 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c78ab9d3088328af69f6522d6f45f7