### PR TITLE
Improve chat bridge channel validation and namespacing

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -134,7 +134,7 @@ public class ChatWindow : IDisposable
         _emojiPicker = new EmojiPicker(_emojiService);
         _ = _emojiService.RefreshAsync();
         _useCharacterName = config.UseCharacterName;
-        _bridge = new ChatBridge(config, httpClient, tokenManager, BuildWebSocketUri);
+        _bridge = new ChatBridge(config, httpClient, tokenManager, BuildWebSocketUri, channelSelection);
         _bridge.MessageReceived += HandleBridgeMessage;
         _bridge.TypingReceived += HandleBridgeTyping;
         _bridge.Linked += HandleBridgeLinked;

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -56,7 +56,7 @@ public class TemplatesWindow
         var token = TokenManager.Instance;
         if (token != null)
         {
-            _bridge = new ChatBridge(config, httpClient, token, BuildWebSocketUri);
+            _bridge = new ChatBridge(config, httpClient, token, BuildWebSocketUri, channelSelection);
             _bridge.TemplatesUpdated += () => _ = LoadTemplates();
         }
         _channelSelection.ChannelChanged += HandleChannelChanged;

--- a/tests/ChatBridgeNoTokenTests.cs
+++ b/tests/ChatBridgeNoTokenTests.cs
@@ -18,7 +18,7 @@ public class ChatBridgeNoTokenTests
         typeof(TokenManager).GetField("_token", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(tm, null);
         typeof(TokenManager).GetProperty("State", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!.SetValue(tm, LinkState.Unlinked);
 
-        var bridge = new ChatBridge(config, client, tm, () => new Uri("ws://localhost"));
+        var bridge = new ChatBridge(config, client, tm, () => new Uri("ws://localhost"), new ChannelSelectionService(config));
         bridge.Start();
         await Task.Delay(100);
         bridge.Stop();


### PR DESCRIPTION
## Summary
- namespace chat bridge cursor, ack, and subscription tracking with composite keys and metadata validation
- drop websocket batches/resyncs that do not match the current selection while logging throttled warnings
- wire channel selection service into chat bridge consumers and extend websocket tests for guild/kind metadata coverage

## Testing
- `dotnet test tests` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ea67ac4c8328aefa88a54f3979fe