### PR TITLE
Retry emoji refresh on transient failures

### DIFF
--- a/DemiCatPlugin/Emoji/EmojiService.cs
+++ b/DemiCatPlugin/Emoji/EmojiService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -27,37 +28,70 @@ namespace DemiCatPlugin.Emoji
                 return;
             }
 
+            Custom = new();
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/discord/emojis";
-            var req = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(req, _tokens);
+            const int maxAttempts = 3;
 
-            using var res = await _http.SendAsync(req, ct);
-            if (res.StatusCode == HttpStatusCode.Unauthorized)
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
             {
-                PluginServices.Instance?.ToastGui.ShowError("Emoji auth failed");
-                _tokens.Clear("Authentication failed");
-                Custom = new();
-                return;
-            }
-
-            res.EnsureSuccessStatusCode();
-            using var stream = await res.Content.ReadAsStreamAsync(ct);
-            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
-
-            var list = new List<CustomEmoji>();
-            if (doc.RootElement.TryGetProperty("emojis", out var arr))
-            {
-                foreach (var e in arr.EnumerateArray())
+                HttpResponseMessage? res = null;
+                try
                 {
-                    var id = e.GetProperty("id").GetString()!;
-                    var name = e.GetProperty("name").GetString()!;
-                    var animated = e.GetProperty("animated").GetBoolean();
-                    var available = e.TryGetProperty("available", out var a) ? a.GetBoolean() : true;
-                    if (available)
-                        list.Add(new CustomEmoji(id, name, animated));
+                    using var req = new HttpRequestMessage(HttpMethod.Get, url);
+                    ApiHelpers.AddAuthHeader(req, _tokens);
+
+                    res = await _http.SendAsync(req, ct);
+                    if (res.StatusCode == HttpStatusCode.Unauthorized)
+                    {
+                        PluginServices.Instance?.ToastGui.ShowError("Emoji auth failed");
+                        _tokens.Clear("Authentication failed");
+                        return;
+                    }
+
+                    res.EnsureSuccessStatusCode();
+                    using var stream = await res.Content.ReadAsStreamAsync(ct);
+                    using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct);
+
+                    var list = new List<CustomEmoji>();
+                    if (doc.RootElement.TryGetProperty("emojis", out var arr))
+                    {
+                        foreach (var e in arr.EnumerateArray())
+                        {
+                            var id = e.GetProperty("id").GetString()!;
+                            var name = e.GetProperty("name").GetString()!;
+                            var animated = e.GetProperty("animated").GetBoolean();
+                            var available = e.TryGetProperty("available", out var a) ? a.GetBoolean() : true;
+                            if (available)
+                                list.Add(new CustomEmoji(id, name, animated));
+                        }
+                    }
+                    Custom = list;
+                    return;
+                }
+                catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.ServiceUnavailable && attempt < maxAttempts)
+                {
+                    PluginServices.Instance?.Log.Warning(ex, $"Emoji refresh failed with 503, attempt {attempt}/{maxAttempts}");
+                    var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt - 1));
+                    await Task.Delay(delay, ct);
+                }
+                catch (HttpRequestException ex) when (attempt < maxAttempts)
+                {
+                    PluginServices.Instance?.Log.Warning(ex, $"Emoji refresh failed, attempt {attempt}/{maxAttempts}");
+                    var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt - 1));
+                    await Task.Delay(delay, ct);
+                }
+                catch (HttpRequestException ex)
+                {
+                    PluginServices.Instance?.Log.Error(ex, "Emoji refresh failed");
+                    return;
+                }
+                finally
+                {
+                    res?.Dispose();
                 }
             }
-            Custom = list;
+
+            PluginServices.Instance?.Log.Error("Emoji refresh failed after maximum retries");
         }
     }
 }


### PR DESCRIPTION
## Summary
- retry emoji refresh on transient HTTP errors with exponential backoff
- log failures and clear custom emoji list until successful fetch

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: A compatible .NET SDK was not found)*
- `pytest -q` *(fails: missing dependencies such as fastapi, discord, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fe04f4d88328b9a8e23c96292230