### PR TITLE
Clear chat status when stopping networking

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -194,6 +194,7 @@ public class ChatWindow : IDisposable
     {
         _bridge.Stop();
         _presence?.Stop();
+        _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
     }
 
     // ---- UTF-8 helpers for ImGui byte-buffer overloads ----


### PR DESCRIPTION
## Summary
- clear the chat window status text when the networking bridge is stopped to avoid stale messages

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cecc8cb01c8328955f24aca14c0961