### PR TITLE
Handle empty Discord emoji catalogs without retries

### DIFF
--- a/DemiCatPlugin/Emoji/EmojiService.cs
+++ b/DemiCatPlugin/Emoji/EmojiService.cs
@@ -153,7 +153,7 @@ namespace DemiCatPlugin.Emoji
                     break;
                 }
 
-                var shouldRetry = ShouldRetry(result.ok, result.list, result.status);
+                var shouldRetry = ShouldRetry(result.ok, result.list, result.status, result.retryAfterSeconds);
                 var nextDelay = shouldRetry && !ct.IsCancellationRequested
                     ? GetNextDelay(attempt, result.retryAfterSeconds)
                     : (TimeSpan?)null;
@@ -218,11 +218,16 @@ namespace DemiCatPlugin.Emoji
             return TimeSpan.FromSeconds(jitter);
         }
 
-        private static bool ShouldRetry(bool ok, List<CustomEmoji> list, HttpStatusCode status)
+        private static bool ShouldRetry(bool ok, List<CustomEmoji> list, HttpStatusCode status, int? retryAfterSeconds)
         {
             if (ok)
             {
-                return list.Count == 0;
+                if (list.Count == 0)
+                {
+                    return retryAfterSeconds.HasValue;
+                }
+
+                return false;
             }
 
             if (status == HttpStatusCode.Unauthorized || status == HttpStatusCode.Forbidden)

--- a/demibot/demibot/http/routes/discord_emojis.py
+++ b/demibot/demibot/http/routes/discord_emojis.py
@@ -66,8 +66,5 @@ async def list_emojis(ctx: RequestContext = Depends(api_key_auth)):
         )
         return _retry_response()
 
-    if not emojis:
-        return _retry_response()
-
     _emoji_cache[ctx.guild.id] = emojis
     return {"ok": True, "emojis": emojis}

--- a/tests/EmojiServiceTests.cs
+++ b/tests/EmojiServiceTests.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using DemiCatPlugin;
+using DemiCatPlugin.Emoji;
+using Xunit;
+
+public class EmojiServiceTests
+{
+    private sealed class EmptyEmojiHandler : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ok\": true, \"emojis\": []}", Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    [Fact]
+    public async Task RefreshStopsAfterEmptyResponseWithoutRetryAfter()
+    {
+        var handler = new EmptyEmojiHandler();
+        using var client = new HttpClient(handler);
+        var tokens = new TokenManager();
+        var config = new Config { ApiBaseUrl = "http://localhost" };
+        var service = new EmojiService(client, tokens, config);
+
+        var updates = 0;
+        service.Updated += () => updates++;
+
+        await service.RefreshAsync();
+
+        Assert.Equal(1, handler.CallCount);
+        Assert.Empty(service.Custom);
+        Assert.Equal(1, updates);
+    }
+}

--- a/tests/test_discord_emojis.py
+++ b/tests/test_discord_emojis.py
@@ -1,5 +1,7 @@
 import json
 import sys
+import types
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -9,6 +11,62 @@ from fastapi.responses import JSONResponse
 root = Path(__file__).resolve().parents[1] / "demibot"
 if str(root) not in sys.path:
     sys.path.append(str(root))
+
+# Stub the core package structure to avoid importing heavy optional
+# dependencies during test discovery. The routes themselves continue to be
+# loaded from the actual source files via the configured package paths.
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+routes_pkg = types.ModuleType("demibot.http.routes")
+routes_pkg.__path__ = [str(root / "demibot/http/routes")]
+sys.modules.setdefault("demibot.http.routes", routes_pkg)
+
+# Minimal stand-ins for auth dependencies required only for type hints.
+deps_pkg = types.ModuleType("demibot.http.deps")
+
+
+@dataclass
+class _RequestContext:
+    user: object
+    guild: object
+    key: object
+    roles: list[str]
+
+
+deps_pkg.RequestContext = _RequestContext
+
+
+def _api_key_auth():  # pragma: no cover - FastAPI dependency placeholder
+    raise NotImplementedError
+
+
+deps_pkg.api_key_auth = _api_key_auth
+sys.modules.setdefault("demibot.http.deps", deps_pkg)
+
+# Provide lightweight stubs for discord.py so the route can be imported
+# without pulling in the full dependency graph during tests.
+discord_pkg = types.ModuleType("discord")
+discord_ext_pkg = types.ModuleType("discord.ext")
+discord_commands_pkg = types.ModuleType("discord.ext.commands")
+
+
+class _DummyBot:
+    pass
+
+
+discord_commands_pkg.Bot = _DummyBot
+discord_ext_pkg.commands = discord_commands_pkg
+discord_pkg.ext = discord_ext_pkg
+
+sys.modules.setdefault("discord", discord_pkg)
+sys.modules.setdefault("discord.ext", discord_ext_pkg)
+sys.modules.setdefault("discord.ext.commands", discord_commands_pkg)
 
 from demibot.http.deps import RequestContext
 from demibot.http.routes import discord_emojis
@@ -106,3 +164,27 @@ async def test_emojis_returns_list_when_ready(monkeypatch):
     }
     # Cached copy should now be available for subsequent calls.
     assert discord_emojis._emoji_cache[ctx.guild.id] == data["emojis"]
+
+
+@pytest.mark.asyncio
+async def test_emojis_returns_empty_list_when_guild_has_no_custom(monkeypatch):
+    discord_emojis._emoji_cache.clear()
+
+    guild = DummyGuild([])
+    monkeypatch.setattr(discord_emojis, "discord_client", DummyClient(guild))
+
+    ctx = RequestContext(
+        user=SimpleNamespace(id=1),
+        guild=SimpleNamespace(id=1, discord_guild_id=100),
+        key=None,
+        roles=[],
+    )
+
+    data = await discord_emojis.list_emojis(ctx=ctx)
+
+    assert data == {"ok": True, "emojis": []}
+    assert discord_emojis._emoji_cache[ctx.guild.id] == []
+
+    # Cached copy should be used on subsequent calls without hitting Discord.
+    cached = await discord_emojis.list_emojis(ctx=ctx)
+    assert cached == data


### PR DESCRIPTION
## Summary
- avoid retrying the emoji refresh loop when the server returns an empty catalog without an explicit Retry-After header
- return a normal OK response (and cache the result) from the Discord emoji route when a guild truly has no custom emojis
- add tests covering zero-emoji guilds for both the FastAPI route and the plugin refresh loop

## Testing
- pytest tests/test_discord_emojis.py
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: Dalamud installation not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb89157ac08328bed60d47e7ec0cdb