### PR TITLE
Marshal token unlink handling to framework thread

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -267,12 +267,33 @@ public class Plugin : IDalamudPlugin
 
     private void HandleTokenUnlinked(string? reason)
     {
-        StopWatchers();
-
-        if (IsAuthenticationFailure(reason))
+        void Execute()
         {
-            ShowInvalidTokenToast();
+            StopWatchers();
+
+            if (IsAuthenticationFailure(reason))
+            {
+                ShowInvalidTokenToast();
+            }
         }
+
+        var framework = PluginServices.Instance?.Framework ?? _services.Framework;
+
+        if (framework != null)
+        {
+            try
+            {
+                framework.RunOnTick(Execute);
+                return;
+            }
+            catch (Exception ex)
+            {
+                var log = PluginServices.Instance?.Log ?? _services.Log;
+                log?.Warning(ex, "Failed to marshal token unlink handling to framework thread");
+            }
+        }
+
+        Execute();
     }
 
     private async Task StartWatchersAsync()


### PR DESCRIPTION
## Summary
- marshal token unlink cleanup through the Dalamud framework thread so UI interactions stay safe
- log and fall back to inline execution if scheduling cannot be performed

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf302e574c83288a5d4acb4c42e57d