### PR TITLE
Fix avatar cache for removed Dalamud URL API

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -76,7 +76,7 @@ public class Plugin : IDalamudPlugin
             : null;
 
         _channelService = new ChannelService(_config, _httpClient, _tokenManager);
-        _avatarCache = new AvatarCache(TextureProvider);
+        _avatarCache = new AvatarCache(TextureProvider, _httpClient);
         _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _avatarCache);
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _avatarCache);
 


### PR DESCRIPTION
## Summary
- load avatars by downloading via `HttpClient` and creating textures
- inject `HttpClient` into avatar cache

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release` *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fb948e4c8328acee5685b2979235