### PR TITLE
Separate REST cursors from websocket cursors

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1361,7 +1361,7 @@ public class ChatWindow : IDisposable
             var all = new List<DiscordMessageDto>();
             string? before = null;
             var cursorKey = ChannelKeyHelper.BuildCursorKey(_config.GuildId, _channelKind, channelId);
-            var hasCursor = _config.ChatCursors.TryGetValue(cursorKey, out var since);
+            var hasCursor = _config.RestChatCursors.TryGetValue(cursorKey, out var since);
             var storedAfter = hasCursor ? since.ToString() : null;
             var firstPage = true;
             while (all.Count < MaxMessages)
@@ -1448,7 +1448,7 @@ public class ChatWindow : IDisposable
             if (!string.IsNullOrEmpty(channelId))
             {
                 var cursorKey = ChannelKeyHelper.BuildCursorKey(_config.GuildId, _channelKind, channelId);
-                _config.ChatCursors[cursorKey] = last;
+                _config.RestChatCursors[cursorKey] = last;
             }
         }
     }

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -9,7 +9,7 @@ namespace DemiCatPlugin;
 public class Config : IPluginConfiguration
 {
     // Required by Dalamud
-    public int Version { get; set; } = 6;
+    public int Version { get; set; } = 7;
 
     public bool Enabled { get; set; } = true;
     public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
@@ -19,6 +19,7 @@ public class Config : IPluginConfiguration
     public string GuildId { get; set; } = string.Empty;
     public string ChatChannelId { get; set; } = string.Empty;
     public Dictionary<string, long> ChatCursors { get; set; } = new();
+    public Dictionary<string, long> RestChatCursors { get; set; } = new();
     public Dictionary<string, string> ChannelSelections { get; set; } = new();
     public string EventChannelId { get; set; } = string.Empty;
     public string FcChannelId { get; set; } = string.Empty;
@@ -92,6 +93,8 @@ public class Config : IPluginConfiguration
 
     public void Migrate()
     {
+        RestChatCursors ??= new Dictionary<string, long>();
+
         if (Version < 3)
         {
             if (ExtensionData != null)
@@ -214,6 +217,22 @@ public class Config : IPluginConfiguration
             }
 
             Version = 6;
+            ExtensionData = null;
+        }
+        if (Version < 7)
+        {
+            if (RestChatCursors.Count == 0 && ChatCursors.Count > 0)
+            {
+                foreach (var kvp in ChatCursors)
+                {
+                    if (!RestChatCursors.ContainsKey(kvp.Key))
+                    {
+                        RestChatCursors[kvp.Key] = kvp.Value;
+                    }
+                }
+            }
+
+            Version = 7;
             ExtensionData = null;
         }
     }

--- a/tests/ChatWindowMessageLimitTests.cs
+++ b/tests/ChatWindowMessageLimitTests.cs
@@ -33,7 +33,8 @@ public class ChatWindowMessageLimitTests
         Assert.Equal("21", msgs[0].Id);
         Assert.Equal("120", msgs[^1].Id);
         var cursorKey = ChannelKeyHelper.BuildCursorKey(config.GuildId, ChannelKind.Chat, "1");
-        Assert.Equal(120, config.ChatCursors[cursorKey]);
+        Assert.Equal(120, config.RestChatCursors[cursorKey]);
+        Assert.False(config.ChatCursors.ContainsKey(cursorKey));
         Assert.Equal(2, handler.Requests.Count);
 
         handler.Requests.Clear();
@@ -44,7 +45,8 @@ public class ChatWindowMessageLimitTests
         Assert.Equal(100, msgs.Count);
         Assert.Equal("31", msgs[0].Id);
         Assert.Equal("130", msgs[^1].Id);
-        Assert.Equal(130, config.ChatCursors[cursorKey]);
+        Assert.Equal(130, config.RestChatCursors[cursorKey]);
+        Assert.False(config.ChatCursors.ContainsKey(cursorKey));
         Assert.Single(handler.Requests);
         Assert.DoesNotContain("after=", handler.Requests[0].Query);
     }
@@ -66,7 +68,8 @@ public class ChatWindowMessageLimitTests
 
         Assert.Single(handler.Requests);
         Assert.DoesNotContain("after=", handler.Requests[0].Query);
-        Assert.Equal(20, config.ChatCursors[cursorKey]);
+        Assert.Equal(20, config.RestChatCursors[cursorKey]);
+        Assert.False(config.ChatCursors.ContainsKey(cursorKey));
     }
 
     [Fact]
@@ -80,7 +83,7 @@ public class ChatWindowMessageLimitTests
         var channelService = new ChannelService(config, client, tm);
         var window = new ChatWindow(config, client, null, tm, channelService);
         var cursorKey = ChannelKeyHelper.BuildCursorKey(config.GuildId, ChannelKind.Chat, "1");
-        config.ChatCursors[cursorKey] = 120;
+        config.RestChatCursors[cursorKey] = 120;
 
         handler.EnqueueResponse(SerializeMessages(71, 120));
         handler.EnqueueResponse(SerializeMessages(21, 70));
@@ -107,6 +110,7 @@ public class ChatWindowMessageLimitTests
         for (int i = 1; i <= 100; i++)
             msgs.Add(new DiscordMessageDto { Id = i.ToString(), ChannelId = "1", Author = new DiscordUserDto(), Timestamp = DateTime.UtcNow });
         config.ChatCursors[cursorKey] = 100;
+        config.RestChatCursors[cursorKey] = 100;
 
         var method = typeof(ChatWindow).GetMethod("HandleBridgeMessage", BindingFlags.Instance | BindingFlags.NonPublic)!;
         var newMsg = new DiscordMessageDto { Id = "101", ChannelId = "1", Author = new DiscordUserDto(), Timestamp = DateTime.UtcNow };
@@ -116,7 +120,8 @@ public class ChatWindowMessageLimitTests
         Assert.Equal(100, msgs.Count);
         Assert.Equal("2", msgs[0].Id);
         Assert.Equal("101", msgs[^1].Id);
-        Assert.Equal(101, config.ChatCursors[cursorKey]);
+        Assert.Equal(101, config.RestChatCursors[cursorKey]);
+        Assert.Equal(100, config.ChatCursors[cursorKey]);
     }
 
     private static List<DiscordMessageDto> GetMessages(ChatWindow window)

--- a/tests/ChatWindowWebSocketTests.cs
+++ b/tests/ChatWindowWebSocketTests.cs
@@ -514,6 +514,92 @@ public class ChatWindowWebSocketTests
     }
 
     [Fact]
+    public async Task WebSocket_SecondLaunchAfterRestRefreshReceivesHistory()
+    {
+        var observedSince = -1;
+
+        using var server = new MockWsServer(async (ws, _, srv) =>
+        {
+            while (ws.State == WebSocketState.Open)
+            {
+                var msg = await srv.Receive(ws);
+                if (msg.Contains("\"op\":\"sub\""))
+                {
+                    var since = ExtractSince(msg);
+                    Volatile.Write(ref observedSince, since);
+
+                    var ack = JsonSerializer.Serialize(new { op = "ack", channel = "1", guildId = "", kind = "CHAT" });
+                    await srv.Send(ws, ack);
+
+                    var batch = JsonSerializer.Serialize(new
+                    {
+                        op = "batch",
+                        channel = "1",
+                        guildId = "",
+                        kind = "CHAT",
+                        messages = new[]
+                        {
+                            new
+                            {
+                                cursor = 5,
+                                op = "mc",
+                                d = new
+                                {
+                                    id = "m5",
+                                    channelId = "1",
+                                    content = "hello",
+                                    author = new { id = "u1", name = "Tester" },
+                                    timestamp = DateTime.UtcNow
+                                }
+                            }
+                        }
+                    });
+                    await srv.Send(ws, batch);
+                }
+            }
+        });
+
+        _ = SetupServices();
+        var config = new Config { ApiBaseUrl = "http://localhost", ChatChannelId = "1" };
+        var restHandler = new RestMessageHandler(SerializeMessages(1, 5));
+        using var restClient = new HttpClient(restHandler);
+        var tm = new TokenManager();
+        var channelService = new ChannelService(config, restClient, tm);
+        var window = new ChatWindow(config, restClient, null, tm, channelService);
+        var cursorKey = ChannelKeyHelper.BuildCursorKey(config.GuildId, ChannelKind.Chat, "1");
+
+        await window.RefreshMessages();
+
+        Assert.True(config.RestChatCursors.TryGetValue(cursorKey, out var restCursor));
+        Assert.Equal(5, restCursor);
+        Assert.False(config.ChatCursors.ContainsKey(cursorKey));
+
+        config.ApiBaseUrl = server.HttpBase;
+        var selection = new ChannelSelectionService(config);
+        using var client = new HttpClient();
+        var bridge = new ChatBridge(config, client, new TokenManager(), () => server.Uri, selection);
+
+        var messageCount = 0;
+        bridge.MessageReceived += _ => Interlocked.Increment(ref messageCount);
+
+        bridge.Start();
+        bridge.Subscribe("1", config.GuildId, ChannelKind.Chat);
+
+        try
+        {
+            await WaitUntil(() => Volatile.Read(ref observedSince) >= 0, TimeSpan.FromSeconds(5));
+            await WaitUntil(() => Volatile.Read(ref messageCount) > 0, TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            bridge.Stop();
+        }
+
+        Assert.Equal(0, Volatile.Read(ref observedSince));
+        Assert.True(messageCount > 0);
+    }
+
+    [Fact]
     public async Task WebSocket_DropsMismatchedBatch()
     {
         using var server = new MockWsServer(async (ws, _, srv) =>
@@ -669,6 +755,24 @@ public class ChatWindowWebSocketTests
         }
     }
 
+    private static string SerializeMessages(int start, int end, string channelId = "1")
+    {
+        var list = new List<object>();
+        for (var i = start; i <= end; i++)
+        {
+            list.Add(new
+            {
+                id = i.ToString(),
+                channelId,
+                author = new { id = "u", name = "n" },
+                content = string.Empty,
+                timestamp = DateTime.UtcNow
+            });
+        }
+
+        return JsonSerializer.Serialize(list);
+    }
+
     private static TestLog SetupServices()
     {
         var ps = new PluginServices();
@@ -724,6 +828,30 @@ public class ChatWindowWebSocketTests
             {
                 _warnings.Add(message);
             }
+        }
+    }
+
+    private sealed class RestMessageHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+
+        public RestMessageHandler(params string[] payloads)
+        {
+            _responses = new Queue<HttpResponseMessage>(payloads.Select(payload =>
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
+                }));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_responses.Count == 0)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
+            return Task.FromResult(_responses.Dequeue());
         }
     }
 


### PR DESCRIPTION
## Summary
- add a dedicated REST cursor store to Config and teach ChatWindow to use it for pagination
- migrate existing configs to populate the new store while leaving websocket cursors intact
- update chat window tests for the new split and add a regression test covering history on a second launch

## Testing
- `dotnet test` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0493ac2b88328b8b069fc716699cd