### PR TITLE
Add coverage for emoji warmup and officer channel errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+- Added API tests covering Discord emoji warm-up responses and cached emoji listings.
+- Added officer message endpoint test ensuring unresolved channels return HTTP 409 with structured error details.

--- a/tests/test_discord_emojis.py
+++ b/tests/test_discord_emojis.py
@@ -1,0 +1,90 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.responses import JSONResponse
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+if str(root) not in sys.path:
+    sys.path.append(str(root))
+
+from demibot.http.deps import RequestContext
+from demibot.http.routes import discord_emojis
+
+
+class DummyEmoji:
+    def __init__(self, eid, name, animated):
+        self.id = eid
+        self.name = name
+        self.animated = animated
+
+
+class DummyGuild:
+    def __init__(self, emojis):
+        self.emojis = emojis
+
+
+class DummyClient:
+    def __init__(self, guild):
+        self._guild = guild
+
+    def get_guild(self, guild_id):
+        return self._guild
+
+
+@pytest.mark.asyncio
+async def test_emojis_warmup_returns_empty_and_retry_after(monkeypatch):
+    discord_emojis._emoji_cache.clear()
+
+    class WarmupClient:
+        def get_guild(self, guild_id):
+            return None
+
+    monkeypatch.setattr(discord_emojis, "discord_client", WarmupClient())
+
+    ctx = RequestContext(
+        user=SimpleNamespace(id=1),
+        guild=SimpleNamespace(id=1, discord_guild_id=100),
+        key=None,
+        roles=[],
+    )
+
+    response = await discord_emojis.list_emojis(ctx=ctx)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 200
+    assert response.headers["Retry-After"] == str(
+        discord_emojis._RETRY_AFTER_SECONDS
+    )
+    assert json.loads(response.body) == {"ok": True, "emojis": []}
+
+
+@pytest.mark.asyncio
+async def test_emojis_returns_list_when_ready(monkeypatch):
+    discord_emojis._emoji_cache.clear()
+
+    guild = DummyGuild(
+        [DummyEmoji(1, "sparkle", False), DummyEmoji(2, "dance", True)]
+    )
+    monkeypatch.setattr(discord_emojis, "discord_client", DummyClient(guild))
+
+    ctx = RequestContext(
+        user=SimpleNamespace(id=1),
+        guild=SimpleNamespace(id=1, discord_guild_id=100),
+        key=None,
+        roles=[],
+    )
+
+    data = await discord_emojis.list_emojis(ctx=ctx)
+
+    assert data == {
+        "ok": True,
+        "emojis": [
+            {"id": "1", "name": "sparkle", "animated": False},
+            {"id": "2", "name": "dance", "animated": True},
+        ],
+    }
+    # Cached copy should now be available for subsequent calls.
+    assert discord_emojis._emoji_cache[ctx.guild.id] == data["emojis"]

--- a/tests/test_officer_messages_endpoint.py
+++ b/tests/test_officer_messages_endpoint.py
@@ -1,0 +1,89 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+if str(root) not in sys.path:
+    sys.path.append(str(root))
+
+from demibot.db.models import Guild, User, Membership, GuildChannel, ChannelKind
+from demibot.db.session import get_session, init_db
+from demibot.http.api import create_app
+from demibot.http.deps import RequestContext, api_key_auth, get_db
+import demibot.http.routes._messages_common as mc
+
+
+@pytest.mark.asyncio
+async def test_officer_unresolved_returns_409(monkeypatch):
+    await init_db("sqlite+aiosqlite://")
+    async with get_session() as db:
+        await db.execute(text("DELETE FROM messages"))
+        await db.execute(text("DELETE FROM memberships"))
+        await db.execute(text("DELETE FROM users"))
+        await db.execute(text("DELETE FROM guild_channels"))
+        await db.execute(text("DELETE FROM guilds"))
+        guild = Guild(id=1, discord_guild_id=101, name="Guild")
+        user = User(id=1, discord_user_id=201, global_name="Officer")
+        membership = Membership(
+            guild_id=guild.id,
+            user_id=user.id,
+            nickname="Officer",
+            avatar_url="http://example.com/avatar.png",
+        )
+        channel = GuildChannel(
+            guild_id=guild.id,
+            channel_id=555,
+            kind=ChannelKind.OFFICER_CHAT,
+        )
+        db.add_all([guild, user, membership, channel])
+        await db.commit()
+
+    class DummyClient:
+        def get_channel(self, channel_id):
+            return None
+
+        async def fetch_channel(self, channel_id):
+            return None
+
+    monkeypatch.setattr(mc, "discord_client", DummyClient())
+    monkeypatch.setattr(mc, "_channel_webhooks", {})
+
+    app = create_app()
+
+    user_ctx = SimpleNamespace(
+        id=1,
+        discord_user_id=201,
+        global_name="Officer",
+        character_name=None,
+    )
+    guild_ctx = SimpleNamespace(id=1, discord_guild_id=101)
+
+    async def override_auth():
+        return RequestContext(user=user_ctx, guild=guild_ctx, key=None, roles=["officer"])
+
+    async def override_db():
+        async with get_session() as session:
+            yield session
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/officer-messages",
+            json={"channelId": "555", "content": "Hello"},
+        )
+
+    assert resp.status_code == 409
+    assert resp.json() == {
+        "detail": {
+            "code": "OFFICER_CHANNEL_UNRESOLVED",
+            "message": "Officer channel could not be resolved",
+            "channelId": "555",
+        }
+    }


### PR DESCRIPTION
## Summary
- add Discord emoji API warm-up and ready state tests
- add officer message endpoint regression test for unresolved channels
- note the added coverage in the changelog

## Testing
- pytest tests/test_discord_emojis.py tests/test_officer_messages_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68c94daea19c8328a93d29b43a8f1bf5