### PR TITLE
Guard FC chat window draw when feature disabled

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -50,7 +50,7 @@ public class FcChatWindow : ChatWindow
 
     public override void Draw()
     {
-        if (!_config.SyncedChat)
+        if (!_config.SyncedChat || !_config.EnableFcChat)
         {
             ImGui.TextUnformatted("Feature disabled");
             return;


### PR DESCRIPTION
## Summary
- ensure the FC chat window draw path respects both the synced chat and Enable FC Chat toggles so the disabled message shows when the feature is off

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cecad8ace08328b66d915d13b90070