### PR TITLE
Update presence grouping to use highest role

### DIFF
--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -31,6 +31,12 @@ public class PresenceSidebar : IDisposable
         "Server Booster"
     };
 
+    private static readonly HashSet<string> OfflineStatuses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "offline",
+        "invisible",
+    };
+
     public Action<string?, Action<ISharedImmediateTexture?>>? TextureLoader { get; set; }
 
     public PresenceSidebar(DiscordPresenceService service)
@@ -56,93 +62,76 @@ public class PresenceSidebar : IDisposable
 
         var presences = _service.Presences;
         var online = presences
-            .Where(p => !string.Equals(p.Status, "offline", StringComparison.OrdinalIgnoreCase))
+            .Where(p => !IsOffline(p.Status))
             .ToList();
         var offline = presences
-            .Where(p => string.Equals(p.Status, "offline", StringComparison.OrdinalIgnoreCase))
+            .Where(p => IsOffline(p.Status))
             .OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        var roleGroups = new Dictionary<string, RoleGroup>(StringComparer.Ordinal);
-        var orderedRoleIds = new List<string>();
-        var orderedRoleIndices = new Dictionary<string, int>(StringComparer.Ordinal);
-        for (var index = 0; index < RoleCache.Roles.Count; index++)
+        var roleById = new Dictionary<string, RoleDto>(StringComparer.Ordinal);
+        foreach (var role in RoleCache.Roles)
         {
-            var role = RoleCache.Roles[index];
-            if (string.IsNullOrEmpty(role.Id) || roleGroups.ContainsKey(role.Id))
-            {
-                if (!string.IsNullOrEmpty(role.Id) && !orderedRoleIndices.ContainsKey(role.Id))
-                {
-                    orderedRoleIndices[role.Id] = index;
-                }
+            if (string.IsNullOrEmpty(role.Id))
                 continue;
-            }
-
-            roleGroups[role.Id] = new RoleGroup(role.Id, role.Name);
-            orderedRoleIds.Add(role.Id);
-            orderedRoleIndices[role.Id] = index;
+            roleById[role.Id] = role;
         }
 
-        foreach (var presence in presences)
+        var hoistedOrder = RoleCache.Roles
+            .Where(r => !string.IsNullOrEmpty(r.Id) && IsHoistedRole(r))
+            .OrderByDescending(r => r.Position)
+            .Select(r => r.Id)
+            .ToList();
+
+        var roleGroups = new Dictionary<string, RoleGroup>(StringComparer.Ordinal);
+        foreach (var roleId in hoistedOrder)
         {
-            foreach (var detail in presence.RoleDetails)
-            {
-                if (string.IsNullOrEmpty(detail.Id))
-                    continue;
-                if (!roleGroups.TryGetValue(detail.Id, out var group))
-                {
-                    group = new RoleGroup(detail.Id, detail.Name);
-                    roleGroups[detail.Id] = group;
-                }
-                else if (string.IsNullOrEmpty(group.Name) && !string.IsNullOrEmpty(detail.Name))
-                {
-                    group.Name = detail.Name;
-                }
-            }
+            if (!roleById.TryGetValue(roleId, out var role))
+                continue;
+
+            var label = string.IsNullOrEmpty(role.Name) ? roleId : role.Name;
+            roleGroups[roleId] = new RoleGroup(roleId, label);
         }
 
-        var noRole = new List<PresenceDto>();
+        var ungroupedOnline = new List<PresenceDto>();
         foreach (var presence in online)
         {
-            var primaryRoleId = GetPrimaryRoleId(presence, roleGroups, orderedRoleIndices);
+            var primaryRoleId = GetHighestHoistedRoleId(presence, roleById);
             if (!string.IsNullOrEmpty(primaryRoleId) && roleGroups.TryGetValue(primaryRoleId, out var group))
             {
                 group.Members.Add(presence);
             }
             else
             {
-                noRole.Add(presence);
+                ungroupedOnline.Add(presence);
             }
         }
 
         var anyOnline = false;
-        var orderedSet = new HashSet<string>(orderedRoleIds, StringComparer.Ordinal);
-        foreach (var roleId in orderedRoleIds)
+        foreach (var roleId in hoistedOrder)
         {
             if (!roleGroups.TryGetValue(roleId, out var group) || group.Members.Count == 0)
                 continue;
+
             anyOnline = true;
             DrawRoleGroup(group);
         }
 
-        var extraGroups = roleGroups.Values
-            .Where(g => !orderedSet.Contains(g.Id) && g.Members.Count > 0)
-            .OrderBy(g => g.Name, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        foreach (var group in extraGroups)
+        if (ungroupedOnline.Count > 0)
         {
             anyOnline = true;
-            DrawRoleGroup(group);
-        }
-
-        if (noRole.Count > 0)
-        {
-            anyOnline = true;
-            ImGui.TextUnformatted($"No Role - {noRole.Count}");
-            foreach (var presence in noRole.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase))
+            ungroupedOnline.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparer.OrdinalIgnoreCase));
+            ImGui.TextUnformatted($"ONLINE — {ungroupedOnline.Count}");
+            foreach (var presence in ungroupedOnline)
             {
                 DrawPresence(presence);
             }
+            ImGui.Spacing();
+        }
+
+        if (!anyOnline)
+        {
+            ImGui.TextUnformatted("No one is online.");
             ImGui.Spacing();
         }
 
@@ -152,7 +141,7 @@ public class PresenceSidebar : IDisposable
             {
                 ImGui.Spacing();
             }
-            ImGui.TextUnformatted($"Offline - {offline.Count}");
+            ImGui.TextUnformatted($"OFFLINE — {offline.Count}");
             foreach (var presence in offline)
             {
                 DrawPresence(presence);
@@ -216,112 +205,74 @@ public class PresenceSidebar : IDisposable
         // No resources to dispose; the underlying service is disposed separately.
     }
 
-    private static string? GetPrimaryRoleId(
+    private static bool IsOffline(string? status)
+    {
+        if (string.IsNullOrEmpty(status))
+        {
+            return true;
+        }
+
+        return OfflineStatuses.Contains(status);
+    }
+
+    private static string? GetHighestHoistedRoleId(
         PresenceDto presence,
-        Dictionary<string, RoleGroup> roleGroups,
-        Dictionary<string, int> orderedRoleIndices)
+        IReadOnlyDictionary<string, RoleDto> roleById)
     {
         string? bestRoleId = null;
-        var bestOrderIndex = int.MaxValue;
-        var bestName = string.Empty;
-        var bestPresenceIndex = int.MaxValue;
+        RoleDto? bestRole = null;
 
-        for (var i = 0; i < presence.Roles.Count; i++)
+        foreach (var roleId in presence.Roles)
         {
-            var roleId = presence.Roles[i];
-            if (string.IsNullOrEmpty(roleId))
+            if (string.IsNullOrEmpty(roleId) || !roleById.TryGetValue(roleId, out var role))
             {
                 continue;
             }
 
-            if (!roleGroups.TryGetValue(roleId, out var group))
-            {
-                var display = presence.RoleDetails
-                    .FirstOrDefault(r => string.Equals(r.Id, roleId, StringComparison.Ordinal))?.Name
-                    ?? roleId;
-                group = new RoleGroup(roleId, display);
-                roleGroups[roleId] = group;
-            }
-            else if (string.IsNullOrEmpty(group.Name))
-            {
-                var detailName = presence.RoleDetails
-                    .FirstOrDefault(r => string.Equals(r.Id, roleId, StringComparison.Ordinal))?.Name;
-                if (!string.IsNullOrEmpty(detailName))
-                {
-                    group.Name = detailName;
-                }
-            }
-
-            if (ShouldSkipRoleForPrimary(roleId, group, orderedRoleIndices))
+            if (!IsHoistedRole(role))
             {
                 continue;
             }
 
-            var orderIndex = orderedRoleIndices.TryGetValue(roleId, out var index) ? index : int.MaxValue;
-            var groupName = group.Name;
-
-            var isBetter = false;
-            if (bestRoleId == null)
+            if (bestRole == null || role.Position > bestRole.Position ||
+                (role.Position == bestRole.Position && string.Compare(role.Name, bestRole.Name, StringComparison.OrdinalIgnoreCase) < 0))
             {
-                isBetter = true;
+                bestRoleId = roleId;
+                bestRole = role;
             }
-            else if (orderIndex < bestOrderIndex)
-            {
-                isBetter = true;
-            }
-            else if (orderIndex == bestOrderIndex)
-            {
-                if (orderIndex != int.MaxValue)
-                {
-                    isBetter = string.Compare(groupName, bestName, StringComparison.OrdinalIgnoreCase) < 0;
-                }
-                else if (i < bestPresenceIndex)
-                {
-                    isBetter = true;
-                }
-                else if (i == bestPresenceIndex)
-                {
-                    isBetter = string.Compare(groupName, bestName, StringComparison.OrdinalIgnoreCase) < 0;
-                }
-            }
-
-            if (!isBetter)
-            {
-                continue;
-            }
-
-            bestRoleId = roleId;
-            bestOrderIndex = orderIndex;
-            bestName = groupName;
-            bestPresenceIndex = i;
         }
 
         return bestRoleId;
     }
 
-    private static bool ShouldSkipRoleForPrimary(
-        string roleId,
-        RoleGroup group,
-        Dictionary<string, int> orderedRoleIndices)
-    {
-        if (orderedRoleIndices.ContainsKey(roleId))
-        {
-            return false;
-        }
+    private static bool IsHoistedRole(RoleDto role)
+        => role.Hoist || IsBoosterRole(role);
 
-        if (SyntheticRoleIds.Contains(roleId))
+    private static bool IsBoosterRole(RoleDto role)
+    {
+        if (role.IsPremiumSubscriber)
         {
             return true;
         }
 
-        return SyntheticRoleNames.Contains(group.Name);
+        if (role.Tags?.PremiumSubscriber == true)
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(role.Id) && SyntheticRoleIds.Contains(role.Id))
+        {
+            return true;
+        }
+
+        return SyntheticRoleNames.Contains(role.Name);
     }
 
     private void DrawRoleGroup(RoleGroup group)
     {
         group.Members.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
         var label = string.IsNullOrEmpty(group.Name) ? group.Id : group.Name;
-        ImGui.TextUnformatted($"{label} - {group.Members.Count}");
+        ImGui.TextUnformatted($"{label} — {group.Members.Count}");
         foreach (var member in group.Members)
         {
             DrawPresence(member);

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -21,6 +21,15 @@ public class PresenceSidebar : IDisposable
     private static readonly Vector4 OfflineColor = new(0.5f, 0.5f, 0.5f, 1f);
     private static readonly Vector4 StatusTextColor = new(0.75f, 0.75f, 0.75f, 1f);
     private static readonly ImGuiMouseCursor ResizeEwCursor = ResolveResizeEwCursor();
+    private static readonly HashSet<string> SyntheticRoleIds = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "premium_subscriber"
+    };
+
+    private static readonly HashSet<string> SyntheticRoleNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Server Booster"
+    };
 
     public Action<string?, Action<ISharedImmediateTexture?>>? TextureLoader { get; set; }
 
@@ -56,13 +65,22 @@ public class PresenceSidebar : IDisposable
 
         var roleGroups = new Dictionary<string, RoleGroup>(StringComparer.Ordinal);
         var orderedRoleIds = new List<string>();
-        foreach (var role in RoleCache.Roles)
+        var orderedRoleIndices = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var index = 0; index < RoleCache.Roles.Count; index++)
         {
-            if (!roleGroups.ContainsKey(role.Id))
+            var role = RoleCache.Roles[index];
+            if (string.IsNullOrEmpty(role.Id) || roleGroups.ContainsKey(role.Id))
             {
-                roleGroups[role.Id] = new RoleGroup(role.Id, role.Name);
-                orderedRoleIds.Add(role.Id);
+                if (!string.IsNullOrEmpty(role.Id) && !orderedRoleIndices.ContainsKey(role.Id))
+                {
+                    orderedRoleIndices[role.Id] = index;
+                }
+                continue;
             }
+
+            roleGroups[role.Id] = new RoleGroup(role.Id, role.Name);
+            orderedRoleIds.Add(role.Id);
+            orderedRoleIndices[role.Id] = index;
         }
 
         foreach (var presence in presences)
@@ -86,23 +104,12 @@ public class PresenceSidebar : IDisposable
         var noRole = new List<PresenceDto>();
         foreach (var presence in online)
         {
-            var mapped = false;
-            foreach (var roleId in presence.Roles)
+            var primaryRoleId = GetPrimaryRoleId(presence, roleGroups, orderedRoleIndices);
+            if (!string.IsNullOrEmpty(primaryRoleId) && roleGroups.TryGetValue(primaryRoleId, out var group))
             {
-                if (string.IsNullOrEmpty(roleId))
-                    continue;
-                if (!roleGroups.TryGetValue(roleId, out var group))
-                {
-                    var display = presence.RoleDetails
-                        .FirstOrDefault(r => string.Equals(r.Id, roleId, StringComparison.Ordinal))?.Name
-                        ?? roleId;
-                    group = new RoleGroup(roleId, display);
-                    roleGroups[roleId] = group;
-                }
                 group.Members.Add(presence);
-                mapped = true;
             }
-            if (!mapped)
+            else
             {
                 noRole.Add(presence);
             }
@@ -207,6 +214,107 @@ public class PresenceSidebar : IDisposable
     public void Dispose()
     {
         // No resources to dispose; the underlying service is disposed separately.
+    }
+
+    private static string? GetPrimaryRoleId(
+        PresenceDto presence,
+        Dictionary<string, RoleGroup> roleGroups,
+        Dictionary<string, int> orderedRoleIndices)
+    {
+        string? bestRoleId = null;
+        var bestOrderIndex = int.MaxValue;
+        var bestName = string.Empty;
+        var bestPresenceIndex = int.MaxValue;
+
+        for (var i = 0; i < presence.Roles.Count; i++)
+        {
+            var roleId = presence.Roles[i];
+            if (string.IsNullOrEmpty(roleId))
+            {
+                continue;
+            }
+
+            if (!roleGroups.TryGetValue(roleId, out var group))
+            {
+                var display = presence.RoleDetails
+                    .FirstOrDefault(r => string.Equals(r.Id, roleId, StringComparison.Ordinal))?.Name
+                    ?? roleId;
+                group = new RoleGroup(roleId, display);
+                roleGroups[roleId] = group;
+            }
+            else if (string.IsNullOrEmpty(group.Name))
+            {
+                var detailName = presence.RoleDetails
+                    .FirstOrDefault(r => string.Equals(r.Id, roleId, StringComparison.Ordinal))?.Name;
+                if (!string.IsNullOrEmpty(detailName))
+                {
+                    group.Name = detailName;
+                }
+            }
+
+            if (ShouldSkipRoleForPrimary(roleId, group, orderedRoleIndices))
+            {
+                continue;
+            }
+
+            var orderIndex = orderedRoleIndices.TryGetValue(roleId, out var index) ? index : int.MaxValue;
+            var groupName = group.Name;
+
+            var isBetter = false;
+            if (bestRoleId == null)
+            {
+                isBetter = true;
+            }
+            else if (orderIndex < bestOrderIndex)
+            {
+                isBetter = true;
+            }
+            else if (orderIndex == bestOrderIndex)
+            {
+                if (orderIndex != int.MaxValue)
+                {
+                    isBetter = string.Compare(groupName, bestName, StringComparison.OrdinalIgnoreCase) < 0;
+                }
+                else if (i < bestPresenceIndex)
+                {
+                    isBetter = true;
+                }
+                else if (i == bestPresenceIndex)
+                {
+                    isBetter = string.Compare(groupName, bestName, StringComparison.OrdinalIgnoreCase) < 0;
+                }
+            }
+
+            if (!isBetter)
+            {
+                continue;
+            }
+
+            bestRoleId = roleId;
+            bestOrderIndex = orderIndex;
+            bestName = groupName;
+            bestPresenceIndex = i;
+        }
+
+        return bestRoleId;
+    }
+
+    private static bool ShouldSkipRoleForPrimary(
+        string roleId,
+        RoleGroup group,
+        Dictionary<string, int> orderedRoleIndices)
+    {
+        if (orderedRoleIndices.ContainsKey(roleId))
+        {
+            return false;
+        }
+
+        if (SyntheticRoleIds.Contains(roleId))
+        {
+            return true;
+        }
+
+        return SyntheticRoleNames.Contains(group.Name);
     }
 
     private void DrawRoleGroup(RoleGroup group)

--- a/DemiCatPlugin/RoleDto.cs
+++ b/DemiCatPlugin/RoleDto.cs
@@ -6,5 +6,17 @@ public class RoleDto
 {
     [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("position")] public int Position { get; set; }
+    [JsonPropertyName("hoist")] public bool Hoist { get; set; }
+    [JsonPropertyName("tags")] public RoleTagsDto? Tags { get; set; }
+
+    [JsonIgnore]
+    public bool IsPremiumSubscriber => Tags?.PremiumSubscriber == true;
+}
+
+public class RoleTagsDto
+{
+    [JsonPropertyName("premium_subscriber")]
+    public bool PremiumSubscriber { get; set; }
 }
 


### PR DESCRIPTION
## Summary
- determine each presence's primary role using the cached guild ordering
- avoid treating synthetic roles such as Server Booster as primary unless ordered by the guild
- keep no-role and offline sections intact while only assigning users to a single role group

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3e912ac88328b9124074b32f88f7