### PR TITLE
Fix build error from using variable name conflict

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -410,7 +410,7 @@ public class ChatWindow : IDisposable
 
                         if (!handled)
                         {
-                            using var _ = _emojiManager.PushEmojiFont();
+                            using var emojiFont = _emojiManager.PushEmojiFont();
                             if (ImGui.SmallButton($"{reaction.Emoji} {reaction.Count}##{msg.Id}{reaction.Emoji}"))
                             {
                                 _ = React(msg.Id, reaction.Emoji, reaction.Me);
@@ -430,7 +430,7 @@ public class ChatWindow : IDisposable
                     ImGui.TextUnformatted("Pick an emoji:");
                     foreach (var emoji in DefaultReactions)
                     {
-                        using var _ = _emojiManager.PushEmojiFont();
+                        using var emojiFont = _emojiManager.PushEmojiFont();
                         if (ImGui.Button($"{emoji}##pick{msg.Id}{emoji}"))
                         {
                             _ = React(msg.Id, emoji, false);


### PR DESCRIPTION
## Summary
- rename using variable for emoji font scope to avoid conflicting with throwaway assignment

## Testing
- dotnet build -c Release *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d06dc80d7883289d5103aaeef899df