### PR TITLE
Add guard to channel fetch and tests

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -31,6 +31,7 @@ public class ChatWindow : IDisposable
     protected readonly List<ChannelDto> _channels = new();
     protected int _selectedIndex;
     protected bool _channelsLoaded;
+    protected bool _channelsLoading;
     protected bool _channelFetchFailed;
     protected string _channelErrorMessage = string.Empty;
     protected string _input = string.Empty;
@@ -229,7 +230,7 @@ public class ChatWindow : IDisposable
             return;
         }
 
-        if (!_channelsLoaded)
+        if (!_channelsLoaded && !_channelsLoading)
         {
             _ = FetchChannels();
         }
@@ -1522,9 +1523,15 @@ public class ChatWindow : IDisposable
 
     protected virtual async Task FetchChannels(bool refreshed = false)
     {
+        if (_channelsLoading && !refreshed)
+        {
+            return;
+        }
+
         if (!_tokenManager.IsReady())
         {
             _channelsLoaded = true;
+            _channelsLoading = false;
             return;
         }
 
@@ -1536,20 +1543,37 @@ public class ChatWindow : IDisposable
                 _channelFetchFailed = true;
                 _channelErrorMessage = "Invalid API URL";
                 _channelsLoaded = true;
+                _channelsLoading = false;
             });
             return;
         }
 
+        _channelsLoading = true;
+
         try
         {
             var channels = (await _channelService.FetchAsync(_channelKind, CancellationToken.None)).ToList();
-            if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true))) return;
+            if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true)))
+            {
+                if (refreshed)
+                {
+                    _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                    {
+                        _channelFetchFailed = true;
+                        _channelErrorMessage = "Failed to load channels";
+                        _channelsLoaded = true;
+                        _channelsLoading = false;
+                    });
+                }
+                return;
+            }
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(channels);
                 _channelsLoaded = true;
                 _channelFetchFailed = false;
                 _channelErrorMessage = string.Empty;
+                _channelsLoading = false;
             });
         }
         catch (HttpRequestException ex)
@@ -1564,6 +1588,7 @@ public class ChatWindow : IDisposable
                         ? "Forbidden – check API key/roles"
                         : "Failed to load channels";
                 _channelsLoaded = true;
+                _channelsLoading = false;
             });
         }
         catch (Exception ex)
@@ -1574,6 +1599,7 @@ public class ChatWindow : IDisposable
                 _channelFetchFailed = true;
                 _channelErrorMessage = "Failed to load channels";
                 _channelsLoaded = true;
+                _channelsLoading = false;
             });
         }
     }

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -265,9 +265,15 @@ public class OfficerChatWindow : ChatWindow
 
     protected override async Task FetchChannels(bool refreshed = false)
     {
+        if (_channelsLoading && !refreshed)
+        {
+            return;
+        }
+
         if (!_tokenManager.IsReady())
         {
             _channelsLoaded = true;
+            _channelsLoading = false;
             return;
         }
 
@@ -279,21 +285,37 @@ public class OfficerChatWindow : ChatWindow
                 _channelFetchFailed = true;
                 _channelErrorMessage = "Invalid API URL";
                 _channelsLoaded = true;
+                _channelsLoading = false;
             });
             return;
         }
+
+        _channelsLoading = true;
 
         try
         {
             var channels = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(global::DemiCatPlugin.ChannelKind.OfficerChat, CancellationToken.None)).ToList());
             if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true)))
+            {
+                if (refreshed)
+                {
+                    _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                    {
+                        _channelFetchFailed = true;
+                        _channelErrorMessage = "Failed to load channels";
+                        _channelsLoaded = true;
+                        _channelsLoading = false;
+                    });
+                }
                 return;
+            }
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 SetChannels(channels);
                 _channelsLoaded = true;
                 _channelFetchFailed = false;
                 _channelErrorMessage = string.Empty;
+                _channelsLoading = false;
             });
         }
         catch (HttpRequestException ex)
@@ -306,6 +328,7 @@ public class OfficerChatWindow : ChatWindow
                     ? "Forbidden – check API key/roles"
                     : "Failed to load channels";
                 _channelsLoaded = true;
+                _channelsLoading = false;
             });
         }
         catch (Exception ex)
@@ -316,6 +339,7 @@ public class OfficerChatWindow : ChatWindow
                 _channelFetchFailed = true;
                 _channelErrorMessage = "Failed to load channels";
                 _channelsLoaded = true;
+                _channelsLoading = false;
             });
         }
     }

--- a/tests/ChatWindowChannelFetchTests.cs
+++ b/tests/ChatWindowChannelFetchTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Plugin.Services;
+using DemiCatPlugin;
+using Xunit;
+
+public class ChatWindowChannelFetchTests
+{
+    [Fact]
+    public async Task RefreshChannels_DeduplicatesConcurrentRequests()
+    {
+        SetupServices();
+        var config = new Config
+        {
+            ApiBaseUrl = "http://localhost",
+            GuildId = "guild"
+        };
+        var handler = new SequenceHandler();
+        handler.EnqueueResponse(SerializeChannels(("1", "general")));
+        using var client = new HttpClient(handler);
+        var tokenManager = new TokenManager();
+        var channelService = new ChannelService(config, client, tokenManager);
+        var window = new ChatWindow(config, client, null, tokenManager, channelService);
+
+        await Task.WhenAll(window.RefreshChannels(), window.RefreshChannels());
+
+        Assert.Single(handler.Requests);
+        Assert.Equal("/api/channels", handler.Requests[0].AbsolutePath);
+
+        handler.EnqueueResponse(SerializeChannels(("2", "general")));
+        await window.RefreshChannels();
+
+        Assert.Equal(2, handler.Requests.Count);
+        window.Dispose();
+    }
+
+    [Fact]
+    public async Task OfficerRefreshChannels_DeduplicatesConcurrentRequests()
+    {
+        SetupServices();
+        var config = new Config
+        {
+            ApiBaseUrl = "http://localhost",
+            GuildId = "guild",
+            Roles = new[] { "officer" }
+        };
+        var handler = new SequenceHandler();
+        handler.EnqueueResponse(SerializeChannels(("1", "officer")));
+        using var client = new HttpClient(handler);
+        var tokenManager = new TokenManager();
+        var channelService = new ChannelService(config, client, tokenManager);
+        var window = new OfficerChatWindow(config, client, null, tokenManager, channelService);
+
+        await Task.WhenAll(window.RefreshChannels(), window.RefreshChannels());
+
+        Assert.Single(handler.Requests);
+        Assert.Equal("/api/channels", handler.Requests[0].AbsolutePath);
+
+        handler.EnqueueResponse(SerializeChannels(("2", "officer")));
+        await window.RefreshChannels();
+
+        Assert.Equal(2, handler.Requests.Count);
+        window.Dispose();
+    }
+
+    private static string SerializeChannels(params (string Id, string Name)[] channels)
+    {
+        var list = new List<object>();
+        foreach (var (id, name) in channels)
+        {
+            list.Add(new
+            {
+                id,
+                name,
+                parentId = (string?)null
+            });
+        }
+        return System.Text.Json.JsonSerializer.Serialize(list);
+    }
+
+    private static void SetupServices()
+    {
+        var services = new PluginServices();
+        var framework = new TestFramework();
+        var log = new TestLog();
+        typeof(PluginServices).GetProperty("Framework", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, framework);
+        typeof(PluginServices).GetProperty("Log", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, log);
+    }
+
+    private sealed class SequenceHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new();
+        public List<Uri> Requests { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request.RequestUri!);
+            if (_responses.Count == 0)
+            {
+                throw new InvalidOperationException("No response queued.");
+            }
+            return Task.FromResult(_responses.Dequeue());
+        }
+
+        public void EnqueueResponse(string json)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+            _responses.Enqueue(response);
+        }
+    }
+
+    private sealed class TestFramework : IFramework
+    {
+        public event FrameworkUpdateDelegate? Update { add { } remove { } }
+        public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
+        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+    }
+
+    private sealed class TestLog : IPluginLog
+    {
+        public void Verbose(string message) { }
+        public void Verbose(string message, Exception exception) { }
+        public void Debug(string message) { }
+        public void Debug(string message, Exception exception) { }
+        public void Info(string message) { }
+        public void Info(string message, Exception exception) { }
+        public void Warning(string message) { }
+        public void Warning(string message, Exception exception) { }
+        public void Error(string message) { }
+        public void Error(Exception exception, string message) { }
+        public void Fatal(string message) { }
+        public void Fatal(Exception exception, string message) { }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `_channelsLoading` guard in `ChatWindow` so Draw only triggers one fetch at a time and clear it when callbacks finish
- update `OfficerChatWindow.FetchChannels` to cooperate with the guard
- add unit tests that log channel requests to ensure only one fetch is issued per refresh cycle

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0588cc3b08328828631763a8b37b1