### PR TITLE
Add avatar cache for chat avatars

### DIFF
--- a/DemiCatPlugin/Avatars/AvatarCache.cs
+++ b/DemiCatPlugin/Avatars/AvatarCache.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dalamud.Interface.Textures;
+
+namespace DemiCatPlugin.Avatars;
+
+public class AvatarCache : IDisposable
+{
+    private readonly ITextureProvider _textureProvider;
+    private readonly Dictionary<string, CacheEntry> _cache = new();
+    private readonly TimeSpan _ttl = TimeSpan.FromHours(12);
+    private readonly object _lock = new();
+
+    private class CacheEntry
+    {
+        public ISharedImmediateTexture? Texture;
+        public DateTime Expiration;
+        public Task<ISharedImmediateTexture?>? Pending;
+    }
+
+    public AvatarCache(ITextureProvider textureProvider)
+    {
+        _textureProvider = textureProvider;
+    }
+
+    public Task<ISharedImmediateTexture?> GetAsync(string? avatarUrl, string? userId)
+    {
+        var url = string.IsNullOrEmpty(avatarUrl) ? DefaultAvatarUrl(userId) : avatarUrl;
+        if (string.IsNullOrEmpty(url))
+            return Task.FromResult<ISharedImmediateTexture?>(null);
+
+        lock (_lock)
+        {
+            if (_cache.TryGetValue(url, out var entry))
+            {
+                if (entry.Texture != null && entry.Expiration > DateTime.UtcNow)
+                    return Task.FromResult(entry.Texture);
+                if (entry.Pending != null)
+                    return entry.Pending;
+            }
+
+            var task = FetchAsync(url);
+            _cache[url] = new CacheEntry { Pending = task };
+            return task;
+        }
+    }
+
+    private async Task<ISharedImmediateTexture?> FetchAsync(string url)
+    {
+        var tex = await _textureProvider.GetFromUrlAsync(url);
+        lock (_lock)
+        {
+            _cache[url] = new CacheEntry
+            {
+                Texture = tex,
+                Expiration = DateTime.UtcNow + _ttl
+            };
+        }
+        return tex;
+    }
+
+    private static string DefaultAvatarUrl(string? userId)
+    {
+        if (string.IsNullOrEmpty(userId))
+            return "https://cdn.discordapp.com/embed/avatars/0.png";
+        if (ulong.TryParse(userId, out var id))
+            return $"https://cdn.discordapp.com/embed/avatars/{id % 5}.png";
+        return "https://cdn.discordapp.com/embed/avatars/0.png";
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            foreach (var entry in _cache.Values)
+            {
+                if (entry.Texture?.GetWrapOrEmpty() is IDisposable wrap)
+                    wrap.Dispose();
+            }
+            _cache.Clear();
+        }
+    }
+}
+

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using System.Numerics;
+using DemiCatPlugin.Avatars;
 
 namespace DemiCatPlugin;
 
@@ -11,8 +12,8 @@ public class FcChatWindow : ChatWindow
     private readonly PresenceSidebar? _presenceSidebar;
     private float _presenceWidth = 150f;
 
-    public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService, ChannelSelectionService channelSelection)
-        : base(config, httpClient, presence, tokenManager, channelService, channelSelection, ChannelKind.FcChat)
+    public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService, ChannelSelectionService channelSelection, AvatarCache avatarCache)
+        : base(config, httpClient, presence, tokenManager, channelService, channelSelection, ChannelKind.FcChat, avatarCache)
     {
         if (presence != null)
         {

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System.Numerics;
 using System.IO;
 using System.Linq;
+using DemiCatPlugin.Avatars;
 
 namespace DemiCatPlugin;
 
@@ -19,8 +20,8 @@ public class OfficerChatWindow : ChatWindow
     private DateTime _lastRolesRefresh = DateTime.MinValue;
     private bool _subscribed;
 
-    public OfficerChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService, ChannelSelectionService channelSelection)
-        : base(config, httpClient, presence, tokenManager, channelService, channelSelection, ChannelKind.OfficerChat)
+    public OfficerChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService, ChannelSelectionService channelSelection, AvatarCache avatarCache)
+        : base(config, httpClient, presence, tokenManager, channelService, channelSelection, ChannelKind.OfficerChat, avatarCache)
     {
         _bridge.StatusChanged += s =>
         {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -10,6 +10,7 @@ using DiscordHelper;
 using Dalamud.Plugin;
 using Dalamud.IoC;
 using Dalamud.Plugin.Services;
+using DemiCatPlugin.Avatars;
 
 namespace DemiCatPlugin;
 
@@ -18,10 +19,12 @@ public class Plugin : IDalamudPlugin
     public string Name => "DemiCat";
 
     [PluginService] internal IDalamudPluginInterface PluginInterface { get; private set; } = null!;
+    [PluginService] internal ITextureProvider TextureProvider { get; private set; } = null!;
 
     private readonly PluginServices _services;
     private readonly UiRenderer _ui;
     private readonly SettingsWindow _settings;
+    private readonly AvatarCache _avatarCache;
     private readonly ChatWindow _chatWindow;
     private readonly OfficerChatWindow _officerChatWindow;
     private readonly DiscordPresenceService? _presenceService;
@@ -73,8 +76,9 @@ public class Plugin : IDalamudPlugin
             : null;
 
         _channelService = new ChannelService(_config, _httpClient, _tokenManager);
-        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection);
-        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection);
+        _avatarCache = new AvatarCache(TextureProvider);
+        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _avatarCache);
+        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _avatarCache);
 
         _presenceService?.Reset();
 
@@ -146,6 +150,7 @@ public class Plugin : IDalamudPlugin
         _mainWindow.Dispose();
         _ui.DisposeAsync().GetAwaiter().GetResult();
         _settings.Dispose();
+        _avatarCache.Dispose();
         _httpClient.Dispose();
     }
 


### PR DESCRIPTION
## Summary
- implement 12-hour AvatarCache backed by Dalamud ITextureProvider and default Discord fallback
- wire AvatarCache through plugin and chat windows to show 20x20 avatars
- remove direct HttpClient avatar fetches

## Testing
- `dotnet test` *(fails: requires .NET SDK 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c79507af648328b38048514a9ae824