### PR TITLE
Fix toast call for missing channel

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -223,7 +223,7 @@ public class Plugin : IDalamudPlugin
             {
                 PluginServices.Instance?.Framework.RunOnTick(() =>
                 {
-                    PluginServices.Instance?.ToastGui.ShowWarning(
+                    PluginServices.Instance?.ToastGui.ShowError(
                         "Selected channel is no longer configured."
                     );
                 });


### PR DESCRIPTION
## Summary
- replace the NOT_FOUND toast validation to use ShowError instead of the removed ShowWarning helper

## Testing
- dotnet build *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68cae4a060d88328bfa1b6551679977e