### PR TITLE
Propagate Discord send errors for failed channel delivery

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -664,7 +664,10 @@ async def save_message(
                     error_details.append(f"Direct send failed: {e}")
         else:
             logging.warning("Failed to resolve channel %s", cid)
-            raise HTTPException(status_code=404, detail="channel not found")
+            detail: dict[str, object] = {"message": "channel not found"}
+            if error_details:
+                detail["discord"] = error_details
+            raise HTTPException(status_code=404, detail=detail)
 
     if discord_msg_id is None:
         logging.warning(


### PR DESCRIPTION
## Summary
- include Discord error details when a channel cannot be resolved after webhook failure
- add test ensuring 404 responses return underlying Discord errors

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_webhook_errors_returned tests/test_messages_common.py::test_channel_not_found_returns_error_details -q`

------
https://chatgpt.com/codex/tasks/task_e_68c80af0f0388328bb3f7cc9a2a16b35