### PR TITLE
Align officer chat websocket endpoint

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -50,6 +50,26 @@ public class OfficerChatWindow : ChatWindow
         };
     }
 
+#if TEST
+    internal OfficerChatWindow(
+        Config config,
+        HttpClient httpClient,
+        DiscordPresenceService? presence,
+        TokenManager tokenManager,
+        ChannelService channelService)
+        : this(
+            config,
+            httpClient,
+            presence,
+            tokenManager,
+            channelService,
+            new ChannelSelectionService(config),
+            null!,
+            new EmojiManager(httpClient, tokenManager, config))
+    {
+    }
+#endif
+
     public override void StartNetworking()
     {
         _bridge.Start();
@@ -338,17 +358,7 @@ public class OfficerChatWindow : ChatWindow
 
     protected override Uri BuildWebSocketUri()
     {
-        var baseUri = _config.ApiBaseUrl.TrimEnd('/') + "/ws/officer-messages";
-        var builder = new UriBuilder(baseUri);
-        if (builder.Scheme == "https")
-        {
-            builder.Scheme = "wss";
-        }
-        else if (builder.Scheme == "http")
-        {
-            builder.Scheme = "ws";
-        }
-        return builder.Uri;
+        return base.BuildWebSocketUri();
     }
 }
 


### PR DESCRIPTION
## Summary
- update OfficerChatWindow to reuse the shared /ws/chat websocket endpoint and expose a slimmed test-only constructor
- add coverage that Officer chat subscriptions emit the officer_chat kind while exercising ack/batch/live handshake
- ensure OfficerChatWindow reports the shared websocket URI via a dedicated unit test

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj --configuration Release *(fails: Dalamud installation is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cde707cf0483288a3192ec5055dac1