### PR TITLE
Handle archived threads when sending messages

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -506,6 +506,8 @@ async def save_message(
     if channel is not None:
         if isinstance(channel, discord.Thread):
             thread_obj = channel
+            if getattr(channel, "archived", False):
+                raise HTTPException(status_code=400, detail="thread is archived")
             base_channel = getattr(channel, "parent", None)
             if base_channel is None:
                 raise HTTPException(status_code=400, detail="parent channel not found")


### PR DESCRIPTION
## Summary
- reject sending messages to archived threads
- test archived threads return 400 error

## Testing
- `PYTHONPATH=demibot python -m pytest tests/test_messages_common.py::test_archived_thread_rejected -q`


------
https://chatgpt.com/codex/tasks/task_e_68c793e3d0148328a53a114f1816bb8d