### PR TITLE
Ensure request status enums store lowercase values

### DIFF
--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -420,7 +420,15 @@ class Request(Base):
             native_enum=False,
         )
     )
-    status: Mapped[RequestStatus] = mapped_column(SAEnum(RequestStatus))
+    status: Mapped[RequestStatus] = mapped_column(
+        SAEnum(
+            RequestStatus,
+            name="request_status",
+            values_callable=lambda e: [v.value for v in e],
+            native_enum=False,
+            validate_strings=True,
+        )
+    )
     urgency: Mapped[Urgency] = mapped_column(SAEnum(Urgency))
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(

--- a/tests/test_request_status_lowercase.py
+++ b/tests/test_request_status_lowercase.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from demibot.http.api import create_app
+from demibot.http.deps import RequestContext, api_key_auth
+from demibot.db.session import init_db, get_session
+from demibot.db.models import Guild, Request as DbRequest, RequestStatus, User
+
+
+def test_create_request_persists_lowercase_status(monkeypatch):
+    user = User(id=1, discord_user_id=1)
+    guild = Guild(id=1, discord_guild_id=1, name="G")
+
+    async def _setup():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            db.add_all([user, guild])
+            await db.commit()
+
+    asyncio.run(_setup())
+
+    app = create_app()
+    app.dependency_overrides[api_key_auth] = lambda: RequestContext(
+        user=user, guild=guild, key=None, roles=[]
+    )
+
+    async def _noop(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr("demibot.http.routes.requests._broadcast", _noop)
+    monkeypatch.setattr("demibot.http.routes.requests._notify", _noop)
+    monkeypatch.setattr("demibot.http.routes.requests._dto", lambda req: {"id": str(req.id)})
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/requests", json={"title": "t", "type": "item", "urgency": "low"}
+    )
+    assert resp.status_code == 200
+
+    async def _statuses():
+        async with get_session() as db:
+            rows = await db.execute(select(DbRequest.__table__.c.status))
+            return [status for (status,) in rows.all()]
+
+    statuses = asyncio.run(_statuses())
+
+    assert statuses == [RequestStatus.OPEN.value]
+    assert set(statuses) <= {status.value for status in RequestStatus}


### PR DESCRIPTION
## Summary
- configure the Request.status SQLAlchemy enum to persist validated lowercase string values that match the database enum
- add a regression test that creates a request via the API and checks the stored status strings against RequestStatus values

## Testing
- PYTHONPATH=demibot pytest tests/test_request_type_lowercase.py -vv
- PYTHONPATH=demibot pytest tests/test_request_status_lowercase.py -vv
- PYTHONPATH=demibot pytest tests/test_request_status_permissions.py::test_start_requires_assignee -q
- PYTHONPATH=demibot pytest tests/test_request_status_permissions.py::test_complete_requires_assignee -q
- PYTHONPATH=demibot pytest tests/test_request_status_permissions.py::test_confirm_requires_requester -q
- PYTHONPATH=demibot pytest tests/test_request_status_permissions.py::test_cancel_requires_requester -q
- PYTHONPATH=demibot pytest tests/test_request_status_permissions.py::test_cancel_returns_dto -q
- PYTHONPATH=demibot pytest tests/test_requests_delta.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cb57538e908328a70da3b19dfea395