### PR TITLE
Load emoji font for unicode reactions

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -410,6 +410,7 @@ public class ChatWindow : IDisposable
 
                         if (!handled)
                         {
+                            using var _ = _emojiManager.PushEmojiFont();
                             if (ImGui.SmallButton($"{reaction.Emoji} {reaction.Count}##{msg.Id}{reaction.Emoji}"))
                             {
                                 _ = React(msg.Id, reaction.Emoji, reaction.Me);
@@ -429,6 +430,7 @@ public class ChatWindow : IDisposable
                     ImGui.TextUnformatted("Pick an emoji:");
                     foreach (var emoji in DefaultReactions)
                     {
+                        using var _ = _emojiManager.PushEmojiFont();
                         if (ImGui.Button($"{emoji}##pick{msg.Id}{emoji}"))
                         {
                             _ = React(msg.Id, emoji, false);
@@ -590,7 +592,11 @@ public class ChatWindow : IDisposable
         var style = ImGui.GetStyle();
         var availableWidth = ImGui.GetContentRegionAvail().X;
         var framePadding = style.FramePadding.X * 2f;
-        var emojiButtonWidth = ImGui.CalcTextSize("😊").X + framePadding;
+        var emojiButtonWidth = 0f;
+        using (var _ = _emojiManager.PushEmojiFont())
+        {
+            emojiButtonWidth = ImGui.CalcTextSize("😊").X + framePadding;
+        }
         var sendButtonWidth = ImGui.CalcTextSize("Send").X + framePadding;
         var spacing = style.ItemSpacing.X * 2f;
         var inputWidth = Math.Max(120f, availableWidth - emojiButtonWidth - sendButtonWidth - spacing);
@@ -605,7 +611,10 @@ public class ChatWindow : IDisposable
         _input = ImGuiTextUtil.ReadUtf8Buffer(inputBuf);
 
         ImGui.SameLine();
-        if (ImGui.Button("😊")) ImGui.OpenPopup("##dc_emoji_picker");
+        using (var _ = _emojiManager.PushEmojiFont())
+        {
+            if (ImGui.Button("😊")) ImGui.OpenPopup("##dc_emoji_picker");
+        }
         if (ImGui.BeginPopup("##dc_emoji_picker"))
         {
             _emojiPicker.Draw(ref _input);

--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -40,7 +40,10 @@
     <EmbeddedResource Include="icon.png" />
   </ItemGroup>
 
-  <ItemGroup Condition="Exists('NotoColorEmoji.ttf')">
+  <ItemGroup Condition="Exists('Emoji/NotoColorEmoji.ttf')">
+    <None Include="Emoji/NotoColorEmoji.ttf" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup Condition="!Exists('Emoji/NotoColorEmoji.ttf') and Exists('NotoColorEmoji.ttf')">
     <None Include="NotoColorEmoji.ttf" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>

--- a/DemiCatPlugin/Emoji/EmojiFormatter.cs
+++ b/DemiCatPlugin/Emoji/EmojiFormatter.cs
@@ -26,15 +26,32 @@ public static class EmojiFormatter
     public static string CreateCustomToken(string id) => string.Concat(CustomPrefix, id);
 
     public static bool TryParseCustomToken(string value, out string id)
+        => TryParseCustomToken(value, out id, out _, out _);
+
+    public static bool TryParseCustomToken(string value, out string id, out string? name, out bool animated)
     {
-        if (!string.IsNullOrWhiteSpace(value) &&
-            value.StartsWith(CustomPrefix, StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrWhiteSpace(value))
         {
-            id = value.Substring(CustomPrefix.Length);
-            return !string.IsNullOrEmpty(id);
+            if (value.StartsWith(CustomPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                var parsedId = value.Substring(CustomPrefix.Length);
+                if (!string.IsNullOrEmpty(parsedId))
+                {
+                    id = parsedId;
+                    name = null;
+                    animated = false;
+                    return true;
+                }
+            }
+            else if (TryParseDiscordToken(value, out name, out id, out animated))
+            {
+                return true;
+            }
         }
 
         id = string.Empty;
+        name = null;
+        animated = false;
         return false;
     }
 
@@ -47,7 +64,7 @@ public static class EmojiFormatter
             return null;
         }
 
-        if (!TryParseCustomToken(value, out var id))
+        if (!TryParseCustomToken(value, out var id, out var name, out var animated))
         {
             return value;
         }
@@ -58,6 +75,78 @@ public static class EmojiFormatter
             return $"{prefix}{emoji.Name}:{emoji.Id}>";
         }
 
+        if (!string.IsNullOrEmpty(name))
+        {
+            var prefix = animated ? "<a:" : "<:";
+            return $"{prefix}{name}:{id}>";
+        }
+
         return $"<:{DefaultCustomName}:{id}>";
+    }
+
+    private static bool TryParseDiscordToken(string value, out string? name, out string id, out bool animated)
+    {
+        name = null;
+        id = string.Empty;
+        animated = false;
+
+        if (value.Length < 5 || value[0] != '<' || value[^1] != '>')
+        {
+            return false;
+        }
+
+        var span = value.AsSpan(1, value.Length - 2);
+        if (span.Length == 0)
+        {
+            return false;
+        }
+
+        var index = 0;
+        if (span[index] == 'a' || span[index] == 'A')
+        {
+            animated = true;
+            index++;
+            if (index >= span.Length || span[index] != ':')
+            {
+                return false;
+            }
+            index++;
+        }
+        else
+        {
+            if (span[index] != ':')
+            {
+                return false;
+            }
+            index++;
+        }
+
+        if (index >= span.Length)
+        {
+            return false;
+        }
+
+        var remainder = span[index..];
+        var colonIndex = remainder.IndexOf(':');
+        if (colonIndex < 0)
+        {
+            return false;
+        }
+
+        var nameSpan = remainder[..colonIndex];
+        if (nameSpan.IsEmpty)
+        {
+            return false;
+        }
+
+        var idSpan = remainder[(colonIndex + 1)..];
+        if (idSpan.IsEmpty)
+        {
+            return false;
+        }
+
+        name = nameSpan.ToString();
+        id = idSpan.ToString();
+        return true;
     }
 }

--- a/DemiCatPlugin/Emoji/EmojiManager.cs
+++ b/DemiCatPlugin/Emoji/EmojiManager.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Dalamud.Interface.ManagedFontAtlas;
 
 namespace DemiCatPlugin.Emoji;
 
@@ -69,6 +70,10 @@ public sealed class EmojiManager : IDisposable
             }
         }
     }
+
+    public IFontHandle? EmojiFontHandle { get; internal set; }
+
+    public IDisposable? PushEmojiFont() => EmojiFontHandle?.Push();
 
     public Task EnsureUnicodeAsync(CancellationToken ct = default) => StartUnicodeLoad(ct, false);
     public Task RefreshUnicodeAsync(CancellationToken ct = default) => StartUnicodeLoad(ct, true);

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -110,6 +110,7 @@ public sealed class EmojiPicker
 
             var emoji = filtered[i];
             ImGui.PushID(i);
+            using var _ = _manager.PushEmojiFont();
             if (ImGui.Button(emoji.Emoji, new Vector2(size, size)))
             {
                 EmojiFormatter.InsertUnicode(ref targetText, emoji);

--- a/DemiCatPlugin/Emoji/EmojiRenderer.cs
+++ b/DemiCatPlugin/Emoji/EmojiRenderer.cs
@@ -13,16 +13,16 @@ public static class EmojiRenderer
             return;
         }
 
-        if (!EmojiFormatter.TryParseCustomToken(value, out var id))
+        if (!EmojiFormatter.TryParseCustomToken(value, out var id, out var fallbackName, out var fallbackAnimated))
         {
             using var font = manager.PushEmojiFont();
             ImGui.TextUnformatted(value);
             return;
         }
 
-        var label = ":emoji:";
-        var imageUrl = BuildCdnUrl(id, animated: false);
-        var animated = false;
+        var label = string.IsNullOrEmpty(fallbackName) ? ":emoji:" : $":{fallbackName}:";
+        var animated = fallbackAnimated;
+        var imageUrl = BuildCdnUrl(id, animated);
 
         if (manager.TryGetCustomEmoji(id, out var emoji) && emoji != null)
         {

--- a/DemiCatPlugin/Emoji/EmojiRenderer.cs
+++ b/DemiCatPlugin/Emoji/EmojiRenderer.cs
@@ -15,6 +15,7 @@ public static class EmojiRenderer
 
         if (!EmojiFormatter.TryParseCustomToken(value, out var id))
         {
+            using var font = manager.PushEmojiFont();
             ImGui.TextUnformatted(value);
             return;
         }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
@@ -10,8 +11,9 @@ using DiscordHelper;
 using Dalamud.Game.Gui.Toast;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
-using Dalamud.Plugin;
+using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.IoC;
+using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 using DemiCatPlugin.Avatars;
 using DemiCatPlugin.Emoji;
@@ -49,6 +51,7 @@ public class Plugin : IDalamudPlugin
     private bool _officerWatcherRunning;
     private bool _invalidTokenToastShown;
     private readonly SemaphoreSlim _watcherRestartLock = new(1, 1);
+    private readonly IFontHandle? _emojiFontHandle;
 
     public Plugin()
     {
@@ -79,6 +82,8 @@ public class Plugin : IDalamudPlugin
 
         _channelSelection = new ChannelSelectionService(_config);
         _emojiManager = new EmojiManager(_httpClient, _tokenManager, _config);
+        _emojiFontHandle = InitializeEmojiFont();
+        _emojiManager.EmojiFontHandle = _emojiFontHandle;
         _ui = new UiRenderer(_config, _httpClient, _channelSelection, _emojiManager);
         _settings = new SettingsWindow(_config, _tokenManager, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
 
@@ -121,9 +126,6 @@ public class Plugin : IDalamudPlugin
 
         _ = RoleCache.EnsureLoaded(_httpClient, _config);
 
-        // Note: API 13 removed UiBuilder.BuildFonts/RebuildFonts and the old ImGuiNET attach path.
-        // We intentionally skip emoji font merging since ImGui/Dalamud cannot render SMP color emoji anyway.
-
         _services.PluginInterface.UiBuilder.Draw += _mainWindow.Draw;
         _services.PluginInterface.UiBuilder.Draw += _settings.Draw;
 
@@ -144,6 +146,9 @@ public class Plugin : IDalamudPlugin
 
     public void Dispose()
     {
+        _emojiManager.EmojiFontHandle = null;
+        _emojiFontHandle?.Dispose();
+
         // Unsubscribe UI draw handlers
         _services.PluginInterface.UiBuilder.Draw -= _mainWindow.Draw;
         _services.PluginInterface.UiBuilder.Draw -= _settings.Draw;
@@ -170,6 +175,50 @@ public class Plugin : IDalamudPlugin
         _avatarCache.Dispose();
         _emojiManager.Dispose();
         _httpClient.Dispose();
+    }
+
+    private IFontHandle? InitializeEmojiFont()
+    {
+        try
+        {
+            var directory = _services.PluginInterface.AssemblyLocation.Directory;
+            if (directory == null)
+            {
+                return null;
+            }
+
+            var fontPath = Path.Combine(directory.FullName, "NotoColorEmoji.ttf");
+            if (!File.Exists(fontPath))
+            {
+                _services.Log.Info("Emoji font not found at {Path}. Unicode emoji will use fallback glyphs.", fontPath);
+                return null;
+            }
+
+            var atlas = _services.PluginInterface.UiBuilder.FontAtlas;
+            var fontSize = _services.PluginInterface.UiBuilder.FontDefaultSizePx;
+
+            var handle = atlas.NewDelegateFontHandle(toolkit =>
+                toolkit.OnPreBuild(pre =>
+                {
+                    var baseFont = pre.AddDalamudDefaultFont(fontSize);
+                    var config = new SafeFontConfig
+                    {
+                        SizePx = fontSize,
+                        MergeFont = baseFont,
+                        PixelSnapH = true
+                    };
+                    pre.AddFontFromFile(fontPath, config);
+                    pre.Font = baseFont;
+                }));
+
+            _services.Log.Info("Loaded emoji font from {Path}.", fontPath);
+            return handle;
+        }
+        catch (Exception ex)
+        {
+            _services.Log.Warning(ex, "Failed to load emoji font. Unicode emoji will use fallback glyphs.");
+            return null;
+        }
     }
 
     private async void HandleChannelSelectionValidation(string kind, string guildId, string oldId, string newId)

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -187,10 +187,29 @@ public class Plugin : IDalamudPlugin
                 return null;
             }
 
-            var fontPath = Path.Combine(directory.FullName, "NotoColorEmoji.ttf");
-            if (!File.Exists(fontPath))
+            string? fontPath = null;
+            var basePath = directory.FullName;
+            var candidates = new[]
             {
-                _services.Log.Info("Emoji font not found at {Path}. Unicode emoji will use fallback glyphs.", fontPath);
+                Path.Combine(basePath, "Emoji", "NotoColorEmoji.ttf"),
+                Path.Combine(basePath, "NotoColorEmoji.ttf"),
+            };
+
+            foreach (var candidate in candidates)
+            {
+                if (File.Exists(candidate))
+                {
+                    fontPath = candidate;
+                    break;
+                }
+            }
+
+            if (fontPath == null)
+            {
+                _services.Log.Info(
+                    "Emoji font not found at any known path ({Paths}). Unicode emoji will use fallback glyphs.",
+                    string.Join(", ", candidates)
+                );
                 return null;
             }
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ DemiCat/
 - A database (SQLite by default, MySQL optional)
 - A Discord bot token and Apollo-managed channels
 - FFXIV with the [Dalamud](https://github.com/goatcorp/Dalamud) plugin framework
-- [Noto Color Emoji](https://github.com/googlefonts/noto-emoji/releases) font placed at `DemiCatPlugin/NotoColorEmoji.ttf`
+- [Noto Color Emoji](https://github.com/googlefonts/noto-emoji/releases) font placed at `DemiCatPlugin/Emoji/NotoColorEmoji.ttf`
 
 Optional tools for automated setup:
 - [uv](https://github.com/astral-sh/uv) or [Homebrew](https://brew.sh/) for installing Python/.NET if missing
@@ -137,7 +137,7 @@ dotnet build
 The build output `DemiCatPlugin.dll` can be found under `bin/Debug/net9.0/`. Copy it into your Dalamud plugins folder and enable it.
 
 #### Emoji Font
-Download the [Noto Color Emoji](https://github.com/googlefonts/noto-emoji/releases) font and save it as `DemiCatPlugin/NotoColorEmoji.ttf` before building. The plugin merges this font into Dalamud's atlas at startup so Unicode reactions and emoji pickers render correctly. If the file is missing, DemiCat falls back to Dalamud's default glyphs and emoji will display as placeholder squares.
+Download the [Noto Color Emoji](https://github.com/googlefonts/noto-emoji/releases) font and save it as `DemiCatPlugin/Emoji/NotoColorEmoji.ttf` before building. The plugin merges this font into Dalamud's atlas at startup so Unicode reactions and emoji pickers render correctly. If the file is missing, DemiCat falls back to Dalamud's default glyphs and emoji will display as placeholder squares.
 
 WebSocket communication now streams data in 1 KB chunks and continues reading until the end of each message, allowing the plugin to handle payloads larger than the previous 16-byte limit.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ dotnet build
 The build output `DemiCatPlugin.dll` can be found under `bin/Debug/net9.0/`. Copy it into your Dalamud plugins folder and enable it.
 
 #### Emoji Font
-Download the [Noto Color Emoji](https://github.com/googlefonts/noto-emoji/releases) font and save it as `DemiCatPlugin/NotoColorEmoji.ttf` before building. The file is ignored by git but will be copied into the build output and loaded at runtime if present. Without it, the plugin will fall back to monochrome emoji glyphs.
+Download the [Noto Color Emoji](https://github.com/googlefonts/noto-emoji/releases) font and save it as `DemiCatPlugin/NotoColorEmoji.ttf` before building. The plugin merges this font into Dalamud's atlas at startup so Unicode reactions and emoji pickers render correctly. If the file is missing, DemiCat falls back to Dalamud's default glyphs and emoji will display as placeholder squares.
 
 WebSocket communication now streams data in 1 KB chunks and continues reading until the end of each message, allowing the plugin to handle payloads larger than the previous 16-byte limit.
 

--- a/tests/EmojiPopupGuildTests.cs
+++ b/tests/EmojiPopupGuildTests.cs
@@ -110,4 +110,32 @@ public class EmojiFormatterTests
 
         Assert.Equal(smile, normalized);
     }
+
+    [Fact]
+    public void NormalizeDiscordTokenWithoutLookupPreservesName()
+    {
+        SetupPluginServices();
+        using var client = new HttpClient(new StubHandler(HttpStatusCode.OK, "[]"));
+        var config = new Config { ApiBaseUrl = "http://host", GuildId = "1" };
+        using var manager = new EmojiManager(client, new TokenManager(), config);
+
+        const string token = "<:foo:123>";
+        var normalized = EmojiFormatter.Normalize(manager, token);
+
+        Assert.Equal(token, normalized);
+    }
+
+    [Fact]
+    public void NormalizeAnimatedDiscordTokenWithoutLookupPreservesAnimation()
+    {
+        SetupPluginServices();
+        using var client = new HttpClient(new StubHandler(HttpStatusCode.OK, "[]"));
+        var config = new Config { ApiBaseUrl = "http://host", GuildId = "1" };
+        using var manager = new EmojiManager(client, new TokenManager(), config);
+
+        const string token = "<a:bar:456>";
+        var normalized = EmojiFormatter.Normalize(manager, token);
+
+        Assert.Equal(token, normalized);
+    }
 }


### PR DESCRIPTION
## Summary
- register Noto Color Emoji with Dalamud's managed font atlas and expose the handle through `EmojiManager`
- push the emoji font around chat reactions, picker buttons, and emoji rendering helpers so unicode glyphs render correctly
- update the README to clarify the runtime font requirement and fallback behaviour

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d06347bb70832896da9605e66a0fe9