### PR TITLE
Fix channel references for attachment replies

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1026,7 +1026,7 @@ public class ChatWindow : IDisposable
         if (!string.IsNullOrEmpty(_replyToId))
         {
             var reference = new MessageBuilder()
-                .WithMessageReference(_replyToId)
+                .WithMessageReference(_replyToId, channelId)
                 .BuildMessageReference();
             if (reference != null)
             {

--- a/tests/test_messages_endpoint.py
+++ b/tests/test_messages_endpoint.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -57,3 +58,64 @@ async def test_post_message_accepts_channel_aliases(channel_key, monkeypatch):
     assert captured["channel_id"] == "123"
     assert isinstance(captured["body"], messages_routes.PostBody)
     assert captured["channel_kind"] == ChannelKind.FC_CHAT
+
+
+@pytest.mark.asyncio
+async def test_channel_messages_multipart_accepts_message_reference(monkeypatch):
+    app = create_app()
+
+    captured: dict[str, object] = {}
+
+    async def fake_save_message(body, ctx, db, *, channel_kind, files=None):  # type: ignore[override]
+        captured["body"] = body
+        captured["channel_kind"] = channel_kind
+        captured["files"] = files
+        return {"ok": True, "id": "42"}
+
+    monkeypatch.setattr(messages_routes, "save_message", fake_save_message)
+
+    user_ctx = SimpleNamespace(id=1)
+    guild_ctx = SimpleNamespace(id=2)
+
+    async def override_auth():
+        return RequestContext(user=user_ctx, guild=guild_ctx, key=None, roles=["chat"])
+
+    async def override_db():
+        yield None
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        files = [("files", ("hi.txt", b"hello", "text/plain"))]
+        data = {
+            "content": "Hello",
+            "useCharacterName": "true",
+            "message_reference": json.dumps({"messageId": "5", "channelId": "555"}),
+        }
+        resp = await client.post(
+            "/api/channels/555/messages",
+            data=data,
+            files=files,
+        )
+
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "id": "42"}
+
+    body = captured["body"]
+    assert isinstance(body, messages_routes.PostBody)
+    assert body.channel_id == "555"
+    assert body.use_character_name is True
+    assert body.message_reference is not None
+    assert body.message_reference.channel_id == "555"
+    assert body.message_reference.message_id == "5"
+
+    assert captured["channel_kind"] == ChannelKind.FC_CHAT
+
+    files = captured["files"]
+    assert files is not None and len(files) == 1
+    upload = files[0]
+    assert getattr(upload, "filename", None) == "hi.txt"


### PR DESCRIPTION
## Summary
- include the current channel id when building multipart reply requests so attachment replies carry full message references
- add regression coverage for replying with attachments via /api/channels/{channelId}/messages

## Testing
- pytest tests/test_messages_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68cdec086278832891f85e10349afd86