### PR TITLE
Ensure event channel selection is guild scoped

### DIFF
--- a/DemiCatPlugin/EmbedDto.cs
+++ b/DemiCatPlugin/EmbedDto.cs
@@ -26,6 +26,7 @@ public class EmbedDto
     public int? VideoHeight { get; set; }
     public List<EmbedButtonDto>? Buttons { get; set; }
     public ulong? ChannelId { get; set; }
+    public string? GuildId { get; set; }
     public List<ulong>? Mentions { get; set; }
 }
 

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -63,6 +63,8 @@ public class EventView : IDisposable
 
     public string ChannelId => _dto.ChannelId?.ToString() ?? string.Empty;
 
+    public string GuildId => _dto.GuildId ?? string.Empty;
+
     public IReadOnlyList<EmbedButtonDto>? Buttons => _dto.Buttons;
 
     public void Draw()


### PR DESCRIPTION
## Summary
- teach `ChannelSelectionService` to store event selections under an `Event:<guild>` key and expose whether a guild-scoped value exists
- update the UI renderer to pick event channels per guild, persist a default choice when none is stored, and filter embeds by both channel and guild
- surface embed guild identifiers via `EmbedDto`/`EventView` for filtering

## Testing
- `dotnet test` *(fails: dotnet is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca133e74d083288784276bb70eda10