### PR TITLE
Handle missing event RSVP embed

### DIFF
--- a/tests/test_event_rsvp_http.py
+++ b/tests/test_event_rsvp_http.py
@@ -1,0 +1,40 @@
+import asyncio
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+from demibot.db.models import Guild, User
+from demibot.db.session import init_db
+import demibot.db.session as db_session
+from demibot.http.api import create_app
+from demibot.http.deps import RequestContext, api_key_auth
+
+
+async def _setup_db() -> None:
+    db_session._engine = None
+    db_session._Session = None
+    await init_db("sqlite+aiosqlite://")
+
+
+def test_rsvp_unknown_event_returns_404() -> None:
+    asyncio.run(_setup_db())
+
+    user = User(id=1, discord_user_id=1)
+    guild = Guild(id=1, discord_guild_id=1, name="Guild")
+
+    app = create_app()
+    app.dependency_overrides[api_key_auth] = lambda: RequestContext(
+        user=user,
+        guild=guild,
+        key=None,
+        roles=[],
+    )
+
+    client = TestClient(app)
+    response = client.post("/api/events/999999/rsvp", json={"tag": "join"})
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- raise an HTTP 404 when an RSVP embed cannot be found so the handler exits early
- ensure RSVP logic only uses embed-derived data once the embed is loaded
- add an HTTP-level test that posts to an unknown RSVP and asserts a 404 response

## Testing
- pytest ../tests/test_event_rsvp_http.py

------
https://chatgpt.com/codex/tasks/task_e_68cb2dd636808328a60c6e5d96bcb469