### PR TITLE
Implement chat fade state handling

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -24,6 +24,10 @@ public class MainWindow : IDisposable
     private readonly Func<Task<bool>> _refreshRoles;
     private bool _checkingOfficer;
     private bool _officerChecked;
+    private const float FadeAlphaTolerance = 0.001f;
+    private const float MinimumFadeDuration = 0.001f;
+    private float _timeSinceLastInteraction;
+    private float _fadeAlpha = 1f;
 
     public bool IsOpen;
     public bool HasOfficerRole { get; set; }
@@ -82,206 +86,250 @@ public class MainWindow : IDisposable
 
         if (!IsOpen)
         {
+            ResetFadeTimer();
             return;
         }
+
+        var io = ImGui.GetIO();
+        var deltaTime = Math.Max(0f, io.DeltaTime);
+        var fadeAlpha = GetCurrentFadeAlpha();
+        var fadeActive = _config.ChatFadeOutEnabled && fadeAlpha < 1f - FadeAlphaTolerance;
+
         ImGui.SetNextWindowSize(new Vector2(800, 600), ImGuiCond.FirstUseEver);
         ImGui.SetNextWindowSizeConstraints(new Vector2(600, 400), new Vector2(float.MaxValue, float.MaxValue));
-        ImGui.PushStyleColor(ImGuiCol.WindowBg, new Vector4(0.11f, 0.11f, 0.12f, 1f));
-        ImGui.PushStyleColor(ImGuiCol.ChildBg, new Vector4(0.09f, 0.09f, 0.1f, 1f));
-        ImGui.PushStyleColor(ImGuiCol.Tab, new Vector4(0.15f, 0.15f, 0.16f, 1f));
-        ImGui.PushStyleColor(ImGuiCol.TabActive, new Vector4(0.2f, 0.2f, 0.21f, 1f));
-        ImGui.PushStyleColor(ImGuiCol.TabHovered, new Vector4(0.25f, 0.25f, 0.26f, 1f));
+        ImGui.PushStyleColor(ImGuiCol.WindowBg, new Vector4(0.11f, 0.11f, 0.12f, fadeAlpha));
+        ImGui.PushStyleColor(ImGuiCol.ChildBg, new Vector4(0.09f, 0.09f, 0.1f, fadeAlpha));
+        ImGui.PushStyleColor(ImGuiCol.Tab, new Vector4(0.15f, 0.15f, 0.16f, fadeAlpha));
+        ImGui.PushStyleColor(ImGuiCol.TabActive, new Vector4(0.2f, 0.2f, 0.21f, fadeAlpha));
+        ImGui.PushStyleColor(ImGuiCol.TabHovered, new Vector4(0.25f, 0.25f, 0.26f, fadeAlpha));
 
-        if (!ImGui.Begin("DemiCat", ref IsOpen, ImGuiWindowFlags.NoCollapse))
+        var styleAlphaPushed = false;
+        if (fadeActive)
         {
-            ImGui.End();
-            ImGui.PopStyleColor(5);
-            return;
+            ImGui.PushStyleVar(ImGuiStyleVar.Alpha, fadeAlpha);
+            styleAlphaPushed = true;
         }
 
-        var linked = TokenManager.Instance?.State == LinkState.Linked;
-        if (!linked)
+        var windowOpen = ImGui.Begin("DemiCat", ref IsOpen, ImGuiWindowFlags.NoCollapse);
+        var interacted = windowOpen && HasWindowInteraction();
+
+        if (windowOpen)
         {
-            ImGui.TextColored(new Vector4(1f, 0.85f, 0f, 1f), "Link DemiCat: run `/demibot embed` in Discord and paste the key.");
-            ImGui.SameLine();
-            if (ImGui.Button("Open Settings"))
+            var linked = TokenManager.Instance?.State == LinkState.Linked;
+            if (!linked)
+            {
+                ImGui.TextColored(new Vector4(1f, 0.85f, 0f, 1f), "Link DemiCat: run `/demibot embed` in Discord and paste the key.");
+                ImGui.SameLine();
+                if (ImGui.Button("Open Settings"))
+                {
+                    _settings.IsOpen = true;
+                }
+                ImGui.Separator();
+            }
+
+            var padding = ImGui.GetStyle().FramePadding;
+            ImGui.Dummy(new Vector2(0f, padding.Y));
+            var buttonSize = ImGui.GetFrameHeight();
+            var cursor = ImGui.GetCursorPos();
+            ImGui.SetCursorPos(new Vector2(ImGui.GetWindowContentRegionMax().X - buttonSize - padding.X, cursor.Y));
+            if (ImGui.Button("\u2699\uFE0F##dc_settings", new Vector2(buttonSize, buttonSize)))
             {
                 _settings.IsOpen = true;
             }
-            ImGui.Separator();
-        }
+            ImGui.SetCursorPos(cursor);
 
-        var padding = ImGui.GetStyle().FramePadding;
-        ImGui.Dummy(new Vector2(0f, padding.Y));
-        var buttonSize = ImGui.GetFrameHeight();
-        var cursor = ImGui.GetCursorPos();
-        ImGui.SetCursorPos(new Vector2(ImGui.GetWindowContentRegionMax().X - buttonSize - padding.X, cursor.Y));
-        if (ImGui.Button("\u2699\uFE0F##dc_settings", new Vector2(buttonSize, buttonSize)))
-        {
-            _settings.IsOpen = true;
-        }
-        ImGui.SetCursorPos(cursor);
-
-        if (ImGui.BeginTabBar("MainTabs"))
-        {
-            if (!linked)
+            if (ImGui.BeginTabBar("MainTabs"))
             {
-                ImGui.BeginDisabled();
-                ImGui.TabItemButton("Events");
-                ImGui.EndDisabled();
-                if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                    ImGui.SetTooltip("Link DemiCat to view events.");
-            }
-            else if (ImGui.BeginTabItem("Events"))
-            {
-                ImGui.BeginChild("##eventsArea", ImGui.GetContentRegionAvail(), false);
-                _ui.Draw();
-                ImGui.EndChild();
-                ImGui.EndTabItem();
-            }
-
-            if (!linked)
-            {
-                ImGui.BeginDisabled();
-                ImGui.TabItemButton("Create");
-                ImGui.EndDisabled();
-                if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                    ImGui.SetTooltip("Link DemiCat to create events.");
-            }
-            else if (ImGui.BeginTabItem("Create"))
-            {
-                _create.Draw();
-                ImGui.EndTabItem();
-            }
-
-            if (!linked)
-            {
-                _templatesTabActive = false;
-                ImGui.BeginDisabled();
-                ImGui.TabItemButton("Templates");
-                ImGui.EndDisabled();
-                if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                    ImGui.SetTooltip("Link DemiCat to use templates.");
-            }
-            else
-            {
-                var templatesOpen = ImGui.BeginTabItem("Templates");
-                if (templatesOpen)
-                {
-                    if (!_templatesTabActive)
-                    {
-                        _templates.OnTabActivated();
-                    }
-                    _templatesTabActive = true;
-                    _templates.Draw();
-                    ImGui.EndTabItem();
-                }
-                else
-                {
-                    _templatesTabActive = false;
-                }
-            }
-
-            if (!linked)
-            {
-                ImGui.BeginDisabled();
-                ImGui.TabItemButton("Request Board");
-                ImGui.EndDisabled();
-                if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                    ImGui.SetTooltip("Link DemiCat to use request board.");
-            }
-            else if (ImGui.BeginTabItem("Request Board"))
-            {
-                _requestBoard.Draw();
-                ImGui.EndTabItem();
-            }
-
-            if (!linked)
-            {
-                if (_config.FCSyncShell)
-                {
-                    ImGui.BeginDisabled();
-                    ImGui.TabItemButton("Syncshell");
-                    ImGui.EndDisabled();
-                    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                        ImGui.SetTooltip("Link DemiCat to use syncshell.");
-                }
-            }
-            else if (_config.FCSyncShell && _syncshell != null && ImGui.BeginTabItem("Syncshell"))
-            {
-                _syncshell.Draw();
-                ImGui.EndTabItem();
-            }
-
-            if (_chat != null)
-            {
-                var chatLabel = _chat is FcChatWindow ? "FC Chat" : "Chat";
-                var chatTooltip = _chat is FcChatWindow ? "Link DemiCat to use FC chat." : "Link DemiCat to use chat.";
                 if (!linked)
                 {
                     ImGui.BeginDisabled();
-                    ImGui.TabItemButton(chatLabel);
+                    ImGui.TabItemButton("Events");
                     ImGui.EndDisabled();
                     if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                        ImGui.SetTooltip(chatTooltip);
+                        ImGui.SetTooltip("Link DemiCat to view events.");
                 }
-                else if (ImGui.BeginTabItem(chatLabel))
+                else if (ImGui.BeginTabItem("Events"))
                 {
-                    ImGui.BeginChild("##chatArea", ImGui.GetContentRegionAvail(), false);
-                    _chat.Draw();
+                    ImGui.BeginChild("##eventsArea", ImGui.GetContentRegionAvail(), false);
+                    _ui.Draw();
                     ImGui.EndChild();
                     ImGui.EndTabItem();
                 }
-            }
 
-            if (HasOfficerRole)
-            {
                 if (!linked)
                 {
                     ImGui.BeginDisabled();
-                    ImGui.TabItemButton("Officer");
+                    ImGui.TabItemButton("Create");
                     ImGui.EndDisabled();
                     if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                        ImGui.SetTooltip("Link DemiCat to use officer chat.");
+                        ImGui.SetTooltip("Link DemiCat to create events.");
+                }
+                else if (ImGui.BeginTabItem("Create"))
+                {
+                    _create.Draw();
+                    ImGui.EndTabItem();
+                }
+
+                if (!linked)
+                {
+                    _templatesTabActive = false;
+                    ImGui.BeginDisabled();
+                    ImGui.TabItemButton("Templates");
+                    ImGui.EndDisabled();
+                    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                        ImGui.SetTooltip("Link DemiCat to use templates.");
                 }
                 else
                 {
-                    var officerOpen = ImGui.BeginTabItem("Officer");
-                    if (officerOpen)
+                    var templatesOpen = ImGui.BeginTabItem("Templates");
+                    if (templatesOpen)
                     {
-                        if (!_officerChecked && !_checkingOfficer)
+                        if (!_templatesTabActive)
                         {
-                            _officerChecked = true;
-                            _checkingOfficer = true;
-                            _ = Task.Run(async () =>
-                            {
-                                await _refreshRoles();
-                                PluginServices.Instance?.Framework.RunOnTick(() =>
-                                {
-                                    _checkingOfficer = false;
-                                    if (!HasOfficerRole)
-                                        ImGui.SetTabItemClosed("Officer");
-                                });
-                            });
+                            _templates.OnTabActivated();
                         }
-                        ImGui.BeginChild("##officerChatArea", ImGui.GetContentRegionAvail(), false);
-                        _officer.Draw();
-                        ImGui.EndChild();
+                        _templatesTabActive = true;
+                        _templates.Draw();
                         ImGui.EndTabItem();
                     }
                     else
                     {
-                        _officerChecked = false;
+                        _templatesTabActive = false;
                     }
                 }
-            }
 
-            ImGui.EndTabBar();
+                if (!linked)
+                {
+                    ImGui.BeginDisabled();
+                    ImGui.TabItemButton("Request Board");
+                    ImGui.EndDisabled();
+                    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                        ImGui.SetTooltip("Link DemiCat to use request board.");
+                }
+                else if (ImGui.BeginTabItem("Request Board"))
+                {
+                    _requestBoard.Draw();
+                    ImGui.EndTabItem();
+                }
+
+                if (!linked)
+                {
+                    if (_config.FCSyncShell)
+                    {
+                        ImGui.BeginDisabled();
+                        ImGui.TabItemButton("Syncshell");
+                        ImGui.EndDisabled();
+                        if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                            ImGui.SetTooltip("Link DemiCat to use syncshell.");
+                    }
+                }
+                else if (_config.FCSyncShell && _syncshell != null && ImGui.BeginTabItem("Syncshell"))
+                {
+                    _syncshell.Draw();
+                    ImGui.EndTabItem();
+                }
+
+                if (_chat != null)
+                {
+                    var chatLabel = _chat is FcChatWindow ? "FC Chat" : "Chat";
+                    var chatTooltip = _chat is FcChatWindow ? "Link DemiCat to use FC chat." : "Link DemiCat to use chat.";
+                    if (!linked)
+                    {
+                        ImGui.BeginDisabled();
+                        ImGui.TabItemButton(chatLabel);
+                        ImGui.EndDisabled();
+                        if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                            ImGui.SetTooltip(chatTooltip);
+                    }
+                    else if (ImGui.BeginTabItem(chatLabel))
+                    {
+                        var applyChatOpacity = !_config.ChatFadeOutEnabled && _chat is FcChatWindow;
+                        if (applyChatOpacity)
+                        {
+                            var tabAlpha = Math.Clamp(_config.FcChatOpacity, 0f, 1f);
+                            ImGui.PushStyleVar(ImGuiStyleVar.Alpha, tabAlpha);
+                        }
+
+                        ImGui.BeginChild("##chatArea", ImGui.GetContentRegionAvail(), false);
+                        _chat.Draw();
+                        ImGui.EndChild();
+                        ImGui.EndTabItem();
+
+                        if (applyChatOpacity)
+                        {
+                            ImGui.PopStyleVar();
+                        }
+                    }
+                }
+
+                if (HasOfficerRole)
+                {
+                    if (!linked)
+                    {
+                        ImGui.BeginDisabled();
+                        ImGui.TabItemButton("Officer");
+                        ImGui.EndDisabled();
+                        if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                            ImGui.SetTooltip("Link DemiCat to use officer chat.");
+                    }
+                    else
+                    {
+                        var officerOpen = ImGui.BeginTabItem("Officer");
+                        if (officerOpen)
+                        {
+                            var applyOfficerOpacity = !_config.ChatFadeOutEnabled;
+                            if (applyOfficerOpacity)
+                            {
+                                var officerAlpha = Math.Clamp(_config.OfficerChatOpacity, 0f, 1f);
+                                ImGui.PushStyleVar(ImGuiStyleVar.Alpha, officerAlpha);
+                            }
+
+                            if (!_officerChecked && !_checkingOfficer)
+                            {
+                                _officerChecked = true;
+                                _checkingOfficer = true;
+                                _ = Task.Run(async () =>
+                                {
+                                    await _refreshRoles();
+                                    PluginServices.Instance?.Framework.RunOnTick(() =>
+                                    {
+                                        _checkingOfficer = false;
+                                        if (!HasOfficerRole)
+                                            ImGui.SetTabItemClosed("Officer");
+                                    });
+                                });
+                            }
+                            ImGui.BeginChild("##officerChatArea", ImGui.GetContentRegionAvail(), false);
+                            _officer.Draw();
+                            ImGui.EndChild();
+                            ImGui.EndTabItem();
+
+                            if (applyOfficerOpacity)
+                            {
+                                ImGui.PopStyleVar();
+                            }
+                        }
+                        else
+                        {
+                            _officerChecked = false;
+                        }
+                    }
+                }
+
+                ImGui.EndTabBar();
+            }
         }
 
-
         ImGui.End();
+
+        if (styleAlphaPushed)
+        {
+            ImGui.PopStyleVar();
+        }
+
         ImGui.PopStyleColor(5);
+
+        UpdateFadeState(interacted, deltaTime);
     }
 
     public void ResetEventCreateRoles()
@@ -297,6 +345,59 @@ public class MainWindow : IDisposable
 
     public void ResetFadeTimer()
     {
+        _timeSinceLastInteraction = 0f;
+        _fadeAlpha = 1f;
+    }
+
+    private float GetCurrentFadeAlpha()
+    {
+        if (!_config.ChatFadeOutEnabled)
+        {
+            return 1f;
+        }
+
+        var minAlpha = Math.Clamp(_config.ChatFadeOutMinimumAlpha, 0f, 1f);
+        return Math.Clamp(_fadeAlpha, minAlpha, 1f);
+    }
+
+    private void UpdateFadeState(bool interacted, float deltaTime)
+    {
+        if (!_config.ChatFadeOutEnabled)
+        {
+            ResetFadeTimer();
+            return;
+        }
+
+        if (interacted)
+        {
+            ResetFadeTimer();
+            return;
+        }
+
+        if (deltaTime <= 0f)
+        {
+            return;
+        }
+
+        var minAlpha = Math.Clamp(_config.ChatFadeOutMinimumAlpha, 0f, 1f);
+        if (minAlpha >= 1f - FadeAlphaTolerance)
+        {
+            ResetFadeTimer();
+            return;
+        }
+
+        var duration = Math.Max(MinimumFadeDuration, (float)_config.ChatFadeOutDelaySeconds);
+        _timeSinceLastInteraction = Math.Clamp(_timeSinceLastInteraction + deltaTime, 0f, duration);
+        var progress = Math.Clamp(_timeSinceLastInteraction / duration, 0f, 1f);
+        var targetAlpha = 1f - (1f - minAlpha) * progress;
+        _fadeAlpha = Math.Clamp(targetAlpha, minAlpha, 1f);
+    }
+
+    private static bool HasWindowInteraction()
+    {
+        var hovered = ImGui.IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows | ImGuiHoveredFlags.AllowWhenBlockedByActiveItem | ImGuiHoveredFlags.AllowWhenBlockedByPopup);
+        var focused = ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows);
+        return hovered || focused;
     }
 
     private void SaveConfig()


### PR DESCRIPTION
## Summary
- track fade timing in MainWindow to compute the active chat fade alpha each frame
- scale DemiCat window colors and style alpha based on the computed fade, resetting when users interact
- apply FC Chat and Officer tab opacity overrides only when fade-out is disabled and expose ResetFadeTimer for settings

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0308ee40883288ef94fde8815d212