### PR TITLE
Add chat opacity settings and migrate config

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -9,7 +9,7 @@ namespace DemiCatPlugin;
 public class Config : IPluginConfiguration
 {
     // Required by Dalamud
-    public int Version { get; set; } = 5;
+    public int Version { get; set; } = 6;
 
     public bool Enabled { get; set; } = true;
     public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
@@ -26,11 +26,11 @@ public class Config : IPluginConfiguration
     public string OfficerChannelId { get; set; } = string.Empty;
     public bool EnableFcChat { get; set; } = true;
     public bool EnableFcChatUserSet { get; set; } = false;
-    public float FcChatTransparency { get; set; } = 1f;
-    public float OfficerChatTransparency { get; set; } = 1f;
+    public float FcChatOpacity { get; set; } = 1f;
+    public float OfficerChatOpacity { get; set; } = 1f;
     public bool ChatFadeOutEnabled { get; set; } = false;
-    public int ChatFadeOutDelaySeconds { get; set; } = 15;
-    public float ChatFadeOutAlpha { get; set; } = 0.3f;
+    public int ChatFadeOutDelaySeconds { get; set; } = 10;
+    public float ChatFadeOutMinimumAlpha { get; set; } = 0.3f;
 
     [JsonPropertyName("syncedChat")]
     public bool SyncedChat { get; set; } = true;
@@ -185,6 +185,35 @@ public class Config : IPluginConfiguration
             }
 
             Version = 5;
+            ExtensionData = null;
+        }
+        if (Version < 6)
+        {
+            if (ExtensionData != null)
+            {
+                if (ExtensionData.TryGetValue("FcChatTransparency", out var fcOpacityElement) && fcOpacityElement.ValueKind == JsonValueKind.Number && fcOpacityElement.TryGetDouble(out var fcOpacity))
+                {
+                    FcChatOpacity = (float)Math.Clamp(fcOpacity, 0d, 1d);
+                }
+                if (ExtensionData.TryGetValue("OfficerChatTransparency", out var officerOpacityElement) && officerOpacityElement.ValueKind == JsonValueKind.Number && officerOpacityElement.TryGetDouble(out var officerOpacity))
+                {
+                    OfficerChatOpacity = (float)Math.Clamp(officerOpacity, 0d, 1d);
+                }
+                if (ExtensionData.TryGetValue("ChatFadeOutAlpha", out var fadeAlphaElement) && fadeAlphaElement.ValueKind == JsonValueKind.Number && fadeAlphaElement.TryGetDouble(out var fadeAlpha))
+                {
+                    ChatFadeOutMinimumAlpha = (float)Math.Clamp(fadeAlpha, 0d, 1d);
+                }
+            }
+
+            FcChatOpacity = Math.Clamp(FcChatOpacity, 0f, 1f);
+            OfficerChatOpacity = Math.Clamp(OfficerChatOpacity, 0f, 1f);
+            ChatFadeOutMinimumAlpha = Math.Clamp(ChatFadeOutMinimumAlpha, 0f, 1f);
+            if (ChatFadeOutDelaySeconds <= 0)
+            {
+                ChatFadeOutDelaySeconds = 10;
+            }
+
+            Version = 6;
             ExtensionData = null;
         }
     }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -249,28 +249,28 @@ public class SettingsWindow : IDisposable
         var fadeOutEnabled = _config.ChatFadeOutEnabled;
 
         ImGui.BeginDisabled(fadeOutEnabled);
-        var fcTransparency = _config.FcChatTransparency * 100f;
-        if (ImGui.SliderFloat("FC Chat Transparency", ref fcTransparency, 0f, 100f, "%.0f%%"))
+        var fcOpacity = _config.FcChatOpacity * 100f;
+        if (ImGui.SliderFloat("FC Chat Opacity", ref fcOpacity, 0f, 100f, "%.0f%%"))
         {
-            _config.FcChatTransparency = Math.Clamp(fcTransparency / 100f, 0f, 1f);
+            _config.FcChatOpacity = Math.Clamp(fcOpacity / 100f, 0f, 1f);
             SaveConfig();
             MainWindow?.ResetFadeTimer();
         }
         ImGui.EndDisabled();
         if (fadeOutEnabled && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-            ImGui.SetTooltip("Disable fade-out to adjust per-tab transparency.");
+            ImGui.SetTooltip("Disable fade-out to adjust per-tab opacity.");
 
         ImGui.BeginDisabled(fadeOutEnabled);
-        var officerTransparency = _config.OfficerChatTransparency * 100f;
-        if (ImGui.SliderFloat("Officer Tab Transparency", ref officerTransparency, 0f, 100f, "%.0f%%"))
+        var officerOpacity = _config.OfficerChatOpacity * 100f;
+        if (ImGui.SliderFloat("Officer Tab Opacity", ref officerOpacity, 0f, 100f, "%.0f%%"))
         {
-            _config.OfficerChatTransparency = Math.Clamp(officerTransparency / 100f, 0f, 1f);
+            _config.OfficerChatOpacity = Math.Clamp(officerOpacity / 100f, 0f, 1f);
             SaveConfig();
             MainWindow?.ResetFadeTimer();
         }
         ImGui.EndDisabled();
         if (fadeOutEnabled && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-            ImGui.SetTooltip("Disable fade-out to adjust per-tab transparency.");
+            ImGui.SetTooltip("Disable fade-out to adjust per-tab opacity.");
 
         ImGui.Separator();
 
@@ -309,16 +309,16 @@ public class SettingsWindow : IDisposable
             ImGui.EndCombo();
         }
 
-        var fadeAlphaPercent = _config.ChatFadeOutAlpha * 100f;
-        if (ImGui.SliderFloat("Fade-out transparency", ref fadeAlphaPercent, 0f, 100f, "%.0f%%"))
+        var fadeMinimumAlphaPercent = _config.ChatFadeOutMinimumAlpha * 100f;
+        if (ImGui.SliderFloat("Fade-out minimum opacity", ref fadeMinimumAlphaPercent, 0f, 100f, "%.0f%%"))
         {
-            _config.ChatFadeOutAlpha = Math.Clamp(fadeAlphaPercent / 100f, 0f, 1f);
+            _config.ChatFadeOutMinimumAlpha = Math.Clamp(fadeMinimumAlphaPercent / 100f, 0f, 1f);
             SaveConfig();
             MainWindow?.ResetFadeTimer();
         }
 
         ImGui.SameLine();
-        DrawFadePreview("##fadePreview", _config.ChatFadeOutAlpha);
+        DrawFadePreview("##fadePreview", _config.ChatFadeOutMinimumAlpha);
         ImGui.EndDisabled();
     }
 

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -25,4 +25,15 @@ public class ConfigDefaultsTests
         Assert.Throws<InvalidOperationException>(() => new SyncshellWindow(cfg, new HttpClient()));
         Assert.Null(SyncshellWindow.Instance);
     }
+
+    [Fact]
+    public void Appearance_DefaultValues()
+    {
+        var cfg = new Config();
+        Assert.Equal(1f, cfg.FcChatOpacity);
+        Assert.Equal(1f, cfg.OfficerChatOpacity);
+        Assert.False(cfg.ChatFadeOutEnabled);
+        Assert.Equal(10, cfg.ChatFadeOutDelaySeconds);
+        Assert.Equal(0.3f, cfg.ChatFadeOutMinimumAlpha);
+    }
 }


### PR DESCRIPTION
## Summary
- add new config properties for FC/officer chat opacity and fade-out settings with updated defaults
- migrate existing configs to preserve prior transparency values and enforce defaults when upgrading
- refresh the settings UI labels and default config tests to cover the new properties

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d02ea056588328870cd5393db196b3