### PR TITLE
Update channel message request for text messages

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -844,13 +844,17 @@ public class ChatWindow : IDisposable
             }
             else
             {
-                var body = new MessageBuilder()
-                    .WithChannelId(channelId)
-                    .WithContent(content)
-                    .UseCharacterName(_useCharacterName)
+                var messageReference = new MessageBuilder()
                     .WithMessageReference(_replyToId, channelId)
-                    .Build();
-                request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}{MessagesPath}");
+                    .BuildMessageReference();
+                var body = new
+                {
+                    content,
+                    useCharacterName = _useCharacterName,
+                    messageReference
+                };
+                var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{channelId}/messages";
+                request = new HttpRequestMessage(HttpMethod.Post, url);
                 request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
             }
             ApiHelpers.AddAuthHeader(request, _tokenManager);

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -87,6 +87,25 @@ public class OfficerChatWindow : ChatWindow
 
     protected override string MessagesPath => "/api/officer-messages";
 
+    protected override HttpRequestMessage BuildTextMessageRequest(string channelId, string content, object? messageReference)
+    {
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}{MessagesPath}";
+        var body = new Dictionary<string, object?>
+        {
+            ["channelId"] = channelId,
+            ["content"] = content,
+            ["useCharacterName"] = _useCharacterName
+        };
+        if (messageReference != null)
+        {
+            body["messageReference"] = messageReference;
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+        return request;
+    }
+
     protected override async Task<HttpRequestMessage> BuildMultipartRequest(string content)
     {
         var url = $"{_config.ApiBaseUrl.TrimEnd('/')}{MessagesPath}";


### PR DESCRIPTION
## Summary
- post text-only chat messages to the channel-specific endpoint used by file uploads
- build the JSON payload without the redundant channel identifier while still including message references

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb919990d88328b16c76fd33aead0a