### PR TITLE
fix: import texture provider

### DIFF
--- a/DemiCatPlugin/Avatars/AvatarCache.cs
+++ b/DemiCatPlugin/Avatars/AvatarCache.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dalamud.Interface.Textures;
+using Dalamud.Plugin.Services;
 
 namespace DemiCatPlugin.Avatars;
 


### PR DESCRIPTION
## Summary
- fix AvatarCache import for ITextureProvider

## Testing
- `dotnet build -c release` *(fails: A compatible .NET SDK was not found; requested 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fa51634c8328a55cc6e5f93da337