### PR TITLE
Send mention IDs as strings when posting templates

### DIFF
--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -624,7 +624,7 @@ public class TemplatesWindow
                 channelId,
                 time = string.IsNullOrWhiteSpace(tmpl.Time) ? null : tmpl.Time,
                 buttons = buttonsBody,
-                mentions = _mentions.Count > 0 ? _mentions.Select(ulong.Parse).ToList() : null
+                mentions = _mentions.Count > 0 ? _mentions.ToList() : null
             };
             var id = _templates[_selectedIndex].Id;
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates/{id}/post");

--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -1,8 +1,16 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Reflection;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Dalamud.Plugin.Services;
 using DemiCatPlugin;
+using DemiCatPlugin.Emoji;
 using DemiCat.UI;
 using DiscordHelper;
 using Xunit;
@@ -15,14 +23,66 @@ public class TemplateButtonRoundTripTests
             => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
     }
 
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public string? Body { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Body = request.Content == null ? null : await request.Content.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private sealed class TestFramework : IFramework
+    {
+        public event FrameworkUpdateDelegate? Update { add { } remove { } }
+        public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
+        public void RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+            => action();
+    }
+
+    private sealed class TestLog : IPluginLog
+    {
+        public void Verbose(string message) { }
+        public void Verbose(string message, System.Exception exception) { }
+        public void Debug(string message) { }
+        public void Debug(string message, System.Exception exception) { }
+        public void Info(string message) { }
+        public void Info(string message, System.Exception exception) { }
+        public void Warning(string message) { }
+        public void Warning(string message, System.Exception exception) { }
+        public void Error(string message) { }
+        public void Error(System.Exception exception, string message) { }
+        public void Fatal(string message) { }
+        public void Fatal(System.Exception exception, string message) { }
+    }
+
+    private static PluginServices? SetupPluginServices()
+    {
+        var previous = PluginServices.Instance;
+        var services = new PluginServices();
+        typeof(PluginServices).GetProperty("Framework", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, new TestFramework());
+        typeof(PluginServices).GetProperty("Log", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, new TestLog());
+        return previous;
+    }
+
+    private static void RestorePluginServices(PluginServices? previous)
+        => typeof(PluginServices).GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic)!
+            .SetValue(null, previous);
+
     private static TemplatesWindow CreateWindow(ButtonRows state)
     {
         var config = new Config();
         var http = new HttpClient(new StubHandler());
-        var channelService = new ChannelService(config, http, new TokenManager());
+        var tokenManager = new TokenManager();
+        var channelService = new ChannelService(config, http, tokenManager);
         var selection = new ChannelSelectionService(config);
-        var window = new TemplatesWindow(config, http, channelService, selection);
-        var field = typeof(TemplatesWindow).GetField("_buttonRows", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var emojiManager = new EmojiManager(http, tokenManager, config);
+        var window = new TemplatesWindow(config, http, channelService, selection, emojiManager);
+        var field = typeof(TemplatesWindow).GetField("_buttonRows", BindingFlags.NonPublic | BindingFlags.Instance);
         field!.SetValue(window, state);
         return window;
     }
@@ -131,5 +191,76 @@ public class TemplateButtonRoundTripTests
         Assert.Equal(ButtonSizeHelper.ComputeWidth("Short"), payload[0].width);
         Assert.Equal(ButtonSizeHelper.ComputeWidth("Much Longer Label"), payload[1].width);
         Assert.True(payload[1].width > payload[0].width);
+    }
+
+    [Fact]
+    public async Task PostTemplate_MentionsRemainStrings()
+    {
+        var previousServices = SetupPluginServices();
+        var previousTokenManager = TokenManager.Instance;
+        try
+        {
+            var handler = new CapturingHandler();
+            using var http = new HttpClient(handler);
+            var config = new Config
+            {
+                ApiBaseUrl = "http://localhost",
+                EventChannelId = "channel-1"
+            };
+            var tokenManager = new TokenManager();
+            var channelService = new ChannelService(config, http, tokenManager);
+            var selection = new ChannelSelectionService(config);
+            using var emojiManager = new EmojiManager(http, tokenManager, config);
+            var window = new TemplatesWindow(config, http, channelService, selection, emojiManager);
+            var template = new Template { Title = "T", Description = "D" };
+
+            var templatesField = typeof(TemplatesWindow).GetField("_templates", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var templateList = (IList)templatesField.GetValue(window)!;
+            var templateItemType = typeof(TemplatesWindow).GetNestedType("TemplateItem", BindingFlags.NonPublic)!;
+            var templateItem = Activator.CreateInstance(templateItemType!, "tmpl-id", template)!;
+            templateList.Add(templateItem);
+
+            typeof(TemplatesWindow).GetField("_selectedIndex", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(window, 0);
+
+            var mentionsField = typeof(TemplatesWindow).GetField("_mentions", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var mentions = (HashSet<string>)mentionsField.GetValue(window)!;
+            mentions.Clear();
+            mentions.Add("123456789012345678");
+            mentions.Add("987654321098765432");
+
+            var postMethod = typeof(TemplatesWindow).GetMethod("PostTemplate", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var task = (Task)postMethod.Invoke(window, new object[] { template })!;
+            await task.ConfigureAwait(false);
+
+            Assert.NotNull(handler.Body);
+            using var doc = JsonDocument.Parse(handler.Body!);
+            var root = doc.RootElement;
+
+            Assert.True(root.TryGetProperty("mentions", out var mentionsElement));
+            Assert.Equal(JsonValueKind.Array, mentionsElement.ValueKind);
+
+            var actual = mentionsElement.EnumerateArray()
+                .Select(element =>
+                {
+                    Assert.Equal(JsonValueKind.String, element.ValueKind);
+                    return element.GetString();
+                })
+                .Where(value => value != null)
+                .OrderBy(value => value)
+                .ToList();
+
+            var expected = new[] { "123456789012345678", "987654321098765432" }
+                .OrderBy(value => value)
+                .ToList();
+
+            Assert.Equal(expected, actual);
+        }
+        finally
+        {
+            RestorePluginServices(previousServices);
+            var tokenField = typeof(TokenManager).GetField("<Instance>k__BackingField", BindingFlags.Static | BindingFlags.NonPublic)!;
+            tokenField.SetValue(null, previousTokenManager);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- send selected mention IDs verbatim when posting a template so they remain strings in the request payload
- add coverage that exercises posting with mentions and asserts the serialized JSON keeps string IDs

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d00c9a32a48328bca0bd235f47be7d