### PR TITLE
Mirror Discord roles in presence updates

### DIFF
--- a/demibot/demibot/discordbot/cogs/presence.py
+++ b/demibot/demibot/discordbot/cogs/presence.py
@@ -5,10 +5,18 @@ from datetime import datetime
 
 import discord
 from discord.ext import commands
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 
-from ...db.models import Guild, Membership, Presence as DbPresence, User
+from ...db.models import (
+    Guild,
+    GuildConfig,
+    Membership,
+    MembershipRole,
+    Presence as DbPresence,
+    Role,
+    User,
+)
 from ...db.session import get_session
 from ...http.ws import manager
 from ..presence_store import Presence as StorePresence, set_presence
@@ -52,11 +60,11 @@ class PresenceTracker(commands.Cog):
         return None
 
     async def _update(self, member: discord.Member) -> dict[str, str | None]:
-        role_ids = [r.id for r in member.roles if r.name != "@everyone"]
+        member_roles = [r for r in member.roles if r.name != "@everyone"]
+        role_ids = [r.id for r in member_roles]
         role_details = [
             {"id": str(r.id), "name": r.name}
-            for r in member.roles
-            if r.name != "@everyone"
+            for r in member_roles
         ]
         display_name = member.display_name or member.name
         avatar_url = str(member.display_avatar.url)
@@ -121,6 +129,53 @@ class PresenceTracker(commands.Cog):
                 db.add(mem)
             mem.nickname = display_name
             mem.avatar_url = avatar_url
+
+            cfg_res = await db.execute(
+                select(GuildConfig).where(GuildConfig.guild_id == guild_row.id)
+            )
+            cfg = cfg_res.scalar_one_or_none()
+            officer_role_ids = (
+                {int(rid) for rid in cfg.officer_role_ids.split(",") if rid}
+                if cfg and cfg.officer_role_ids
+                else set()
+            )
+            chat_role_ids = (
+                {int(rid) for rid in cfg.mention_role_ids.split(",") if rid}
+                if cfg and cfg.mention_role_ids
+                else set()
+            )
+
+            role_res = await db.execute(select(Role).where(Role.guild_id == guild_row.id))
+            role_map = {role.discord_role_id: role for role in role_res.scalars()}
+
+            for role in member_roles:
+                is_officer = role.id in officer_role_ids
+                is_chat = role.id in chat_role_ids
+                mapped = role_map.get(role.id)
+                if mapped is None:
+                    mapped = Role(
+                        guild_id=guild_row.id,
+                        discord_role_id=role.id,
+                        name=role.name,
+                        is_officer=is_officer,
+                        is_chat=is_chat,
+                    )
+                    db.add(mapped)
+                    await db.flush()
+                    role_map[role.id] = mapped
+                else:
+                    mapped.name = role.name
+                    mapped.is_officer = is_officer
+                    mapped.is_chat = is_chat
+
+            await db.execute(
+                delete(MembershipRole).where(MembershipRole.membership_id == mem.id)
+            )
+
+            for role in member_roles:
+                mapped = role_map.get(role.id)
+                if mapped is not None:
+                    db.add(MembershipRole(membership_id=mem.id, role_id=mapped.id))
 
             stmt = select(DbPresence).where(
                 DbPresence.guild_id == guild_row.id,

--- a/tests/test_presence_role_mirror.py
+++ b/tests/test_presence_role_mirror.py
@@ -1,0 +1,142 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+from sqlalchemy import select
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+discordbot_pkg = types.ModuleType("demibot.discordbot")
+discordbot_pkg.__path__ = [str(root / "demibot/discordbot")]
+sys.modules.setdefault("demibot.discordbot", discordbot_pkg)
+
+from demibot.db import session as db_session
+from demibot.db.models import (
+    Guild,
+    GuildConfig,
+    Membership,
+    MembershipRole,
+    Role,
+    User,
+    UserKey,
+)
+from demibot.db.session import get_session, init_db
+from demibot.discordbot.cogs.presence import PresenceTracker
+from demibot.http.deps import api_key_auth
+from demibot.http.routes import validate_roles
+
+
+class DummyMember:
+    def __init__(self, guild, roles):
+        self.id = 2
+        self.guild = guild
+        self.roles = roles
+        self.display_name = "Member"
+        self.name = "Member"
+        self.display_avatar = SimpleNamespace(url="https://example.com/avatar.png")
+        self.status = "online"
+        self.activities: list = []
+        self.global_name = "Member"
+        self.discriminator = "0001"
+
+
+def _reset_db(path: Path) -> None:
+    if path.exists():
+        path.unlink()
+    db_session._engine = None
+    db_session._Session = None
+
+
+def test_presence_updates_membership_roles_for_api():
+    async def _run():
+        db_path = Path("presence_roles.db")
+        _reset_db(db_path)
+        url = f"sqlite+aiosqlite:///{db_path}"
+        await init_db(url)
+
+        async with get_session() as db:
+            guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
+            db.add(guild)
+            db.add(
+                GuildConfig(
+                    guild_id=guild.id,
+                    officer_role_ids="10",
+                    mention_role_ids="20",
+                )
+            )
+            db.add(
+                User(
+                    id=1,
+                    discord_user_id=2,
+                    global_name="Member",
+                    discriminator="0001",
+                )
+            )
+            await db.commit()
+
+        tracker = PresenceTracker(bot=SimpleNamespace())
+        guild_stub = SimpleNamespace(id=1, name="Test Guild")
+        officer_role = SimpleNamespace(id=10, name="Officer")
+        chat_role = SimpleNamespace(id=20, name="Chat")
+        member = DummyMember(guild_stub, [officer_role])
+
+        await tracker._update(member)
+
+        async with get_session() as db:
+            user = (
+                await db.execute(select(User).where(User.discord_user_id == member.id))
+            ).scalar_one()
+            guild_row = (
+                await db.execute(select(Guild).where(Guild.discord_guild_id == 1))
+            ).scalar_one()
+            db.add(UserKey(user_id=user.id, guild_id=guild_row.id, token="token"))
+            await db.commit()
+            user_id = user.id
+            guild_id = guild_row.id
+
+        async def fetch_flags():
+            async with get_session() as db:
+                ctx = await api_key_auth(x_api_key="token", x_discord_id=None, db=db)
+                roles_resp = await validate_roles.roles(ctx=ctx)
+                membership_role_ids = sorted(
+                    (
+                        await db.execute(
+                            select(Role.discord_role_id)
+                            .join(MembershipRole, MembershipRole.role_id == Role.id)
+                            .join(
+                                Membership,
+                                MembershipRole.membership_id == Membership.id,
+                            )
+                            .where(
+                                Membership.guild_id == guild_id,
+                                Membership.user_id == user_id,
+                            )
+                        )
+                    ).scalars().all()
+                )
+                return roles_resp.roles, membership_role_ids
+
+        roles_flags, membership_role_ids = await fetch_flags()
+        assert membership_role_ids == [10]
+        assert set(roles_flags) == {"officer"}
+
+        member.roles = [chat_role]
+        await tracker._update(member)
+
+        roles_flags, membership_role_ids = await fetch_flags()
+        assert membership_role_ids == [20]
+        assert set(roles_flags) == {"chat"}
+
+        engine = db_session._engine
+        if engine is not None:
+            await engine.dispose()
+        _reset_db(db_path)
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- update the presence tracker to refresh membership_roles and role metadata from Discord roles during presence updates
- ensure officer and chat flags are synchronized with guild configuration when presences change
- add a regression test that flips a member's roles and confirms the /roles endpoint reflects the new officer/chat status

## Testing
- `pytest tests/test_presence_role_mirror.py`


------
https://chatgpt.com/codex/tasks/task_e_68cf253bb3e4832888fd51eb19c1b382