### PR TITLE
Use fully qualified channel enums

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -13,7 +13,7 @@ public class FcChatWindow : ChatWindow
     private float _presenceWidth = 150f;
 
     public FcChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService, ChannelSelectionService channelSelection, AvatarCache avatarCache)
-        : base(config, httpClient, presence, tokenManager, channelService, channelSelection, ChannelKind.FcChat, avatarCache)
+        : base(config, httpClient, presence, tokenManager, channelService, channelSelection, global::DemiCatPlugin.ChannelKind.FcChat, avatarCache)
     {
         if (presence != null)
         {

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -21,7 +21,7 @@ public class OfficerChatWindow : ChatWindow
     private bool _subscribed;
 
     public OfficerChatWindow(Config config, HttpClient httpClient, DiscordPresenceService? presence, TokenManager tokenManager, ChannelService channelService, ChannelSelectionService channelSelection, AvatarCache avatarCache)
-        : base(config, httpClient, presence, tokenManager, channelService, channelSelection, ChannelKind.OfficerChat, avatarCache)
+        : base(config, httpClient, presence, tokenManager, channelService, channelSelection, global::DemiCatPlugin.ChannelKind.OfficerChat, avatarCache)
     {
         _bridge.StatusChanged += s =>
         {
@@ -209,7 +209,7 @@ public class OfficerChatWindow : ChatWindow
 
         try
         {
-            var channels = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(ChannelKind.OfficerChat, CancellationToken.None)).ToList());
+            var channels = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(global::DemiCatPlugin.ChannelKind.OfficerChat, CancellationToken.None)).ToList());
             if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true)))
                 return;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>


### PR DESCRIPTION
## Summary
- pass the fully qualified FcChat channel enum when constructing the free company chat window
- use the fully qualified officer channel enum throughout the officer chat window

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cae4081f7c8328af8e59a765007159