### PR TITLE
Add shared event formatting helper and parity tests

### DIFF
--- a/DemiCatPlugin/EmbedValidation.cs
+++ b/DemiCatPlugin/EmbedValidation.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using DiscordHelper;
+
+namespace DemiCatPlugin;
+
+internal static class EmbedValidation
+{
+    private const int TitleLimit = 256;
+    private const int DescriptionLimit = 4096;
+    private const int FieldNameLimit = 256;
+    private const int FieldValueLimit = 1024;
+    private const int FieldCountLimit = 25;
+    private const int FooterTextLimit = 2048;
+    private const int AuthorNameLimit = 256;
+    private const int TotalCharLimit = 6000;
+    private const int ButtonLabelLimit = 80;
+    private const int ButtonCountLimit = 25;
+    private const int ButtonWidthLimit = 200;
+
+    internal static List<string> Validate(EmbedDto embed, IReadOnlyList<EmbedButtonDto> buttons)
+    {
+        var warnings = new List<string>();
+        var total = 0;
+
+        if (!string.IsNullOrEmpty(embed.Title))
+        {
+            if (embed.Title.Length > TitleLimit)
+            {
+                warnings.Add("Title too long");
+            }
+            total += embed.Title.Length;
+        }
+
+        if (!string.IsNullOrEmpty(embed.Description))
+        {
+            if (embed.Description.Length > DescriptionLimit)
+            {
+                warnings.Add("Description too long");
+            }
+            total += embed.Description.Length;
+        }
+
+        if (!string.IsNullOrEmpty(embed.FooterText))
+        {
+            if (embed.FooterText.Length > FooterTextLimit)
+            {
+                warnings.Add("Footer too long");
+            }
+            total += embed.FooterText.Length;
+        }
+
+        if (!string.IsNullOrEmpty(embed.AuthorName))
+        {
+            if (embed.AuthorName.Length > AuthorNameLimit)
+            {
+                warnings.Add("Author name too long");
+            }
+            total += embed.AuthorName.Length;
+        }
+
+        if (embed.Fields != null)
+        {
+            if (embed.Fields.Count > FieldCountLimit)
+            {
+                warnings.Add("Too many fields");
+            }
+
+            foreach (var field in embed.Fields)
+            {
+                if (field.Name.Length > FieldNameLimit)
+                {
+                    warnings.Add("Field name too long");
+                }
+
+                if (field.Value.Length > FieldValueLimit)
+                {
+                    warnings.Add("Field value too long");
+                }
+
+                total += field.Name.Length + field.Value.Length;
+            }
+        }
+
+        if (total > TotalCharLimit)
+        {
+            warnings.Add("Embed too large");
+        }
+
+        CheckUrl("url", embed.Url, warnings);
+        CheckUrl("thumbnail url", embed.ThumbnailUrl, warnings);
+        CheckUrl("image url", embed.ImageUrl, warnings);
+        CheckUrl("provider url", embed.ProviderUrl, warnings);
+        CheckUrl("footer icon url", embed.FooterIconUrl, warnings);
+        CheckUrl("author icon url", embed.AuthorIconUrl, warnings);
+        CheckUrl("video url", embed.VideoUrl, warnings);
+
+        if (embed.Authors != null)
+        {
+            foreach (var author in embed.Authors)
+            {
+                if (!string.IsNullOrEmpty(author.Name) && author.Name.Length > AuthorNameLimit)
+                {
+                    warnings.Add("Author name too long");
+                }
+
+                CheckUrl("author url", author.Url, warnings);
+                CheckUrl("author icon url", author.IconUrl, warnings);
+            }
+        }
+
+        if (buttons.Count > 0)
+        {
+            if (buttons.Count > ButtonCountLimit)
+            {
+                warnings.Add("Too many buttons");
+            }
+
+            foreach (var button in buttons)
+            {
+                if (!string.IsNullOrEmpty(button.Label) && button.Label.Length > ButtonLabelLimit)
+                {
+                    warnings.Add("Button label too long");
+                }
+
+                CheckUrl("button url", button.Url, warnings);
+
+                var width = button.Width ?? 1;
+                if (width < 1 || width > ButtonWidthLimit)
+                {
+                    warnings.Add("Invalid button width");
+                }
+            }
+        }
+
+        return warnings;
+    }
+
+    private static void CheckUrl(string name, string? url, List<string> warnings)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return;
+        }
+
+        if (!IsHttpUrl(url))
+        {
+            warnings.Add($"Invalid {name}");
+        }
+    }
+
+    internal static bool IsHttpUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return true;
+        }
+
+        return url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+            || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/DemiCatPlugin/EventPreviewFormatter.cs
+++ b/DemiCatPlugin/EventPreviewFormatter.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DiscordHelper;
+using DemiCat.UI;
+
+namespace DemiCatPlugin;
+
+public static class EventPreviewFormatter
+{
+    public sealed record Result(
+        EmbedDto Embed,
+        string? Content,
+        IReadOnlyList<EmbedButtonDto> Buttons,
+        IReadOnlyList<string> Warnings);
+
+    private static readonly IReadOnlyList<string> DefaultAttendance = new[] { "yes", "maybe", "no" };
+
+    public static Result Build(
+        string? title,
+        string? description,
+        DateTimeOffset? timestamp,
+        string? url,
+        string? imageUrl,
+        string? thumbnailUrl,
+        uint? color,
+        IEnumerable<EmbedFieldDto>? fields,
+        IEnumerable<EmbedButtonDto>? buttons,
+        IEnumerable<ulong>? mentions,
+        IEnumerable<string>? attendance = null,
+        string? embedId = null)
+    {
+        var fieldList = fields?
+            .Where(f => !string.IsNullOrWhiteSpace(f.Name) && !string.IsNullOrWhiteSpace(f.Value))
+            .Select(f => new EmbedFieldDto { Name = f.Name, Value = f.Value, Inline = f.Inline })
+            .ToList() ?? new List<EmbedFieldDto>();
+
+        var buttonList = buttons?
+            .Where(b => !string.IsNullOrWhiteSpace(b.Label))
+            .Select(CopyButton)
+            .ToList() ?? new List<EmbedButtonDto>();
+
+        foreach (var button in buttonList)
+        {
+            if (button.Width.HasValue)
+            {
+                button.Width = button.Width.Value > 0
+                    ? Math.Min(button.Width.Value, ButtonSizeHelper.Max)
+                    : null;
+            }
+        }
+
+        EnsureDefaultButtons(buttonList, attendance);
+
+        var mentionList = new List<ulong>();
+        if (mentions != null)
+        {
+            var seen = new HashSet<ulong>();
+            foreach (var mention in mentions)
+            {
+                if (seen.Add(mention))
+                {
+                    mentionList.Add(mention);
+                }
+            }
+        }
+
+        var content = mentionList.Count > 0
+            ? string.Join(" ", mentionList.Select(id => $"<@&{id}>"))
+            : null;
+
+        var embed = new EmbedDto
+        {
+            Id = string.IsNullOrWhiteSpace(embedId) ? "preview" : embedId!,
+            Title = string.IsNullOrWhiteSpace(title) ? null : title,
+            Description = string.IsNullOrWhiteSpace(description) ? null : description,
+            Url = string.IsNullOrWhiteSpace(url) ? null : url,
+            ImageUrl = string.IsNullOrWhiteSpace(imageUrl) ? null : imageUrl,
+            ThumbnailUrl = string.IsNullOrWhiteSpace(thumbnailUrl) ? null : thumbnailUrl,
+            Color = color,
+            Timestamp = timestamp,
+            Fields = fieldList.Count > 0 ? fieldList : null,
+            Buttons = buttonList.Count > 0 ? buttonList : null,
+            Mentions = mentionList.Count > 0 ? mentionList : null
+        };
+
+        var warnings = new List<string>();
+        warnings.AddRange(EmbedValidation.Validate(embed, buttonList));
+        warnings.AddRange(ValidateButtonLayout(buttonList));
+
+        return new Result(embed, content, buttonList, warnings);
+    }
+
+    private static EmbedButtonDto CopyButton(EmbedButtonDto button)
+        => new()
+        {
+            Label = button.Label,
+            Url = string.IsNullOrWhiteSpace(button.Url) ? null : button.Url,
+            CustomId = string.IsNullOrWhiteSpace(button.CustomId) ? null : button.CustomId,
+            Emoji = string.IsNullOrWhiteSpace(button.Emoji) ? null : button.Emoji,
+            Style = button.Style,
+            MaxSignups = button.MaxSignups,
+            Width = button.Width,
+            RowIndex = button.RowIndex
+        };
+
+    private static IEnumerable<string> ValidateButtonLayout(IReadOnlyList<EmbedButtonDto> buttons)
+    {
+        var warnings = new List<string>();
+        if (buttons.Count == 0)
+        {
+            return warnings;
+        }
+
+        var rows = buttons.GroupBy(b => b.RowIndex ?? 0).ToList();
+        var tooManyRows = rows.Count > ButtonRows.MaxRows || rows.Any(r => r.Key >= ButtonRows.MaxRows || r.Key < 0);
+        if (tooManyRows)
+        {
+            warnings.Add($"Too many button rows (max {ButtonRows.MaxRows})");
+        }
+
+        foreach (var row in rows)
+        {
+            var rowButtons = row.ToList();
+            if (rowButtons.Count > ButtonRows.MaxPerRow && !warnings.Contains($"Too many buttons in row (max {ButtonRows.MaxPerRow})"))
+            {
+                warnings.Add($"Too many buttons in row (max {ButtonRows.MaxPerRow})");
+            }
+
+            foreach (var button in rowButtons)
+            {
+                if (button.Style == ButtonStyle.Link)
+                {
+                    if (string.IsNullOrWhiteSpace(button.Url))
+                    {
+                        warnings.Add("Link buttons require a URL");
+                    }
+                }
+                else
+                {
+                    if (string.IsNullOrWhiteSpace(button.CustomId))
+                    {
+                        warnings.Add("Non-link buttons require customId");
+                    }
+                }
+            }
+        }
+
+        return warnings;
+    }
+
+    private static void EnsureDefaultButtons(List<EmbedButtonDto> buttonList, IEnumerable<string>? attendance)
+    {
+        if (buttonList.Count > 0)
+        {
+            return;
+        }
+
+        var tags = attendance?.ToList();
+        if (tags == null || tags.Count == 0)
+        {
+            tags = new List<string>(DefaultAttendance);
+        }
+
+        foreach (var tag in tags)
+        {
+            var value = tag ?? string.Empty;
+            var label = Capitalize(value);
+            buttonList.Add(new EmbedButtonDto
+            {
+                Label = label,
+                CustomId = $"rsvp:{value}",
+                Width = ButtonSizeHelper.ComputeWidth(label)
+            });
+        }
+    }
+
+    private static string Capitalize(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        if (value.Length == 1)
+        {
+            return value.ToUpperInvariant();
+        }
+
+        return char.ToUpperInvariant(value[0]) + value.Substring(1).ToLowerInvariant();
+    }
+}

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -648,11 +648,11 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 ids.Add(dto.Id);
                 if (_embeds.TryGetValue(dto.Id, out var view))
                 {
-                    view.Update(dto);
+                    view.Update(dto, BuildMentionContent(dto));
                 }
                 else
                 {
-                    _embeds[dto.Id] = new EventView(dto, _config, _httpClient, RefreshEmbeds, _emojiManager);
+                    _embeds[dto.Id] = new EventView(dto, _config, _httpClient, RefreshEmbeds, _emojiManager, BuildMentionContent(dto));
                 }
             }
 
@@ -662,6 +662,16 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 _embeds.Remove(key);
             }
         }
+    }
+
+    private static string? BuildMentionContent(EmbedDto dto)
+    {
+        if (dto.Mentions == null || dto.Mentions.Count == 0)
+        {
+            return null;
+        }
+
+        return string.Join(" ", dto.Mentions.Select(id => $"<@&{id}>"));
     }
 
     public async Task RefreshEmbeds()

--- a/tests/DemiCatPlugin.Tests.csproj
+++ b/tests/DemiCatPlugin.Tests.csproj
@@ -17,4 +17,9 @@
   <ItemGroup>
     <ProjectReference Include="../DemiCatPlugin/DemiCatPlugin.csproj" AdditionalProperties="DefineConstants=$(DefineConstants);TEST" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="data/event_preview_samples.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/tests/EventPreviewFormatterTests.cs
+++ b/tests/EventPreviewFormatterTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using DemiCatPlugin;
+using DemiCat.UI;
+using DiscordHelper;
+using Xunit;
+
+public class EventPreviewFormatterTests
+{
+    private static readonly DateTimeOffset Timestamp = new(2024, 4, 1, 20, 0, 0, TimeSpan.Zero);
+
+    private static JsonElement GetExpected(string key)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "data", "event_preview_samples.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        return doc.RootElement.GetProperty(key).Clone();
+    }
+
+    [Fact]
+    public void EventPreviewMatchesFixtureForFc()
+    {
+        var result = EventPreviewFormatter.Build(
+            "Raid Night",
+            "Clear the raid together.",
+            Timestamp,
+            "https://example.com/event",
+            "https://example.com/image.png",
+            "https://example.com/thumb.png",
+            0x123456,
+            BuildEventFields(),
+            BuildEventButtons(),
+            new[] { 12345UL },
+            embedId: "event-create-preview");
+
+        AssertPreviewMatches(GetExpected("event_fc"), result);
+    }
+
+    [Fact]
+    public void EventPreviewMatchesFixtureForOfficer()
+    {
+        var result = EventPreviewFormatter.Build(
+            "Raid Night",
+            "Clear the raid together.",
+            Timestamp,
+            "https://example.com/event",
+            "https://example.com/image.png",
+            "https://example.com/thumb.png",
+            0x123456,
+            BuildEventFields(),
+            BuildEventButtons(),
+            new[] { 12345UL, 67890UL },
+            embedId: "event-create-preview");
+
+        AssertPreviewMatches(GetExpected("event_officer"), result);
+    }
+
+    [Fact]
+    public void TemplatePreviewMatchesFixtureForFc()
+    {
+        var result = EventPreviewFormatter.Build(
+            "Static Meeting",
+            "Discuss strategy.",
+            Timestamp,
+            "https://example.com/template",
+            "https://example.com/template-image.png",
+            "https://example.com/template-thumb.png",
+            0xAA55CC,
+            BuildTemplateFields(),
+            BuildTemplateButtons(),
+            new[] { 12345UL },
+            embedId: "template-preview");
+
+        AssertPreviewMatches(GetExpected("template_fc"), result);
+    }
+
+    [Fact]
+    public void TemplatePreviewMatchesFixtureForOfficer()
+    {
+        var result = EventPreviewFormatter.Build(
+            "Static Meeting",
+            "Discuss strategy.",
+            Timestamp,
+            "https://example.com/template",
+            "https://example.com/template-image.png",
+            "https://example.com/template-thumb.png",
+            0xAA55CC,
+            BuildTemplateFields(),
+            BuildTemplateButtons(),
+            new[] { 12345UL, 67890UL },
+            embedId: "template-preview");
+
+        AssertPreviewMatches(GetExpected("template_officer"), result);
+    }
+
+    private static List<EmbedFieldDto> BuildEventFields() => new()
+    {
+        new EmbedFieldDto { Name = "When", Value = "Tonight 8pm", Inline = false },
+        new EmbedFieldDto { Name = "Where", Value = "Discord", Inline = true }
+    };
+
+    private static List<EmbedFieldDto> BuildTemplateFields() => new()
+    {
+        new EmbedFieldDto { Name = "Agenda", Value = "Discuss plan", Inline = false },
+        new EmbedFieldDto { Name = "Duration", Value = "60 min", Inline = true }
+    };
+
+    private static List<EmbedButtonDto> BuildEventButtons() => new()
+    {
+        new EmbedButtonDto { Label = "Sign Up", CustomId = "rsvp:yes", Style = ButtonStyle.Primary, Width = 80, RowIndex = 0 },
+        new EmbedButtonDto { Label = "Info", Url = "https://example.com/info", Style = ButtonStyle.Link, Width = 56, RowIndex = 0 }
+    };
+
+    private static List<EmbedButtonDto> BuildTemplateButtons() => new()
+    {
+        new EmbedButtonDto { Label = "DPS Signup", CustomId = "rsvp:dps", Style = ButtonStyle.Primary, Width = 112, RowIndex = 0 },
+        new EmbedButtonDto { Label = "Healer Signup", CustomId = "rsvp:heals", Style = ButtonStyle.Success, Width = 128, RowIndex = 0 },
+        new EmbedButtonDto { Label = "Tank Signup", CustomId = "rsvp:tanks", Style = ButtonStyle.Secondary, Width = 104, RowIndex = 1 },
+        new EmbedButtonDto { Label = "Guide", Url = "https://example.com/guide", Style = ButtonStyle.Link, Width = 64, RowIndex = 1 }
+    };
+
+    [Fact]
+    public void AddsDefaultButtonsWhenNoneProvided()
+    {
+        var result = EventPreviewFormatter.Build(
+            "No Buttons",
+            "Needs defaults",
+            Timestamp,
+            null,
+            null,
+            null,
+            null,
+            Enumerable.Empty<EmbedFieldDto>(),
+            Enumerable.Empty<EmbedButtonDto>(),
+            Enumerable.Empty<ulong>(),
+            embedId: "no-buttons-preview");
+
+        Assert.Collection(
+            result.Buttons,
+            b =>
+            {
+                Assert.Equal("Yes", b.Label);
+                Assert.Equal("rsvp:yes", b.CustomId);
+                Assert.True(b.Width.HasValue && b.Width.Value > 0);
+            },
+            b =>
+            {
+                Assert.Equal("Maybe", b.Label);
+                Assert.Equal("rsvp:maybe", b.CustomId);
+                Assert.True(b.Width.HasValue && b.Width.Value > 0);
+            },
+            b =>
+            {
+                Assert.Equal("No", b.Label);
+                Assert.Equal("rsvp:no", b.CustomId);
+                Assert.True(b.Width.HasValue && b.Width.Value > 0);
+            });
+    }
+
+    private static void AssertPreviewMatches(JsonElement expected, EventPreviewFormatter.Result actual)
+    {
+        Assert.Equal(expected.GetProperty("content").GetString(), actual.Content);
+        AssertJsonEqual(expected.GetProperty("embed"), BuildEmbedElement(actual.Embed));
+        AssertJsonEqual(expected.GetProperty("buttons"), BuildButtonsElement(actual.Buttons));
+    }
+
+    private static JsonElement BuildEmbedElement(EmbedDto embed)
+    {
+        var obj = new Dictionary<string, object?>
+        {
+            ["type"] = "rich",
+            ["flags"] = 0
+        };
+
+        if (!string.IsNullOrWhiteSpace(embed.Title)) obj["title"] = embed.Title;
+        if (!string.IsNullOrWhiteSpace(embed.Description)) obj["description"] = embed.Description;
+        if (!string.IsNullOrWhiteSpace(embed.Url)) obj["url"] = embed.Url;
+        if (embed.Color.HasValue) obj["color"] = (int)embed.Color.Value;
+        if (embed.Timestamp.HasValue) obj["timestamp"] = embed.Timestamp.Value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss+00:00");
+
+        if (embed.Fields != null && embed.Fields.Count > 0)
+        {
+            obj["fields"] = embed.Fields.Select(f => new Dictionary<string, object?>
+            {
+                ["name"] = f.Name,
+                ["value"] = f.Value,
+                ["inline"] = f.Inline ?? false
+            }).ToList();
+        }
+
+        if (!string.IsNullOrWhiteSpace(embed.ThumbnailUrl))
+        {
+            obj["thumbnail"] = new Dictionary<string, object?> { ["url"] = embed.ThumbnailUrl };
+        }
+
+        if (!string.IsNullOrWhiteSpace(embed.ImageUrl))
+        {
+            obj["image"] = new Dictionary<string, object?> { ["url"] = embed.ImageUrl };
+        }
+
+        var json = JsonSerializer.Serialize(obj);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    private static JsonElement BuildButtonsElement(IReadOnlyList<EmbedButtonDto> buttons)
+    {
+        var list = buttons.Select(b =>
+        {
+            var dict = new Dictionary<string, object?>
+            {
+                ["label"] = b.Label,
+                ["style"] = b.Style.HasValue ? (int?)b.Style.Value : null,
+                ["width"] = b.Width,
+                ["rowIndex"] = b.RowIndex
+            };
+            if (!string.IsNullOrWhiteSpace(b.CustomId)) dict["customId"] = b.CustomId;
+            if (!string.IsNullOrWhiteSpace(b.Url)) dict["url"] = b.Url;
+            if (!string.IsNullOrWhiteSpace(b.Emoji)) dict["emoji"] = b.Emoji;
+            if (b.MaxSignups.HasValue) dict["maxSignups"] = b.MaxSignups;
+            return dict;
+        }).ToList();
+
+        var json = JsonSerializer.Serialize(list);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    private static void AssertJsonEqual(JsonElement expected, JsonElement actual)
+        => Assert.Equal(expected.GetRawText(), actual.GetRawText());
+}

--- a/tests/data/event_preview_samples.json
+++ b/tests/data/event_preview_samples.json
@@ -1,0 +1,214 @@
+{
+  "event_fc": {
+    "content": "<@&12345>",
+    "embed": {
+      "image": {
+        "url": "https://example.com/image.png"
+      },
+      "thumbnail": {
+        "url": "https://example.com/thumb.png"
+      },
+      "fields": [
+        {
+          "inline": false,
+          "name": "When",
+          "value": "Tonight 8pm"
+        },
+        {
+          "inline": true,
+          "name": "Where",
+          "value": "Discord"
+        }
+      ],
+      "flags": 0,
+      "color": 1193046,
+      "timestamp": "2024-04-01T20:00:00+00:00",
+      "type": "rich",
+      "description": "Clear the raid together.",
+      "url": "https://example.com/event",
+      "title": "Raid Night"
+    },
+    "buttons": [
+      {
+        "label": "Sign Up",
+        "customId": "rsvp:yes",
+        "style": 1,
+        "width": 80,
+        "rowIndex": 0
+      },
+      {
+        "label": "Info",
+        "url": "https://example.com/info",
+        "style": 5,
+        "width": 56,
+        "rowIndex": 0
+      }
+    ]
+  },
+  "event_officer": {
+    "content": "<@&12345> <@&67890>",
+    "embed": {
+      "image": {
+        "url": "https://example.com/image.png"
+      },
+      "thumbnail": {
+        "url": "https://example.com/thumb.png"
+      },
+      "fields": [
+        {
+          "inline": false,
+          "name": "When",
+          "value": "Tonight 8pm"
+        },
+        {
+          "inline": true,
+          "name": "Where",
+          "value": "Discord"
+        }
+      ],
+      "flags": 0,
+      "color": 1193046,
+      "timestamp": "2024-04-01T20:00:00+00:00",
+      "type": "rich",
+      "description": "Clear the raid together.",
+      "url": "https://example.com/event",
+      "title": "Raid Night"
+    },
+    "buttons": [
+      {
+        "label": "Sign Up",
+        "customId": "rsvp:yes",
+        "style": 1,
+        "width": 80,
+        "rowIndex": 0
+      },
+      {
+        "label": "Info",
+        "url": "https://example.com/info",
+        "style": 5,
+        "width": 56,
+        "rowIndex": 0
+      }
+    ]
+  },
+  "template_fc": {
+    "content": "<@&12345>",
+    "embed": {
+      "image": {
+        "url": "https://example.com/template-image.png"
+      },
+      "thumbnail": {
+        "url": "https://example.com/template-thumb.png"
+      },
+      "fields": [
+        {
+          "inline": false,
+          "name": "Agenda",
+          "value": "Discuss plan"
+        },
+        {
+          "inline": true,
+          "name": "Duration",
+          "value": "60 min"
+        }
+      ],
+      "flags": 0,
+      "color": 11163084,
+      "timestamp": "2024-04-01T20:00:00+00:00",
+      "type": "rich",
+      "description": "Discuss strategy.",
+      "url": "https://example.com/template",
+      "title": "Static Meeting"
+    },
+    "buttons": [
+      {
+        "label": "DPS Signup",
+        "customId": "rsvp:dps",
+        "style": 1,
+        "width": 112,
+        "rowIndex": 0
+      },
+      {
+        "label": "Healer Signup",
+        "customId": "rsvp:heals",
+        "style": 3,
+        "width": 128,
+        "rowIndex": 0
+      },
+      {
+        "label": "Tank Signup",
+        "customId": "rsvp:tanks",
+        "style": 2,
+        "width": 104,
+        "rowIndex": 1
+      },
+      {
+        "label": "Guide",
+        "url": "https://example.com/guide",
+        "style": 5,
+        "width": 64,
+        "rowIndex": 1
+      }
+    ]
+  },
+  "template_officer": {
+    "content": "<@&12345> <@&67890>",
+    "embed": {
+      "image": {
+        "url": "https://example.com/template-image.png"
+      },
+      "thumbnail": {
+        "url": "https://example.com/template-thumb.png"
+      },
+      "fields": [
+        {
+          "inline": false,
+          "name": "Agenda",
+          "value": "Discuss plan"
+        },
+        {
+          "inline": true,
+          "name": "Duration",
+          "value": "60 min"
+        }
+      ],
+      "flags": 0,
+      "color": 11163084,
+      "timestamp": "2024-04-01T20:00:00+00:00",
+      "type": "rich",
+      "description": "Discuss strategy.",
+      "url": "https://example.com/template",
+      "title": "Static Meeting"
+    },
+    "buttons": [
+      {
+        "label": "DPS Signup",
+        "customId": "rsvp:dps",
+        "style": 1,
+        "width": 112,
+        "rowIndex": 0
+      },
+      {
+        "label": "Healer Signup",
+        "customId": "rsvp:heals",
+        "style": 3,
+        "width": 128,
+        "rowIndex": 0
+      },
+      {
+        "label": "Tank Signup",
+        "customId": "rsvp:tanks",
+        "style": 2,
+        "width": 104,
+        "rowIndex": 1
+      },
+      {
+        "label": "Guide",
+        "url": "https://example.com/guide",
+        "style": 5,
+        "width": 64,
+        "rowIndex": 1
+      }
+    ]
+  }
+}

--- a/tests/test_event_format_helper_parity.py
+++ b/tests/test_event_format_helper_parity.py
@@ -1,0 +1,109 @@
+import json
+import sys
+import types
+from pathlib import Path
+from datetime import datetime, timezone
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+from demibot.http.routes.events import CreateEventBody, FieldBody, EmbedButtonDto, ButtonStyle, format_event_embed
+
+FIXTURE = json.loads((Path(__file__).parent / "data" / "event_preview_samples.json").read_text())
+TIMESTAMP = datetime(2024, 4, 1, 20, 0, tzinfo=timezone.utc)
+
+
+def _embed_to_dict(embed):
+    return embed.to_dict()
+
+
+def _buttons_to_list(buttons):
+    return [b.model_dump(mode="json", by_alias=True, exclude_none=True) for b in buttons]
+
+
+def _build_event_body():
+    return CreateEventBody(
+        channelId="123",
+        title="Raid Night",
+        description="Clear the raid together.",
+        time=TIMESTAMP,
+        url="https://example.com/event",
+        imageUrl="https://example.com/image.png",
+        thumbnailUrl="https://example.com/thumb.png",
+        color=0x123456,
+        fields=[
+            FieldBody(name="When", value="Tonight 8pm", inline=False),
+            FieldBody(name="Where", value="Discord", inline=True),
+        ],
+        buttons=[
+            EmbedButtonDto(label="Sign Up", custom_id="rsvp:yes", style=ButtonStyle.primary, width=80, row_index=0),
+            EmbedButtonDto(label="Info", url="https://example.com/info", style=ButtonStyle.link, width=56, row_index=0),
+        ],
+    )
+
+
+def _build_template_body():
+    return CreateEventBody(
+        channelId="456",
+        title="Static Meeting",
+        description="Discuss strategy.",
+        time=TIMESTAMP,
+        url="https://example.com/template",
+        imageUrl="https://example.com/template-image.png",
+        thumbnailUrl="https://example.com/template-thumb.png",
+        color=0xAA55CC,
+        fields=[
+            FieldBody(name="Agenda", value="Discuss plan", inline=False),
+            FieldBody(name="Duration", value="60 min", inline=True),
+        ],
+        buttons=[
+            EmbedButtonDto(label="DPS Signup", custom_id="rsvp:dps", style=ButtonStyle.primary, width=112, row_index=0),
+            EmbedButtonDto(label="Healer Signup", custom_id="rsvp:heals", style=ButtonStyle.success, width=128, row_index=0),
+            EmbedButtonDto(label="Tank Signup", custom_id="rsvp:tanks", style=ButtonStyle.secondary, width=104, row_index=1),
+            EmbedButtonDto(label="Guide", url="https://example.com/guide", style=ButtonStyle.link, width=64, row_index=1),
+        ],
+    )
+
+
+def test_event_helper_fc_matches_fixture():
+    body = _build_event_body()
+    formatted = format_event_embed(body, timestamp=TIMESTAMP, mention_ids=[12345])
+    expected = FIXTURE["event_fc"]
+    assert formatted.content == expected["content"]
+    assert _embed_to_dict(formatted.embed) == expected["embed"]
+    assert _buttons_to_list(formatted.buttons) == expected["buttons"]
+
+
+def test_event_helper_officer_matches_fixture():
+    body = _build_event_body()
+    formatted = format_event_embed(body, timestamp=TIMESTAMP, mention_ids=[12345, 67890])
+    expected = FIXTURE["event_officer"]
+    assert formatted.content == expected["content"]
+    assert _embed_to_dict(formatted.embed) == expected["embed"]
+    assert _buttons_to_list(formatted.buttons) == expected["buttons"]
+
+
+def test_template_helper_fc_matches_fixture():
+    body = _build_template_body()
+    formatted = format_event_embed(body, timestamp=TIMESTAMP, mention_ids=[12345])
+    expected = FIXTURE["template_fc"]
+    assert formatted.content == expected["content"]
+    assert _embed_to_dict(formatted.embed) == expected["embed"]
+    assert _buttons_to_list(formatted.buttons) == expected["buttons"]
+
+
+def test_template_helper_officer_matches_fixture():
+    body = _build_template_body()
+    formatted = format_event_embed(body, timestamp=TIMESTAMP, mention_ids=[12345, 67890])
+    expected = FIXTURE["template_officer"]
+    assert formatted.content == expected["content"]
+    assert _embed_to_dict(formatted.embed) == expected["embed"]
+    assert _buttons_to_list(formatted.buttons) == expected["buttons"]


### PR DESCRIPTION
## Summary
- extract format_event_embed helper that returns embed, default RSVP buttons, and mention content for events
- wire the plugin previews through EventPreviewFormatter + EmbedValidation to match server validation, mentions, and layouts
- extend EventView/UiRenderer to render mention content and warnings while sharing fixtures/tests between server and plugin

## Testing
- pytest tests/test_event_format_helper_parity.py
- pip install httpx
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet not available)*

------
https://chatgpt.com/codex/tasks/task_e_68cea0dfd29c832897e2fa01e919443d