### PR TITLE
Add auth header to asset downloads

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -411,7 +411,9 @@ public class SyncshellWindow : IDisposable
                 : $"{baseUrl}{asset.DownloadUrl}";
 
             var tmp = Path.GetTempFileName();
-            using var resp = await _httpClient.GetAsync(url);
+            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
+            using var resp = await _httpClient.SendAsync(req);
             resp.EnsureSuccessStatusCode();
             await using var fs = File.Create(tmp);
             await resp.Content.CopyToAsync(fs);


### PR DESCRIPTION
## Summary
- send Syncshell asset downloads through an HttpRequestMessage so auth headers are included

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d07a9be9388328938dd7fd0950a17a