### PR TITLE
Ensure channel selection persists fallback defaults

### DIFF
--- a/DemiCatPlugin/ChannelSelectionService.cs
+++ b/DemiCatPlugin/ChannelSelectionService.cs
@@ -67,23 +67,31 @@ public class ChannelSelectionService
         guildId ??= string.Empty;
         var normalizedKind = ChannelKeyHelper.NormalizeKind(kind);
         var normalizedGuild = ChannelKeyHelper.NormalizeGuildId(guildId);
+        var key = ChannelKeyHelper.BuildSelectionKey(guildId, kind);
         var old = GetChannel(kind, guildId, out _);
         var scopedKey = normalizedKind == NormalizedEventKind ? BuildEventSelectionKey(normalizedGuild) : null;
 
         if (old == id)
         {
+            var hasStoredNormal = _config.ChannelSelections.TryGetValue(key, out var existingNormal) && existingNormal == id;
+
             if (scopedKey == null)
             {
-                return;
+                if (hasStoredNormal)
+                {
+                    return;
+                }
             }
-
-            if (_config.ChannelSelections.TryGetValue(scopedKey, out var existingScoped) && existingScoped == id)
+            else
             {
-                return;
+                var hasStoredScoped = _config.ChannelSelections.TryGetValue(scopedKey, out var existingScoped) && existingScoped == id;
+                if (hasStoredNormal && hasStoredScoped)
+                {
+                    return;
+                }
             }
         }
 
-        var key = ChannelKeyHelper.BuildSelectionKey(guildId, kind);
         if (string.IsNullOrEmpty(id))
         {
             _config.ChannelSelections.Remove(key);

--- a/tests/ChannelSelectionServiceTests.cs
+++ b/tests/ChannelSelectionServiceTests.cs
@@ -34,4 +34,94 @@ public class ChannelSelectionServiceTests
         Assert.Equal("chan-3", service.GetChannel(ChannelKind.Chat, "guild-a", out _));
         Assert.Equal("chan-2", service.GetChannel(ChannelKind.Chat, "guild-b", out _));
     }
+
+    [Fact]
+    public void SetChannel_PersistsDefaultSelectionWhenMatchingExistingConfig()
+    {
+        var config = new Config
+        {
+            FcChannelId = "chan-1"
+        };
+        var service = new ChannelSelectionService(config);
+
+        var initial = service.GetChannel(ChannelKind.FcChat, null, out var hasStored);
+        Assert.False(hasStored);
+        Assert.Equal("chan-1", initial);
+
+        var key = ChannelKeyHelper.BuildSelectionKey(null, ChannelKind.FcChat);
+        Assert.False(config.ChannelSelections.ContainsKey(key));
+
+        var events = 0;
+        (string Kind, string Guild, string OldId, string NewId) last = default;
+        service.ChannelChanged += (kind, guild, oldId, newId) =>
+        {
+            events++;
+            last = (kind, guild, oldId, newId);
+        };
+
+        service.SetChannel(ChannelKind.FcChat, null, "chan-1");
+
+        Assert.True(config.ChannelSelections.TryGetValue(key, out var stored));
+        Assert.Equal("chan-1", stored);
+        Assert.Equal(1, events);
+        Assert.Equal(ChannelKind.FcChat, last.Kind);
+        Assert.Equal(string.Empty, last.Guild);
+        Assert.Equal("chan-1", last.OldId);
+        Assert.Equal("chan-1", last.NewId);
+    }
+
+    [Fact]
+    public void SetChannel_EventDoesNotNotifyWhenKeysMatch()
+    {
+        const string guildId = "guild-1";
+        var normalizedGuild = ChannelKeyHelper.NormalizeGuildId(guildId);
+        var key = ChannelKeyHelper.BuildSelectionKey(guildId, ChannelKind.Event);
+        var scopedKey = $"Event:{normalizedGuild}";
+
+        var config = new Config();
+        config.ChannelSelections[key] = "event-42";
+        config.ChannelSelections[scopedKey] = "event-42";
+
+        var service = new ChannelSelectionService(config);
+
+        var events = 0;
+        service.ChannelChanged += (kind, guild, oldId, newId) => events++;
+
+        service.SetChannel(ChannelKind.Event, guildId, "event-42");
+
+        Assert.Equal(0, events);
+        Assert.Equal("event-42", config.ChannelSelections[key]);
+        Assert.Equal("event-42", config.ChannelSelections[scopedKey]);
+    }
+
+    [Fact]
+    public void SetChannel_EventPersistsMissingNormalKey()
+    {
+        const string guildId = "guild-1";
+        var normalizedGuild = ChannelKeyHelper.NormalizeGuildId(guildId);
+        var scopedKey = $"Event:{normalizedGuild}";
+
+        var config = new Config();
+        config.ChannelSelections[scopedKey] = "event-42";
+
+        var service = new ChannelSelectionService(config);
+
+        var events = 0;
+        (string OldId, string NewId) last = default;
+        service.ChannelChanged += (kind, guild, oldId, newId) =>
+        {
+            events++;
+            last = (oldId, newId);
+        };
+
+        service.SetChannel(ChannelKind.Event, guildId, "event-42");
+
+        var key = ChannelKeyHelper.BuildSelectionKey(guildId, ChannelKind.Event);
+        Assert.True(config.ChannelSelections.TryGetValue(key, out var storedNormal));
+        Assert.Equal("event-42", storedNormal);
+        Assert.Equal("event-42", config.ChannelSelections[scopedKey]);
+        Assert.Equal(1, events);
+        Assert.Equal("event-42", last.OldId);
+        Assert.Equal("event-42", last.NewId);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `SetChannel` writes selections even when the prior value matches a fallback default
- continue suppressing redundant notifications once both normal and scoped keys already contain the requested id
- extend the channel selection tests to cover default fallback persistence and event key handling

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d054bc92888328877490a21f0350bb