### PR TITLE
Cache user avatars from membership and presence data

### DIFF
--- a/demibot/demibot/http/routes/users.py
+++ b/demibot/demibot/http/routes/users.py
@@ -47,6 +47,7 @@ async def get_users(
             DbPresence.status_text,
             Role.discord_role_id,
             Role.name,
+            Membership.avatar_url,
         )
         .join(Membership, Membership.user_id == User.id)
         .join(
@@ -70,7 +71,7 @@ async def get_users(
     cache = {p.id: p for p in get_presences(ctx.guild.id)}
 
     user_map: dict[int, dict[str, object]] = {}
-    for u, n, s, st, rid, role_name in rows:
+    for u, n, s, st, rid, role_name, avatar in rows:
         entry = user_map.setdefault(
             u.discord_user_id,
             {
@@ -79,6 +80,7 @@ async def get_users(
                 "status": s,
                 "status_text": st,
                 "roles": {},
+                "avatar": avatar,
             },
         )
         if entry["status"] is None and s is not None:
@@ -87,6 +89,8 @@ async def get_users(
             entry["status_text"] = st
         if entry["nickname"] is None and n is not None:
             entry["nickname"] = n
+        if entry["avatar"] is None and avatar is not None:
+            entry["avatar"] = avatar
         if rid is not None:
             roles_dict = entry["roles"]  # type: ignore[assignment]
             if role_name is not None:
@@ -94,7 +98,16 @@ async def get_users(
             else:
                 roles_dict.setdefault(rid, None)
 
+    for uid, data in user_map.items():
+        presence = cache.get(uid)
+        if presence and presence.avatar_url and not data.get("avatar"):
+            data["avatar"] = presence.avatar_url
+
     avatars: dict[int, str] = {}
+    for uid, data in user_map.items():
+        avatar_value = data.get("avatar")
+        if isinstance(avatar_value, str):
+            avatars[uid] = avatar_value
     usernames: dict[int, str] = {}
     missing_ids: set[int] = set()
     role_names: dict[int, str] = {}
@@ -109,8 +122,8 @@ async def get_users(
             }
         for data in user_map.values():
             u = data["user"]  # type: ignore[assignment]
-            avatar: str | None = None
-            username: str | None = None
+            avatar: str | None = avatars.get(u.discord_user_id)
+            username: str | None = usernames.get(u.discord_user_id)
 
             member = guild.get_member(u.discord_user_id) if guild else None
             if member:

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -93,6 +93,47 @@ def test_get_users_includes_status_from_cache():
     asyncio.run(_run())
 
 
+def test_get_users_uses_cached_avatars_without_discord():
+    async def _run():
+        await init_db('sqlite+aiosqlite://')
+        async with get_session() as db:
+            await db.execute(delete(MembershipRole))
+            await db.execute(delete(Role))
+            await db.execute(delete(DbPresence))
+            await db.execute(delete(Membership))
+            await db.execute(delete(User))
+            await db.commit()
+            db.add(User(id=11, discord_user_id=110, global_name='CacheUser'))
+            db.add(User(id=12, discord_user_id=120, global_name='PresenceUser'))
+            db.add(
+                Membership(
+                    id=11,
+                    guild_id=99,
+                    user_id=11,
+                    avatar_url='https://example.com/avatar.png',
+                )
+            )
+            db.add(Membership(id=12, guild_id=99, user_id=12))
+            await db.commit()
+            set_presence(
+                99,
+                StorePresence(
+                    id=120,
+                    name='PresenceUser',
+                    status='online',
+                    avatar_url='https://example.com/presence.png',
+                ),
+            )
+            users_route.discord_client = None
+            ctx = StubContext(99)
+            res = await get_users(ctx=ctx, db=db)
+            data = {u['id']: u for u in res}
+            assert data['110']['avatar_url'] == 'https://example.com/avatar.png'
+            assert data['120']['avatar_url'] == 'https://example.com/presence.png'
+
+    asyncio.run(_run())
+
+
 def test_get_users_reads_presence_from_db():
     async def _run():
         await init_db('sqlite+aiosqlite://')


### PR DESCRIPTION
## Summary
- prepopulate cached avatars for guild members using membership records and presence data
- only request Discord data when avatars are missing so cached values survive when the bot is offline
- add coverage ensuring the users endpoint returns stored avatar URLs without a Discord client

## Testing
- pytest tests/test_users.py

------
https://chatgpt.com/codex/tasks/task_e_68d043c902a48328b464ecb87d22997a