### PR TITLE
Add RSVP separator to event create window

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -296,6 +296,8 @@ public class EventCreateWindow
             ImGui.EndPopup();
         }
 
+        ImGui.Separator();
+
         for (var i = 0; i < _buttons.Count; i++)
         {
             var button = _buttons[i];


### PR DESCRIPTION
## Summary
- add an ImGui separator above the RSVP button editor so the section is visually distinct

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cef7a2dfa48328a91f44c411e782d9