### PR TITLE
Fix mirror cog DTO serialization

### DIFF
--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -339,7 +339,7 @@ class Mirror(commands.Cog):
             await db.commit()
 
             await manager.broadcast_text(
-                json.dumps(dto.model_dump(by_alias=True, exclude_none=True)),
+                dto.model_dump_json(by_alias=True, exclude_none=True),
                 guild_id,
                 officer_only=is_officer,
                 path="/ws/messages",
@@ -349,7 +349,7 @@ class Mirror(commands.Cog):
                 {
                     "channel": str(channel_id),
                     "op": "mc",
-                    "d": dto.model_dump(by_alias=True, exclude_none=True),
+                    "d": dto.model_dump(mode="json", by_alias=True, exclude_none=True),
                 }
             )
 
@@ -460,7 +460,7 @@ class Mirror(commands.Cog):
                 await db.commit()
 
                 await manager.broadcast_text(
-                    json.dumps(dto.model_dump(by_alias=True, exclude_none=True)),
+                    dto.model_dump_json(by_alias=True, exclude_none=True),
                     guild_id,
                     officer_only=is_officer,
                     path="/ws/messages",
@@ -470,7 +470,7 @@ class Mirror(commands.Cog):
                     {
                         "channel": str(channel_id),
                         "op": "mu",
-                        "d": dto.model_dump(by_alias=True, exclude_none=True),
+                        "d": dto.model_dump(mode="json", by_alias=True, exclude_none=True),
                     }
                 )
 
@@ -490,7 +490,7 @@ class Mirror(commands.Cog):
                 reactions_json = json.dumps(
                     [
                         reaction_to_dto(r).model_dump(
-                            by_alias=True, exclude_none=True
+                            mode="json", by_alias=True, exclude_none=True
                         )
                         for r in reaction.message.reactions
                     ]
@@ -502,7 +502,7 @@ class Mirror(commands.Cog):
 
             dto = message_to_chat_message(reaction.message)
             await manager.broadcast_text(
-                json.dumps(dto.model_dump(by_alias=True, exclude_none=True)),
+                dto.model_dump_json(by_alias=True, exclude_none=True),
                 msg.guild_id,
                 officer_only=msg.is_officer,
                 path="/ws/messages",
@@ -525,7 +525,7 @@ class Mirror(commands.Cog):
                 reactions_json = json.dumps(
                     [
                         reaction_to_dto(r).model_dump(
-                            by_alias=True, exclude_none=True
+                            mode="json", by_alias=True, exclude_none=True
                         )
                         for r in reaction.message.reactions
                     ]
@@ -537,7 +537,7 @@ class Mirror(commands.Cog):
 
             dto = message_to_chat_message(reaction.message)
             await manager.broadcast_text(
-                json.dumps(dto.model_dump(by_alias=True, exclude_none=True)),
+                dto.model_dump_json(by_alias=True, exclude_none=True),
                 msg.guild_id,
                 officer_only=msg.is_officer,
                 path="/ws/messages",


### PR DESCRIPTION
## Summary
- ensure message mirror broadcasts and events dump DTOs in JSON mode to avoid datetime serialization errors
- update reaction synchronization to serialize reaction DTOs in JSON mode before persisting or broadcasting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caf3376730832897c90182ce4ee77a