### PR TITLE
Disable emoji sync requests

### DIFF
--- a/DemiCatPlugin/Emoji/EmojiService.cs
+++ b/DemiCatPlugin/Emoji/EmojiService.cs
@@ -19,6 +19,7 @@ namespace DemiCatPlugin.Emoji
         private string? _lastLoopErrorSignature;
         private DateTime _lastLoopErrorLoggedAt;
         private static readonly TimeSpan LoopErrorThrottle = TimeSpan.FromSeconds(30);
+        private const bool EmojisEnabled = false; // Temporarily disable custom emoji syncing until feature is redesigned.
 
         public List<CustomEmoji> Custom { get; private set; } = new();
 
@@ -29,6 +30,20 @@ namespace DemiCatPlugin.Emoji
 
         public Task RefreshAsync(CancellationToken ct = default)
         {
+            if (!EmojisEnabled)
+            {
+                lock (_refreshLock)
+                {
+                    _refreshCancellation?.Cancel();
+                    _refreshCancellation?.Dispose();
+                    _refreshCancellation = null;
+                }
+
+                Custom = new();
+                PublishUpdate();
+                return Task.CompletedTask;
+            }
+
             CancellationTokenSource linked;
             lock (_refreshLock)
             {

--- a/tests/EmojiServiceTests.cs
+++ b/tests/EmojiServiceTests.cs
@@ -38,7 +38,7 @@ public class EmojiServiceTests
 
         await service.RefreshAsync();
 
-        Assert.Equal(1, handler.CallCount);
+        Assert.Equal(0, handler.CallCount);
         Assert.Empty(service.Custom);
         Assert.Equal(1, updates);
     }


### PR DESCRIPTION
## Summary
- short-circuit the emoji service refresh so no HTTP calls are made while the feature is disabled
- adjust the emoji service unit test to match the temporary shutdown of the network fetch

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb984d44bc832886db1445cb31d492