### PR TITLE
Colorize style selections in signup editor

### DIFF
--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -84,7 +84,10 @@ public class SignupOptionEditor
                 {
                     if (bs == ButtonStyle.Link) continue;
                     var sel = bs == _working.Style;
+                    var color = EmbedPreviewRenderer.GetStyleColor(bs);
+                    ImGui.PushStyleColor(ImGuiCol.Text, color);
                     if (ImGui.Selectable(bs.ToString(), sel)) _working.Style = bs;
+                    ImGui.PopStyleColor();
                     if (sel) ImGui.SetItemDefaultFocus();
                 }
                 ImGui.EndCombo();


### PR DESCRIPTION
## Summary
- tint each non-link style option in the signup editor dropdown with its Discord button color

## Testing
- dotnet build DemiCatPlugin *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cec78413588328b93be822af23a2f7