### PR TITLE
Ensure attachment serialization aligns with DTO expectations

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -585,7 +585,7 @@ async def _send_via_webhook(
             AttachmentDto(
                 url=a.url,
                 filename=a.filename,
-                contentType=a.content_type,
+                content_type=a.content_type,
             )
             for a in sent.attachments
         ]
@@ -926,7 +926,7 @@ async def save_message(
                         AttachmentDto(
                             url=a.url,
                             filename=a.filename,
-                            contentType=a.content_type,
+                            content_type=a.content_type,
                         )
                         for a in sent.attachments
                     ]
@@ -1030,7 +1030,9 @@ async def save_message(
                             AttachmentDto(
                                 url=a.get("url"),
                                 filename=a.get("filename"),
-                                contentType=a.get("content_type"),
+                                content_type=(
+                                    a.get("content_type") or a.get("contentType")
+                                ),
                             )
                             for a in attachments_data
                             if isinstance(a, dict)
@@ -1112,7 +1114,9 @@ async def save_message(
         content=bridge_content,
         attachments=[
             types.SimpleNamespace(
-                url=a.url, filename=a.filename, content_type=a.contentType
+                url=a.url,
+                filename=a.filename,
+                content_type=getattr(a, "content_type", getattr(a, "contentType", None)),
             )
             for a in (attachments or [])
         ],

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -153,6 +153,83 @@ def test_save_and_fetch_messages(monkeypatch):
     asyncio.run(_run())
 
 
+def test_fetch_messages_attachment_aliases():
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
+            await db.execute(text("DELETE FROM messages"))
+            await db.execute(text("DELETE FROM memberships"))
+            await db.execute(text("DELETE FROM users"))
+            await db.execute(text("DELETE FROM guilds"))
+            await db.execute(text("DELETE FROM guild_channels"))
+
+            guild_id = 5
+            user_id = 6
+            channel_id = 7
+            message_id = 8
+
+            db.add(Guild(id=guild_id, discord_guild_id=500, name="Guild"))
+            db.add(User(id=user_id, discord_user_id=600, global_name="Tester"))
+            db.add(
+                GuildChannel(
+                    guild_id=guild_id,
+                    channel_id=channel_id,
+                    kind=ChannelKind.FC_CHAT,
+                )
+            )
+
+            attachments = [
+                {
+                    "url": "https://example.com/a.png",
+                    "filename": "a.png",
+                    "content_type": "image/png",
+                },
+                {
+                    "url": "https://example.com/b.jpg",
+                    "filename": "b.jpg",
+                    "contentType": "image/jpeg",
+                },
+            ]
+
+            db.add(
+                Message(
+                    discord_message_id=message_id,
+                    channel_id=channel_id,
+                    guild_id=guild_id,
+                    author_id=user_id,
+                    author_name="Tester",
+                    author_avatar_url="https://example.com/avatar.png",
+                    content_raw="Hi",
+                    content_display="Hi",
+                    content="Hi",
+                    attachments_json=json.dumps(attachments),
+                    author_json=None,
+                    embeds_json=None,
+                    mentions_json=None,
+                    reference_json=None,
+                    components_json=None,
+                    reactions_json=None,
+                    is_officer=False,
+                )
+            )
+            await db.commit()
+
+            guild = await db.get(Guild, guild_id)
+            user = await db.get(User, user_id)
+            ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=["chat"])
+
+            data = await mc.fetch_messages(str(channel_id), ctx, db, is_officer=False)
+
+            assert data and data[0]["id"] == str(message_id)
+            attachments_payload = data[0].get("attachments")
+            assert isinstance(attachments_payload, list) and len(attachments_payload) == 2
+            assert attachments_payload[0]["contentType"] == "image/png"
+            assert attachments_payload[1]["contentType"] == "image/jpeg"
+
+    asyncio.run(_run())
+
+
 def test_save_message_resolves_channel_via_guild_lookup(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")

--- a/tests/test_ws_retry.py
+++ b/tests/test_ws_retry.py
@@ -27,7 +27,11 @@ from demibot.http.deps import RequestContext
 
 def _make_ctx() -> RequestContext:
     guild = types.SimpleNamespace(id=1)
-    user = types.SimpleNamespace(character_name="Alice")
+    user = types.SimpleNamespace(
+        id=42,
+        character_name="Alice",
+        global_name="Alice",
+    )
     return RequestContext(user=user, guild=guild, key=None, roles=[])
 
 
@@ -46,9 +50,50 @@ def test_webhook_retry_success(monkeypatch):
 
         @asynccontextmanager
         async def fake_get_session():
+            channel_id = 123
+
+            class DummyResult:
+                def __init__(self, row, rows):
+                    self._row = row
+                    self._rows = rows
+
+                def one_or_none(self):
+                    return self._row
+
+                def all(self):
+                    return self._rows
+
             class DummyDB:
+                def __init__(self):
+                    self._calls = 0
+
+                async def execute(self, query):
+                    self._calls += 1
+                    if self._calls == 1:
+                        return DummyResult(
+                            (
+                                "http://example.com",
+                                ws_chat.ChannelKind.FC_CHAT,
+                            ),
+                            [],
+                        )
+                    return DummyResult(
+                        None,
+                        [
+                            (
+                                channel_id,
+                                ctx.guild.id,
+                                ws_chat.ChannelKind.CHAT,
+                                getattr(ctx.guild, "discord_guild_id", None),
+                            )
+                        ],
+                    )
+
                 async def scalar(self, query):
-                    return "http://example.com"
+                    return None
+
+                async def commit(self):
+                    return None
 
             yield DummyDB()
 
@@ -111,9 +156,50 @@ def test_webhook_retry_failure(monkeypatch):
 
         @asynccontextmanager
         async def fake_get_session():
+            channel_id = 123
+
+            class DummyResult:
+                def __init__(self, row, rows):
+                    self._row = row
+                    self._rows = rows
+
+                def one_or_none(self):
+                    return self._row
+
+                def all(self):
+                    return self._rows
+
             class DummyDB:
+                def __init__(self):
+                    self._calls = 0
+
+                async def execute(self, query):
+                    self._calls += 1
+                    if self._calls == 1:
+                        return DummyResult(
+                            (
+                                "http://example.com",
+                                ws_chat.ChannelKind.FC_CHAT,
+                            ),
+                            [],
+                        )
+                    return DummyResult(
+                        None,
+                        [
+                            (
+                                channel_id,
+                                ctx.guild.id,
+                                ws_chat.ChannelKind.CHAT,
+                                getattr(ctx.guild, "discord_guild_id", None),
+                            )
+                        ],
+                    )
+
                 async def scalar(self, query):
-                    return "http://example.com"
+                    return None
+
+                async def commit(self):
+                    return None
 
             yield DummyDB()
 


### PR DESCRIPTION
## Summary
- ensure AttachmentDto serialization consistently uses the snake_case field so model dumps expose the `contentType` alias expected by the client
- add a regression test that exercises `fetch_messages` to confirm attachment payloads expose `contentType`
- harden the webhook retry tests by providing RequestContext/user metadata and a dummy session that implements the async SQLAlchemy surface used in production

## Testing
- PYTHONPATH=demibot pytest tests/test_messages_common.py -q
- PYTHONPATH=demibot pytest tests/test_ws_retry.py -q
- PYTHONPATH=demibot pytest tests/test_messages_endpoint.py -q
- PYTHONPATH=demibot pytest tests/test_chat_ws.py -q
- PYTHONPATH=demibot pytest tests/test_officer_messages_endpoint.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cf857c14a4832897418598571fc19c