### PR TITLE
Fix world name extraction

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -897,7 +897,16 @@ public class ChatWindow : IDisposable
         var presences = _presence?.Presences ?? Array.Empty<PresenceDto>();
         var player = PluginServices.Instance?.ClientState?.LocalPlayer;
         var characterName = player?.Name.TextValue ?? player?.Name.ToString();
-        var worldName = player != null ? player.HomeWorld.ValueNullable?.Name?.ToString() : null;
+        string? worldName = null;
+
+        if (player != null)
+        {
+            var homeWorld = player.HomeWorld.ValueNullable;
+            if (homeWorld.HasValue)
+            {
+                worldName = homeWorld.Value.Name.ToString();
+            }
+        }
 
         return new BridgeMessageFormatter.BridgeFormatterOptions
         {


### PR DESCRIPTION
## Summary
- adjust world name extraction in ChatWindow to avoid null-conditional access on ReadOnlySeString values

## Testing
- `dotnet build -c Release` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb95a26b48328a741c12d0c218bb4