### PR TITLE
Allow FC chat reactions without chat role

### DIFF
--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -85,10 +85,7 @@ async def add_reaction(
     row = await db.get(Message, int(message_id))
     if not row or row.channel_id != cid:
         raise HTTPException(status_code=404, detail="message not found")
-    if row.is_officer:
-        if "officer" not in ctx.roles:
-            raise HTTPException(status_code=403, detail="forbidden")
-    elif "chat" not in ctx.roles:
+    if row.is_officer and "officer" not in ctx.roles:
         raise HTTPException(status_code=403, detail="forbidden")
     channel = discord_client.get_channel(cid)
     if not channel or not isinstance(channel, discord.abc.Messageable):
@@ -127,10 +124,7 @@ async def remove_reaction(
     row = await db.get(Message, int(message_id))
     if not row or row.channel_id != cid:
         raise HTTPException(status_code=404, detail="message not found")
-    if row.is_officer:
-        if "officer" not in ctx.roles:
-            raise HTTPException(status_code=403, detail="forbidden")
-    elif "chat" not in ctx.roles:
+    if row.is_officer and "officer" not in ctx.roles:
         raise HTTPException(status_code=403, detail="forbidden")
     channel = discord_client.get_channel(cid)
     if not channel or not isinstance(channel, discord.abc.Messageable):

--- a/tests/test_messages_endpoint.py
+++ b/tests/test_messages_endpoint.py
@@ -213,6 +213,103 @@ async def test_channel_history_returns_messages():
 
 
 @pytest.mark.asyncio
+async def test_add_reaction_does_not_require_chat_role(monkeypatch):
+    await init_db("sqlite+aiosqlite://")
+    async with get_session() as db:
+        await db.execute(text("DELETE FROM messages"))
+        await db.execute(text("DELETE FROM guild_channels"))
+        await db.execute(text("DELETE FROM users"))
+        await db.execute(text("DELETE FROM guilds"))
+
+        guild_id = 151
+        user_id = 251
+        channel_id = 351
+        message_id = 451
+
+        db.add(Guild(id=guild_id, discord_guild_id=2001, name="Guild"))
+        db.add(User(id=user_id, discord_user_id=2002, global_name="Member"))
+        db.add(
+            GuildChannel(
+                guild_id=guild_id,
+                channel_id=channel_id,
+                kind=ChannelKind.FC_CHAT,
+                name="FC Chat",
+            )
+        )
+        db.add(
+            Message(
+                discord_message_id=message_id,
+                channel_id=channel_id,
+                guild_id=guild_id,
+                author_id=user_id,
+                author_name="Member",
+                author_avatar_url=None,
+                content_raw="Hello",
+                content_display="Hello",
+                content="Hello",
+                attachments_json=None,
+                author_json=None,
+                embeds_json=None,
+                mentions_json=None,
+                reference_json=None,
+                components_json=None,
+                reactions_json=None,
+                is_officer=False,
+            )
+        )
+        await db.commit()
+
+    class DummyMessage:
+        def __init__(self) -> None:
+            self.called_with: str | None = None
+
+        async def add_reaction(self, emoji: str) -> None:
+            self.called_with = emoji
+
+    dummy_message = DummyMessage()
+
+    class DummyChannel:
+        async def fetch_message(self, mid: int) -> DummyMessage:
+            return dummy_message
+
+    dummy_channel = DummyChannel()
+
+    class DummyDiscordClient:
+        def get_channel(self, cid: int):
+            return dummy_channel if cid == channel_id else None
+
+    monkeypatch.setattr(messages_routes, "discord_client", DummyDiscordClient())
+    monkeypatch.setattr(messages_routes.discord.abc, "Messageable", DummyChannel)
+
+    app = create_app()
+
+    user_ctx = SimpleNamespace(id=user_id, global_name="Member", character_name=None)
+    guild_ctx = SimpleNamespace(id=guild_id, discord_guild_id=2001)
+
+    async def override_auth():
+        return RequestContext(user=user_ctx, guild=guild_ctx, key=None, roles=[])
+
+    async def override_db():
+        async with get_session() as session:
+            yield session
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.put(
+            f"/api/channels/{channel_id}/messages/{message_id}/reactions/smile"
+        )
+
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert dummy_message.called_with == "smile"
+
+
+@pytest.mark.asyncio
 async def test_channel_history_officer_requires_role():
     await init_db("sqlite+aiosqlite://")
     async with get_session() as db:

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -38,10 +38,14 @@ if 'discord' not in sys.modules:
     class NotFound(Exception):
         pass
 
+    class ClientException(Exception):
+        pass
+
     abc_mod.Messageable = Messageable
     discord_mod.abc = abc_mod
     discord_mod.Forbidden = Forbidden
     discord_mod.NotFound = NotFound
+    discord_mod.ClientException = ClientException
     ext_mod = types.ModuleType('discord.ext')
     commands_mod = types.ModuleType('discord.ext.commands')
     discord_mod.ext = ext_mod
@@ -106,7 +110,7 @@ def test_add_reaction_success():
             await db.commit()
             guild = await db.get(Guild, 1)
             user = await db.get(User, 1)
-            ctx = RequestContext(user=user, guild=guild, key=object(), roles=["chat"])
+            ctx = RequestContext(user=user, guild=guild, key=object(), roles=[])
             dummy_msg = DummyMessage()
             dummy_channel = DummyChannel(msg=dummy_msg)
             messages.discord_client = types.SimpleNamespace(get_channel=lambda _: dummy_channel)
@@ -141,7 +145,7 @@ def test_add_reaction_not_found():
             await db.commit()
             guild = await db.get(Guild, 1)
             user = await db.get(User, 1)
-            ctx = RequestContext(user=user, guild=guild, key=object(), roles=["chat"])
+            ctx = RequestContext(user=user, guild=guild, key=object(), roles=[])
             dummy_channel = DummyChannel(raise_not_found=True)
             messages.discord_client = types.SimpleNamespace(get_channel=lambda _: dummy_channel)
             with pytest.raises(HTTPException) as exc:
@@ -175,8 +179,44 @@ def test_add_reaction_forbidden():
             await db.commit()
             guild = await db.get(Guild, 1)
             user = await db.get(User, 1)
-            ctx = RequestContext(user=user, guild=guild, key=object(), roles=["chat"])
+            ctx = RequestContext(user=user, guild=guild, key=object(), roles=[])
             dummy_msg = DummyMessage(raise_forbidden=True)
+            dummy_channel = DummyChannel(msg=dummy_msg)
+            messages.discord_client = types.SimpleNamespace(get_channel=lambda _: dummy_channel)
+            with pytest.raises(HTTPException) as exc:
+                await messages.add_reaction("1", "1", "😀", ctx, db)
+            assert exc.value.status_code == 403
+    asyncio.run(run())
+
+
+def test_add_reaction_officer_channel_requires_officer_role():
+    async def run():
+        db_path = Path('test_reactions_officer_forbidden.db')
+        if db_path.exists():
+            db_path.unlink()
+        session_module._engine = None
+        session_module._Session = None
+        await init_db(f"sqlite+aiosqlite:///{db_path}")
+        async with get_session() as db:
+            db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
+            db.add(User(id=1, discord_user_id=10, global_name="Alice"))
+            db.add(
+                Message(
+                    discord_message_id=1,
+                    channel_id=1,
+                    guild_id=1,
+                    author_id=1,
+                    author_name="Alice",
+                    content_raw="",
+                    content_display="",
+                    is_officer=True,
+                )
+            )
+            await db.commit()
+            guild = await db.get(Guild, 1)
+            user = await db.get(User, 1)
+            ctx = RequestContext(user=user, guild=guild, key=object(), roles=[])
+            dummy_msg = DummyMessage()
             dummy_channel = DummyChannel(msg=dummy_msg)
             messages.discord_client = types.SimpleNamespace(get_channel=lambda _: dummy_channel)
             with pytest.raises(HTTPException) as exc:


### PR DESCRIPTION
## Summary
- drop the legacy `"chat"` role requirement when adding or removing reactions in FC chat while keeping officer-only protections in place
- expand the reaction unit tests to cover members without chat role access and officer-channel restrictions
- add an HTTP endpoint test to ensure FC chat reactions succeed for members who lack the legacy role

## Testing
- pytest *(fails: numerous pre-existing suite failures in this environment; see run for details)*

------
https://chatgpt.com/codex/tasks/task_e_68d00b047e488328836a173ae14b52e2