### PR TITLE
Add channel history endpoint with role gating

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -51,6 +51,44 @@ MAX_ATTACHMENTS = 10
 MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024  # 25MB
 
 
+CHANNEL_NOT_CONFIGURED_DETAIL = (
+    "channel not configured for this tab; re-run wizard or pick a configured channel"
+)
+
+
+async def require_guild_channel(
+    ctx: RequestContext,
+    db: AsyncSession,
+    *,
+    channel_kind: ChannelKind,
+    channel_id: int | None = None,
+) -> GuildChannel:
+    """Return the configured guild channel for the given kind.
+
+    This helper enforces the same validation as :func:`save_message`, ensuring the
+    requested channel is configured for the active guild and that officer-only
+    channels remain restricted to members with the ``officer`` role.  The
+    resolved :class:`GuildChannel` row is returned so callers can reuse the
+    persisted metadata without re-querying the database.
+    """
+
+    stmt = select(GuildChannel).where(
+        GuildChannel.guild_id == ctx.guild.id,
+        GuildChannel.kind == channel_kind,
+    )
+    if channel_id is not None:
+        stmt = stmt.where(GuildChannel.channel_id == channel_id)
+    stmt = stmt.limit(1)
+    result = await db.execute(stmt)
+    guild_channel = result.scalar_one_or_none()
+    if guild_channel is None:
+        raise HTTPException(status_code=400, detail=CHANNEL_NOT_CONFIGURED_DETAIL)
+    if guild_channel.kind in {ChannelKind.OFFICER_CHAT, ChannelKind.OFFICER_VISIBLE}:
+        if "officer" not in ctx.roles:
+            raise HTTPException(status_code=403)
+    return guild_channel
+
+
 def _make_discord_files(
     files: Sequence[discord.File | BridgeUpload] | None,
 ) -> list[discord.File] | None:
@@ -768,21 +806,11 @@ async def save_message(
         cid = int(body.channel_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="invalid channel id")
-    gc_kind = await db.scalar(
-        select(GuildChannel.kind).where(
-            GuildChannel.guild_id == ctx.guild.id,
-            GuildChannel.channel_id == cid,
-            GuildChannel.kind == channel_kind,
-        )
+    guild_channel = await require_guild_channel(
+        ctx, db, channel_kind=channel_kind, channel_id=cid
     )
-    if gc_kind is None:
-        raise HTTPException(
-            status_code=400,
-            detail="channel not configured for this tab; re-run wizard or pick a configured channel",
-        )
+    gc_kind = guild_channel.kind
     is_officer = gc_kind == ChannelKind.OFFICER_CHAT
-    if is_officer and "officer" not in ctx.roles:
-        raise HTTPException(status_code=403)
     discord_msg_id: int | None = None
     attachments: list[AttachmentDto] | None = None
     channel = None

--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse as FastAPIJSONResponse
 import json
 import logging
@@ -9,10 +9,16 @@ from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
+from ..schemas import ChatMessage
 from ...db.models import GuildChannel, ChannelKind
 from ...channel_names import ensure_channel_name
 from ..discord_client import discord_client
 from ..ws import manager
+from ._messages_common import (
+    CHANNEL_NOT_CONFIGURED_DETAIL,
+    fetch_messages,
+    require_guild_channel,
+)
 
 router = APIRouter(prefix="/api")
 
@@ -221,6 +227,65 @@ async def get_channels(
         await db.commit()
         await manager.broadcast_text("update", ctx.guild.id, path="/ws/channels")
     return JSONResponse(content=by_kind, ensure_ascii=False)
+
+
+@router.get("/channels/history", response_model=list[ChatMessage])
+async def get_channel_history(
+    kind: str,
+    limit: int | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    channel_kind = _parse_channel_kind(kind)
+    if channel_kind is None:
+        raise HTTPException(status_code=400, detail="invalid channel kind")
+
+    candidate_kinds: list[ChannelKind]
+    if channel_kind == ChannelKind.OFFICER_CHAT:
+        candidate_kinds = [ChannelKind.OFFICER_CHAT]
+    elif channel_kind == ChannelKind.FC_CHAT:
+        candidate_kinds = [ChannelKind.FC_CHAT]
+    elif channel_kind == ChannelKind.CHAT:
+        candidate_kinds = [ChannelKind.CHAT, ChannelKind.FC_CHAT]
+    else:
+        raise HTTPException(status_code=400, detail="unsupported channel kind")
+
+    guild_channel: GuildChannel | None = None
+    resolved_kind: ChannelKind | None = None
+    last_error: HTTPException | None = None
+
+    for candidate in candidate_kinds:
+        try:
+            guild_channel = await require_guild_channel(
+                ctx, db, channel_kind=candidate
+            )
+        except HTTPException as exc:
+            if exc.status_code != 400:
+                raise
+            last_error = exc
+        else:
+            resolved_kind = candidate
+            break
+
+    if guild_channel is None or resolved_kind is None:
+        if last_error is not None:
+            raise last_error
+        raise HTTPException(
+            status_code=400, detail=CHANNEL_NOT_CONFIGURED_DETAIL
+        )
+
+    is_officer = resolved_kind == ChannelKind.OFFICER_CHAT
+    return await fetch_messages(
+        str(guild_channel.channel_id),
+        ctx,
+        db,
+        is_officer=is_officer,
+        limit=limit,
+        before=before,
+        after=after,
+    )
 
 
 @router.get("/channels/{channel_id}/validate")

--- a/tests/test_messages_endpoint.py
+++ b/tests/test_messages_endpoint.py
@@ -16,6 +16,7 @@ from demibot.db.models import (
     Guild,
     Membership,
     GuildChannel,
+    Message,
     User,
 )
 from demibot.db.session import get_session, init_db
@@ -128,6 +129,241 @@ async def test_channel_messages_multipart_accepts_message_reference(monkeypatch)
     assert files is not None and len(files) == 1
     upload = files[0]
     assert getattr(upload, "filename", None) == "hi.txt"
+
+
+@pytest.mark.asyncio
+async def test_channel_history_returns_messages():
+    await init_db("sqlite+aiosqlite://")
+    async with get_session() as db:
+        await db.execute(text("DELETE FROM messages"))
+        await db.execute(text("DELETE FROM guild_channels"))
+        await db.execute(text("DELETE FROM users"))
+        await db.execute(text("DELETE FROM guilds"))
+
+        guild_id = 100
+        user_id = 200
+        channel_id = 300
+        message_id = 400
+
+        db.add(Guild(id=guild_id, discord_guild_id=999, name="Guild"))
+        db.add(User(id=user_id, discord_user_id=555, global_name="Tester"))
+        db.add(
+            GuildChannel(
+                guild_id=guild_id,
+                channel_id=channel_id,
+                kind=ChannelKind.FC_CHAT,
+                name="FC Chat",
+            )
+        )
+        db.add(
+            Message(
+                discord_message_id=message_id,
+                channel_id=channel_id,
+                guild_id=guild_id,
+                author_id=user_id,
+                author_name="Tester",
+                author_avatar_url=None,
+                content_raw="Hello history",
+                content_display="Hello history",
+                content="Hello history",
+                attachments_json=None,
+                author_json=None,
+                embeds_json=None,
+                mentions_json=None,
+                reference_json=None,
+                components_json=None,
+                reactions_json=None,
+                is_officer=False,
+            )
+        )
+        await db.commit()
+
+    app = create_app()
+
+    user_ctx = SimpleNamespace(id=user_id, global_name="Tester", character_name=None)
+    guild_ctx = SimpleNamespace(id=guild_id, discord_guild_id=999)
+
+    async def override_auth():
+        return RequestContext(user=user_ctx, guild=guild_ctx, key=None, roles=["chat"])
+
+    async def override_db():
+        async with get_session() as session:
+            yield session
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/channels/history",
+            params={"kind": "fc_chat"},
+        )
+
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert data
+    first = data[0]
+    assert first["id"] == str(message_id)
+    assert first["content"] == "Hello history"
+    assert first["channelId"] == str(channel_id)
+
+
+@pytest.mark.asyncio
+async def test_channel_history_officer_requires_role():
+    await init_db("sqlite+aiosqlite://")
+    async with get_session() as db:
+        await db.execute(text("DELETE FROM messages"))
+        await db.execute(text("DELETE FROM guild_channels"))
+        await db.execute(text("DELETE FROM users"))
+        await db.execute(text("DELETE FROM guilds"))
+
+        guild_id = 101
+        user_id = 201
+        channel_id = 301
+        message_id = 401
+
+        db.add(Guild(id=guild_id, discord_guild_id=1001, name="Guild"))
+        db.add(User(id=user_id, discord_user_id=556, global_name="Officer"))
+        db.add(
+            GuildChannel(
+                guild_id=guild_id,
+                channel_id=channel_id,
+                kind=ChannelKind.OFFICER_CHAT,
+                name="Officer Chat",
+            )
+        )
+        db.add(
+            Message(
+                discord_message_id=message_id,
+                channel_id=channel_id,
+                guild_id=guild_id,
+                author_id=user_id,
+                author_name="Officer",
+                author_avatar_url=None,
+                content_raw="Secret",
+                content_display="Secret",
+                content="Secret",
+                attachments_json=None,
+                author_json=None,
+                embeds_json=None,
+                mentions_json=None,
+                reference_json=None,
+                components_json=None,
+                reactions_json=None,
+                is_officer=True,
+            )
+        )
+        await db.commit()
+
+    app = create_app()
+
+    user_ctx = SimpleNamespace(id=user_id, global_name="Officer", character_name=None)
+    guild_ctx = SimpleNamespace(id=guild_id, discord_guild_id=1001)
+
+    async def override_auth():
+        return RequestContext(user=user_ctx, guild=guild_ctx, key=None, roles=["chat"])
+
+    async def override_db():
+        async with get_session() as session:
+            yield session
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/channels/history",
+            params={"kind": "officer_chat"},
+        )
+
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_channel_history_officer_allows_authorized_user():
+    await init_db("sqlite+aiosqlite://")
+    async with get_session() as db:
+        await db.execute(text("DELETE FROM messages"))
+        await db.execute(text("DELETE FROM guild_channels"))
+        await db.execute(text("DELETE FROM users"))
+        await db.execute(text("DELETE FROM guilds"))
+
+        guild_id = 102
+        user_id = 202
+        channel_id = 302
+        message_id = 402
+
+        db.add(Guild(id=guild_id, discord_guild_id=1002, name="Guild"))
+        db.add(User(id=user_id, discord_user_id=557, global_name="Officer"))
+        db.add(
+            GuildChannel(
+                guild_id=guild_id,
+                channel_id=channel_id,
+                kind=ChannelKind.OFFICER_CHAT,
+                name="Officer Chat",
+            )
+        )
+        db.add(
+            Message(
+                discord_message_id=message_id,
+                channel_id=channel_id,
+                guild_id=guild_id,
+                author_id=user_id,
+                author_name="Officer",
+                author_avatar_url=None,
+                content_raw="Secret",
+                content_display="Secret",
+                content="Secret",
+                attachments_json=None,
+                author_json=None,
+                embeds_json=None,
+                mentions_json=None,
+                reference_json=None,
+                components_json=None,
+                reactions_json=None,
+                is_officer=True,
+            )
+        )
+        await db.commit()
+
+    app = create_app()
+
+    user_ctx = SimpleNamespace(id=user_id, global_name="Officer", character_name=None)
+    guild_ctx = SimpleNamespace(id=guild_id, discord_guild_id=1002)
+
+    async def override_auth():
+        return RequestContext(user=user_ctx, guild=guild_ctx, key=None, roles=["officer"])
+
+    async def override_db():
+        async with get_session() as session:
+            yield session
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/channels/history",
+            params={"kind": "officer_chat"},
+        )
+
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert data
+    first = data[0]
+    assert first["id"] == str(message_id)
+    assert first["channelId"] == str(channel_id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a `/channels/history` endpoint that resolves configured channel IDs by kind and reuses the shared guild-channel access checks
- expose a helper to centralize guild channel validation so message posting and history requests share officer gating logic
- cover the new history endpoint with tests for FC chat access and officer-only protection

## Testing
- `pytest tests/test_messages_endpoint.py::test_channel_history_returns_messages tests/test_messages_endpoint.py::test_channel_history_officer_requires_role tests/test_messages_endpoint.py::test_channel_history_officer_allows_authorized_user -q`


------
https://chatgpt.com/codex/tasks/task_e_68cf5eb789a883288cba63635719c551