### PR TITLE
Ensure thread channels reuse stored webhook URLs

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -47,6 +47,55 @@ from ..discord_client import discord_client, is_discord_client_ready
 # Cache webhook URLs per channel to avoid recreation
 _channel_webhooks: dict[int, str] = {}
 
+
+async def _cache_and_store_webhook_url(
+    *,
+    db: AsyncSession,
+    guild_id: int,
+    webhook_url: str,
+    channel_id: int | None,
+    configured_channel_id: int | None,
+    channel_kind: ChannelKind | None,
+) -> None:
+    """Persist the provided webhook URL for the supplied channel ids."""
+
+    targets: dict[int, ChannelKind] = {}
+    if channel_id is not None:
+        targets[channel_id] = ChannelKind.CHAT
+    if configured_channel_id is not None:
+        targets.setdefault(
+            configured_channel_id,
+            channel_kind or ChannelKind.CHAT,
+        )
+    if not targets:
+        return
+
+    for cid in targets:
+        _channel_webhooks[cid] = webhook_url
+
+    result = await db.execute(
+        select(GuildChannel).where(
+            GuildChannel.guild_id == guild_id,
+            GuildChannel.channel_id.in_(list(targets.keys())),
+        )
+    )
+    rows = result.scalars().all()
+    seen_ids = {row.channel_id for row in rows}
+    for row in rows:
+        if row.webhook_url != webhook_url:
+            row.webhook_url = webhook_url
+    for cid, default_kind in targets.items():
+        if cid in seen_ids:
+            continue
+        db.add(
+            GuildChannel(
+                guild_id=guild_id,
+                channel_id=cid,
+                kind=default_kind,
+                webhook_url=webhook_url,
+            )
+        )
+
 MAX_ATTACHMENTS = 10
 MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024  # 25MB
 
@@ -195,6 +244,8 @@ async def create_webhook_for_channel(
     guild_id: int,
     guild_discord_id: int | None = None,
     db: AsyncSession,
+    channel_kind: ChannelKind | None = None,
+    configured_channel_id: int | None = None,
 ) -> tuple[discord.Webhook | None, str | None, list[str]]:
     """Create a webhook for the given channel and persist its URL.
 
@@ -289,26 +340,14 @@ async def create_webhook_for_channel(
         return None, None, errors
 
     webhook_url = created.url
-    _channel_webhooks[channel_id] = webhook_url
-    result = await db.execute(
-        select(GuildChannel).where(
-            GuildChannel.guild_id == guild_id,
-            GuildChannel.channel_id == channel_id,
-        )
+    await _cache_and_store_webhook_url(
+        db=db,
+        guild_id=guild_id,
+        webhook_url=webhook_url,
+        channel_id=channel_id,
+        configured_channel_id=configured_channel_id,
+        channel_kind=channel_kind,
     )
-    rows = result.scalars().all()
-    if rows:
-        for gc in rows:
-            gc.webhook_url = webhook_url
-    else:
-        db.add(
-            GuildChannel(
-                guild_id=guild_id,
-                channel_id=channel_id,
-                kind=ChannelKind.CHAT,
-                webhook_url=webhook_url,
-            )
-        )
     return created, webhook_url, errors
 
 
@@ -411,6 +450,7 @@ async def _send_via_webhook(
     channel_id: int,
     guild_id: int,
     guild_discord_id: int | None = None,
+    configured_channel_id: int | None = None,
     content: str,
     username: str,
     avatar: str | None,
@@ -425,7 +465,9 @@ async def _send_via_webhook(
 
     ``channel`` should be the channel owning the webhook.  When ``thread`` is
     provided, the message will be sent to that thread using the parent
-    channel's webhook.
+    channel's webhook.  ``configured_channel_id`` should be the configured
+    channel identifier which may differ from ``channel_id`` when sending to a
+    thread.
 
     ``embeds`` and ``view`` are optional and allow rich messages to be sent via
     the webhook.  Returns the Discord message id, attachments, any error
@@ -433,7 +475,34 @@ async def _send_via_webhook(
     """
 
     errors: list[str] = []
-    webhook_url: str | None = _channel_webhooks.get(channel_id)
+    candidate_ids: list[int] = []
+    if channel_id is not None:
+        candidate_ids.append(channel_id)
+    if (
+        configured_channel_id is not None
+        and configured_channel_id not in candidate_ids
+    ):
+        candidate_ids.append(configured_channel_id)
+
+    webhook_url: str | None = None
+    for candidate in candidate_ids:
+        cached_url = _channel_webhooks.get(candidate)
+        if cached_url:
+            webhook_url = cached_url
+            break
+
+    if webhook_url and any(
+        _channel_webhooks.get(cid) != webhook_url for cid in candidate_ids
+    ):
+        await _cache_and_store_webhook_url(
+            db=db,
+            guild_id=guild_id,
+            webhook_url=webhook_url,
+            channel_id=channel_id,
+            configured_channel_id=configured_channel_id,
+            channel_kind=channel_kind,
+        )
+
     if not webhook_url:
         stmt = select(GuildChannel.webhook_url).where(
             GuildChannel.guild_id == guild_id,
@@ -444,7 +513,69 @@ async def _send_via_webhook(
             stmt = stmt.where(GuildChannel.kind == channel_kind)
         webhook_url = await db.scalar(stmt)
         if webhook_url:
-            _channel_webhooks[channel_id] = webhook_url
+            await _cache_and_store_webhook_url(
+                db=db,
+                guild_id=guild_id,
+                webhook_url=webhook_url,
+                channel_id=channel_id,
+                configured_channel_id=configured_channel_id,
+                channel_kind=channel_kind,
+            )
+        elif channel_kind is not None:
+            fallback_stmt = select(GuildChannel.webhook_url).where(
+                GuildChannel.guild_id == guild_id,
+                GuildChannel.channel_id == channel_id,
+                GuildChannel.webhook_url.is_not(None),
+            )
+            webhook_url = await db.scalar(fallback_stmt)
+            if webhook_url:
+                await _cache_and_store_webhook_url(
+                    db=db,
+                    guild_id=guild_id,
+                    webhook_url=webhook_url,
+                    channel_id=channel_id,
+                    configured_channel_id=configured_channel_id,
+                    channel_kind=channel_kind,
+                )
+
+    if (
+        not webhook_url
+        and configured_channel_id is not None
+        and configured_channel_id != channel_id
+    ):
+        stmt = select(GuildChannel.webhook_url).where(
+            GuildChannel.guild_id == guild_id,
+            GuildChannel.channel_id == configured_channel_id,
+            GuildChannel.webhook_url.is_not(None),
+        )
+        if channel_kind is not None:
+            stmt = stmt.where(GuildChannel.kind == channel_kind)
+        webhook_url = await db.scalar(stmt)
+        if webhook_url:
+            await _cache_and_store_webhook_url(
+                db=db,
+                guild_id=guild_id,
+                webhook_url=webhook_url,
+                channel_id=channel_id,
+                configured_channel_id=configured_channel_id,
+                channel_kind=channel_kind,
+            )
+        elif channel_kind is not None:
+            fallback_stmt = select(GuildChannel.webhook_url).where(
+                GuildChannel.guild_id == guild_id,
+                GuildChannel.channel_id == configured_channel_id,
+                GuildChannel.webhook_url.is_not(None),
+            )
+            webhook_url = await db.scalar(fallback_stmt)
+            if webhook_url:
+                await _cache_and_store_webhook_url(
+                    db=db,
+                    guild_id=guild_id,
+                    webhook_url=webhook_url,
+                    channel_id=channel_id,
+                    configured_channel_id=configured_channel_id,
+                    channel_kind=channel_kind,
+                )
 
     webhook = None
     if webhook_url:
@@ -462,6 +593,8 @@ async def _send_via_webhook(
             guild_id=guild_id,
             guild_discord_id=guild_discord_id,
             db=db,
+            channel_kind=channel_kind,
+            configured_channel_id=configured_channel_id,
         )
         errors.extend(creation_errors)
         if created_url:
@@ -525,6 +658,8 @@ async def _send_via_webhook(
             guild_id=guild_id,
             guild_discord_id=guild_discord_id,
             db=db,
+            channel_kind=channel_kind,
+            configured_channel_id=configured_channel_id,
         )
         errors.extend(retry_errors)
         if created_url:
@@ -902,6 +1037,7 @@ async def save_message(
         channel_id=getattr(base_channel, "id", cid),
         guild_id=ctx.guild.id,
         guild_discord_id=guild_discord_id,
+        configured_channel_id=cid,
         content=bridge_content,
         username=username,
         avatar=avatar,
@@ -980,7 +1116,11 @@ async def save_message(
                         for a in sent.attachments
                     ]
                 if webhook_url is None:
-                    webhook_url = _channel_webhooks.get(cid)
+                    for candidate in candidate_ids:
+                        cached_url = _channel_webhooks.get(candidate)
+                        if cached_url:
+                            webhook_url = cached_url
+                            break
             except Exception as e:
                 if isinstance(e, discord.HTTPException):
                     logging.error(
@@ -1087,7 +1227,11 @@ async def save_message(
                             if isinstance(a, dict)
                         ]
                     if webhook_url is None:
-                        webhook_url = _channel_webhooks.get(cid)
+                        for candidate in candidate_ids:
+                            cached_url = _channel_webhooks.get(candidate)
+                            if cached_url:
+                                webhook_url = cached_url
+                                break
 
             if discord_msg_id is None:
                 if is_officer:

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -354,6 +354,7 @@ async def create_event(
                         channel=base_channel,
                         channel_id=base_channel.id,
                         guild_id=ctx.guild.id,
+                        configured_channel_id=channel_id,
                         content=content or "",
                         username="DemiCat",
                         avatar=None,

--- a/demibot/demibot/http/ws_chat.py
+++ b/demibot/demibot/http/ws_chat.py
@@ -923,6 +923,8 @@ class ChatConnectionManager:
                         channel_id=channel_id,
                         guild_id=info.ctx.guild.id,
                         db=db,
+                        channel_kind=channel_kind_value or ChannelKind.FC_CHAT,
+                        configured_channel_id=channel_id,
                     )
                 except HTTPException:
                     logger.warning(

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -1331,6 +1331,7 @@ def test_send_via_webhook_reuses_existing_url(monkeypatch):
                     channel=None,
                     channel_id=channel_id,
                     guild_id=guild_id,
+                    configured_channel_id=channel_id,
                     content="hello",
                     username="Tester",
                     avatar=None,
@@ -1353,6 +1354,110 @@ def test_send_via_webhook_reuses_existing_url(monkeypatch):
             db_session._Session = None
             if unique_constraint is not None:
                 table.constraints.add(unique_constraint)
+
+    asyncio.run(_run())
+
+
+def test_send_via_webhook_thread_reuses_cached_url(monkeypatch):
+    async def _run():
+        from demibot.db import session as db_session
+
+        db_session._engine = None
+        db_session._Session = None
+
+        engine = await init_db("sqlite+aiosqlite://")
+        try:
+            async with get_session() as db:
+                await db.execute(text("DELETE FROM posted_messages"))
+                await db.execute(text("DELETE FROM messages"))
+                await db.execute(text("DELETE FROM memberships"))
+                await db.execute(text("DELETE FROM users"))
+                await db.execute(text("DELETE FROM guilds"))
+                await db.execute(text("DELETE FROM guild_channels"))
+
+                guild_id = 12
+                parent_channel_id = 555
+                thread_channel_id = 556
+                webhook_url = "https://example.com/thread/webhook"
+
+                db.add(Guild(id=guild_id, discord_guild_id=912, name="Guild"))
+                db.add(
+                    GuildChannel(
+                        guild_id=guild_id,
+                        channel_id=thread_channel_id,
+                        kind=ChannelKind.FC_CHAT,
+                    )
+                )
+                db.add(
+                    GuildChannel(
+                        guild_id=guild_id,
+                        channel_id=parent_channel_id,
+                        kind=ChannelKind.CHAT,
+                        webhook_url=webhook_url,
+                    )
+                )
+                await db.commit()
+
+                monkeypatch.setattr(mc, "_channel_webhooks", {})
+
+                async def fail_create(**kwargs):
+                    raise AssertionError("should not create webhook")
+
+                monkeypatch.setattr(mc, "create_webhook_for_channel", fail_create)
+                monkeypatch.setattr(mc, "discord_client", None)
+
+                captured: dict[str, object] = {}
+
+                class DummyWebhook:
+                    async def send(self, *args, **kwargs):
+                        captured["send_kwargs"] = kwargs
+                        return types.SimpleNamespace(id=111, attachments=[])
+
+                class DummyWebhookCls:
+                    @staticmethod
+                    def from_url(url: str, client=None):
+                        captured["url"] = url
+                        return DummyWebhook()
+
+                monkeypatch.setattr(mc.discord, "Webhook", DummyWebhookCls)
+
+                msg_id, attachments, errors, used_url = await mc._send_via_webhook(
+                    channel=None,
+                    channel_id=parent_channel_id,
+                    guild_id=guild_id,
+                    configured_channel_id=thread_channel_id,
+                    content="hello",
+                    username="Tester",
+                    avatar=None,
+                    files=None,
+                    channel_kind=ChannelKind.FC_CHAT,
+                    db=db,
+                    thread=None,
+                )
+
+                assert msg_id == 111
+                assert attachments is None
+                assert errors == []
+                assert used_url == webhook_url
+                assert captured.get("url") == webhook_url
+                assert mc._channel_webhooks.get(parent_channel_id) == webhook_url
+                assert mc._channel_webhooks.get(thread_channel_id) == webhook_url
+
+                result = await db.execute(
+                    select(GuildChannel.channel_id, GuildChannel.webhook_url).where(
+                        GuildChannel.guild_id == guild_id,
+                        GuildChannel.channel_id.in_(
+                            [parent_channel_id, thread_channel_id]
+                        ),
+                    )
+                )
+                stored = {cid: url for cid, url in result.all()}
+                assert stored[parent_channel_id] == webhook_url
+                assert stored[thread_channel_id] == webhook_url
+        finally:
+            await engine.dispose()
+            db_session._engine = None
+            db_session._Session = None
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary
- persist webhook URLs for both parent and configured channel ids so cached webhooks survive restarts
- let `_send_via_webhook` fall back to kind-agnostic lookups and pass configured ids from REST, events, and websocket flows
- add a regression test covering thread-backed channels reusing cached webhook URLs

## Testing
- pytest tests/test_messages_common.py::test_send_via_webhook_reuses_existing_url tests/test_messages_common.py::test_send_via_webhook_thread_reuses_cached_url
- pytest tests/test_event_channel_validation.py::test_create_event_thread_uses_webhook

------
https://chatgpt.com/codex/tasks/task_e_68d05c910870832892f14ea26fa5e19a