### PR TITLE
Add enable FC chat default

### DIFF
--- a/demibot/demibot/http/routes/settings.py
+++ b/demibot/demibot/http/routes/settings.py
@@ -10,5 +10,6 @@ async def get_settings():
         "templates": True,
         "requests": True,
         "officer": True,
+        "enableFcChat": True,
         "fcSyncShell": False,
     }

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -10,4 +10,5 @@ async def test_settings_endpoint():
     assert resp.status_code == 200
     data = resp.json()
     assert data["syncedChat"] is True
+    assert data["enableFcChat"] is True
     assert data["fcSyncShell"] is False


### PR DESCRIPTION
## Summary
- enable FC chat by default in the /api/settings response so new clients opt-in automatically
- extend the settings endpoint test to cover the new flag

## Testing
- PYTHONPATH=demibot pytest tests/test_settings_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68cb8d1568e083289e39d409098c0123