### PR TITLE
Fix ImGuiNET namespace dependency

### DIFF
--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures;
-using ImGuiNET;
+using ImGuiMouseCursor = Dalamud.Bindings.ImGui.ImGuiMouseCursor;
 
 namespace DemiCatPlugin;
 


### PR DESCRIPTION
## Summary
- stop importing the ImGuiNET namespace in PresenceSidebar and use the Dalamud bindings cursor alias instead

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d038661fa8832896d8a86e4a25361a