### PR TITLE
Join Discord threads before direct send fallback

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -917,6 +917,44 @@ async def save_message(
         target_channel = thread_obj or base_channel
         log_extra = {"guild_id": ctx.guild.id, "channel_id": cid}
         if target_channel and isinstance(target_channel, discord.abc.Messageable):
+            thread_identifier = getattr(target_channel, "id", cid)
+            if isinstance(target_channel, discord.Thread):
+                joined = getattr(target_channel, "joined", None)
+                if joined is None:
+                    thread_member = getattr(target_channel, "me", None)
+                    joined = getattr(thread_member, "joined", None) if thread_member else None
+                if joined is not True:
+                    logging.info(
+                        "Joining thread %s prior to direct send fallback",
+                        thread_identifier,
+                        extra=log_extra,
+                    )
+                    try:
+                        await target_channel.join()
+                    except discord.HTTPException as exc:
+                        logging.error(
+                            "thread.join failed for thread %s: %s %s",
+                            thread_identifier,
+                            exc.status,
+                            exc.text,
+                            extra=log_extra,
+                        )
+                        error_details.append(
+                            f"Thread join failed: {exc.status} {exc.text or _discord_error(exc)}"
+                        )
+                    except Exception as exc:
+                        logging.exception(
+                            "thread.join failed for thread %s",
+                            thread_identifier,
+                            extra=log_extra,
+                        )
+                        error_details.append(f"Thread join failed: {exc}")
+                    else:
+                        logging.info(
+                            "Joined thread %s prior to direct send fallback",
+                            thread_identifier,
+                            extra=log_extra,
+                        )
             try:
                 fallback_files = _make_discord_files(uploads)
                 sent = await target_channel.send(
@@ -1064,7 +1102,14 @@ async def save_message(
                             "channelId": str(cid),
                         },
                     )
-                logging.warning("Failed to resolve channel", extra=log_extra)
+                if error_details:
+                    logging.error(
+                        "Failed to resolve channel due to Discord errors: %s",
+                        error_details,
+                        extra=log_extra,
+                    )
+                else:
+                    logging.warning("Failed to resolve channel", extra=log_extra)
                 detail: dict[str, object] = {"message": "channel not found"}
                 if error_details:
                     detail["discord"] = error_details

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -153,6 +153,100 @@ def test_save_and_fetch_messages(monkeypatch):
     asyncio.run(_run())
 
 
+def test_save_message_private_thread(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
+            await db.execute(text("DELETE FROM messages"))
+            await db.execute(text("DELETE FROM memberships"))
+            await db.execute(text("DELETE FROM users"))
+            await db.execute(text("DELETE FROM guilds"))
+            await db.execute(text("DELETE FROM guild_channels"))
+            db.add(Guild(id=1, discord_guild_id=1, name="Guild"))
+            db.add(User(id=1, discord_user_id=10, global_name="Alice"))
+            db.add(
+                Membership(
+                    guild_id=1,
+                    user_id=1,
+                    nickname="AliceNick",
+                    avatar_url="http://example.com/avatar.png",
+                )
+            )
+            thread_id = 456
+            db.add(
+                GuildChannel(
+                    guild_id=1,
+                    channel_id=thread_id,
+                    kind=ChannelKind.FC_CHAT,
+                )
+            )
+            await db.commit()
+            guild = await db.get(Guild, 1)
+            user = await db.get(User, 1)
+            ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=[])
+
+            broadcast_calls: List[Tuple[str, int, bool, str | None]] = []
+
+            async def dummy_broadcast(message: str, guild_id: int, officer_only: bool = False, path: str | None = None):
+                broadcast_calls.append((message, guild_id, officer_only, path))
+
+            monkeypatch.setattr(mc.manager, "broadcast_text", dummy_broadcast)
+
+            class DummyMessageable:
+                pass
+
+            class DummyParent:
+                id = 123
+
+            class DummyThread(DummyMessageable):
+                def __init__(self) -> None:
+                    self.id = thread_id
+                    self.parent = DummyParent()
+                    self.archived = False
+                    self.joined = False
+                    self.join_calls = 0
+                    self.send_calls = 0
+
+                async def join(self) -> None:
+                    self.join_calls += 1
+                    self.joined = True
+
+                async def send(self, *args, **kwargs):
+                    if not self.joined:
+                        raise AssertionError("thread must be joined before send")
+                    self.send_calls += 1
+                    return types.SimpleNamespace(id=99, attachments=[])
+
+            thread = DummyThread()
+
+            class DummyClient:
+                def get_channel(self, cid: int):
+                    assert cid == thread_id
+                    return thread
+
+            async def fake_send_via_webhook(**kwargs):
+                return None, None, ["webhook unavailable"], None
+
+            monkeypatch.setattr(mc, "discord_client", DummyClient())
+            monkeypatch.setattr(mc.discord, "Thread", DummyThread, raising=False)
+            monkeypatch.setattr(mc.discord.abc, "Messageable", DummyMessageable, raising=False)
+            monkeypatch.setattr(mc, "_channel_supports_webhooks", lambda channel: True)
+            monkeypatch.setattr(mc, "_send_via_webhook", fake_send_via_webhook)
+            monkeypatch.setattr(mc, "_channel_webhooks", {})
+
+            body = mc.PostBody(channel_id=str(thread_id), content="hello thread")
+            res = await mc.save_message(body, ctx, db, channel_kind=ChannelKind.FC_CHAT)
+
+            assert res["ok"] is True
+            assert res["id"] == "99"
+            assert broadcast_calls
+            assert thread.join_calls == 1
+            assert thread.send_calls == 1
+
+    asyncio.run(_run())
+
+
 def test_fetch_messages_attachment_aliases():
     async def _run():
         await init_db("sqlite+aiosqlite://")


### PR DESCRIPTION
## Summary
- join Discord threads before invoking the direct send fallback so private threads become messageable, logging join attempts and failures
- surface detailed Discord errors when the direct fallback cannot resolve a channel
- add a regression test covering the private thread fallback path

## Testing
- `PYTHONPATH=demibot pytest tests/test_messages_common.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0464f29288328b8caefb724922794