### PR TITLE
feat: support camelcase aliases

### DIFF
--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -8,8 +8,14 @@ from enum import IntEnum
 
 # ---- Embeds ----
 
+
+def to_camel(string: str) -> str:
+    parts = string.split("_")
+    return parts[0] + "".join(word.capitalize() for word in parts[1:])
+
+
 class CamelModel(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
 
 
 class EmbedFieldDto(CamelModel):


### PR DESCRIPTION
## Summary
- add `to_camel` helper and use as alias generator in `CamelModel`
- ensure HTTP schemas serialize snake_case fields as camelCase

## Testing
- `python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location('schemas', 'demibot/demibot/http/schemas.py')
schemas = importlib.util.module_from_spec(spec)
spec.loader.exec_module(schemas)
schemas.ChatMessage.model_rebuild(_types_namespace=schemas.__dict__)
msg = schemas.ChatMessage(id='1', channel_id='2', author_name='user', content='hello')
print(msg.model_dump(by_alias=True))
PY`
- `pytest` *(fails: ERROR tests/test_apollo_embed.py, tests/test_asset_download.py, tests/test_asset_purge.py, tests/test_assets_bundles_etag.py, tests/test_bot_mirror_whitelist.py, tests/test_channel_kind_enum.py, tests/test_channel_name_retry.py, tests/test_channels_endpoint.py, tests/test_chat_ws.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c798ee4cc88328aea853a0c268bdf1