### PR TITLE
Prevent null warnings in markdown selection wrappers

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -831,7 +831,9 @@ public class ChatWindow : IDisposable
 
     private void WrapSelection(string prefix, string suffix)
     {
-        MarkdownSelectionHelper.WrapSelection(ref _input, prefix, suffix, ref _selectionStart, ref _selectionEnd);
+        var input = _input;
+        MarkdownSelectionHelper.WrapSelection(ref input, prefix, suffix, ref _selectionStart, ref _selectionEnd);
+        _input = input ?? string.Empty;
     }
 
     private void InvalidatePreview()

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -802,7 +802,9 @@ public class EventCreateWindow
 
     private void WrapDescription(string prefix, string suffix)
     {
-        MarkdownSelectionHelper.WrapSelection(ref _description, prefix, suffix, ref _descriptionSelectionStart, ref _descriptionSelectionEnd);
+        var description = _description;
+        MarkdownSelectionHelper.WrapSelection(ref description, prefix, suffix, ref _descriptionSelectionStart, ref _descriptionSelectionEnd);
+        _description = description ?? string.Empty;
     }
 
     private int OnDescriptionEdited(ref ImGuiInputTextCallbackData data)


### PR DESCRIPTION
## Summary
- ensure WrapSelection in ChatWindow updates the backing input safely after using the markdown helper
- guard EventCreateWindow's description field when wrapping selections to avoid nullable assignment warnings

## Testing
- dotnet build -c Release *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0027d0ecc832890a8393f6536705c