### PR TITLE
Add event creator footers for previews and events

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -95,6 +95,7 @@ public class EventCreateWindow
             return;
         }
 
+        _ = MembershipCache.EnsureLoaded(_httpClient, _config);
         _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
         _ = RefreshChannels();
     }
@@ -812,6 +813,8 @@ public class EventCreateWindow
             timestamp = parsedTs;
         }
 
+        var creatorLabel = MembershipCache.GetCreatorLabel();
+
         return EventPreviewFormatter.Build(
             _title,
             _description,
@@ -823,6 +826,7 @@ public class EventCreateWindow
             fields,
             buttons,
             mentionIds,
+            creatorLabel: creatorLabel,
             embedId: "event-create-preview");
     }
 

--- a/DemiCatPlugin/EventPreviewFormatter.cs
+++ b/DemiCatPlugin/EventPreviewFormatter.cs
@@ -16,6 +16,8 @@ public static class EventPreviewFormatter
 
     private static readonly IReadOnlyList<string> DefaultAttendance = new[] { "yes", "maybe", "no" };
 
+    private const int FooterTextLimit = 2048;
+
     public static Result Build(
         string? title,
         string? description,
@@ -28,6 +30,7 @@ public static class EventPreviewFormatter
         IEnumerable<EmbedButtonDto>? buttons,
         IEnumerable<ulong>? mentions,
         IEnumerable<string>? attendance = null,
+        string? creatorLabel = null,
         string? embedId = null)
     {
         var fieldList = fields?
@@ -69,6 +72,8 @@ public static class EventPreviewFormatter
             ? string.Join(" ", mentionList.Select(id => $"<@&{id}>"))
             : null;
 
+        var footer = NormalizeFooter(creatorLabel);
+
         var embed = new EmbedDto
         {
             Id = string.IsNullOrWhiteSpace(embedId) ? "preview" : embedId!,
@@ -81,7 +86,8 @@ public static class EventPreviewFormatter
             Timestamp = timestamp,
             Fields = fieldList.Count > 0 ? fieldList : null,
             Buttons = buttonList.Count > 0 ? buttonList : null,
-            Mentions = mentionList.Count > 0 ? mentionList : null
+            Mentions = mentionList.Count > 0 ? mentionList : null,
+            FooterText = footer
         };
 
         var warnings = new List<string>();
@@ -89,6 +95,22 @@ public static class EventPreviewFormatter
         warnings.AddRange(ValidateButtonLayout(buttonList));
 
         return new Result(embed, content, buttonList, warnings);
+    }
+
+    private static string? NormalizeFooter(string? creatorLabel)
+    {
+        if (string.IsNullOrWhiteSpace(creatorLabel))
+        {
+            return null;
+        }
+
+        var trimmed = creatorLabel.Trim();
+        if (trimmed.Length <= FooterTextLimit)
+        {
+            return trimmed;
+        }
+
+        return trimmed.Substring(0, FooterTextLimit);
     }
 
     private static EmbedButtonDto CopyButton(EmbedButtonDto button)

--- a/DemiCatPlugin/MembershipCache.cs
+++ b/DemiCatPlugin/MembershipCache.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace DemiCatPlugin;
+
+internal static class MembershipCache
+{
+    private static readonly object SyncRoot = new();
+    private static string? _displayName;
+    private static bool _loading;
+
+    internal static string? DisplayName
+    {
+        get
+        {
+            lock (SyncRoot)
+            {
+                return _displayName;
+            }
+        }
+    }
+
+    internal static void Reset()
+    {
+        lock (SyncRoot)
+        {
+            _displayName = null;
+            _loading = false;
+        }
+    }
+
+    internal static async Task EnsureLoaded(HttpClient httpClient, Config config)
+    {
+        if (TokenManager.Instance?.IsReady() != true)
+        {
+            return;
+        }
+
+        if (!ApiHelpers.ValidateApiBaseUrl(config))
+        {
+            return;
+        }
+
+        lock (SyncRoot)
+        {
+            if (_displayName != null || _loading)
+            {
+                return;
+            }
+
+            _loading = true;
+        }
+
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/users/me/profile");
+            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            var response = await httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                return;
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync();
+            using var doc = await JsonDocument.ParseAsync(stream);
+            if (doc.RootElement.TryGetProperty("displayName", out var displayNameElement))
+            {
+                var value = displayNameElement.GetString();
+                lock (SyncRoot)
+                {
+                    _displayName = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+                }
+            }
+        }
+        catch
+        {
+            // ignore failures; a placeholder will be used instead
+        }
+        finally
+        {
+            lock (SyncRoot)
+            {
+                _loading = false;
+            }
+        }
+    }
+
+    internal static string GetCreatorLabel()
+    {
+        string? name;
+        lock (SyncRoot)
+        {
+            name = _displayName;
+        }
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            var player = PluginServices.Instance?.ClientState?.LocalPlayer;
+            var characterName = player?.Name.TextValue ?? player?.Name.ToString();
+            if (!string.IsNullOrWhiteSpace(characterName))
+            {
+                name = characterName;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            name = "You";
+        }
+
+        return $"Event created by {name}";
+    }
+}

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -464,6 +464,7 @@ public class Plugin : IDalamudPlugin
         _officerWatcherRunning = false;
         _ui.StopNetworking();
         _mainWindow.TemplatesWindow.StopNetworking();
+        MembershipCache.Reset();
         _services.Log.Info("Watchers stopped");
     }
 

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -99,6 +99,7 @@ public class TemplatesWindow
 
     public void StartNetworking()
     {
+        _ = MembershipCache.EnsureLoaded(_httpClient, _config);
         _bridge?.Start();
         _templatesLoaded = false;
     }
@@ -569,6 +570,8 @@ public class TemplatesWindow
             mentionIds.AddRange(tmpl.Mentions);
         }
 
+        var creatorLabel = MembershipCache.GetCreatorLabel();
+
         return EventPreviewFormatter.Build(
             tmpl.Title,
             tmpl.Description,
@@ -581,7 +584,8 @@ public class TemplatesWindow
             buttons,
             mentionIds,
             null,
-            embedId ?? "template-preview");
+            creatorLabel: creatorLabel,
+            embedId: embedId ?? "template-preview");
     }
 
     internal EmbedDto ToEmbedDto(Template tmpl) => BuildPreview(tmpl).Embed;

--- a/demibot/demibot/http/routes/_user_display.py
+++ b/demibot/demibot/http/routes/_user_display.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from ..deps import RequestContext
+
+FOOTER_TEXT_LIMIT = 2048
+
+
+def compute_creator_base_name(ctx: RequestContext, nickname: str | None) -> str:
+    user = getattr(ctx, "user", None)
+    global_name = getattr(user, "global_name", None)
+    roles = getattr(ctx, "roles", None) or []
+    is_officer = False
+    try:
+        is_officer = "officer" in roles
+    except TypeError:
+        is_officer = False
+
+    name = nickname or global_name or ("Officer" if is_officer else "Player")
+    if name:
+        name = name.strip()
+    if not name:
+        name = "Player"
+    return name
+
+
+def build_creator_label(base_name: str) -> str:
+    label = f"Event created by {base_name}"
+    if len(label) > FOOTER_TEXT_LIMIT:
+        label = label[:FOOTER_TEXT_LIMIT]
+    return label

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, NamedTuple
 
+import copy
 import re
 import discord
 from fastapi import APIRouter, Depends, HTTPException
@@ -29,7 +30,9 @@ from ...db.models import (
     EventSignup,
     User,
     GuildConfig,
+    Membership,
 )
+from ._user_display import compute_creator_base_name, build_creator_label
 from ._messages_common import _send_via_webhook, ALLOWED_MENTIONS
 from models.event import Event
 
@@ -50,6 +53,36 @@ class FieldBody(BaseModel):
     name: str
     value: str
     inline: bool | None = None
+
+async def _resolve_creator_label(ctx: RequestContext, db: AsyncSession) -> str:
+    guild_id = getattr(getattr(ctx, "guild", None), "id", None)
+    user_id = getattr(getattr(ctx, "user", None), "id", None)
+    nickname = None
+    if guild_id is not None and user_id is not None:
+        nickname = await db.scalar(
+            select(Membership.nickname).where(
+                Membership.guild_id == guild_id,
+                Membership.user_id == user_id,
+            )
+        )
+    base_name = compute_creator_base_name(ctx, nickname)
+    return build_creator_label(base_name)
+
+
+def _apply_footer_to_embeds(embeds: List[dict[str, Any]], footer: str) -> List[dict[str, Any]]:
+    updated: List[dict[str, Any]] = []
+    for embed in embeds:
+        if not isinstance(embed, dict):
+            updated.append(embed)
+            continue
+        embed_copy = copy.deepcopy(embed)
+        footer_dict = embed_copy.get("footer")
+        if not isinstance(footer_dict, dict):
+            footer_dict = {}
+        footer_dict["text"] = footer
+        embed_copy["footer"] = footer_dict
+        updated.append(embed_copy)
+    return updated
 
 
 class CreateEventBody(BaseModel):
@@ -167,8 +200,12 @@ async def create_event(
         } if cfg else set()
         mention_ids = [m for m in mention_ids if m in allowed]
 
+    creator_label = await _resolve_creator_label(ctx, db)
     formatted = format_event_embed(body, timestamp=ts, mention_ids=mention_ids)
     buttons = formatted.buttons
+
+    if creator_label:
+        formatted.embed.set_footer(text=creator_label)
 
     dto = EmbedDto(
         id=eid,
@@ -188,6 +225,7 @@ async def create_event(
         buttons=buttons,
         channel_id=channel_id,
         mentions=mention_ids or None,
+        footer_text=creator_label,
     )
     validate_embed_payload(dto, buttons)
     logger.debug(
@@ -389,6 +427,9 @@ async def create_event(
                     }
                     for a in sent.attachments
                 ]
+
+    if stored_embeds:
+        stored_embeds = _apply_footer_to_embeds(stored_embeds, creator_label)
 
     if discord_msg_id is not None:
         eid = str(discord_msg_id)

--- a/demibot/demibot/http/routes/users.py
+++ b/demibot/demibot/http/routes/users.py
@@ -7,6 +7,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
+from ._user_display import compute_creator_base_name, build_creator_label
 from ...db.models import (
     Membership,
     MembershipRole,
@@ -198,3 +199,28 @@ async def get_users(
             }
         )
     return users
+
+
+@router.get("/users/me/profile")
+async def get_my_profile(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, object | None]:
+    guild_id = getattr(getattr(ctx, "guild", None), "id", None)
+    user_id = getattr(getattr(ctx, "user", None), "id", None)
+    nickname = None
+    if guild_id is not None and user_id is not None:
+        nickname = await db.scalar(
+            select(Membership.nickname).where(
+                Membership.guild_id == guild_id,
+                Membership.user_id == user_id,
+            )
+        )
+    base_name = compute_creator_base_name(ctx, nickname)
+    creator_label = build_creator_label(base_name)
+    return {
+        "displayName": base_name,
+        "creatorLabel": creator_label,
+        "nickname": nickname,
+        "globalName": ctx.user.global_name,
+    }

--- a/tests/EventPreviewFormatterTests.cs
+++ b/tests/EventPreviewFormatterTests.cs
@@ -11,6 +11,8 @@ using Xunit;
 public class EventPreviewFormatterTests
 {
     private static readonly DateTimeOffset Timestamp = new(2024, 4, 1, 20, 0, 0, TimeSpan.Zero);
+    private const string FcCreatorLabel = "Event created by Example Member";
+    private const string OfficerCreatorLabel = "Event created by Officer Example";
 
     private static JsonElement GetExpected(string key)
     {
@@ -33,6 +35,7 @@ public class EventPreviewFormatterTests
             BuildEventFields(),
             BuildEventButtons(),
             new[] { 12345UL },
+            creatorLabel: FcCreatorLabel,
             embedId: "event-create-preview");
 
         AssertPreviewMatches(GetExpected("event_fc"), result);
@@ -52,6 +55,7 @@ public class EventPreviewFormatterTests
             BuildEventFields(),
             BuildEventButtons(),
             new[] { 12345UL, 67890UL },
+            creatorLabel: OfficerCreatorLabel,
             embedId: "event-create-preview");
 
         AssertPreviewMatches(GetExpected("event_officer"), result);
@@ -71,6 +75,7 @@ public class EventPreviewFormatterTests
             BuildTemplateFields(),
             BuildTemplateButtons(),
             new[] { 12345UL },
+            creatorLabel: FcCreatorLabel,
             embedId: "template-preview");
 
         AssertPreviewMatches(GetExpected("template_fc"), result);
@@ -90,6 +95,7 @@ public class EventPreviewFormatterTests
             BuildTemplateFields(),
             BuildTemplateButtons(),
             new[] { 12345UL, 67890UL },
+            creatorLabel: OfficerCreatorLabel,
             embedId: "template-preview");
 
         AssertPreviewMatches(GetExpected("template_officer"), result);
@@ -135,6 +141,7 @@ public class EventPreviewFormatterTests
             Enumerable.Empty<EmbedFieldDto>(),
             Enumerable.Empty<EmbedButtonDto>(),
             Enumerable.Empty<ulong>(),
+            creatorLabel: FcCreatorLabel,
             embedId: "no-buttons-preview");
 
         Assert.Collection(
@@ -198,6 +205,11 @@ public class EventPreviewFormatterTests
         if (!string.IsNullOrWhiteSpace(embed.ImageUrl))
         {
             obj["image"] = new Dictionary<string, object?> { ["url"] = embed.ImageUrl };
+        }
+
+        if (!string.IsNullOrWhiteSpace(embed.FooterText))
+        {
+            obj["footer"] = new Dictionary<string, object?> { ["text"] = embed.FooterText };
         }
 
         var json = JsonSerializer.Serialize(obj);

--- a/tests/data/event_preview_samples.json
+++ b/tests/data/event_preview_samples.json
@@ -26,7 +26,10 @@
       "type": "rich",
       "description": "Clear the raid together.",
       "url": "https://example.com/event",
-      "title": "Raid Night"
+      "title": "Raid Night",
+      "footer": {
+        "text": "Event created by Example Member"
+      }
     },
     "buttons": [
       {
@@ -72,7 +75,10 @@
       "type": "rich",
       "description": "Clear the raid together.",
       "url": "https://example.com/event",
-      "title": "Raid Night"
+      "title": "Raid Night",
+      "footer": {
+        "text": "Event created by Officer Example"
+      }
     },
     "buttons": [
       {
@@ -118,7 +124,10 @@
       "type": "rich",
       "description": "Discuss strategy.",
       "url": "https://example.com/template",
-      "title": "Static Meeting"
+      "title": "Static Meeting",
+      "footer": {
+        "text": "Event created by Example Member"
+      }
     },
     "buttons": [
       {
@@ -178,7 +187,10 @@
       "type": "rich",
       "description": "Discuss strategy.",
       "url": "https://example.com/template",
-      "title": "Static Meeting"
+      "title": "Static Meeting",
+      "footer": {
+        "text": "Event created by Officer Example"
+      }
     },
     "buttons": [
       {

--- a/tests/test_create_event_mentions.py
+++ b/tests/test_create_event_mentions.py
@@ -66,7 +66,7 @@ async def _run_test() -> None:
         description="desc",
         mentions=["1", "2"],
     )
-    ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
+    ctx = SimpleNamespace(guild=SimpleNamespace(id=1), user=SimpleNamespace(id=1, global_name="Tester"), roles=[])
     client = DummyClient()
     async with get_session() as db:
         original_dumps = json.dumps
@@ -80,6 +80,7 @@ async def _run_test() -> None:
         ).scalar_one()
         payload = json.loads(row.payload_json)
         assert payload["mentions"] == [1, 2]
+        assert payload["footerText"] == "Event created by Tester"
         assert client.channel.last_content == "<@&1> <@&2>"
 
 

--- a/tests/test_create_event_source.py
+++ b/tests/test_create_event_source.py
@@ -41,7 +41,7 @@ async def _run_test() -> None:
         time="2024-01-01T00:00:00Z",
         description="desc",
     )
-    ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
+    ctx = SimpleNamespace(guild=SimpleNamespace(id=1), user=SimpleNamespace(id=1, global_name="SourceTester"), roles=[])
     async with get_session() as db:
         original_dumps = json.dumps
         with patch(

--- a/tests/test_event_emit_event.py
+++ b/tests/test_event_emit_event.py
@@ -42,7 +42,7 @@ async def _run_test() -> None:
         db.add(User(id=9991, discord_user_id=9991))
         await db.commit()
 
-        ctx = SimpleNamespace(guild=SimpleNamespace(id=guild.id))
+        ctx = SimpleNamespace(guild=SimpleNamespace(id=guild.id), user=SimpleNamespace(id=9990, global_name=None), roles=[])
         body = CreateEventBody(
             channelId="9999",
             title="Title",
@@ -72,6 +72,7 @@ async def _run_test() -> None:
             dt.fromisoformat.side_effect = datetime.fromisoformat
             res = await create_event(body=body, ctx=ctx, db=db)
         assert events and events[0]["op"] == "ec" and events[0]["channel"] == 9999
+        assert events[0]["d"]["footerText"] == "Event created by Player"
         event_id = res["id"]
 
         ctx_user = SimpleNamespace(user=SimpleNamespace(id=9991), guild=SimpleNamespace(id=guild.id))

--- a/tests/test_event_preview_parity.py
+++ b/tests/test_event_preview_parity.py
@@ -34,11 +34,14 @@ async def _run_test() -> None:
 
     embed = {"title": "Sample", "description": "Desc"}
     body = CreateEventBody(channelId="123", title="Sample", description="Desc", embeds=[embed])
-    ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
+    ctx = SimpleNamespace(guild=SimpleNamespace(id=1), user=SimpleNamespace(id=1, global_name=None), roles=[])
     async with get_session() as db:
         await create_event(body=body, ctx=ctx, db=db)
         events = await list_events(ctx=ctx, db=db)
-        assert events[0]["embeds"][0] == embed
+        stored = events[0]["embeds"][0]
+        assert stored["title"] == embed["title"]
+        assert stored["description"] == embed["description"]
+        assert stored["footer"]["text"] == "Event created by Player"
 
 
 def test_preview_matches_server():

--- a/tests/test_event_update.py
+++ b/tests/test_event_update.py
@@ -40,7 +40,7 @@ async def _run_test() -> None:
         db.add(GuildChannel(guild_id=1, channel_id=123, kind=ChannelKind.EVENT))
         await db.commit()
 
-    ctx = SimpleNamespace(guild=SimpleNamespace(id=1))
+    ctx = SimpleNamespace(guild=SimpleNamespace(id=1), user=SimpleNamespace(id=1, global_name="Updater"), roles=[])
     body = CreateEventBody(
         channelId="123",
         title="First",
@@ -77,6 +77,7 @@ async def _run_test() -> None:
         row = await db.get(Embed, int(eid))
         payload = json.loads(row.payload_json)
         assert payload["title"] == "Second"
+        assert payload["footerText"] == "Event created by Updater"
         res = await db.execute(select(Embed))
         embeds = res.scalars().all()
         assert len(embeds) == 1

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -32,7 +32,7 @@ ext_pkg.commands = commands_pkg
 sys.modules.setdefault('discord.ext', ext_pkg)
 sys.modules.setdefault('discord.ext.commands', commands_pkg)
 
-from demibot.http.routes.users import get_users
+from demibot.http.routes.users import get_users, get_my_profile
 import demibot.http.routes.users as users_route
 from demibot.discordbot.presence_store import set_presence, Presence as StorePresence
 from demibot.db.models import (
@@ -50,7 +50,7 @@ class StubContext:
     def __init__(self, guild_id: int):
         self.guild = types.SimpleNamespace(id=guild_id, discord_guild_id=guild_id)
         self.roles = []
-
+        
 
 def test_get_users_includes_status_from_cache():
     async def _run():
@@ -210,5 +210,26 @@ def test_get_users_fetches_multiple_users_once():
             assert names['90'] == 'Name90'
             assert set(client.fetched) == {80, 90}
             users_route.discord_client = None
+
+    asyncio.run(_run())
+
+
+def test_get_my_profile_returns_creator_label():
+    async def _run():
+        await init_db('sqlite+aiosqlite://')
+        async with get_session() as db:
+            await db.execute(delete(MembershipRole))
+            await db.execute(delete(Role))
+            await db.execute(delete(Membership))
+            await db.execute(delete(User))
+            await db.commit()
+            db.add(User(id=10, discord_user_id=100, global_name='ProfileUser'))
+            db.add(Membership(id=10, guild_id=1, user_id=10, nickname='ProfileNick'))
+            await db.commit()
+            ctx = StubContext(1)
+            ctx.user = types.SimpleNamespace(id=10, global_name='ProfileUser')
+            res = await get_my_profile(ctx=ctx, db=db)
+            assert res['displayName'] == 'ProfileNick'
+            assert res['creatorLabel'] == 'Event created by ProfileNick'
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- allow the preview formatter to accept a creator label and populate the embed footer while truncating to Discord limits
- surface the local creator label in the UI via a cached profile lookup so event and template previews match Discord output
- set creator footers when creating events on the API, add a profile endpoint, and update the stored/broadcast embeds alongside new tests

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: dotnet not installed in container)*
- `pytest` *(fails during collection: missing python dependencies such as fastapi, sqlalchemy, discord)*

------
https://chatgpt.com/codex/tasks/task_e_68cf51a30da48328bfa0ad494f489977