### PR TITLE
Use shared UnicodeEmoji model in popup

### DIFF
--- a/DemiCatPlugin/Emoji/EmojiModels.cs
+++ b/DemiCatPlugin/Emoji/EmojiModels.cs
@@ -1,5 +1,12 @@
 namespace DemiCatPlugin.Emoji
 {
+    public class UnicodeEmoji
+    {
+        public string Emoji    { get; set; } = string.Empty;
+        public string Name     { get; set; } = string.Empty;
+        public string ImageUrl { get; set; } = string.Empty;
+    }
+
     public record CustomEmoji(string Id, string Name, bool Animated);
     public record EmojiRefUnicode(string Emoji);
     public record EmojiRefCustom(string Id, string Name, bool Animated);

--- a/DemiCatPlugin/EmojiPopup.cs
+++ b/DemiCatPlugin/EmojiPopup.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
+using DemiCatPlugin.Emoji;
 
 namespace DemiCatPlugin;
 
@@ -254,13 +255,6 @@ public class EmojiPopup
     // Static lookups used elsewhere
     public static string? LookupGuildName(string id) => EmojiAssets.LookupGuildName(id);
     public static bool IsGuildEmojiAnimated(string id) => EmojiAssets.IsGuildEmojiAnimated(id);
-
-    public class UnicodeEmoji
-    {
-        public string Emoji { get; set; } = string.Empty;
-        public string Name   { get; set; } = string.Empty;
-        public string ImageUrl { get; set; } = string.Empty;
-    }
 
     public class GuildEmoji
     {


### PR DESCRIPTION
## Summary
- add the shared UnicodeEmoji model to the emoji namespace so it can be reused outside the popup
- reference the shared model inside EmojiPopup and remove the nested definition that shadowed it

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb221d8fa08328bb84ed1409516746