### PR TITLE
Add shared markdown wrapping for event description

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -198,32 +198,6 @@ public class ChatWindow : IDisposable
         _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
     }
 
-    // ---- UTF-8 helpers for ImGui byte-buffer overloads ----
-    private static byte[] MakeUtf8Buffer(string? text, int capacity)
-    {
-        if (capacity < 1) capacity = 1;
-        var buf = new byte[capacity];
-        if (!string.IsNullOrEmpty(text))
-        {
-            var encoded = Encoding.UTF8.GetBytes(text);
-            var len = Math.Min(encoded.Length, capacity - 1); // leave room for NUL
-            Array.Copy(encoded, 0, buf, 0, len);
-            buf[len] = 0;
-        }
-        else
-        {
-            buf[0] = 0;
-        }
-        return buf;
-    }
-
-    private static string ReadUtf8Buffer(byte[] buf)
-    {
-        var len = Array.IndexOf(buf, (byte)0);
-        if (len < 0) len = buf.Length;
-        return Encoding.UTF8.GetString(buf, 0, len);
-    }
-
     private void HandleChannelSelectionChanged(string kind, string guildId, string oldId, string newId)
     {
         if (kind != _channelKind) return;
@@ -505,9 +479,9 @@ public class ChatWindow : IDisposable
 
         if (ImGui.BeginPopup("editMessage"))
         {
-            var editBuf = MakeUtf8Buffer(_editContent, 2048);
+            var editBuf = ImGuiTextUtil.MakeUtf8Buffer(_editContent, 2048);
             ImGui.InputTextMultiline("##editContent", editBuf, new Vector2(400, ImGui.GetTextLineHeight() * 5));
-            _editContent = ReadUtf8Buffer(editBuf);
+            _editContent = ImGuiTextUtil.ReadUtf8Buffer(editBuf);
 
             if (ImGui.Button("Save"))
             {
@@ -596,7 +570,7 @@ public class ChatWindow : IDisposable
         ImGui.SameLine();
         if (ImGui.SmallButton("Link")) WrapSelection("[", "](url)");
 
-        var inputBuf = MakeUtf8Buffer(_input, 2048);
+        var inputBuf = ImGuiTextUtil.MakeUtf8Buffer(_input, 2048);
         var style = ImGui.GetStyle();
         var availableWidth = ImGui.GetContentRegionAvail().X;
         var framePadding = style.FramePadding.X * 2f;
@@ -612,7 +586,7 @@ public class ChatWindow : IDisposable
             new ImGui.ImGuiInputTextCallbackDelegate(OnInputEdited)
         );
         ImGui.PopItemWidth();
-        _input = ReadUtf8Buffer(inputBuf);
+        _input = ImGuiTextUtil.ReadUtf8Buffer(inputBuf);
 
         ImGui.SameLine();
         if (ImGui.Button("😊")) ImGui.OpenPopup("##dc_emoji_picker");
@@ -857,26 +831,7 @@ public class ChatWindow : IDisposable
 
     private void WrapSelection(string prefix, string suffix)
     {
-        _input ??= string.Empty;
-        var len = _input.Length;
-        var s = Math.Clamp(_selectionStart, 0, len);
-        var e = Math.Clamp(_selectionEnd, 0, len);
-        var start = Math.Min(s, e);
-        var end = Math.Max(s, e);
-
-        if (start == end)
-        {
-            while (start > 0 && char.IsLetterOrDigit(_input[start - 1]))
-                start--;
-            while (end < len && char.IsLetterOrDigit(_input[end]))
-                end++;
-        }
-
-        var selected = _input.Substring(start, end - start);
-        _input = _input[..start] + prefix + selected + suffix + _input[end..];
-
-        var cursor = start + prefix.Length + selected.Length + suffix.Length;
-        _selectionStart = _selectionEnd = cursor;
+        MarkdownSelectionHelper.WrapSelection(ref _input, prefix, suffix, ref _selectionStart, ref _selectionEnd);
     }
 
     private void InvalidatePreview()

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -26,6 +26,8 @@ public class EventCreateWindow
 
     private string _title = string.Empty;
     private string _description = string.Empty;
+    private int _descriptionSelectionStart;
+    private int _descriptionSelectionEnd;
     private string _time = DateTime.UtcNow.ToString("O");
     private string _imageUrl = string.Empty;
     private string _url = string.Empty;
@@ -170,9 +172,28 @@ public class EventCreateWindow
                 "Description",
                 () =>
                 {
+                    if (ImGui.SmallButton("B##descBold")) WrapDescription("**", "**");
+                    ImGui.SameLine();
+                    if (ImGui.SmallButton("I##descItalic")) WrapDescription("*", "*");
+                    ImGui.SameLine();
+                    if (ImGui.SmallButton("Code##descCode")) WrapDescription("`", "`");
+                    ImGui.SameLine();
+                    if (ImGui.SmallButton("Spoiler##descSpoiler")) WrapDescription("||", "||");
+                    ImGui.SameLine();
+                    if (ImGui.SmallButton("Link##descLink")) WrapDescription("[", "](url)");
+                    ImGui.Spacing();
+
                     var avail = ImGui.GetContentRegionAvail();
                     var descHeight = ImGui.GetTextLineHeight() * 6f;
-                    ImGui.InputTextMultiline("##Description", ref _description, 4096, new Vector2(avail.X, descHeight));
+                    var descBuf = ImGuiTextUtil.MakeUtf8Buffer(_description, 4096);
+                    ImGui.InputTextMultiline(
+                        "##Description",
+                        descBuf,
+                        new Vector2(avail.X, descHeight),
+                        ImGuiInputTextFlags.CallbackAlways,
+                        new ImGui.ImGuiInputTextCallbackDelegate(OnDescriptionEdited)
+                    );
+                    _description = ImGuiTextUtil.ReadUtf8Buffer(descBuf);
                 },
                 alignLabel: false,
                 setFullWidth: false);
@@ -571,7 +592,8 @@ public class EventCreateWindow
     public void LoadTemplate(Template template)
     {
         _title = template.Title;
-        _description = template.Description;
+        _description = template.Description ?? string.Empty;
+        _descriptionSelectionStart = _descriptionSelectionEnd = _description.Length;
         _time = string.IsNullOrEmpty(template.Time)
             ? DateTime.UtcNow.ToString("O")
             : template.Time;
@@ -776,6 +798,18 @@ public class EventCreateWindow
                 Width = b.Width
             });
         }
+    }
+
+    private void WrapDescription(string prefix, string suffix)
+    {
+        MarkdownSelectionHelper.WrapSelection(ref _description, prefix, suffix, ref _descriptionSelectionStart, ref _descriptionSelectionEnd);
+    }
+
+    private int OnDescriptionEdited(ref ImGuiInputTextCallbackData data)
+    {
+        _descriptionSelectionStart = data.SelectionStart;
+        _descriptionSelectionEnd = data.SelectionEnd;
+        return 0;
     }
 
     private void SaveConfig()

--- a/DemiCatPlugin/ImGuiTextUtil.cs
+++ b/DemiCatPlugin/ImGuiTextUtil.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Text;
+
+namespace DemiCatPlugin;
+
+internal static class ImGuiTextUtil
+{
+    public static byte[] MakeUtf8Buffer(string? text, int capacity)
+    {
+        if (capacity < 1)
+        {
+            capacity = 1;
+        }
+
+        var buffer = new byte[capacity];
+        if (!string.IsNullOrEmpty(text))
+        {
+            var encoded = Encoding.UTF8.GetBytes(text);
+            var length = Math.Min(encoded.Length, capacity - 1); // leave room for NUL
+            Array.Copy(encoded, 0, buffer, 0, length);
+            buffer[length] = 0;
+        }
+        else
+        {
+            buffer[0] = 0;
+        }
+
+        return buffer;
+    }
+
+    public static string ReadUtf8Buffer(byte[] buffer)
+    {
+        var nulIndex = Array.IndexOf(buffer, (byte)0);
+        var length = nulIndex >= 0 ? nulIndex : buffer.Length;
+        return Encoding.UTF8.GetString(buffer, 0, length);
+    }
+}

--- a/DemiCatPlugin/MarkdownSelectionHelper.cs
+++ b/DemiCatPlugin/MarkdownSelectionHelper.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace DemiCatPlugin;
+
+internal static class MarkdownSelectionHelper
+{
+    public static void WrapSelection(ref string? text, string prefix, string suffix, ref int selectionStart, ref int selectionEnd)
+    {
+        text ??= string.Empty;
+        var original = text;
+        var length = original.Length;
+
+        var startIndex = Math.Clamp(selectionStart, 0, length);
+        var endIndex = Math.Clamp(selectionEnd, 0, length);
+
+        var start = Math.Min(startIndex, endIndex);
+        var end = Math.Max(startIndex, endIndex);
+
+        if (start == end)
+        {
+            while (start > 0 && char.IsLetterOrDigit(original[start - 1]))
+            {
+                start--;
+            }
+
+            while (end < length && char.IsLetterOrDigit(original[end]))
+            {
+                end++;
+            }
+        }
+
+        var selected = original.Substring(start, end - start);
+        text = original[..start] + prefix + selected + suffix + original[end..];
+
+        var cursor = start + prefix.Length + selected.Length + suffix.Length;
+        selectionStart = selectionEnd = cursor;
+    }
+}

--- a/tests/EventCreateWindowFormattingTests.cs
+++ b/tests/EventCreateWindowFormattingTests.cs
@@ -1,0 +1,64 @@
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DemiCatPlugin;
+using Xunit;
+
+public class EventCreateWindowFormattingTests
+{
+    [Fact]
+    public void BoldButton_WrapsSelection()
+    {
+        var window = CreateWindow();
+        SetDescription(window, "hello world", 6, 11);
+        InvokeWrap(window, "**", "**");
+        Assert.Equal("hello **world**", GetDescription(window));
+    }
+
+    [Fact]
+    public void ItalicButton_WrapsWord_WhenNoSelection()
+    {
+        var window = CreateWindow();
+        SetDescription(window, "hello world", 8, 8);
+        InvokeWrap(window, "*", "*");
+        Assert.Equal("hello *world*", GetDescription(window));
+    }
+
+    private static EventCreateWindow CreateWindow()
+    {
+        var config = new Config();
+        var handler = new DummyHandler();
+        var http = new HttpClient(handler);
+        var channelService = new ChannelService(config, http, new TokenManager());
+        var selection = new ChannelSelectionService(config);
+        return new EventCreateWindow(config, http, channelService, selection);
+    }
+
+    private static void SetDescription(EventCreateWindow window, string text, int start, int end)
+    {
+        typeof(EventCreateWindow).GetField("_description", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(window, text);
+        typeof(EventCreateWindow).GetField("_descriptionSelectionStart", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(window, start);
+        typeof(EventCreateWindow).GetField("_descriptionSelectionEnd", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(window, end);
+    }
+
+    private static void InvokeWrap(EventCreateWindow window, string prefix, string suffix)
+    {
+        typeof(EventCreateWindow).GetMethod("WrapDescription", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(window, new object[] { prefix, suffix });
+    }
+
+    private static string GetDescription(EventCreateWindow window)
+    {
+        return (string)typeof(EventCreateWindow).GetField("_description", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!;
+    }
+
+    private class DummyHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract shared helpers for wrapping markdown selections and working with ImGui UTF-8 buffers
- update ChatWindow and EventCreateWindow to use the helpers, track description selection, and expose markdown buttons in the event creator
- add unit tests covering the event description markdown wrapping behavior

## Testing
- `dotnet test` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8c0920348328abf1750492c3cee9