### PR TITLE
Adjust chat bridge subscription payload

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -756,7 +756,9 @@ public class ChatBridge : IDisposable
             };
 
             var normalizedGuild = ChannelKeyHelper.NormalizeGuildId(meta.GuildId);
-            if (!string.IsNullOrEmpty(normalizedGuild))
+            var defaultGuildSentinel = ChannelKeyHelper.NormalizeGuildId(null);
+            if (!string.IsNullOrEmpty(normalizedGuild) &&
+                !string.Equals(normalizedGuild, defaultGuildSentinel, StringComparison.Ordinal))
             {
                 channel["guildId"] = normalizedGuild;
             }
@@ -764,7 +766,7 @@ public class ChatBridge : IDisposable
             var normalizedKind = ChannelKeyHelper.NormalizeKind(meta.Kind);
             if (!string.IsNullOrEmpty(normalizedKind))
             {
-                channel["kind"] = normalizedKind;
+                channel["kind"] = normalizedKind.ToLowerInvariant();
             }
 
             chans.Add(channel);


### PR DESCRIPTION
## Summary
- avoid sending the default guild sentinel with chat subscription frames
- emit lowercase channel kind values when serializing subscriptions so the backend sees the expected casing

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8f515a748328b19765ef334ea331