### PR TITLE
Reload templates when tab is opened

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -19,6 +19,7 @@ public class MainWindow : IDisposable
     private readonly RequestBoardWindow _requestBoard;
     private SyncshellWindow? _syncshell;
     private bool _syncshellEnabled;
+    private bool _templatesTabActive;
     private readonly HttpClient _httpClient;
     private readonly Func<Task<bool>> _refreshRoles;
     private bool _checkingOfficer;
@@ -155,16 +156,30 @@ public class MainWindow : IDisposable
 
             if (!linked)
             {
+                _templatesTabActive = false;
                 ImGui.BeginDisabled();
                 ImGui.TabItemButton("Templates");
                 ImGui.EndDisabled();
                 if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
                     ImGui.SetTooltip("Link DemiCat to use templates.");
             }
-            else if (ImGui.BeginTabItem("Templates"))
+            else
             {
-                _templates.Draw();
-                ImGui.EndTabItem();
+                var templatesOpen = ImGui.BeginTabItem("Templates");
+                if (templatesOpen)
+                {
+                    if (!_templatesTabActive)
+                    {
+                        _templates.OnTabActivated();
+                    }
+                    _templatesTabActive = true;
+                    _templates.Draw();
+                    ImGui.EndTabItem();
+                }
+                else
+                {
+                    _templatesTabActive = false;
+                }
             }
 
             if (!linked)

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -108,6 +108,15 @@ public class TemplatesWindow
         _bridge?.Stop();
     }
 
+    public void OnTabActivated()
+    {
+        _templatesLoaded = false;
+        if (!_templatesLoading)
+        {
+            _templatesReloadPending = false;
+        }
+    }
+
     public void Draw()
     {
         if (!_config.Templates)


### PR DESCRIPTION
## Summary
- add a Templates window hook that marks template data as stale when the tab is activated
- update MainWindow to detect Templates tab activation and call the hook

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: dotnet not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cec69c972483289e0d17353daab545