### PR TITLE
Add websocket metadata tests and log throttling

### DIFF
--- a/tests/ChannelSelectionServiceTests.cs
+++ b/tests/ChannelSelectionServiceTests.cs
@@ -1,0 +1,37 @@
+using DemiCatPlugin;
+using Xunit;
+
+public class ChannelSelectionServiceTests
+{
+    [Fact]
+    public void SetChannel_PersistsSelectionsPerGuild()
+    {
+        var config = new Config();
+        var service = new ChannelSelectionService(config);
+
+        service.SetChannel(ChannelKind.Chat, "guild-a", "chan-1");
+        service.SetChannel(ChannelKind.Chat, "guild-b", "chan-2");
+
+        var keyA = ChannelKeyHelper.BuildSelectionKey("guild-a", ChannelKind.Chat);
+        var keyB = ChannelKeyHelper.BuildSelectionKey("guild-b", ChannelKind.Chat);
+
+        Assert.Equal("chan-1", config.ChannelSelections[keyA]);
+        Assert.Equal("chan-2", config.ChannelSelections[keyB]);
+        Assert.Equal(2, config.ChannelSelections.Count);
+
+        var selectedA = service.GetChannel(ChannelKind.Chat, "guild-a", out var storedA);
+        var selectedB = service.GetChannel(ChannelKind.Chat, "guild-b", out var storedB);
+        var defaultSelection = service.GetChannel(ChannelKind.Chat, null, out var storedDefault);
+
+        Assert.True(storedA);
+        Assert.True(storedB);
+        Assert.False(storedDefault);
+        Assert.Equal("chan-1", selectedA);
+        Assert.Equal("chan-2", selectedB);
+        Assert.Equal(string.Empty, defaultSelection);
+
+        service.SetChannel(ChannelKind.Chat, "guild-a", "chan-3");
+        Assert.Equal("chan-3", service.GetChannel(ChannelKind.Chat, "guild-a", out _));
+        Assert.Equal("chan-2", service.GetChannel(ChannelKind.Chat, "guild-b", out _));
+    }
+}


### PR DESCRIPTION
## Summary
- throttle repeated wrong-kind batch warnings in the chat bridge
- add client tests covering per-guild channel selection and cursor key storage
- add server websocket tests asserting metadata fields and mixed-channel drops

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet SDK not installed in container)*
- pytest tests/test_chat_ws.py tests/test_channels_endpoint.py *(fails: missing fastapi/sqlalchemy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68caac2117cc8328b852a6b06da2a9e8