### PR TITLE
Add readiness guard for emoji routes

### DIFF
--- a/demibot/demibot/http/discord_client.py
+++ b/demibot/demibot/http/discord_client.py
@@ -17,3 +17,39 @@ def set_discord_client(client: commands.Bot) -> None:
     global discord_client
     discord_client = client
 
+
+def is_discord_client_ready(client: commands.Bot | None = None) -> bool:
+    """Return ``True`` when the Discord client is ready for API access.
+
+    The helper performs defensive checks around the lifecycle helpers exposed
+    by :mod:`discord.py`, ensuring the client both exists and has completed its
+    internal startup sequence.  Any unexpected exceptions are treated as a
+    disconnected state so that HTTP routes can fail fast while the bot is still
+    syncing with Discord.
+    """
+
+    client = client or discord_client
+    if client is None:
+        return False
+
+    try:
+        is_closed = getattr(client, "is_closed", None)
+        if callable(is_closed):
+            if is_closed():
+                return False
+        elif is_closed:
+            return False
+    except Exception:
+        return False
+
+    try:
+        ready_attr = getattr(client, "is_ready", None)
+        if callable(ready_attr):
+            return bool(ready_attr())
+        if ready_attr is not None:
+            return bool(ready_attr)
+    except Exception:
+        return False
+
+    return False
+


### PR DESCRIPTION
## Summary
- add an `is_discord_client_ready` helper so HTTP routes can check the Discord client's connection state
- guard the Discord emoji endpoints so they short-circuit when the bot is not ready instead of calling `get_guild`
- update unit tests to cover the new readiness behaviour for both emoji route modules

## Testing
- pytest *(fails: missing optional dependencies such as fastapi, discord, sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_68caf6db87a0832899ffc368c8d3bcd5