### PR TITLE
Add channel validation endpoint and client integration

### DIFF
--- a/DemiCatPlugin/ChannelValidationResponse.cs
+++ b/DemiCatPlugin/ChannelValidationResponse.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace DemiCatPlugin;
+
+public class ChannelValidationResponse
+{
+    [JsonPropertyName("ok")]
+    public bool Ok { get; set; }
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
+
+    [JsonPropertyName("guildId")]
+    public string? GuildId { get; set; }
+
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}


### PR DESCRIPTION
## Summary
- add a GET /api/channels/{id}/validate endpoint that validates channel kind, respects officer roles, and normalizes channel type filtering
- create a ChannelValidationResponse model plus a ChannelService helper and wire validation into the plugin's channel selection flow with refresh/toast handling
- extend channel endpoint tests to cover validation success, mismatches, invalid kinds, and officer permissions

## Testing
- PYTHONPATH=demibot pytest tests/test_channels_endpoint.py
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca15eab1a08328b6fd6bf0f996f7c5