### PR TITLE
Fix config wizard channel reuse

### DIFF
--- a/tests/test_config_wizard_rerun.py
+++ b/tests/test_config_wizard_rerun.py
@@ -21,10 +21,136 @@ discordbot_module.__path__ = [
 ]
 sys.modules.setdefault("demibot.discordbot", discordbot_module)
 
+discord_module = types.ModuleType("discord")
+
+
+class _DummyButtonStyle:
+    secondary = 1
+    primary = 2
+    success = 3
+
+
+class _DummyEmbed:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def set_image(self, *args, **kwargs):
+        pass
+
+
+class _DummyHTTPException(Exception):
+    pass
+
+
+class _DummyView:
+    def __init__(self, timeout: int | None = None) -> None:
+        self.timeout = timeout
+        self.children: list[object] = []
+
+    def clear_items(self) -> None:
+        self.children.clear()
+
+    def add_item(self, item: object) -> None:
+        self.children.append(item)
+
+    def stop(self) -> None:
+        pass
+
+
+class _DummyButton:
+    def __init__(self, *, label: str | None = None, style: int | None = None):
+        self.label = label
+        self.style = style
+        self.callback = None
+        self.disabled = False
+
+
+class _DummyRoleSelect:
+    def __init__(
+        self,
+        *,
+        placeholder: str | None = None,
+        min_values: int = 0,
+        max_values: int = 1,
+        default_values: list[object] | None = None,
+    ) -> None:
+        self.placeholder = placeholder
+        self.min_values = min_values
+        self.max_values = max_values
+        self.values = default_values or []
+        self.callback = None
+
+
+def _dummy_button_decorator(*args, **kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+ui_module = types.ModuleType("discord.ui")
+ui_module.View = _DummyView
+ui_module.Button = _DummyButton
+ui_module.RoleSelect = _DummyRoleSelect
+ui_module.button = _dummy_button_decorator
+
+
+class _DummyGroup:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def command(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+def _dummy_describe(**kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+app_commands_module = types.ModuleType("discord.app_commands")
+app_commands_module.Group = _DummyGroup
+app_commands_module.describe = _dummy_describe
+
+
+commands_module = types.ModuleType("discord.ext.commands")
+
+
+class _DummyCog:
+    pass
+
+
+class _DummyBot:
+    pass
+
+
+commands_module.Cog = _DummyCog
+commands_module.Bot = _DummyBot
+
+ext_module = types.ModuleType("discord.ext")
+ext_module.commands = commands_module
+
+discord_module.ButtonStyle = _DummyButtonStyle
+discord_module.Embed = _DummyEmbed
+discord_module.HTTPException = _DummyHTTPException
+discord_module.ui = ui_module
+discord_module.app_commands = app_commands_module
+
+sys.modules.setdefault("discord", discord_module)
+sys.modules.setdefault("discord.ui", ui_module)
+sys.modules.setdefault("discord.app_commands", app_commands_module)
+sys.modules.setdefault("discord.ext", ext_module)
+sys.modules.setdefault("discord.ext.commands", commands_module)
+
 from sqlalchemy import select
 
 from demibot.discordbot.cogs.admin import ConfigWizard
-from demibot.db.models import GuildChannel, ChannelKind
+from demibot.db.models import Guild, GuildChannel, ChannelKind
 from demibot.db.session import init_db, get_session
 
 
@@ -222,5 +348,85 @@ def test_second_wizard_run_preserves_existing_webhook() -> None:
             assert fc_rows[0].webhook_url == webhook_url
             channel_ids = [row.channel_id for row in rows]
             assert len(channel_ids) == len(set(channel_ids))
+
+    asyncio.run(_run())
+
+
+def test_existing_chat_channel_promoted_to_fc_chat() -> None:
+    async def _run():
+        db_path = Path("test_rerun_wizard.db")
+        await init_db(f"sqlite+aiosqlite:///{db_path}")
+
+        guild = DummyGuild(3)
+        guild.text_channels = [
+            DummyChannel(1001, "one"),
+            DummyChannel(2002, "two"),
+            DummyChannel(3003, "three"),
+            DummyChannel(4004, "four"),
+            DummyChannel(5005, "five"),
+        ]
+        fc_channel_id = 2002
+        webhook_url = "https://example.com/chat-webhook"
+        guild_db_id = None
+
+        async with get_session() as db:
+            guild_row = await db.scalar(
+                select(Guild).where(Guild.discord_guild_id == guild.id)
+            )
+            if guild_row is None:
+                guild_row = Guild(discord_guild_id=guild.id, name=guild.name)
+                db.add(guild_row)
+                await db.flush()
+
+            guild_db_id = guild_row.id
+
+            existing_channel = await db.scalar(
+                select(GuildChannel).where(
+                    GuildChannel.guild_id == guild_db_id,
+                    GuildChannel.channel_id == fc_channel_id,
+                )
+            )
+            if existing_channel is None:
+                existing_channel = GuildChannel(
+                    guild_id=guild_db_id,
+                    channel_id=fc_channel_id,
+                    kind=ChannelKind.CHAT,
+                    name="two",
+                    webhook_url=webhook_url,
+                )
+                db.add(existing_channel)
+            else:
+                existing_channel.kind = ChannelKind.CHAT
+                existing_channel.name = "two"
+                existing_channel.webhook_url = webhook_url
+
+            await db.commit()
+
+        assert guild_db_id is not None
+
+        view = ConfigWizard(guild, "title", "final", "done")
+        view.event_channel_ids = [1001]
+        view.fc_chat_channel_ids = [fc_channel_id]
+        view.officer_chat_channel_ids = [3003]
+        view.officer_role_ids = [21]
+        view.mention_role_ids = [21]
+        await view.on_finish(DummyInteraction())
+
+        async with get_session() as db:
+            rows = (
+                await db.execute(
+                    select(GuildChannel)
+                    .where(
+                        GuildChannel.guild_id == guild_db_id,
+                        GuildChannel.channel_id == fc_channel_id,
+                    )
+                    .order_by(GuildChannel.kind)
+                )
+            ).scalars().all()
+
+            assert len(rows) == 1
+            fc_row = rows[0]
+            assert fc_row.kind == ChannelKind.FC_CHAT
+            assert fc_row.webhook_url == webhook_url
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- reuse existing guild channel rows when rerunning the config wizard so channel kind updates rather than creating duplicates
- clean up conflicting channel rows while preserving webhook URLs when switching selections
- extend the config wizard regression tests with Discord stubs to cover promoting a chat channel to FC chat

## Testing
- `pytest tests/test_config_wizard_rerun.py`


------
https://chatgpt.com/codex/tasks/task_e_68cd43e678f88328bed59f85c90aa889