### PR TITLE
Improve WebSocket resilience and logging

### DIFF
--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -27,6 +27,10 @@ public class DiscordPresenceService : IDisposable
     private CancellationTokenSource? _wsCts;
     private bool _loaded;
     private string _statusMessage = string.Empty;
+    private int _retryAttempt;
+    private string? _lastErrorSignature;
+    private DateTime _lastErrorLog;
+    private static readonly TimeSpan ErrorLogThrottle = TimeSpan.FromSeconds(30);
 
     public IReadOnlyList<PresenceDto> Presences => _presences;
     public string StatusMessage => _statusMessage;
@@ -55,6 +59,7 @@ public class DiscordPresenceService : IDisposable
     public void Reset()
     {
         _loaded = false;
+        _retryAttempt = 0;
         _wsCts?.Cancel();
         _ws?.Dispose();
         _ws = null;
@@ -116,17 +121,12 @@ public class DiscordPresenceService : IDisposable
             {
                 _ = PluginServices.Instance!.Framework.RunOnTick(() =>
                     _statusMessage = "Invalid API URL");
-                try
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(5), token);
-                }
-                catch
-                {
-                    // ignore cancellation
-                }
+                await DelayWithBackoff(TimeSpan.FromSeconds(5), token);
+                _retryAttempt = 0;
                 continue;
             }
 
+            var hadTransportError = true;
             try
             {
                 var pingService = PingService.Instance ?? new PingService(_httpClient, _config, TokenManager.Instance!);
@@ -137,14 +137,37 @@ public class DiscordPresenceService : IDisposable
                     {
                         PluginServices.Instance!.Log.Error("Backend ping endpoints missing. Please update or restart the backend.");
                     }
-                    try { await Task.Delay(TimeSpan.FromSeconds(5), token); } catch { }
+                    await DelayWithBackoff(TimeSpan.FromSeconds(5), token);
+                    _retryAttempt = 0;
                     continue;
                 }
                 _ws?.Dispose();
                 _ws = new ClientWebSocket();
                 ApiHelpers.AddAuthHeader(_ws, TokenManager.Instance!);
-                var uri = BuildWebSocketUri();
-                await _ws.ConnectAsync(uri, token);
+                Uri? uri;
+                try
+                {
+                    uri = BuildWebSocketUri();
+                }
+                catch (Exception ex)
+                {
+                    LogConnectionException(ex, "uri");
+                    await DelayWithBackoff(TimeSpan.FromSeconds(5), token);
+                    _retryAttempt = 0;
+                    continue;
+                }
+
+                if (!IsValidWebSocketUri(uri))
+                {
+                    LogConnectionException(new InvalidOperationException("Missing WebSocket URL"), "uri");
+                    await DelayWithBackoff(TimeSpan.FromSeconds(5), token);
+                    _retryAttempt = 0;
+                    continue;
+                }
+
+                await _ws.ConnectAsync(uri!, token);
+                _retryAttempt = 0;
+                hadTransportError = false;
                 _loaded = false;
                 await Refresh();
                 _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
@@ -207,28 +230,122 @@ public class DiscordPresenceService : IDisposable
                     }
                 }
             }
+            catch (OperationCanceledException ex) when (!ShouldRethrow(ex, token))
+            {
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (HttpRequestException ex)
+            {
+                hadTransportError = true;
+                HandleConnectionException(ex);
+            }
+            catch (WebSocketException ex)
+            {
+                hadTransportError = true;
+                HandleConnectionException(ex);
+            }
+            catch (IOException ex)
+            {
+                hadTransportError = true;
+                HandleConnectionException(ex);
+            }
             catch (Exception ex)
             {
-                PluginServices.Instance!.Log.Error(ex, "WebSocket connection error");
-                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
-                    _statusMessage = $"Connection failed: {ex.Message}");
+                hadTransportError = true;
+                HandleConnectionException(ex);
             }
             finally
             {
                 _ws?.Dispose();
                 _ws = null;
             }
-            try
+
+            if (token.IsCancellationRequested)
+                break;
+
+            if (hadTransportError)
             {
+                _retryAttempt++;
+                var delay = GetRetryDelay(_retryAttempt);
+                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                    _statusMessage = $"Reconnecting in {delay.TotalSeconds:0.#}s...");
+                await DelayWithBackoff(delay, token);
+            }
+            else
+            {
+                _retryAttempt = 0;
                 _ = PluginServices.Instance!.Framework.RunOnTick(() =>
                     _statusMessage = "Reconnecting...");
-                await Task.Delay(TimeSpan.FromSeconds(5), token);
-            }
-            catch
-            {
-                // ignore cancellation
+                await DelayWithBackoff(TimeSpan.FromSeconds(5), token);
             }
         }
+    }
+
+    private void HandleConnectionException(Exception ex)
+    {
+        LogConnectionException(ex, "connect");
+        _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+            _statusMessage = $"Connection failed: {ex.Message}");
+    }
+
+    private async Task DelayWithBackoff(TimeSpan delay, CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(delay, token);
+        }
+        catch (OperationCanceledException ex) when (!ShouldRethrow(ex, token))
+        {
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+    }
+
+    private static TimeSpan GetRetryDelay(int attempt)
+    {
+        var cappedAttempt = Math.Max(1, attempt);
+        var baseDelay = Math.Min(15d, Math.Pow(2, cappedAttempt - 1));
+        var min = Math.Max(0.5d, baseDelay / 2d);
+        var max = Math.Max(min, baseDelay);
+        var jitter = min + (max - min) * Random.Shared.NextDouble();
+        return TimeSpan.FromSeconds(jitter);
+    }
+
+    private static bool ShouldRethrow(OperationCanceledException _, CancellationToken token)
+        => token.CanBeCanceled && token.IsCancellationRequested;
+
+    private static bool IsValidWebSocketUri(Uri? uri)
+    {
+        if (uri == null || !uri.IsAbsoluteUri)
+            return false;
+
+        if (string.IsNullOrWhiteSpace(uri.ToString()))
+            return false;
+
+        return string.Equals(uri.Scheme, "ws", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(uri.Scheme, "wss", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void LogConnectionException(Exception ex, string stage)
+    {
+        var now = DateTime.UtcNow;
+        var signature = $"{stage}:{ex.GetType().FullName}:{ex.Message}";
+        if (_lastErrorSignature == signature && (now - _lastErrorLog) < ErrorLogThrottle)
+        {
+            return;
+        }
+
+        _lastErrorSignature = signature;
+        _lastErrorLog = now;
+        PluginServices.Instance!.Log.Error(ex, $"presence.ws {stage} failed");
     }
 
     private Uri BuildWebSocketUri()


### PR DESCRIPTION
## Summary
- harden the chat bridge by validating websocket URLs, throttling disconnect logging, and using jittered backoff for reconnect attempts
- apply the same resilient connect/send/receive handling to the request watcher, channel watcher, and discord presence service
- rework the UI renderer websocket workflow to respect networking state, schedule retries with jitter, and log repeated failures only once

## Testing
- `dotnet --version` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ca4240e48328ad70f76436701f48