### PR TITLE
Fix mention preview types and template event args

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -742,7 +742,7 @@ public class ChatWindow : IDisposable
         ImGui.PopTextWrapPos();
     }
 
-    internal static string ReplaceMentionTokens(string text, List<DiscordMentionDto>? mentions)
+    internal static string ReplaceMentionTokens(string text, IReadOnlyList<DiscordMentionDto>? mentions)
     {
         if (mentions == null)
             return text;
@@ -897,7 +897,7 @@ public class ChatWindow : IDisposable
         var presences = _presence?.Presences ?? Array.Empty<PresenceDto>();
         var player = PluginServices.Instance?.ClientState?.LocalPlayer;
         var characterName = player?.Name.TextValue ?? player?.Name.ToString();
-        var worldName = player?.HomeWorld?.GameData?.Name?.ToString();
+        var worldName = player != null ? player.HomeWorld.GameData?.Name?.ToString() : null;
 
         return new BridgeMessageFormatter.BridgeFormatterOptions
         {

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -568,6 +568,7 @@ public class TemplatesWindow
             fields,
             buttons,
             mentionIds,
+            null,
             embedId ?? "template-preview");
     }
 


### PR DESCRIPTION
## Summary
- allow `ChatWindow.ReplaceMentionTokens` to accept read-only mention collections so bridge previews render correctly
- guard world name lookup against nullable RowRef access when building chat preview options
- ensure template event previews pass an explicit attendance argument to `EventPreviewFormatter.Build`

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce2526940c8328b25cbc9f3089bf78