### PR TITLE
Fix world name lookup for formatter options

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -897,7 +897,7 @@ public class ChatWindow : IDisposable
         var presences = _presence?.Presences ?? Array.Empty<PresenceDto>();
         var player = PluginServices.Instance?.ClientState?.LocalPlayer;
         var characterName = player?.Name.TextValue ?? player?.Name.ToString();
-        var worldName = player != null ? player.HomeWorld.GameData?.Name?.ToString() : null;
+        var worldName = player != null ? player.HomeWorld.ValueNullable?.Name?.ToString() : null;
 
         return new BridgeMessageFormatter.BridgeFormatterOptions
         {


### PR DESCRIPTION
## Summary
- resolve the chat formatter's world name through the RowRef API now that GameData is unavailable

## Testing
- dotnet build -c Release *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb7228ee48328b7f18a00cf8a9220