### PR TITLE
Support template button URLs

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -601,6 +601,7 @@ public class EventCreateWindow
                     Label = b.Label,
                     Emoji = EmojiFormatter.Normalize(_emojiManager, b.Emoji) ?? string.Empty,
                     Style = b.Style,
+                    Url = b.Url,
                     MaxSignups = b.MaxSignups,
                     Width = b.Width
                 });
@@ -635,7 +636,7 @@ public class EventCreateWindow
                 thumbnailUrl = dto.ThumbnailUrl,
                 color = dto.Color,
                 fields = dto.Fields?.Select(f => new { name = f.Name, value = f.Value, inline = f.Inline }).ToList(),
-                buttons = buttons.Select(b => new { label = b.Label, customId = b.CustomId, style = b.Style.HasValue ? (int?)b.Style : null, emoji = b.Emoji, maxSignups = b.MaxSignups, width = b.Width, rowIndex = b.RowIndex }).ToList(),
+                buttons = buttons.Select(b => new { label = b.Label, customId = b.CustomId, url = b.Url, style = b.Style.HasValue ? (int?)b.Style : null, emoji = b.Emoji, maxSignups = b.MaxSignups, width = b.Width, rowIndex = b.RowIndex }).ToList(),
                 mentions = _mentions.Count > 0 ? _mentions.ToList() : null
             };
             var body = new
@@ -755,18 +756,19 @@ public class EventCreateWindow
         _buttons.Clear();
         foreach (var b in preset.Buttons)
         {
-                _buttons.Add(new Template.TemplateButton
-                {
-                    Tag = b.Tag,
-                    Include = b.Include,
-                    Label = b.Label,
-                    Emoji = EmojiFormatter.Normalize(_emojiManager, b.Emoji) ?? string.Empty,
-                    Style = b.Style,
-                    MaxSignups = b.MaxSignups,
-                    Width = b.Width
-                });
-            }
+            _buttons.Add(new Template.TemplateButton
+            {
+                Tag = b.Tag,
+                Include = b.Include,
+                Label = b.Label,
+                Emoji = EmojiFormatter.Normalize(_emojiManager, b.Emoji) ?? string.Empty,
+                Style = b.Style,
+                Url = b.Url,
+                MaxSignups = b.MaxSignups,
+                Width = b.Width
+            });
         }
+    }
 
     private void SaveConfig()
     {
@@ -786,6 +788,7 @@ public class EventCreateWindow
             {
                 Label = b.Label,
                 CustomId = $"rsvp:{b.Tag}",
+                Url = string.IsNullOrWhiteSpace(b.Url) ? null : b.Url,
                 Emoji = string.IsNullOrWhiteSpace(b.Emoji) ? null : b.Emoji,
                 Style = b.Style,
                 MaxSignups = b.MaxSignups,
@@ -918,6 +921,7 @@ public class EventCreateWindow
                 Label = b.Label,
                 Emoji = EmojiFormatter.Normalize(_emojiManager, b.Emoji) ?? string.Empty,
                 Style = b.Style,
+                Url = b.Url,
                 MaxSignups = b.MaxSignups,
                 Width = b.Width
             }).ToList()

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -31,6 +31,7 @@ public class SignupOptionEditor
             Label = button.Label,
             Emoji = button.Emoji,
             Style = button.Style,
+            Url = button.Url,
             MaxSignups = button.MaxSignups,
             Width = button.Width
         };
@@ -103,6 +104,7 @@ public class SignupOptionEditor
                     Label = _working.Label,
                     Emoji = _working.Emoji,
                     Style = _working.Style,
+                    Url = _working.Url,
                     MaxSignups = _working.MaxSignups,
                     Width = _working.Width ?? ButtonSizeHelper.ComputeWidth(_working.Label)
                 });

--- a/DemiCatPlugin/Template.cs
+++ b/DemiCatPlugin/Template.cs
@@ -36,6 +36,7 @@ public class Template
         public string Label { get; set; } = string.Empty;
         public string Emoji { get; set; } = string.Empty;
         public ButtonStyle Style { get; set; } = ButtonStyle.Secondary;
+        public string? Url { get; set; }
         public int? MaxSignups { get; set; }
         public int? Width { get; set; }
     }

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -500,7 +500,8 @@ public class TemplatesWindow
         int style,
         string? emoji,
         int? maxSignups,
-        int? width);
+        int? width,
+        string? url);
 
     internal List<ButtonPayload> BuildButtonsPayload(Template tmpl)
     {
@@ -519,7 +520,8 @@ public class TemplatesWindow
                     (int)(b?.Style ?? x.Data.Style),
                     EmojiFormatter.Normalize(_emojiManager, b?.Emoji ?? x.Data.Emoji),
                     b?.MaxSignups ?? x.Data.MaxSignups,
-                    Math.Min(b?.Width ?? x.Data.Width ?? ButtonSizeHelper.ComputeWidth(label), ButtonSizeHelper.Max));
+                    Math.Min(b?.Width ?? x.Data.Width ?? ButtonSizeHelper.ComputeWidth(label), ButtonSizeHelper.Max),
+                    string.IsNullOrWhiteSpace(b?.Url) ? null : b?.Url);
             })
             .ToList();
     }
@@ -542,6 +544,7 @@ public class TemplatesWindow
             {
                 Label = b.label,
                 CustomId = b.customId,
+                Url = string.IsNullOrWhiteSpace(b.url) ? null : b.url,
                 Style = (ButtonStyle)b.style,
                 Emoji = string.IsNullOrWhiteSpace(b.emoji) ? null : b.emoji,
                 MaxSignups = b.maxSignups,
@@ -597,11 +600,24 @@ public class TemplatesWindow
         try
         {
             var buttonsFlat = BuildButtonsPayload(tmpl);
+            var buttonsBody = buttonsFlat.Count > 0
+                ? buttonsFlat.Select(b => new
+                {
+                    b.label,
+                    b.customId,
+                    b.rowIndex,
+                    b.style,
+                    b.emoji,
+                    b.maxSignups,
+                    b.width,
+                    b.url
+                }).ToList()
+                : null;
             var body = new
             {
                 channelId,
                 time = string.IsNullOrWhiteSpace(tmpl.Time) ? null : tmpl.Time,
-                buttons = buttonsFlat.Count > 0 ? buttonsFlat : null,
+                buttons = buttonsBody,
                 mentions = _mentions.Count > 0 ? _mentions.Select(ulong.Parse).ToList() : null
             };
             var id = _templates[_selectedIndex].Id;
@@ -758,6 +774,7 @@ public class TemplatesWindow
                 Label = b.Label,
                 Emoji = b.Emoji ?? string.Empty,
                 Style = b.Style ?? ButtonStyle.Secondary,
+                Url = b.Url,
                 MaxSignups = b.MaxSignups,
                 Width = b.Width
             }).ToList() ?? new List<Template.TemplateButton>(),

--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -60,6 +60,29 @@ public class TemplateButtonRoundTripTests
         Assert.Null(btn.emoji);
         Assert.Null(btn.maxSignups);
         Assert.Equal(ButtonSizeHelper.ComputeWidth("Join"), btn.width);
+        Assert.Null(btn.url);
+    }
+
+    [Fact]
+    public void BuildButtonsPayload_PreservesTemplateButtonUrl()
+    {
+        var rows = new ButtonRows(new()
+        {
+            new() { new ButtonData { Tag = "link", Label = "Guide" } }
+        });
+        var window = CreateWindow(rows);
+
+        var tmpl = new Template
+        {
+            Buttons = new List<Template.TemplateButton>
+            {
+                new Template.TemplateButton { Tag = "link", Label = "Guide", Url = "https://example.com", Style = ButtonStyle.Link }
+            }
+        };
+
+        var payload = window.BuildButtonsPayload(tmpl);
+        var btn = Assert.Single(payload);
+        Assert.Equal("https://example.com", btn.url);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add a Url property to Template.TemplateButton and preserve it whenever buttons are cloned
- plumb button URLs through template conversion, previews, and payload serialization so API posts keep link destinations
- update tests to cover URL propagation in button payloads

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0666231c8328b2a542ae37ed2677