### PR TITLE
Improve Discord client readiness detection

### DIFF
--- a/demibot/demibot/http/discord_client.py
+++ b/demibot/demibot/http/discord_client.py
@@ -44,12 +44,26 @@ def is_discord_client_ready(client: commands.Bot | None = None) -> bool:
 
     try:
         ready_attr = getattr(client, "is_ready", None)
-        if callable(ready_attr):
-            return bool(ready_attr())
-        if ready_attr is not None:
-            return bool(ready_attr)
+    except Exception:
+        ready_attr = None
+
+    if ready_attr is None:
+        return False
+
+    try:
+        ready_value = ready_attr() if callable(ready_attr) else ready_attr
     except Exception:
         return False
 
-    return False
+    if isinstance(ready_value, bool):
+        return ready_value
+
+    try:
+        is_set = getattr(ready_value, "is_set", None)
+        if callable(is_set):
+            return bool(is_set())
+    except Exception:
+        return False
+
+    return bool(ready_value)
 

--- a/tests/test_discord_client_ready.py
+++ b/tests/test_discord_client_ready.py
@@ -1,0 +1,91 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+if str(root) not in sys.path:
+    sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+discord_pkg = types.ModuleType("discord")
+discord_ext_pkg = types.ModuleType("discord.ext")
+discord_commands_pkg = types.ModuleType("discord.ext.commands")
+
+
+class _DummyBot:
+    pass
+
+
+discord_commands_pkg.Bot = _DummyBot
+discord_ext_pkg.commands = discord_commands_pkg
+discord_pkg.ext = discord_ext_pkg
+
+sys.modules.setdefault("discord", discord_pkg)
+sys.modules.setdefault("discord.ext", discord_ext_pkg)
+sys.modules.setdefault("discord.ext.commands", discord_commands_pkg)
+
+from demibot.http.discord_client import is_discord_client_ready
+
+
+class _ReadyMethodClient:
+    def is_closed(self):
+        return False
+
+    def is_ready(self):
+        return True
+
+
+class _NotReadyMethodClient:
+    def is_closed(self):
+        return False
+
+    def is_ready(self):
+        return False
+
+
+class _ReadyAttributeClient:
+    def __init__(self, ready: bool):
+        self.is_closed = False
+        self.is_ready = ready
+
+
+class _ReadyEvent:
+    def __init__(self, is_set: bool):
+        self._is_set = is_set
+
+    def is_set(self):
+        return self._is_set
+
+
+class _ReadyEventClient:
+    def __init__(self, flag: bool):
+        self.is_closed = False
+        self.is_ready = _ReadyEvent(flag)
+
+
+def test_client_ready_with_method():
+    assert is_discord_client_ready(_ReadyMethodClient()) is True
+
+
+def test_client_not_ready_with_method():
+    assert is_discord_client_ready(_NotReadyMethodClient()) is False
+
+
+@pytest.mark.parametrize("ready", [True, False])
+def test_client_ready_with_boolean_attribute(ready):
+    assert is_discord_client_ready(_ReadyAttributeClient(ready)) is ready
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_client_ready_with_event_like(flag):
+    assert is_discord_client_ready(_ReadyEventClient(flag)) is flag
+

--- a/tests/test_discord_emojis.py
+++ b/tests/test_discord_emojis.py
@@ -167,6 +167,45 @@ async def test_emojis_returns_list_when_ready(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_emojis_returns_list_when_ready_attribute(monkeypatch):
+    discord_emojis._emoji_cache.clear()
+
+    class AttributeClient:
+        def __init__(self, guild):
+            self._guild = guild
+            self.is_ready = True
+            self.is_closed = False
+
+        def get_guild(self, guild_id):
+            return self._guild
+
+    guild = DummyGuild(
+        [DummyEmoji(1, "sparkle", False), DummyEmoji(2, "dance", True)]
+    )
+    monkeypatch.setattr(
+        discord_emojis, "discord_client", AttributeClient(guild)
+    )
+
+    ctx = RequestContext(
+        user=SimpleNamespace(id=1),
+        guild=SimpleNamespace(id=2, discord_guild_id=200),
+        key=None,
+        roles=[],
+    )
+
+    data = await discord_emojis.list_emojis(ctx=ctx)
+
+    assert data == {
+        "ok": True,
+        "emojis": [
+            {"id": "1", "name": "sparkle", "animated": False},
+            {"id": "2", "name": "dance", "animated": True},
+        ],
+    }
+    assert discord_emojis._emoji_cache[ctx.guild.id] == data["emojis"]
+
+
+@pytest.mark.asyncio
 async def test_emojis_returns_empty_list_when_guild_has_no_custom(monkeypatch):
     discord_emojis._emoji_cache.clear()
 


### PR DESCRIPTION
## Summary
- make the HTTP readiness helper accept boolean attributes and event-like states from the Discord client while retaining defensive checks
- add regression coverage ensuring emoji routes treat the client as ready once the bot connects

## Testing
- pytest tests/test_discord_client_ready.py tests/test_discord_emojis.py

------
https://chatgpt.com/codex/tasks/task_e_68d01b159e308328ad5c98756f0c0462