### PR TITLE
Add role metadata caching for guild role API

### DIFF
--- a/demibot/demibot/db/migrations/versions/0047_add_role_metadata_fields.py
+++ b/demibot/demibot/db/migrations/versions/0047_add_role_metadata_fields.py
@@ -1,0 +1,48 @@
+"""add role metadata fields
+
+Revision ID: 0047_add_role_metadata_fields
+Revises: 0046_add_bridge_fields_to_posted_messages
+Create Date: 2025-03-15 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0047_add_role_metadata_fields"
+down_revision: str = "0046_add_bridge_fields_to_posted_messages"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "roles",
+        sa.Column("position", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "roles",
+        sa.Column(
+            "hoist",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "roles",
+        sa.Column(
+            "premium_subscriber",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("roles", "premium_subscriber")
+    op.drop_column("roles", "hoist")
+    op.drop_column("roles", "position")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -179,6 +179,9 @@ class Role(Base):
     guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
     discord_role_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), unique=True)
     name: Mapped[str] = mapped_column(String(255))
+    position: Mapped[int] = mapped_column(Integer, default=0)
+    hoist: Mapped[bool] = mapped_column(Boolean, default=False)
+    premium_subscriber: Mapped[bool] = mapped_column(Boolean, default=False)
     is_officer: Mapped[bool] = mapped_column(Boolean, default=False)
     is_chat: Mapped[bool] = mapped_column(Boolean, default=False)
 

--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -25,6 +25,7 @@ from ...db.models import (
     ChannelKind,
 )
 from ...db import session as db_session
+from ..utils import is_premium_subscriber_role
 
 
 logger = logging.getLogger(__name__)
@@ -306,11 +307,10 @@ async def resync_members(interaction: discord.Interaction) -> None:
             )
             return
         stored_role_res = await db.execute(
-            select(Role.id, Role.discord_role_id).where(Role.guild_id == guild.id)
+            select(Role).where(Role.guild_id == guild.id)
         )
         role_map = {
-            discord_role_id: role_id
-            for role_id, discord_role_id in stored_role_res.all()
+            role.discord_role_id: role for role in stored_role_res.scalars()
         }
         result = await db.execute(
             select(UserKey, User)
@@ -339,19 +339,32 @@ async def resync_members(interaction: discord.Interaction) -> None:
                     )
                 )
                 for role in member_roles:
-                    if role.id not in role_map:
-                        db_role = Role(
+                    mapped = role_map.get(role.id)
+                    premium_subscriber = is_premium_subscriber_role(role)
+                    if mapped is None:
+                        mapped = Role(
                             guild_id=guild.id,
                             discord_role_id=role.id,
                             name=role.name,
+                            position=role.position,
+                            hoist=role.hoist,
+                            premium_subscriber=premium_subscriber,
                         )
-                        db.add(db_role)
+                        db.add(mapped)
                         await db.flush()
-                        role_map[role.id] = db_role.id
+                        role_map[role.id] = mapped
+                    else:
+                        mapped.name = role.name
+                        mapped.position = role.position
+                        mapped.hoist = role.hoist
+                        mapped.premium_subscriber = premium_subscriber
                 for role_id in member_role_ids:
+                    mapped = role_map.get(role_id)
+                    if mapped is None:
+                        continue
                     db.add(
                         MembershipRole(
-                            membership_id=membership.id, role_id=role_map[role_id]
+                            membership_id=membership.id, role_id=mapped.id
                         )
                     )
                 key.roles_cached = ",".join(str(rid) for rid in member_role_ids)
@@ -622,11 +635,21 @@ class ConfigWizard(discord.ui.View):
                             guild_id=guild.id,
                             name=role_name,
                             discord_role_id=rid,
+                            position=d_role.position if d_role else 0,
+                            hoist=d_role.hoist if d_role else False,
+                            premium_subscriber=
+                                is_premium_subscriber_role(d_role)
+                                if d_role
+                                else False,
                         )
                         db.add(role)
                         role_map[rid] = role
                     else:
                         role.name = role_name
+                    if d_role:
+                        role.position = d_role.position
+                        role.hoist = d_role.hoist
+                        role.premium_subscriber = is_premium_subscriber_role(d_role)
                     role.is_officer = rid in self.officer_role_ids
                     role.is_chat = rid in self.mention_role_ids
 

--- a/demibot/demibot/discordbot/cogs/keygen.py
+++ b/demibot/demibot/discordbot/cogs/keygen.py
@@ -5,7 +5,7 @@ import secrets
 import discord
 from discord import app_commands
 from discord.ext import commands
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, select
 
 from ...db.models import (
     Guild,
@@ -17,6 +17,7 @@ from ...db.models import (
     UserKey,
 )
 from ...db.session import get_session
+from ..utils import is_premium_subscriber_role
 from .setup_wizard import demi
 
 
@@ -71,8 +72,8 @@ async def key_command(interaction: discord.Interaction) -> None:
 
             # map existing roles for the guild
             role_res = await db.execute(select(Role).where(Role.guild_id == guild.id))
-            role_map: dict[int, tuple[int, bool]] = {
-                r.discord_role_id: (r.id, r.is_officer) for r in role_res.scalars()
+            role_map: dict[int, Role] = {
+                r.discord_role_id: r for r in role_res.scalars()
             }
 
             cfg_res = await db.execute(
@@ -87,35 +88,27 @@ async def key_command(interaction: discord.Interaction) -> None:
 
             for r in member_roles:
                 mapped = role_map.get(r.id)
-                if not mapped:
-                    is_officer = r.id in officer_role_ids
-                    new_role = Role(
+                is_officer = r.id in officer_role_ids
+                premium_subscriber = is_premium_subscriber_role(r)
+                if mapped is None:
+                    mapped = Role(
                         guild_id=guild.id,
                         discord_role_id=r.id,
                         name=r.name,
+                        position=r.position,
+                        hoist=r.hoist,
+                        premium_subscriber=premium_subscriber,
                         is_officer=is_officer,
                     )
-                    db.add(new_role)
+                    db.add(mapped)
                     await db.flush()
-                    role_map[r.id] = (new_role.id, is_officer)
+                    role_map[r.id] = mapped
                 else:
-                    role_id, is_officer = mapped
-                    if r.id in officer_role_ids and not is_officer:
-                        await db.execute(
-                            update(Role)
-                                .where(Role.id == role_id)
-                                .values(is_officer=True)
-                        )
-                        await db.flush()
-                        role_map[r.id] = (role_id, True)
-                    elif r.id not in officer_role_ids and is_officer:
-                        await db.execute(
-                            update(Role)
-                                .where(Role.id == role_id)
-                                .values(is_officer=False)
-                        )
-                        await db.flush()
-                        role_map[r.id] = (role_id, False)
+                    mapped.name = r.name
+                    mapped.is_officer = is_officer
+                    mapped.position = r.position
+                    mapped.hoist = r.hoist
+                    mapped.premium_subscriber = premium_subscriber
 
             await db.execute(
                 delete(MembershipRole).where(
@@ -124,8 +117,12 @@ async def key_command(interaction: discord.Interaction) -> None:
             )
 
             for r in member_roles:
-                role_id, _ = role_map[r.id]
-                db.add(MembershipRole(membership_id=membership.id, role_id=role_id))
+                mapped = role_map.get(r.id)
+                if mapped is None:
+                    continue
+                db.add(
+                    MembershipRole(membership_id=membership.id, role_id=mapped.id)
+                )
             await db.execute(
                 delete(UserKey).where(
                     UserKey.user_id == user.id,

--- a/demibot/demibot/discordbot/cogs/presence.py
+++ b/demibot/demibot/discordbot/cogs/presence.py
@@ -20,6 +20,7 @@ from ...db.models import (
 from ...db.session import get_session
 from ...http.ws import manager
 from ..presence_store import Presence as StorePresence, set_presence
+from ..utils import is_premium_subscriber_role
 
 
 class PresenceTracker(commands.Cog):
@@ -152,11 +153,15 @@ class PresenceTracker(commands.Cog):
                 is_officer = role.id in officer_role_ids
                 is_chat = role.id in chat_role_ids
                 mapped = role_map.get(role.id)
+                premium_subscriber = is_premium_subscriber_role(role)
                 if mapped is None:
                     mapped = Role(
                         guild_id=guild_row.id,
                         discord_role_id=role.id,
                         name=role.name,
+                        position=role.position,
+                        hoist=role.hoist,
+                        premium_subscriber=premium_subscriber,
                         is_officer=is_officer,
                         is_chat=is_chat,
                     )
@@ -167,6 +172,9 @@ class PresenceTracker(commands.Cog):
                     mapped.name = role.name
                     mapped.is_officer = is_officer
                     mapped.is_chat = is_chat
+                    mapped.position = role.position
+                    mapped.hoist = role.hoist
+                    mapped.premium_subscriber = premium_subscriber
 
             await db.execute(
                 delete(MembershipRole).where(MembershipRole.membership_id == mem.id)

--- a/demibot/demibot/discordbot/utils.py
+++ b/demibot/demibot/discordbot/utils.py
@@ -24,6 +24,45 @@ _logger = logging.getLogger(__name__)
 _MISSING = object()
 
 
+def is_premium_subscriber_role(role: Any) -> bool:
+    """Return ``True`` when the provided role represents a boost role.
+
+    The helper defensively probes the :mod:`discord.py` role object for the
+    various attributes that different releases expose.  ``discord.Role``
+    exposes :meth:`is_premium_subscriber`, while older structures may only
+    expose a ``tags`` object with similar helpers.  Any unexpected errors are
+    treated as a negative result so callers can fail safely.
+    """
+
+    is_premium = getattr(role, "is_premium_subscriber", None)
+    if callable(is_premium):
+        try:
+            return bool(is_premium())
+        except Exception:
+            return False
+
+    tags = getattr(role, "tags", None)
+    if tags is not None:
+        tag_callable = getattr(tags, "is_premium_subscriber", None)
+        if callable(tag_callable):
+            try:
+                return bool(tag_callable())
+            except Exception:
+                return False
+        tag_value = getattr(tags, "premium_subscriber", None)
+        if tag_value is not None:
+            return bool(tag_value)
+        tag_value = getattr(tags, "_premium_subscriber", None)
+        if tag_value is not None:
+            return bool(tag_value)
+
+    fallback_value = getattr(role, "_premium_subscriber", None)
+    if fallback_value is not None:
+        return bool(fallback_value)
+
+    return False
+
+
 async def api_call_with_retries(
     func: Callable[..., Awaitable[T]],
     *args: Any,

--- a/demibot/demibot/http/routes/guild_roles.py
+++ b/demibot/demibot/http/routes/guild_roles.py
@@ -6,7 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
 from ..discord_client import discord_client
-from ...db.models import Role, GuildConfig
+from ...db.models import GuildConfig, Role
+from ...discordbot.utils import is_premium_subscriber_role
 
 router = APIRouter(prefix="/api")
 
@@ -28,33 +29,55 @@ async def get_guild_roles(
         else:
             return []
 
-    stmt = select(Role.discord_role_id, Role.name).where(
-        Role.guild_id == ctx.guild.id
-    )
+    stmt = select(Role).where(Role.guild_id == ctx.guild.id)
     if mention_ids is not None:
         stmt = stmt.where(Role.discord_role_id.in_(mention_ids))
     result = await db.execute(stmt)
-    rows = result.all()
+    rows = result.scalars().all()
     if rows:
-        return [{"id": str(rid), "name": name} for rid, name in rows]
+        return [
+            {
+                "id": str(role.discord_role_id),
+                "name": role.name,
+                "position": role.position,
+                "hoist": role.hoist,
+                "tags": {
+                    "premium_subscriber": bool(role.premium_subscriber),
+                },
+            }
+            for role in rows
+        ]
 
     if discord_client:
         guild = discord_client.get_guild(ctx.guild.discord_guild_id)
         if guild is not None:
-            roles_out: list[dict[str, str]] = []
+            roles_out: list[dict[str, object]] = []
             existing = set()
             for r in guild.roles:
                 if r.name == "@everyone":
                     continue
                 if mention_ids is not None and r.id not in mention_ids:
                     continue
-                roles_out.append({"id": str(r.id), "name": r.name})
+                is_premium_subscriber = is_premium_subscriber_role(r)
+                role_data = {
+                    "id": str(r.id),
+                    "name": r.name,
+                    "position": r.position,
+                    "hoist": r.hoist,
+                    "tags": {
+                        "premium_subscriber": is_premium_subscriber,
+                    },
+                }
+                roles_out.append(role_data)
                 existing.add(r.id)
                 await db.merge(
                     Role(
                         guild_id=ctx.guild.id,
                         discord_role_id=r.id,
                         name=r.name,
+                        position=r.position,
+                        hoist=r.hoist,
+                        premium_subscriber=is_premium_subscriber,
                     )
                 )
             await db.commit()


### PR DESCRIPTION
## Summary
- include role position, hoist, and premium subscriber tags in the guild roles API response and persistence layer
- store the new role metadata when syncing Discord roles across admin/keygen/presence flows
- add a migration to introduce the new role metadata columns

## Testing
- pytest *(fails: missing required dependencies such as fastapi and sqlalchemy in the runner)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5ac021c083288f80de10c47ec699