### PR TITLE
Adjust event preview layout to use resizable child areas

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -409,8 +409,13 @@ public class EventCreateWindow
             _previewView.Update(previewResult.Embed, previewResult.Content, previewResult.Warnings);
         }
 
-        ImGui.Separator();
-        _previewView!.Draw();
+        if (_previewView != null)
+        {
+            ImGui.Separator();
+            var previewHeight = EventViewImGuiHelpers.BeginPreviewChild("eventCreatePreview");
+            _previewView.Draw(previewHeight);
+            ImGui.EndChild();
+        }
 
         if (!_schedulesLoaded)
         {

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -128,8 +128,12 @@ public class EventView : IDisposable
     public IReadOnlyList<EmbedButtonDto>? Buttons => _dto.Buttons;
 
     public void Draw()
+        => Draw(null);
+
+    public void Draw(float? availableHeight)
     {
         var dto = _dto;
+        var cursorStart = ImGui.GetCursorPosY();
 
         if (_warnings.Count > 0)
         {
@@ -148,14 +152,57 @@ public class EventView : IDisposable
             ImGui.Spacing();
         }
 
-        DrawEmbed(dto);
+        float? embedHeight = null;
+        if (availableHeight.HasValue)
+        {
+            var usedHeight = ImGui.GetCursorPosY() - cursorStart;
+            var footerReserve = EstimateFooterHeight();
+            var remaining = availableHeight.Value - usedHeight - footerReserve;
+            if (remaining > 0f)
+            {
+                embedHeight = remaining;
+            }
+        }
+
+        DrawEmbed(dto, embedHeight);
 
         DrawButtons();
 
         ImGui.Separator();
     }
 
-    private void DrawEmbed(EmbedDto dto)
+    private float EstimateFooterHeight()
+    {
+        var style = ImGui.GetStyle();
+        var reserve = style.ItemSpacing.Y;
+
+        if (Buttons != null && Buttons.Count > 0)
+        {
+            var rowCount = Buttons
+                .Where(b => b != null)
+                .Select(b => b!.RowIndex ?? 0)
+                .Distinct()
+                .Count();
+
+            if (rowCount > 0)
+            {
+                reserve += rowCount * ImGui.GetFrameHeightWithSpacing();
+            }
+        }
+        else if (IsApolloEvent(_dto))
+        {
+            reserve += 3 * ImGui.GetFrameHeightWithSpacing();
+        }
+
+        if (!string.IsNullOrEmpty(_lastResult))
+        {
+            reserve += ImGui.GetTextLineHeightWithSpacing();
+        }
+
+        return reserve;
+    }
+
+    private void DrawEmbed(EmbedDto dto, float? availableHeight)
     {
         const float stripeWidth = 4f;
         const float contentPadding = 8f;
@@ -168,7 +215,21 @@ public class EventView : IDisposable
             availWidth = 400f;
         }
 
-        ImGui.BeginChild($"eventEmbed{dto.Id}", new Vector2(availWidth, 0), false);
+        float childHeight;
+        if (availableHeight.HasValue)
+        {
+            childHeight = Math.Max(availableHeight.Value, 0f);
+            if (!float.IsFinite(childHeight))
+            {
+                childHeight = 0f;
+            }
+        }
+        else
+        {
+            childHeight = 0f;
+        }
+
+        ImGui.BeginChild($"eventEmbed{dto.Id}", new Vector2(availWidth, childHeight), false);
 
         ImGui.Indent(indent);
         ImGui.Dummy(new Vector2(0f, verticalPadding));
@@ -581,5 +642,24 @@ public class EventView : IDisposable
 
         (_footerIcon as IDisposable)?.Dispose();
         _footerIcon = null;
+    }
+}
+
+internal static class EventViewImGuiHelpers
+{
+    public static float BeginPreviewChild(string childId, bool border = false, float minHeight = 0f, ImGuiWindowFlags flags = ImGuiWindowFlags.None)
+    {
+        var avail = ImGui.GetContentRegionAvail();
+        var width = float.IsFinite(avail.X) ? Math.Max(avail.X, 0f) : 0f;
+        var height = float.IsFinite(avail.Y) ? Math.Max(avail.Y, 0f) : 0f;
+
+        if (minHeight > 0f)
+        {
+            height = Math.Max(height, minHeight);
+        }
+
+        var size = new Vector2(width, height);
+        ImGui.BeginChild(childId, size, border, flags);
+        return size.Y;
     }
 }

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -278,7 +278,9 @@ public class TemplatesWindow
             }
             if (ImGui.Begin("Template Preview", ref _showPreview))
             {
-                _previewEvent.Draw();
+                var previewHeight = EventViewImGuiHelpers.BeginPreviewChild("templatePreviewContent");
+                _previewEvent.Draw(previewHeight);
+                ImGui.EndChild();
             }
             ImGui.End();
         }


### PR DESCRIPTION
## Summary
- wrap event creation previews in a dedicated child region sized from the remaining content area so resizing grows the preview instead of the form
- allow EventView to accept an available height, reserving footer space before sizing the embed child so scrollbars appear when needed
- share a helper for beginning preview children so template previews inherit the improved layout

## Testing
- dotnet test *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4f7608608328bd9895575520c76d