### PR TITLE
Start WebSocket connect in background

### DIFF
--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -125,7 +125,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         StartPolling();
         await RefreshChannels();
         await LoadPresences();
-        await ConnectWebSocket();
+        StartWebSocketConnectTask();
     }
 
     public void StopNetworking()
@@ -169,7 +169,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                         Math.Min(baseInterval.TotalSeconds * Math.Pow(2, _failureCount), 300));
                 if ((_webSocket == null || _webSocket.State != WebSocketState.Open) && DateTime.UtcNow >= _nextWebSocketAttempt)
                 {
-                    _ = ConnectWebSocket();
+                    StartWebSocketConnectTask();
                 }
             }
         }
@@ -177,6 +177,23 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         {
             // ignored
         }
+    }
+
+    private void StartWebSocketConnectTask()
+    {
+        async Task RunAsync()
+        {
+            try
+            {
+                await ConnectWebSocket();
+            }
+            catch (Exception ex)
+            {
+                LogWebSocketException(ex, "connect.task");
+            }
+        }
+
+        _ = RunAsync();
     }
 
     private async Task LoadPresences()


### PR DESCRIPTION
## Summary
- let UiRenderer.StartNetworking finish after refreshing channels and presences by starting the WebSocket connection on a background task
- add a helper that runs ConnectWebSocket without awaiting it and logs any unexpected exceptions so asynchronous socket failures remain visible
- reuse the same helper from the polling loop to avoid unobserved connection task faults

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caf08544388328a35b45911f26eab1