### PR TITLE
Adjust chat refresh backlog pagination

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1369,7 +1369,8 @@ public class ChatWindow : IDisposable
             string? before = null;
             var cursorKey = ChannelKeyHelper.BuildCursorKey(_config.GuildId, _channelKind, channelId);
             var hasCursor = _config.ChatCursors.TryGetValue(cursorKey, out var since);
-            var after = hasCursor ? since.ToString() : null;
+            var storedAfter = hasCursor ? since.ToString() : null;
+            var firstPage = true;
             while (all.Count < MaxMessages)
             {
                 var url = $"{_config.ApiBaseUrl.TrimEnd('/')}{MessagesPath}/{channelId}?limit={PageSize}";
@@ -1377,6 +1378,7 @@ public class ChatWindow : IDisposable
                 {
                     url += $"&before={before}";
                 }
+                var after = !firstPage ? storedAfter : null;
                 if (after != null)
                 {
                     url += $"&after={after}";
@@ -1412,6 +1414,7 @@ public class ChatWindow : IDisposable
                 {
                     break;
                 }
+                firstPage = false;
                 before = msgs[0].Id;
             }
 

--- a/tests/ChatWindowMessageLimitTests.cs
+++ b/tests/ChatWindowMessageLimitTests.cs
@@ -46,7 +46,7 @@ public class ChatWindowMessageLimitTests
         Assert.Equal("130", msgs[^1].Id);
         Assert.Equal(130, config.ChatCursors[cursorKey]);
         Assert.Single(handler.Requests);
-        Assert.Contains("after=120", handler.Requests[0].Query);
+        Assert.DoesNotContain("after=", handler.Requests[0].Query);
     }
 
     [Fact]
@@ -67,6 +67,29 @@ public class ChatWindowMessageLimitTests
         Assert.Single(handler.Requests);
         Assert.DoesNotContain("after=", handler.Requests[0].Query);
         Assert.Equal(20, config.ChatCursors[cursorKey]);
+    }
+
+    [Fact]
+    public async Task RefreshMessages_ReappliesCursorWhenPaginating()
+    {
+        SetupServices();
+        var config = new Config { ApiBaseUrl = "http://localhost", ChatChannelId = "1" };
+        var handler = new SequenceHandler();
+        using var client = new HttpClient(handler);
+        var tm = new TokenManager();
+        var channelService = new ChannelService(config, client, tm);
+        var window = new ChatWindow(config, client, null, tm, channelService);
+        var cursorKey = ChannelKeyHelper.BuildCursorKey(config.GuildId, ChannelKind.Chat, "1");
+        config.ChatCursors[cursorKey] = 120;
+
+        handler.EnqueueResponse(SerializeMessages(71, 120));
+        handler.EnqueueResponse(SerializeMessages(21, 70));
+        await window.RefreshMessages();
+
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.DoesNotContain("after=", handler.Requests[0].Query);
+        Assert.Contains("before=71", handler.Requests[1].Query);
+        Assert.Contains("after=120", handler.Requests[1].Query);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update chat refresh pagination so the first request ignores the stored cursor while continuing pages still honour it
- extend the ChatWindow message limit tests to cover the updated behaviour

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: Dalamud installation not found at $(DalamudLibPath))*

------
https://chatgpt.com/codex/tasks/task_e_68cf2164b1b88328ae1064e0071e239f