### PR TITLE
Clone HTTP requests for retries

### DIFF
--- a/DemiCatPlugin/ApiHelpers.cs
+++ b/DemiCatPlugin/ApiHelpers.cs
@@ -42,45 +42,56 @@ internal static class ApiHelpers
         }
     }
 
-    internal static async Task<HttpResponseMessage?> SendWithRetries(HttpRequestMessage request, HttpClient httpClient)
+    internal static async Task<HttpResponseMessage?> SendWithRetries(Func<HttpRequestMessage> requestFactory, HttpClient httpClient)
     {
         const int maxAttempts = 3;
         const double baseDelaySeconds = 0.5;
 
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
+            HttpRequestMessage? request = null;
+            var methodName = "UNKNOWN";
+            var requestUri = "(null)";
             try
             {
-                PluginServices.Instance!.Log.Debug($"HTTP {request.Method} {request.RequestUri} attempt {attempt}/{maxAttempts}");
+                request = requestFactory() ?? throw new InvalidOperationException("Request factory returned null.");
+                methodName = request.Method.Method;
+                requestUri = request.RequestUri?.ToString() ?? "(null)";
+
+                PluginServices.Instance!.Log.Debug($"HTTP {methodName} {requestUri} attempt {attempt}/{maxAttempts}");
                 var response = await httpClient.SendAsync(request);
-                PluginServices.Instance!.Log.Debug($"HTTP {request.Method} {request.RequestUri} responded {(int)response.StatusCode}");
+                PluginServices.Instance!.Log.Debug($"HTTP {methodName} {requestUri} responded {(int)response.StatusCode}");
 
                 if (response.IsSuccessStatusCode)
                 {
                     // Successful communications are logged at info so they are visible in Dalamud's log file.
-                    PluginServices.Instance!.Log.Information($"HTTP {request.Method} {request.RequestUri} succeeded");
+                    PluginServices.Instance!.Log.Information($"HTTP {methodName} {requestUri} succeeded");
                 }
                 else
                 {
                     // If the server returns an error status code, capture the body so the reason is clear to the user.
                     var body = await response.Content.ReadAsStringAsync();
-                    PluginServices.Instance!.Log.Warning($"HTTP {request.Method} {request.RequestUri} failed with {(int)response.StatusCode} {response.ReasonPhrase}. Body: {body}");
+                    PluginServices.Instance!.Log.Warning($"HTTP {methodName} {requestUri} failed with {(int)response.StatusCode} {response.ReasonPhrase}. Body: {body}");
                 }
 
                 return response;
             }
             catch (Exception ex)
             {
-                PluginServices.Instance!.Log.Warning(ex, $"Attempt {attempt}/{maxAttempts} failed for {request.Method} {request.RequestUri}");
+                PluginServices.Instance!.Log.Warning(ex, $"Attempt {attempt}/{maxAttempts} failed for {methodName} {requestUri}");
                 if (attempt == maxAttempts)
                 {
-                    PluginServices.Instance!.Log.Error($"HTTP {request.Method} {request.RequestUri} failed after {maxAttempts} attempts");
+                    PluginServices.Instance!.Log.Error($"HTTP {methodName} {requestUri} failed after {maxAttempts} attempts");
                     return null;
                 }
 
                 var delay = TimeSpan.FromSeconds(baseDelaySeconds * Math.Pow(2, attempt - 1));
                 PluginServices.Instance!.Log.Debug($"Retrying in {delay.TotalSeconds:0.##}s");
                 await Task.Delay(delay);
+            }
+            finally
+            {
+                request?.Dispose();
             }
         }
 

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -526,9 +526,14 @@ public class EventCreateWindow
         }
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/repeat");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
-            var response = await ApiHelpers.SendWithRetries(request, _httpClient);
+            var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/repeat";
+            var tokenManager = TokenManager.Instance!;
+            var response = await ApiHelpers.SendWithRetries(() =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                ApiHelpers.AddAuthHeader(request, tokenManager);
+                return request;
+            }, _httpClient);
             if (response?.IsSuccessStatusCode == true)
             {
                 var stream = await response.Content.ReadAsStreamAsync();
@@ -566,9 +571,14 @@ public class EventCreateWindow
         if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Delete, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/{id}/repeat");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
-            var response = await ApiHelpers.SendWithRetries(request, _httpClient);
+            var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/{id}/repeat";
+            var tokenManager = TokenManager.Instance!;
+            var response = await ApiHelpers.SendWithRetries(() =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Delete, requestUri);
+                ApiHelpers.AddAuthHeader(request, tokenManager);
+                return request;
+            }, _httpClient);
             if (response?.IsSuccessStatusCode == true)
             {
                 _schedulesLoaded = false;
@@ -675,10 +685,18 @@ public class EventCreateWindow
                 description = _description,
                 payload
             };
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates");
-            request.Content = new StringContent(JsonSerializer.Serialize(body, JsonOpts), Encoding.UTF8, "application/json");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
-            var response = await ApiHelpers.SendWithRetries(request, _httpClient);
+            var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates";
+            var json = JsonSerializer.Serialize(body, JsonOpts);
+            var tokenManager = TokenManager.Instance!;
+            var response = await ApiHelpers.SendWithRetries(() =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+                ApiHelpers.AddAuthHeader(request, tokenManager);
+                return request;
+            }, _httpClient);
             if (response?.IsSuccessStatusCode == true)
             {
                 _lastResult = "Template saved";
@@ -736,11 +754,18 @@ public class EventCreateWindow
                 repeat = _repeat == RepeatOption.None ? null : _repeat.ToString().ToLowerInvariant()
             };
 
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events");
-            request.Content = new StringContent(JsonSerializer.Serialize(body, JsonOpts), Encoding.UTF8, "application/json");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
-
-            var response = await ApiHelpers.SendWithRetries(request, _httpClient);
+            var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events";
+            var json = JsonSerializer.Serialize(body, JsonOpts);
+            var tokenManager = TokenManager.Instance!;
+            var response = await ApiHelpers.SendWithRetries(() =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+                ApiHelpers.AddAuthHeader(request, tokenManager);
+                return request;
+            }, _httpClient);
             if (response?.IsSuccessStatusCode == true)
             {
                 _lastResult = "Event posted";

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -627,12 +627,18 @@ public class TemplatesWindow
                 mentions = _mentions.Count > 0 ? _mentions.ToList() : null
             };
             var id = _templates[_selectedIndex].Id;
-            var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates/{id}/post");
-            var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-            request.Content = content;
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
-            var response = await ApiHelpers.SendWithRetries(request, _httpClient);
+            var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates/{id}/post";
+            var json = JsonSerializer.Serialize(body);
+            var tokenManager = TokenManager.Instance!;
+            var response = await ApiHelpers.SendWithRetries(() =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+                var content = new StringContent(json, Encoding.UTF8, "application/json");
+                content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                request.Content = content;
+                ApiHelpers.AddAuthHeader(request, tokenManager);
+                return request;
+            }, _httpClient);
             if (response?.IsSuccessStatusCode == true)
             {
                 _lastResult = "Template posted";
@@ -703,9 +709,14 @@ public class TemplatesWindow
         }
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
-            var response = await ApiHelpers.SendWithRetries(request, _httpClient);
+            var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates";
+            var tokenManager = TokenManager.Instance!;
+            var response = await ApiHelpers.SendWithRetries(() =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+                ApiHelpers.AddAuthHeader(request, tokenManager);
+                return request;
+            }, _httpClient);
             if (response == null || !response.IsSuccessStatusCode)
             {
                 var bodyText = response != null ? await response.Content.ReadAsStringAsync() : string.Empty;
@@ -797,9 +808,14 @@ public class TemplatesWindow
         }
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Delete, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates/{id}");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
-            var response = await ApiHelpers.SendWithRetries(request, _httpClient);
+            var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates/{id}";
+            var tokenManager = TokenManager.Instance!;
+            var response = await ApiHelpers.SendWithRetries(() =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Delete, requestUri);
+                ApiHelpers.AddAuthHeader(request, tokenManager);
+                return request;
+            }, _httpClient);
             if (response?.IsSuccessStatusCode == true)
             {
                 _lastResult = "Template deleted";

--- a/tests/ApiHelpersTests.cs
+++ b/tests/ApiHelpersTests.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Plugin.Services;
+using DemiCatPlugin;
+using Xunit;
+
+public class ApiHelpersTests
+{
+    private sealed class TestFramework : IFramework
+    {
+        public event FrameworkUpdateDelegate? Update { add { } remove { } }
+
+        public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
+
+        public void RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+            => action();
+    }
+
+    private sealed class TestLog : IPluginLog
+    {
+        public void Verbose(string message)
+        {
+        }
+
+        public void Verbose(string message, System.Exception exception)
+        {
+        }
+
+        public void Debug(string message)
+        {
+        }
+
+        public void Debug(string message, System.Exception exception)
+        {
+        }
+
+        public void Info(string message)
+        {
+        }
+
+        public void Info(string message, System.Exception exception)
+        {
+        }
+
+        public void Warning(string message)
+        {
+        }
+
+        public void Warning(string message, System.Exception exception)
+        {
+        }
+
+        public void Error(string message)
+        {
+        }
+
+        public void Error(System.Exception exception, string message)
+        {
+        }
+
+        public void Fatal(string message)
+        {
+        }
+
+        public void Fatal(System.Exception exception, string message)
+        {
+        }
+    }
+
+    private sealed class FlakyHandler : HttpMessageHandler
+    {
+        private int _calls;
+        private readonly List<string> _bodies = new();
+
+        public int Calls => _calls;
+        public IReadOnlyList<string> Bodies => _bodies;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _calls++;
+            if (request.Content != null)
+            {
+                _bodies.Add(await request.Content.ReadAsStringAsync());
+            }
+
+            if (_calls == 1)
+            {
+                throw new HttpRequestException("Transient failure");
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private static PluginServices? SetupPluginServices()
+    {
+        var previous = PluginServices.Instance;
+        var services = new PluginServices();
+        typeof(PluginServices).GetProperty("Framework", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, new TestFramework());
+        typeof(PluginServices).GetProperty("Log", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, new TestLog());
+        return previous;
+    }
+
+    private static void RestorePluginServices(PluginServices? previous)
+        => typeof(PluginServices).GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic)!
+            .SetValue(null, previous);
+
+    [Fact]
+    public async Task SendWithRetries_RetriesAfterHttpRequestException()
+    {
+        var previousServices = SetupPluginServices();
+        try
+        {
+            var handler = new FlakyHandler();
+            using var client = new HttpClient(handler);
+            const string payload = "{\"message\":\"hello\"}";
+            var factoryCalls = 0;
+
+            var response = await ApiHelpers.SendWithRetries(() =>
+            {
+                factoryCalls++;
+                var request = new HttpRequestMessage(HttpMethod.Post, "https://example.com/api")
+                {
+                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
+                };
+                return request;
+            }, client);
+
+            Assert.NotNull(response);
+            Assert.True(response!.IsSuccessStatusCode);
+            Assert.Equal(2, handler.Calls);
+            Assert.Equal(2, factoryCalls);
+            Assert.Equal(2, handler.Bodies.Count);
+            Assert.All(handler.Bodies, body => Assert.Equal(payload, body));
+            response.Dispose();
+        }
+        finally
+        {
+            RestorePluginServices(previousServices);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update ApiHelpers.SendWithRetries to build a fresh HttpRequestMessage for each attempt while keeping the existing logging/return semantics
- adjust EventCreateWindow and TemplatesWindow call sites to supply request factories and reuse serialized payloads for retries
- add an ApiHelpers unit test that exercises retrying after a transient HttpRequestException

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: missing Dalamud assemblies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0781093288328afaedfc5ae10f25b