### PR TITLE
Add officer chat attachment support

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -146,10 +146,9 @@ public class OfficerChatWindow : ChatWindow
 
     protected override async Task<HttpRequestMessage> BuildMultipartRequest(string content)
     {
-        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}{MessagesPath}";
-        var form = new MultipartFormDataContent();
         var channelId = CurrentChannelId;
-        form.Add(new StringContent(channelId), "channelId");
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{channelId}/officer-messages";
+        var form = new MultipartFormDataContent();
         form.Add(new StringContent(content), "content");
         form.Add(new StringContent(_useCharacterName ? "true" : "false"), "useCharacterName");
         if (!string.IsNullOrEmpty(_replyToId))

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+import json
+
+from fastapi import APIRouter, Depends, UploadFile, File, Form, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
+from ..schemas import MessageReferenceDto
 from ._messages_common import PostBody, fetch_messages, save_message
 from ...db.models import ChannelKind
 
@@ -31,3 +34,36 @@ async def post_officer_message(
     db: AsyncSession = Depends(get_db),
 ):
     return await save_message(body, ctx, db, channel_kind=ChannelKind.OFFICER_CHAT)
+
+
+@router.post("/channels/{channel_id}/officer-messages")
+async def post_officer_message_with_attachments(
+    channel_id: str,
+    content: str = Form(...),
+    useCharacterName: bool | None = Form(False),
+    message_reference: str | None = Form(None),
+    files: list[UploadFile] | None = File(None),
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    ref = None
+    if message_reference:
+        try:
+            ref = MessageReferenceDto(**json.loads(message_reference))
+        except Exception:
+            raise HTTPException(status_code=400, detail="invalid message_reference")
+
+    body = PostBody(
+        channel_id=channel_id,
+        content=content,
+        use_character_name=useCharacterName,
+        message_reference=ref,
+    )
+
+    return await save_message(
+        body,
+        ctx,
+        db,
+        channel_kind=ChannelKind.OFFICER_CHAT,
+        files=files,
+    )


### PR DESCRIPTION
## Summary
- add a dedicated `/api/channels/{channel_id}/officer-messages` endpoint that forwards uploaded files to officer chat
- update the officer chat window to post multipart payloads to the new route while keeping reply metadata intact
- cover the new attachment flow with an integration test exercising the FastAPI endpoint

## Testing
- pytest tests/test_officer_messages_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68cdea0c0a64832893eff87e3dd592d0