### PR TITLE
Add channel kind metadata and namespaced chat cursors

### DIFF
--- a/DemiCatPlugin/ChannelDto.cs
+++ b/DemiCatPlugin/ChannelDto.cs
@@ -9,10 +9,24 @@ public class ChannelDto
     [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
     [JsonPropertyName("parentId")] public string? ParentId { get; set; }
+    [JsonPropertyName("kind")] public string Kind { get; set; } = string.Empty;
 }
 
 public static class ChannelDtoExtensions
 {
+    public static void EnsureKind(this ChannelDto? channel, string fallbackKind)
+    {
+        if (channel == null) return;
+        if (string.IsNullOrEmpty(channel.Kind))
+        {
+            channel.Kind = ChannelKeyHelper.NormalizeKind(fallbackKind);
+        }
+        else
+        {
+            channel.Kind = ChannelKeyHelper.NormalizeKind(channel.Kind);
+        }
+    }
+
     public static List<ChannelDto> SortForDisplay(IEnumerable<ChannelDto> channels)
     {
         var parents = channels.Where(c => string.IsNullOrEmpty(c.ParentId)).ToList();

--- a/DemiCatPlugin/ChannelKeyHelper.cs
+++ b/DemiCatPlugin/ChannelKeyHelper.cs
@@ -1,0 +1,26 @@
+namespace DemiCatPlugin;
+
+public static class ChannelKeyHelper
+{
+    private const string DefaultGuildSentinel = "default";
+
+    public static string NormalizeGuildId(string? guildId)
+        => string.IsNullOrWhiteSpace(guildId) ? DefaultGuildSentinel : guildId.Trim();
+
+    public static string NormalizeKind(string? kind)
+    {
+        if (string.IsNullOrWhiteSpace(kind))
+        {
+            return string.Empty;
+        }
+        return kind.Trim().ToUpperInvariant();
+    }
+
+    public static string BuildSelectionKey(string? guildId, string? kind)
+        => $"{NormalizeGuildId(guildId)}:{NormalizeKind(kind)}";
+
+    public static string BuildCursorKey(string? guildId, string? kind, string channelId)
+        => $"{NormalizeGuildId(guildId)}:{NormalizeKind(kind)}:{channelId}";
+
+    public static bool IsDefaultGuild(string? guildId) => string.IsNullOrWhiteSpace(guildId);
+}

--- a/DemiCatPlugin/ChannelService.cs
+++ b/DemiCatPlugin/ChannelService.cs
@@ -41,6 +41,10 @@ public class ChannelService
                 response.EnsureSuccessStatusCode();
                 var stream = await response.Content.ReadAsStreamAsync(linkedCts.Token);
                 var channels = await JsonSerializer.DeserializeAsync<List<ChannelDto>>(stream, JsonOpts, linkedCts.Token) ?? new List<ChannelDto>();
+                foreach (var channel in channels)
+                {
+                    channel.EnsureKind(kind);
+                }
                 return ChannelDtoExtensions.SortForDisplay(channels);
             }
             catch (HttpRequestException) when (attempt < 2)

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -68,11 +68,13 @@ public class EventCreateWindow
         _channelSelection.ChannelChanged += HandleChannelChanged;
     }
 
-    private string ChannelId => _channelSelection.GetChannel(ChannelKind.Event);
+    private string ChannelId => _channelSelection.GetChannel(ChannelKind.Event, _config.GuildId);
 
-    private void HandleChannelChanged(string kind, string oldId, string newId)
+    private void HandleChannelChanged(string kind, string guildId, string oldId, string newId)
     {
         if (kind != ChannelKind.Event) return;
+        if (!string.Equals(ChannelKeyHelper.NormalizeGuildId(guildId), ChannelKeyHelper.NormalizeGuildId(_config.GuildId), StringComparison.Ordinal))
+            return;
         PluginServices.Instance!.Framework.RunOnTick(() =>
         {
             if (_channels.Count > 0)
@@ -120,7 +122,7 @@ public class EventCreateWindow
             if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
             {
                 var newId = _channels[_selectedIndex].Id;
-                _channelSelection.SetChannel(ChannelKind.Event, newId);
+                _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, newId);
             }
         }
         else
@@ -721,7 +723,7 @@ public class EventCreateWindow
                 }
                 if (_channels.Count > 0)
                 {
-                    _channelSelection.SetChannel(ChannelKind.Event, _channels[_selectedIndex].Id);
+                    _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, _channels[_selectedIndex].Id);
                 }
                 _channelsLoaded = true;
                 _channelFetchFailed = false;

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -248,7 +248,7 @@ public class OfficerChatWindow : ChatWindow
     {
         var chan = CurrentChannelId;
         _bridge.Unsubscribe(chan);
-        _bridge.Subscribe(chan);
+        _bridge.Subscribe(chan, _config.GuildId, ChannelKind);
         _presence?.Reset();
         _ = RefreshMessages();
         _subscribed = true;

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -286,6 +286,10 @@ public class Plugin : IDalamudPlugin
                     var channelStream = await channelResponse.Content.ReadAsStreamAsync();
                     var channelsDto = await JsonSerializer.DeserializeAsync<ChannelListDto>(channelStream) ?? new ChannelListDto();
                     chatChannels = channelsDto.Chat;
+                    foreach (var channel in chatChannels)
+                    {
+                        channel.EnsureKind(ChannelKind.FcChat);
+                    }
                 }
                 else
                 {

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -62,11 +62,13 @@ public class TemplatesWindow
         _channelSelection.ChannelChanged += HandleChannelChanged;
     }
 
-    private string ChannelId => _channelSelection.GetChannel(ChannelKind.Event);
+    private string ChannelId => _channelSelection.GetChannel(ChannelKind.Event, _config.GuildId);
 
-    private void HandleChannelChanged(string kind, string oldId, string newId)
+    private void HandleChannelChanged(string kind, string guildId, string oldId, string newId)
     {
         if (kind != ChannelKind.Event) return;
+        if (!string.Equals(ChannelKeyHelper.NormalizeGuildId(guildId), ChannelKeyHelper.NormalizeGuildId(_config.GuildId), StringComparison.Ordinal))
+            return;
         PluginServices.Instance!.Framework.RunOnTick(() =>
         {
             if (_channels.Count > 0)
@@ -120,7 +122,7 @@ public class TemplatesWindow
             if (ImGui.Combo("Channel", ref _channelIndex, channelNames, channelNames.Length))
             {
                 var newId = _channels[_channelIndex].Id;
-                _channelSelection.SetChannel(ChannelKind.Event, newId);
+                _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, newId);
             }
         }
         else
@@ -370,7 +372,7 @@ public class TemplatesWindow
         }
         if (_channels.Count > 0)
         {
-            _channelSelection.SetChannel(ChannelKind.Event, _channels[_channelIndex].Id);
+            _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, _channels[_channelIndex].Id);
         }
     }
 

--- a/tests/ChatWindowWebSocketTests.cs
+++ b/tests/ChatWindowWebSocketTests.cs
@@ -39,12 +39,12 @@ public class ChatWindowWebSocketTests
         string? payload = null;
         bridge.MessageReceived += p => payload = p;
         bridge.Start();
-        bridge.Subscribe("1");
+        bridge.Subscribe("1", config.GuildId, ChannelKind.Chat);
 
         await WaitUntil(() => server.Received.Exists(m => m.Contains("\"op\":\"sub\"")), TimeSpan.FromSeconds(5));
         await WaitUntil(() => payload != null, TimeSpan.FromSeconds(5));
 
-        bridge.Ack("1");
+        bridge.Ack("1", config.GuildId, ChannelKind.Chat);
         await WaitUntil(() => server.Received.Exists(m => m.Contains("\"op\":\"ack\"")), TimeSpan.FromSeconds(5));
 
         await bridge.Send("1", new { text = "hi" });
@@ -93,10 +93,10 @@ public class ChatWindowWebSocketTests
         bool received = false;
         bridge.MessageReceived += _ => received = true;
         bridge.Start();
-        bridge.Subscribe("1");
+        bridge.Subscribe("1", config.GuildId, ChannelKind.Chat);
 
         await WaitUntil(() => firstBatchSent && received, TimeSpan.FromSeconds(5));
-        bridge.Ack("1");
+        bridge.Ack("1", config.GuildId, ChannelKind.Chat);
 
         await WaitUntil(() => secondSince != -1, TimeSpan.FromSeconds(10));
 
@@ -130,7 +130,7 @@ public class ChatWindowWebSocketTests
         DiscordUserDto? user = null;
         bridge.TypingReceived += u => user = u;
         bridge.Start();
-        bridge.Subscribe("1");
+        bridge.Subscribe("1", config.GuildId, ChannelKind.Chat);
 
         await WaitUntil(() => user != null, TimeSpan.FromSeconds(5));
 
@@ -189,7 +189,7 @@ public class ChatWindowWebSocketTests
         var bridge = new ChatBridge(config, client, new TokenManager(), () => server.Uri);
 
         bridge.Start();
-        bridge.Subscribe("1");
+        bridge.Subscribe("1", config.GuildId, ChannelKind.Chat);
 
         await WaitUntil(() => server.Received.Exists(m => m.Contains("\"op\":\"sub\"")), TimeSpan.FromSeconds(5));
 


### PR DESCRIPTION
## Summary
- add a Kind field to channel DTOs and normalize the value when fetching lists
- namespace chat cursor keys with guild and channel kind information and migrate existing config values
- store channel selections per guild and pass the guild identifier through the UI when updating selections

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9526db4f883289bc3da449d614ce0