### PR TITLE
Fix StartWatchersAsync block placement

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -340,7 +340,18 @@ public class Plugin : IDalamudPlugin
         }
         else
         {
-        _officerWatcherRunning = false;
+            _officerWatcherRunning = false;
+        }
+
+        if (_config.Events)
+        {
+            _services.Log.Info("Starting event watchers");
+            _ = _ui.StartNetworking();
+            _mainWindow.EventCreateWindow.StartNetworking();
+            _mainWindow.TemplatesWindow.StartNetworking();
+        }
+
+        _services.Log.Info("Watchers started");
     }
 
     private static bool IsAuthenticationFailure(string? reason)
@@ -411,17 +422,6 @@ public class Plugin : IDalamudPlugin
         };
 
         toastGui.ShowQuest(message, options);
-    }
-
-        if (_config.Events)
-        {
-            _services.Log.Info("Starting event watchers");
-            _ = _ui.StartNetworking();
-            _mainWindow.EventCreateWindow.StartNetworking();
-            _mainWindow.TemplatesWindow.StartNetworking();
-        }
-
-        _services.Log.Info("Watchers started");
     }
 
     private void HandleWatcherStartupFailure(string statusDetails)


### PR DESCRIPTION
## Summary
- fix the officer watcher reset branch indentation
- move the event watcher startup block and final log back inside StartWatchersAsync

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4a193c5c832884c174471cd711e6