### PR TITLE
Clear token on unauthorized channel watcher ping

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -95,6 +95,8 @@ public class ChannelWatcher : IDisposable
                     if (status == HttpStatusCode.Unauthorized || status == HttpStatusCode.Forbidden)
                     {
                         PluginServices.Instance?.ToastGui.ShowError("Channel watcher auth failed");
+                        PluginServices.Instance!.Log.Warning("Clearing stored token after channel watcher auth failure.");
+                        _tokenManager.Clear("Authentication failed");
                     }
                     try { await Task.Delay(delay, token); } catch { }
                     delay = TimeSpan.FromSeconds(Math.Min(delay.TotalSeconds * 2, 60));

--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -96,7 +96,7 @@ public class ChannelWatcher : IDisposable
                     {
                         PluginServices.Instance?.ToastGui.ShowError("Channel watcher auth failed");
                         PluginServices.Instance!.Log.Warning("Clearing stored token after channel watcher auth failure.");
-                        _tokenManager.Clear("Authentication failed");
+                        _ = Task.Run(() => _tokenManager.Clear("Authentication failed"));
                     }
                     try { await Task.Delay(delay, token); } catch { }
                     delay = TimeSpan.FromSeconds(Math.Min(delay.TotalSeconds * 2, 60));


### PR DESCRIPTION
## Summary
- clear the stored token when the channel watcher ping returns unauthorized or forbidden
- log the token reset so developers understand the authentication failure handling

## Testing
- dotnet build (fails: `dotnet` not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8aa9f73e08328a95090830e5f8b41