### PR TITLE
Use channel field when sending chat frames

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -164,7 +164,7 @@ public class ChatBridge : IDisposable
 
     public Task Send(string channel, object payload)
     {
-        var json = JsonSerializer.Serialize(new { op = "send", ch = channel, d = payload });
+        var json = JsonSerializer.Serialize(new { op = "send", channel, d = payload });
         return SendRaw(json);
     }
 
@@ -731,7 +731,7 @@ public class ChatBridge : IDisposable
         if (_acked.TryGetValue(key, out var acked) && acked == cursor) return Task.CompletedTask;
         _acked[key] = cursor;
         _config.ChatCursors[key] = cursor;
-        var json = JsonSerializer.Serialize(new { op = "ack", ch = channel, cur = cursor });
+        var json = JsonSerializer.Serialize(new { op = "ack", channel, cur = cursor });
         return SendRaw(json);
     }
 


### PR DESCRIPTION
## Summary
- serialize the send and ack websocket frames using the `channel` property expected by inbound handlers

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8edc14208328945f0c83bf83118d