### PR TITLE
Refresh channel on partial error messages

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -939,7 +939,7 @@ public class ChatWindow : IDisposable
                     _lastError = msg;
                 });
                 var lower = detailText.ToLowerInvariant();
-                if (lower == "channel not configured" || lower == "unsupported channel type" || response.StatusCode == HttpStatusCode.NotFound)
+                if (lower.Contains("channel not configured") || lower.Contains("unsupported channel type") || response.StatusCode == HttpStatusCode.NotFound)
                 {
                     _ = PluginServices.Instance!.Framework.RunOnTick(async () => await RefreshChannels());
                 }


### PR DESCRIPTION
## Summary
- Refresh channels when the server detail mentions unsupported or unconfigured channel types

## Testing
- `dotnet test` *(fails: Dalamud installation not found)*
- `pytest` *(fails: 63 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c792abc2548328bd897652cb729a55