### PR TITLE
Add posted message webhook mapping and use for edits

### DIFF
--- a/demibot/demibot/db/migrations/versions/0044_add_posted_messages_table.py
+++ b/demibot/demibot/db/migrations/versions/0044_add_posted_messages_table.py
@@ -1,0 +1,50 @@
+"""add posted messages table
+
+Revision ID: 0044_add_posted_messages_table
+Revises: 0043_add_events_table
+Create Date: 2025-01-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision: str = "0044_add_posted_messages_table"
+down_revision: str = "0043_add_events_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "posted_messages",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("guild_id", sa.Integer(), sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column("channel_id", mysql.BIGINT(unsigned=True), nullable=False),
+        sa.Column("local_message_id", mysql.BIGINT(unsigned=True), nullable=False),
+        sa.Column("discord_message_id", mysql.BIGINT(unsigned=True), nullable=False),
+        sa.Column("webhook_url", sa.String(length=255), nullable=True),
+    )
+    op.create_index(
+        "ix_posted_messages_guild_channel",
+        "posted_messages",
+        ["guild_id", "channel_id"],
+    )
+    op.create_unique_constraint(
+        "uq_posted_messages_guild_local",
+        "posted_messages",
+        ["guild_id", "local_message_id"],
+    )
+    op.create_unique_constraint(
+        "uq_posted_messages_discord",
+        "posted_messages",
+        ["discord_message_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_posted_messages_discord", "posted_messages", type_="unique")
+    op.drop_constraint("uq_posted_messages_guild_local", "posted_messages", type_="unique")
+    op.drop_index("ix_posted_messages_guild_channel", table_name="posted_messages")
+    op.drop_table("posted_messages")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -257,6 +257,33 @@ class Message(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
+class PostedMessage(Base):
+    __tablename__ = "posted_messages"
+    __table_args__ = (
+        Index(
+            "ix_posted_messages_guild_channel",
+            "guild_id",
+            "channel_id",
+        ),
+        UniqueConstraint(
+            "guild_id",
+            "local_message_id",
+            name="uq_posted_messages_guild_local",
+        ),
+        UniqueConstraint(
+            "discord_message_id",
+            name="uq_posted_messages_discord",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"), index=True)
+    channel_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), index=True)
+    local_message_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), index=True)
+    discord_message_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), index=True)
+    webhook_url: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+
 class Embed(Base):
     __tablename__ = "embeds"
 

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -290,7 +290,7 @@ async def create_event(
                     },
                 )
                 if thread_obj:
-                    msg_id, _, _ = await _send_via_webhook(
+                    msg_id, _, _, _ = await _send_via_webhook(
                         channel=base_channel,
                         channel_id=base_channel.id,
                         guild_id=ctx.guild.id,

--- a/tests/test_event_channel_validation.py
+++ b/tests/test_event_channel_validation.py
@@ -90,7 +90,7 @@ def test_create_event_thread_uses_webhook() -> None:
 
         async def fake_webhook(**kwargs):
             captured.update(kwargs)
-            return 123, None, []
+            return 123, None, [], None
 
         body = CreateEventBody(channelId="456", title="T", description="d")
         ctx = SimpleNamespace(guild=SimpleNamespace(id=1), roles=[])

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -8,7 +8,15 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy import select, text
 
-from demibot.db.models import Guild, User, Message, Membership, GuildChannel, ChannelKind
+from demibot.db.models import (
+    Guild,
+    User,
+    Message,
+    Membership,
+    GuildChannel,
+    ChannelKind,
+    PostedMessage,
+)
 from demibot.db.session import init_db, get_session
 from demibot.http.deps import RequestContext
 import importlib.util
@@ -51,6 +59,7 @@ def test_save_and_fetch_messages(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -120,6 +129,7 @@ def test_fetch_messages_backfills_from_discord(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM users"))
             await db.execute(text("DELETE FROM guilds"))
@@ -232,6 +242,7 @@ def test_channel_not_configured(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -255,6 +266,7 @@ def test_forum_root_rejected(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -291,6 +303,7 @@ def test_thread_uses_parent_webhook(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -351,6 +364,7 @@ def test_archived_thread_rejected(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -388,6 +402,7 @@ def test_cached_webhook_without_channel(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -434,6 +449,7 @@ def test_allowed_mentions(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -506,6 +522,7 @@ def test_long_username_truncated(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -568,6 +585,7 @@ def test_message_too_long(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -596,6 +614,7 @@ def test_rest_ws_payload_parity(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -667,6 +686,7 @@ def test_multipart_message(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -779,6 +799,7 @@ def test_discord_failure_details(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -834,6 +855,7 @@ def test_save_message_invalid_channel_id():
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -859,6 +881,7 @@ def test_save_message_unresolved_channel_id(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -897,6 +920,7 @@ def test_save_message_unresolved_officer_channel(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -949,6 +973,7 @@ def test_channel_not_found_returns_error_details(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -963,7 +988,7 @@ def test_channel_not_found_returns_error_details(monkeypatch):
             ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=[])
 
             async def failing_webhook(*args, **kwargs):
-                return None, None, ["Webhook boom"]
+                return None, None, ["Webhook boom"], None
 
             monkeypatch.setattr(mc, "_send_via_webhook", failing_webhook)
             monkeypatch.setattr(mc, "discord_client", None)
@@ -985,6 +1010,7 @@ def test_attachment_validation(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -1042,6 +1068,7 @@ def test_officer_flow(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -1099,6 +1126,7 @@ def test_officer_requires_role(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -1125,6 +1153,7 @@ def test_save_message_webhook_failure(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -1170,6 +1199,7 @@ def test_webhook_errors_returned(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -1187,7 +1217,7 @@ def test_webhook_errors_returned(monkeypatch):
                 return None
 
             async def dummy_webhook(*args, **kwargs):
-                return 123, [], ["Webhook init failed"]
+                return 123, [], ["Webhook init failed"], None
 
             monkeypatch.setattr(mc.manager, "broadcast_text", dummy_broadcast)
             monkeypatch.setattr(mc, "_send_via_webhook", dummy_webhook)
@@ -1205,6 +1235,7 @@ def test_webhook_cache_persist_and_load(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))
@@ -1319,10 +1350,119 @@ def test_webhook_cache_persist_and_load(monkeypatch):
     asyncio.run(_run())
 
 
+def test_posted_message_mapping_and_webhook_usage(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
+            await db.execute(text("DELETE FROM messages"))
+            await db.execute(text("DELETE FROM memberships"))
+            await db.execute(text("DELETE FROM users"))
+            await db.execute(text("DELETE FROM guilds"))
+            await db.execute(text("DELETE FROM guild_channels"))
+            guild = Guild(id=42, discord_guild_id=42, name="Guild")
+            user = User(id=99, discord_user_id=990, global_name="Alice")
+            membership = Membership(
+                guild_id=42,
+                user_id=99,
+                nickname="Alice",
+                avatar_url=None,
+            )
+            channel = GuildChannel(
+                guild_id=42,
+                channel_id=123,
+                kind=ChannelKind.FC_CHAT,
+            )
+            db.add_all([guild, user, membership, channel])
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=[])
+
+            async def dummy_broadcast(*args, **kwargs):
+                return None
+
+            async def fake_webhook(**kwargs):
+                return 555, None, [], "http://webhook.example"
+
+            class DummyChannel:
+                id = 123
+                guild = types.SimpleNamespace(id=42)
+                archived = False
+                parent = None
+                fetch_called = False
+
+            dummy_channel = DummyChannel()
+
+            async def fetch_message(mid: int):
+                dummy_channel.fetch_called = True
+                raise RuntimeError("fetch_message should not be used")
+
+            dummy_channel.fetch_message = fetch_message  # type: ignore[attr-defined]
+
+            monkeypatch.setattr(mc, "_channel_webhooks", {})
+            monkeypatch.setattr(mc.manager, "broadcast_text", dummy_broadcast)
+            monkeypatch.setattr(mc, "_send_via_webhook", fake_webhook)
+            monkeypatch.setattr(mc.discord.abc, "Messageable", DummyChannel, raising=False)
+            monkeypatch.setattr(mc.discord, "TextChannel", DummyChannel, raising=False)
+            monkeypatch.setattr(
+                mc,
+                "discord_client",
+                types.SimpleNamespace(get_channel=lambda cid: dummy_channel),
+            )
+
+            body = mc.PostBody(channelId="123", content="hello")
+            result = await mc.save_message(body, ctx, db, channel_kind=ChannelKind.FC_CHAT)
+            assert result["ok"] is True
+            msg_id = int(result["id"])
+
+            mapping = await db.scalar(
+                select(PostedMessage).where(PostedMessage.discord_message_id == msg_id)
+            )
+            assert mapping is not None
+            assert mapping.webhook_url == "http://webhook.example"
+            assert mapping.channel_id == 123
+
+            edit_calls: list[tuple[int, str]] = []
+            delete_calls: list[int] = []
+
+            class DummyWebhook:
+                async def edit_message(self, message_id: int, *, content: str, allowed_mentions):
+                    edit_calls.append((message_id, content))
+
+                async def delete_message(self, message_id: int):
+                    delete_calls.append(message_id)
+
+            def fake_from_url(cls, url: str, *, client=None, bot_token=None):
+                assert url == "http://webhook.example"
+                return DummyWebhook()
+
+            monkeypatch.setattr(
+                mc.discord.Webhook,
+                "from_url",
+                classmethod(fake_from_url),
+            )
+
+            await mc.edit_message("123", str(msg_id), "updated", ctx, db, is_officer=False)
+            assert edit_calls == [(msg_id, "updated")]
+            assert not dummy_channel.fetch_called
+
+            await mc.delete_message("123", str(msg_id), ctx, db, is_officer=False)
+            assert delete_calls == [msg_id]
+            assert not dummy_channel.fetch_called
+
+            remaining = await db.scalar(
+                select(PostedMessage).where(PostedMessage.discord_message_id == msg_id)
+            )
+            assert remaining is None
+
+    asyncio.run(_run())
+
+
 def test_fetch_messages_pagination():
     async def _run():
         await init_db("sqlite+aiosqlite://")
         async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
             await db.execute(text("DELETE FROM messages"))
             await db.execute(text("DELETE FROM memberships"))
             await db.execute(text("DELETE FROM users"))


### PR DESCRIPTION
## Summary
- add a posted_messages table and migration to persist webhook details for sent messages
- record the webhook mapping when saving chat posts and leverage it during webhook edits/deletes
- update message tests (including a new webhook mapping test) and adjust event validation mocks for the expanded webhook contract

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py::test_posted_message_mapping_and_webhook_usage`
- `PYTHONPATH=demibot pytest tests/test_event_channel_validation.py` *(fails: sqlite unique constraint from cached engine when reusing test database names)*

------
https://chatgpt.com/codex/tasks/task_e_68cad2f64b7c83289164222753aa2de7