### PR TITLE
Gate TokenManager test constructor and add state test

### DIFF
--- a/DemiCatPlugin/TokenManager.cs
+++ b/DemiCatPlugin/TokenManager.cs
@@ -29,13 +29,15 @@ public class TokenManager
     public event Action? OnLinked;
     public event Action<string?>? OnUnlinked;
 
-    public TokenManager()
+#if TEST
+    internal TokenManager()
     {
         _pluginInterface = null!;
         _token = "test";
         State = LinkState.Linked;
         Instance = this;
     }
+#endif
 
     public TokenManager(IDalamudPluginInterface pluginInterface)
     {

--- a/tests/DemiCatPlugin.Tests.csproj
+++ b/tests/DemiCatPlugin.Tests.csproj
@@ -15,6 +15,6 @@
     <Compile Include="../DemiCatPlugin/MarkdownFormatter.cs" Link="MarkdownFormatter.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../DemiCatPlugin/DemiCatPlugin.csproj" />
+    <ProjectReference Include="../DemiCatPlugin/DemiCatPlugin.csproj" AdditionalProperties="DefineConstants=$(DefineConstants);TEST" />
   </ItemGroup>
 </Project>

--- a/tests/TokenManagerTests.cs
+++ b/tests/TokenManagerTests.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using System;
+using DemiCatPlugin;
+using Dalamud.Plugin;
+using Moq;
+using Xunit;
+
+public class TokenManagerTests
+{
+    [Fact]
+    public void WithoutStoredToken_StateIsUnlinked()
+    {
+        var mock = new Mock<IDalamudPluginInterface>();
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        mock.Setup(p => p.ConfigDirectory).Returns(new DirectoryInfo(tempDir));
+
+        var tm = new TokenManager(mock.Object);
+
+        Assert.Equal(LinkState.Unlinked, tm.State);
+    }
+}


### PR DESCRIPTION
## Summary
- Hide TokenManager's parameterless constructor behind `#if TEST`
- Ensure unit tests build the plugin with `TEST` defined
- Add test verifying TokenManager starts unlinked without stored token

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: Dalamud installation not found / missing references)*
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: Dalamud installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c79a60ec5c83289fb2736a56b18069