### PR TITLE
Send resync channel field and assert in tests

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -134,7 +134,7 @@ public class ChatBridge : IDisposable
 
     public void Resync(string channel)
     {
-        var json = JsonSerializer.Serialize(new { op = "resync", ch = channel });
+        var json = JsonSerializer.Serialize(new { op = "resync", channel });
         PluginServices.Instance?.Log.Info($"chat.ws resync channel={channel}");
         _resyncCount++;
         _ = SendRaw(json);

--- a/tests/ChatWindowWebSocketTests.cs
+++ b/tests/ChatWindowWebSocketTests.cs
@@ -66,6 +66,15 @@ public class ChatWindowWebSocketTests
 
         bridge.Resync("1");
         await WaitUntil(() => server.Received.Exists(m => m.Contains("\"op\":\"resync\"")), TimeSpan.FromSeconds(5));
+        var resyncFrame = server.Received.Last(m => m.Contains("\"op\":\"resync\""));
+        using (var doc = JsonDocument.Parse(resyncFrame))
+        {
+            var root = doc.RootElement;
+            Assert.Equal("resync", root.GetProperty("op").GetString());
+            Assert.True(root.TryGetProperty("channel", out var channelProp));
+            Assert.Equal("1", channelProp.GetString());
+            Assert.False(root.TryGetProperty("ch", out _));
+        }
 
         bridge.Stop();
 


### PR DESCRIPTION
## Summary
- serialize resync frames using the channel property so the FastAPI handler can parse them
- extend the WebSocket resync flow test to assert the channel field is present and the legacy ch field is absent

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj -v minimal *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caf290cec08328afd02c6b1e9089b6