### PR TITLE
Add heading for event RSVP buttons

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -289,6 +289,8 @@ public class EventCreateWindow
         }
 
         ImGui.Separator();
+        ImGui.TextUnformatted("RSVP Buttons");
+        ImGui.Spacing();
 
         for (var i = 0; i < _buttons.Count; i++)
         {


### PR DESCRIPTION
## Summary
- add an "RSVP Buttons" label before the signup options in the event creation window for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf8b404df88328a5c2d60b8bf61737