### PR TITLE
Fix presence sorting comparer

### DIFF
--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -120,7 +120,7 @@ public class PresenceSidebar : IDisposable
         if (ungroupedOnline.Count > 0)
         {
             anyOnline = true;
-            ungroupedOnline.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparer.OrdinalIgnoreCase));
+            ungroupedOnline.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
             ImGui.TextUnformatted($"ONLINE — {ungroupedOnline.Count}");
             foreach (var presence in ungroupedOnline)
             {


### PR DESCRIPTION
## Summary
- fix the sort comparer used for ungrouped online presences so the plugin builds with .NET 9

## Testing
- dotnet build -c Release *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfffd7da74832885222d0c5444811f