### PR TITLE
Fix channel kind cleanup in ConfigWizard

### DIFF
--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -635,15 +635,16 @@ class ConfigWizard(discord.ui.View):
                         role.is_officer = False
                         role.is_chat = False
 
-                all_ids = (
-                    self.event_channel_ids
-                    + self.fc_chat_channel_ids
-                    + self.officer_chat_channel_ids
-                )
                 await db.execute(
                     delete(GuildChannel).where(
                         GuildChannel.guild_id == guild.id,
-                        GuildChannel.channel_id.in_(all_ids),
+                        GuildChannel.kind.in_(
+                            (
+                                ChannelKind.EVENT,
+                                ChannelKind.FC_CHAT,
+                                ChannelKind.OFFICER_CHAT,
+                            )
+                        ),
                     )
                 )
                 await db.flush()


### PR DESCRIPTION
## Summary
- clear existing event, FC chat, and officer chat channel rows by kind when saving wizard results
- extend the rerun regression test to cover re-selecting a different FC chat channel and preserving other channel kinds

## Testing
- pytest tests/test_config_wizard_rerun.py


------
https://chatgpt.com/codex/tasks/task_e_68cb894ecd68832886f29fa6a3127197