### PR TITLE
Render custom emoji icons in picker

### DIFF
--- a/DemiCatPlugin/Emoji/EmojiModels.cs
+++ b/DemiCatPlugin/Emoji/EmojiModels.cs
@@ -1,6 +1,9 @@
 namespace DemiCatPlugin.Emoji
 {
-    public record CustomEmoji(string Id, string Name, bool Animated);
+    public record CustomEmoji(string Id, string Name, bool Animated)
+    {
+        public string ImageUrl => $"https://cdn.discordapp.com/emojis/{Id}.{(Animated ? "gif" : "png")}";
+    }
     public record EmojiRefUnicode(string Emoji);
     public record EmojiRefCustom(string Id, string Name, bool Animated);
 

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -56,13 +56,50 @@ namespace DemiCatPlugin.Emoji
                 ? _svc.Custom
                 : _svc.Custom.Where(c => c.Name.Contains(_search, StringComparison.OrdinalIgnoreCase)).ToList();
 
-            int col = 0;
+            const int columns = 8;
+            var col = 0;
             foreach (var e in items)
             {
-                var label = e.Animated ? $":{e.Name}: (gif)" : $":{e.Name}:";
-                if (ImGui.Button(label, new(size * 3.2f, size)))
-                { EmojiInsert.InsertCustom(ref targetText, e); }
-                if (++col % 3 != 0) ImGui.SameLine();
+                if (col == 0) ImGui.BeginGroup();
+
+                var tooltip = e.Animated ? $":{e.Name}: (gif)" : $":{e.Name}:";
+                void Insert() => EmojiInsert.InsertCustom(ref targetText, e);
+                WebTextureCache.Get(e.ImageUrl, tex =>
+                {
+                    if (tex != null)
+                    {
+                        WebTextureCache.DrawImageButton($"custom_{e.Id}", tex, new(size, size), Insert);
+                        if (ImGui.IsItemHovered())
+                            ImGui.SetTooltip(tooltip);
+                    }
+                    else
+                    {
+                        if (ImGui.Button(tooltip, new(size * 3.2f, size)))
+                        {
+                            Insert();
+                        }
+                        if (ImGui.IsItemHovered())
+                            ImGui.SetTooltip(tooltip);
+                    }
+                });
+
+                col++;
+                if (col >= columns)
+                {
+                    ImGui.NewLine();
+                    ImGui.EndGroup();
+                    col = 0;
+                }
+                else
+                {
+                    ImGui.SameLine();
+                }
+            }
+
+            if (col != 0)
+            {
+                ImGui.NewLine();
+                ImGui.EndGroup();
             }
         }
     }

--- a/tests/EmojiPickerTests.cs
+++ b/tests/EmojiPickerTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Numerics;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Textures;
+using DemiCatPlugin;
+using DemiCatPlugin.Emoji;
+using Moq;
+using Xunit;
+
+public sealed class EmojiPickerTests : IDisposable
+{
+    private static readonly IntPtr Context = ImGui.CreateContext();
+    private bool _frameBegun;
+
+    public EmojiPickerTests()
+    {
+        ImGui.SetCurrentContext(Context);
+        var io = ImGui.GetIO();
+        if (io.DisplaySize.X <= 0 || io.DisplaySize.Y <= 0)
+            io.DisplaySize = new Vector2(800, 600);
+        if (io.DeltaTime <= 0f)
+            io.DeltaTime = 1f / 60f;
+    }
+
+    [Fact]
+    public void CustomEmoji_ImageUrlReflectsAnimation()
+    {
+        var still = new CustomEmoji("123", "sparkle", false);
+        var animated = new CustomEmoji("456", "dance", true);
+
+        Assert.Equal("https://cdn.discordapp.com/emojis/123.png", still.ImageUrl);
+        Assert.Equal("https://cdn.discordapp.com/emojis/456.gif", animated.ImageUrl);
+    }
+
+    [Fact]
+    public void DrawCustom_FetchesCustomEmojiTexture()
+    {
+        ImGui.NewFrame();
+        _frameBegun = true;
+
+        var svc = new EmojiService(new HttpClient(new DummyHandler()), new TokenManager(), new Config());
+        svc.Custom.Add(new CustomEmoji("789", "wave", false));
+
+        var picker = new EmojiPicker(svc);
+        string? fetchedUrl = null;
+
+        var wrap = new Mock<ISharedTextureWrap>();
+        wrap.SetupGet(w => w.Handle).Returns(IntPtr.Zero);
+
+        var tex = new Mock<ISharedImmediateTexture>();
+        tex.Setup(t => t.GetWrapOrEmpty()).Returns(wrap.Object);
+
+        WebTextureCache.FetchOverride = (url, cb) =>
+        {
+            fetchedUrl = url;
+            cb(tex.Object);
+            return null;
+        };
+
+        var method = typeof(EmojiPicker).GetMethod("DrawCustom", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var args = new object?[] { string.Empty, 28f };
+
+        var opened = ImGui.Begin("picker-test");
+        try
+        {
+            if (opened)
+            {
+                method.Invoke(picker, args);
+            }
+        }
+        finally
+        {
+            ImGui.End();
+            WebTextureCache.FetchOverride = null;
+        }
+
+        Assert.Equal(svc.Custom[0].ImageUrl, fetchedUrl);
+    }
+
+    public void Dispose()
+    {
+        if (_frameBegun)
+        {
+            ImGui.Render();
+            _frameBegun = false;
+        }
+    }
+
+    private sealed class DummyHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    }
+}


### PR DESCRIPTION
## Summary
- add a CDN image URL helper to `CustomEmoji`
- render custom emojis in the picker with textures from `WebTextureCache`, falling back to the text button when no texture is available
- add UI-centric tests that exercise the picker with mocked textures and verify the computed image URL format

## Testing
- `bash scripts/setup_env.sh --unit-tests` *(fails: Dalamud.NET.Sdk cannot find a Dalamud installation in CI)*
- `pytest -m "not integration"` *(fails: suite expects seeded Discord/DB fixtures; many tests error out with UNIQUE constraint/role assumptions)*

------
https://chatgpt.com/codex/tasks/task_e_68cb20c0e58c83289853a562aa1fab07