### PR TITLE
Add bridge helper and nonce dedupe support

### DIFF
--- a/demibot/demibot/bridge.py
+++ b/demibot/demibot/bridge.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import io
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Mapping, Sequence
+
+import discord
+
+from .db.models import ChannelKind, Membership, User
+
+BRIDGE_MARKER = "bridge:demicat nonce:"
+DISCORD_CONTENT_LIMIT = 2000
+DISCORD_EMBED_DESCRIPTION_LIMIT = 4096
+DISCORD_EMBED_TOTAL_LIMIT = 6000
+DISCORD_EMBED_COUNT_LIMIT = 10
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+
+
+@dataclass
+class BridgeUpload:
+    """In-memory representation of an attachment destined for Discord."""
+
+    filename: str
+    data: bytes
+    content_type: str | None = None
+
+    def to_discord_file(self) -> discord.File:
+        """Return a fresh :class:`discord.File` for this upload."""
+
+        return discord.File(io.BytesIO(self.data), filename=self.filename)
+
+
+def _tab_label(kind: ChannelKind | None) -> str:
+    if kind == ChannelKind.OFFICER_CHAT:
+        return "Officer Chat"
+    if kind == ChannelKind.FC_CHAT:
+        return "FC Chat"
+    return "Chat"
+
+
+def _is_image(filename: str, content_type: str | None) -> bool:
+    if content_type and content_type.startswith("image/"):
+        return True
+    lower = filename.lower()
+    for ext in IMAGE_EXTENSIONS:
+        if lower.endswith(ext):
+            return True
+    return False
+
+
+def _determine_author_name(
+    *,
+    user: User,
+    membership: Membership | None,
+    use_character_name: bool,
+) -> str:
+    if use_character_name and user.character_name:
+        return user.character_name
+    if membership and membership.nickname:
+        return membership.nickname
+    if user.global_name:
+        return user.global_name
+    if user.character_name:
+        return user.character_name
+    return str(user.discord_user_id)
+
+
+def _normalize_content(content: str) -> str:
+    return content.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _split_embed_text(text: str) -> list[str]:
+    """Split ``text`` into chunks that satisfy Discord's embed limits."""
+
+    if not text:
+        return []
+
+    chunks: list[str] = []
+    remaining = text
+    total = 0
+    while (
+        remaining
+        and len(chunks) < DISCORD_EMBED_COUNT_LIMIT
+        and total < DISCORD_EMBED_TOTAL_LIMIT
+    ):
+        remaining_total = DISCORD_EMBED_TOTAL_LIMIT - total
+        take = min(
+            DISCORD_EMBED_DESCRIPTION_LIMIT,
+            remaining_total,
+            len(remaining),
+        )
+        if take <= 0:
+            break
+        slice_text = remaining[:take]
+        if len(remaining) > take:
+            # Prefer splitting at a newline or space when possible to avoid
+            # breaking words mid-stream.
+            split_pos = max(slice_text.rfind("\n"), slice_text.rfind(" "))
+            if split_pos > 0:
+                slice_text = slice_text[:split_pos]
+        if not slice_text:
+            slice_text = remaining[:take]
+        actual = len(slice_text)
+        chunks.append(slice_text)
+        remaining = remaining[actual:]
+        total += actual
+
+    if remaining:
+        # Append an ellipsis to signal truncation while respecting limits.
+        if chunks:
+            last = chunks[-1]
+            if len(last) >= DISCORD_EMBED_DESCRIPTION_LIMIT:
+                last = last[:-1]
+            else:
+                space_available = min(
+                    DISCORD_EMBED_DESCRIPTION_LIMIT - len(last),
+                    DISCORD_EMBED_TOTAL_LIMIT - total,
+                )
+                if space_available <= 0 and len(last) > 0:
+                    last = last[:-1]
+            chunks[-1] = f"{last}…" if last else "…"
+        else:
+            truncated = remaining[: DISCORD_EMBED_DESCRIPTION_LIMIT - 1]
+            chunks.append(f"{truncated}…")
+    return chunks
+
+
+def build_bridge_message(
+    *,
+    content: str,
+    user: User,
+    membership: Membership | None,
+    channel_kind: ChannelKind,
+    use_character_name: bool = False,
+    attachments: Sequence[tuple[str, bytes, str | None]] | None = None,
+    nonce: str | None = None,
+) -> tuple[str, list[discord.Embed], list[BridgeUpload], str]:
+    """Construct the Discord payload for a bridge message."""
+
+    normalized = _normalize_content(content or "")
+    uploads: list[BridgeUpload] = []
+    image_filename: str | None = None
+    if attachments:
+        for name, data, content_type in attachments:
+            filename = name or "attachment"
+            uploads.append(
+                BridgeUpload(filename=filename, data=data, content_type=content_type)
+            )
+            if image_filename is None and _is_image(filename, content_type):
+                image_filename = filename
+
+    chunks = _split_embed_text(normalized)
+    if not chunks:
+        chunks = [""]
+
+    embed_nonce = nonce or uuid.uuid4().hex
+    footer = f"DemiCat • {_tab_label(channel_kind)} • {BRIDGE_MARKER}{embed_nonce}"
+    timestamp = datetime.now(timezone.utc)
+    author_name = _determine_author_name(
+        user=user, membership=membership, use_character_name=use_character_name
+    )
+    author_icon = membership.avatar_url if membership else None
+
+    color = discord.Color(0x5865F2)
+    if channel_kind == ChannelKind.OFFICER_CHAT:
+        color = discord.Color(0xED4245)
+
+    embeds: list[discord.Embed] = []
+    for index, chunk in enumerate(chunks):
+        embed = discord.Embed(description=chunk or None, timestamp=timestamp, color=color)
+        embed.set_footer(text=footer)
+        embed.set_author(name=author_name, icon_url=author_icon)
+        if index == 0 and image_filename:
+            embed.set_image(url=f"attachment://{image_filename}")
+        embeds.append(embed)
+
+    discord_content = normalized[:DISCORD_CONTENT_LIMIT]
+    return discord_content, embeds, uploads, embed_nonce
+
+
+def extract_bridge_nonce_from_footer(text: str | None) -> str | None:
+    if not text:
+        return None
+    marker = BRIDGE_MARKER.lower()
+    lower = text.lower()
+    idx = lower.find(marker)
+    if idx == -1:
+        return None
+    start = idx + len(marker)
+    remainder = text[start:]
+    for separator in ("•", "|", "\n"):
+        parts = remainder.split(separator, 1)
+        if parts:
+            remainder = parts[0]
+    nonce = remainder.strip()
+    if " " in nonce:
+        nonce = nonce.split(" ", 1)[0]
+    return nonce or None
+
+
+def extract_bridge_nonce_from_embed_dict(embed: Mapping[str, object]) -> str | None:
+    footer_text = embed.get("footerText")
+    if isinstance(footer_text, str):
+        nonce = extract_bridge_nonce_from_footer(footer_text)
+        if nonce:
+            return nonce
+    footer = embed.get("footer")
+    if isinstance(footer, Mapping):
+        text = footer.get("text")
+        if isinstance(text, str):
+            nonce = extract_bridge_nonce_from_footer(text)
+            if nonce:
+                return nonce
+    return None
+
+
+def extract_bridge_nonce_from_payload(payload: Mapping[str, object]) -> str | None:
+    embeds = payload.get("embeds")
+    if isinstance(embeds, Iterable):
+        for embed in embeds:
+            if isinstance(embed, Mapping):
+                nonce = extract_bridge_nonce_from_embed_dict(embed)
+                if nonce:
+                    return nonce
+    return None
+
+
+def extract_bridge_nonce_from_embed(embed: discord.Embed) -> str | None:
+    data = embed.to_dict()
+    return extract_bridge_nonce_from_embed_dict(data)

--- a/demibot/demibot/db/migrations/versions/0046_add_bridge_fields_to_posted_messages.py
+++ b/demibot/demibot/db/migrations/versions/0046_add_bridge_fields_to_posted_messages.py
@@ -1,0 +1,41 @@
+"""add nonce and embed json to posted messages
+
+Revision ID: 0046_add_bridge_fields_to_posted_messages
+Revises: 0045_add_presence_status_text
+Create Date: 2025-03-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0046_add_bridge_fields_to_posted_messages"
+down_revision: str = "0045_add_presence_status_text"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "posted_messages",
+        sa.Column("embed_json", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "posted_messages",
+        sa.Column("nonce", sa.String(length=64), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_posted_messages_guild_channel_nonce",
+        "posted_messages",
+        ["guild_id", "channel_id", "nonce"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_posted_messages_guild_channel_nonce",
+        "posted_messages",
+        type_="unique",
+    )
+    op.drop_column("posted_messages", "nonce")
+    op.drop_column("posted_messages", "embed_json")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -274,6 +274,12 @@ class PostedMessage(Base):
             "discord_message_id",
             name="uq_posted_messages_discord",
         ),
+        UniqueConstraint(
+            "guild_id",
+            "channel_id",
+            "nonce",
+            name="uq_posted_messages_guild_channel_nonce",
+        ),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
@@ -282,6 +288,8 @@ class PostedMessage(Base):
     local_message_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), index=True)
     discord_message_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), index=True)
     webhook_url: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    embed_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    nonce: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
 
 class Embed(Base):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,102 @@
+import pytest
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "demibot"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from demibot.bridge import (
+    BRIDGE_MARKER,
+    BridgeUpload,
+    build_bridge_message,
+    extract_bridge_nonce_from_payload,
+)
+from demibot.db.models import ChannelKind, Membership, User
+
+
+@pytest.fixture()
+def sample_user():
+    return User(
+        id=1,
+        discord_user_id=111,
+        global_name="Sample",
+        character_name="Hero",
+    )
+
+
+@pytest.fixture()
+def sample_membership():
+    return Membership(
+        id=1,
+        guild_id=1,
+        user_id=1,
+        nickname="Nick",
+        avatar_url="https://example.com/avatar.png",
+    )
+
+
+def test_build_bridge_message_populates_embed_footer(sample_user, sample_membership):
+    content = "Hello from DemiCat"
+    attachments = [("screenshot.png", b"bytes", "image/png")]
+
+    discord_content, embeds, uploads, nonce = build_bridge_message(
+        content=content,
+        user=sample_user,
+        membership=sample_membership,
+        channel_kind=ChannelKind.FC_CHAT,
+        attachments=attachments,
+    )
+
+    assert discord_content == content
+    assert nonce
+    assert len(embeds) == 1
+
+    embed_dict = embeds[0].to_dict()
+    footer_text = embed_dict.get("footer", {}).get("text")
+    assert footer_text and footer_text.endswith(f"{BRIDGE_MARKER}{nonce}")
+    assert embed_dict.get("author", {}).get("name") == sample_membership.nickname
+    assert embed_dict.get("author", {}).get("icon_url") == sample_membership.avatar_url
+
+    assert embed_dict.get("image", {}).get("url") == "attachment://screenshot.png"
+
+    assert len(uploads) == 1
+    upload = uploads[0]
+    assert isinstance(upload, BridgeUpload)
+    assert upload.filename == "screenshot.png"
+    assert upload.content_type == "image/png"
+    assert upload.data == b"bytes"
+
+    payload = {"embeds": [embed_dict]}
+    assert extract_bridge_nonce_from_payload(payload) == nonce
+
+
+def test_build_bridge_message_splits_long_content(sample_user, sample_membership):
+    long_content = "A" * 7000
+
+    discord_content, embeds, uploads, nonce = build_bridge_message(
+        content=long_content,
+        user=sample_user,
+        membership=sample_membership,
+        channel_kind=ChannelKind.FC_CHAT,
+    )
+
+    assert discord_content == long_content[:2000]
+    assert not uploads
+    assert nonce
+    assert len(embeds) >= 2
+
+    total_length = 0
+    for embed in embeds:
+        data = embed.to_dict()
+        description = data.get("description", "")
+        assert len(description) <= 4096
+        total_length += len(description)
+        assert data.get("footer", {}).get("text", "").endswith(f"{BRIDGE_MARKER}{nonce}")
+
+    assert total_length <= 6000
+    assert embeds[-1].to_dict().get("description", "").endswith("…")
+
+    payload = {"embeds": [embed.to_dict() for embed in embeds]}
+    assert extract_bridge_nonce_from_payload(payload) == nonce

--- a/tests/test_ws_nonce.py
+++ b/tests/test_ws_nonce.py
@@ -1,0 +1,56 @@
+import asyncio
+
+import pytest
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "demibot"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from demibot.bridge import BRIDGE_MARKER
+from demibot.http.ws_chat import ChatConnectionManager
+
+
+@pytest.mark.asyncio
+async def test_should_drop_due_to_nonce_and_cleanup(monkeypatch):
+    manager = ChatConnectionManager()
+
+    flush_calls: list[str] = []
+
+    async def fake_flush(self, channel: str) -> None:
+        flush_calls.append(channel)
+
+    monkeypatch.setattr(
+        ChatConnectionManager,
+        "_flush_channel",
+        fake_flush,
+    )
+
+    payload = {
+        "op": "mc",
+        "d": {
+            "id": "42",
+            "content": "hello",
+            "embeds": [
+                {
+                    "footer": {"text": f"DemiCat • Chat • {BRIDGE_MARKER}abc123"},
+                }
+            ],
+        },
+    }
+
+    await manager.send("100", payload)
+    await asyncio.sleep(0)
+    assert "100" in manager._channel_nonce_cache
+    assert len(manager._channel_queues.get("100", [])) == 1
+
+    await manager.send("100", payload)
+    await asyncio.sleep(0)
+    assert len(manager._channel_queues.get("100", [])) == 1
+
+    manager._cleanup_channel("100")
+    assert "100" not in manager._channel_nonce_cache
+    assert "100" not in manager._channel_nonce_order
+    assert "100" not in manager._channel_queues


### PR DESCRIPTION
## Summary
- add a bridge formatting helper to produce embed payloads, uploads, and nonces for relay messages
- persist the generated embed payloads and nonce on posted messages and update websocket handling to drop duplicate nonce payloads
- expand the test suite to cover bridge formatting, long content splitting, nonce persistence, and websocket dedupe logic

## Testing
- pytest tests/test_bridge.py tests/test_ws_nonce.py tests/test_messages_common.py

------
https://chatgpt.com/codex/tasks/task_e_68ce894bf8a08328a1487e962d5e785c