### PR TITLE
Handle forbidden responses without clearing tokens

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -29,6 +29,8 @@ public class ChannelWatcher : IDisposable
     private string? _lastErrorSignature;
     private DateTime _lastErrorLog;
     private static readonly TimeSpan ErrorLogThrottle = TimeSpan.FromSeconds(30);
+    private const string ForbiddenMessage = "Forbidden – check API key/roles";
+    private bool _permissionWarningShown;
 
     internal static ChannelWatcher? Instance { get; private set; }
 
@@ -104,13 +106,17 @@ public class ChannelWatcher : IDisposable
                     {
                         PluginServices.Instance!.Log.Error("Backend ping endpoints missing. Please update or restart the backend.");
                     }
-                    if (status == HttpStatusCode.Unauthorized || status == HttpStatusCode.Forbidden)
+                    if (status == HttpStatusCode.Unauthorized)
                     {
                         if (_tokenManager.IsReady())
                         {
                             PluginServices.Instance!.Log.Warning("Clearing stored token after channel watcher auth failure.");
                             _ = Task.Run(() => _tokenManager.Clear("Authentication failed"));
                         }
+                    }
+                    else if (status == HttpStatusCode.Forbidden)
+                    {
+                        ShowPermissionWarning();
                     }
                     await DelayWithBackoff(baseDelay, token);
                     _retryAttempt = 0;
@@ -147,6 +153,7 @@ public class ChannelWatcher : IDisposable
                 PluginServices.Instance!.Log.Information("Channel watcher connected to {Uri}", uri);
                 _retryAttempt = 0;
                 hadTransportError = false;
+                ResetPermissionWarning();
 
                 var buffer = new byte[1024];
                 while (_ws.State == WebSocketState.Open && !token.IsCancellationRequested)
@@ -167,10 +174,7 @@ public class ChannelWatcher : IDisposable
 
                 if (_ws.CloseStatus == WebSocketCloseStatus.PolicyViolation)
                 {
-                    if (_tokenManager.IsReady())
-                    {
-                        _ = Task.Run(() => _tokenManager.Clear("Authentication failed"));
-                    }
+                    ShowPermissionWarning();
                     retryStatusCode = (int)WebSocketCloseStatus.PolicyViolation;
                     retryStatusDetail = WebSocketCloseStatus.PolicyViolation.ToString();
                     hadTransportError = true;
@@ -191,6 +195,10 @@ public class ChannelWatcher : IDisposable
                 hadTransportError = true;
                 retryStatusCode = ex.StatusCode.HasValue ? (int)ex.StatusCode.Value : null;
                 retryStatusDetail = ex.StatusCode?.ToString() ?? ex.Message;
+                if (ex.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    ShowPermissionWarning();
+                }
                 LogConnectionException(ex, "connect");
             }
             catch (WebSocketException ex)
@@ -198,10 +206,7 @@ public class ChannelWatcher : IDisposable
                 hadTransportError = true;
                 if (_ws?.CloseStatus == WebSocketCloseStatus.PolicyViolation || ex.Message?.Contains("403", StringComparison.Ordinal) == true)
                 {
-                    if (_tokenManager.IsReady())
-                    {
-                        _ = Task.Run(() => _tokenManager.Clear("Authentication failed"));
-                    }
+                    ShowPermissionWarning();
                 }
                 retryStatusCode = (int)ex.WebSocketErrorCode;
                 retryStatusDetail = ex.WebSocketErrorCode.ToString();
@@ -266,6 +271,25 @@ public class ChannelWatcher : IDisposable
                 await DelayWithBackoff(baseDelay, token);
             }
         }
+    }
+
+    private void ShowPermissionWarning()
+    {
+        if (_permissionWarningShown)
+        {
+            return;
+        }
+
+        _permissionWarningShown = true;
+        _ = PluginServices.Instance?.Framework.RunOnTick(() =>
+        {
+            PluginServices.Instance?.ToastGui.ShowError(ForbiddenMessage);
+        });
+    }
+
+    private void ResetPermissionWarning()
+    {
+        _permissionWarningShown = false;
     }
 
     private async Task DelayWithBackoff(TimeSpan delay, CancellationToken token)

--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -51,6 +51,8 @@ public class ChatBridge : IDisposable
     private static readonly TimeSpan SubscribeMismatchThrottle = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan BatchDropThrottle = TimeSpan.FromSeconds(30);
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+    private const string ForbiddenMessage = "Forbidden – check API key/roles";
+    private bool _permissionWarningShown;
 
     public event Action<string>? MessageReceived;
     public event Action<DiscordUserDto>? TypingReceived;
@@ -117,6 +119,25 @@ public class ChatBridge : IDisposable
         _lastSubscribeMismatchLog = default;
         _lastBatchDropSignature = null;
         _lastBatchDropLog = default;
+    }
+
+    private void ShowPermissionWarning()
+    {
+        if (_permissionWarningShown)
+        {
+            return;
+        }
+
+        _permissionWarningShown = true;
+        _ = PluginServices.Instance?.Framework.RunOnTick(() =>
+        {
+            PluginServices.Instance?.ToastGui.ShowError(ForbiddenMessage);
+        });
+    }
+
+    private void ResetPermissionWarning()
+    {
+        _permissionWarningShown = false;
     }
 
     public bool IsReady() => _tokenValid && _ws?.State == WebSocketState.Open;
@@ -387,12 +408,31 @@ public class ChatBridge : IDisposable
                 continue;
             }
 
-            if (!await ValidateToken(token))
+            var tokenStatus = await ValidateToken(token);
+            if (tokenStatus != TokenValidationResult.Success)
             {
-                _tokenManager.Clear("Invalid API key");
-                ResetState();
-                Unlinked?.Invoke();
-                StatusChanged?.Invoke("Authentication failed");
+                if (tokenStatus == TokenValidationResult.Unauthorized)
+                {
+                    _tokenManager.Clear("Invalid API key");
+                    ResetState();
+                    Unlinked?.Invoke();
+                    _tokenValid = false;
+                    StatusChanged?.Invoke("Authentication failed");
+                }
+                else if (tokenStatus == TokenValidationResult.Forbidden)
+                {
+                    PluginServices.Instance?.Log.Warning("Chat bridge forbidden during token validation; check API key/roles.");
+                    ShowPermissionWarning();
+                    ResetState();
+                    Unlinked?.Invoke();
+                    _tokenValid = false;
+                    StatusChanged?.Invoke(ForbiddenMessage);
+                }
+                else
+                {
+                    StatusChanged?.Invoke("Authentication failed");
+                }
+
                 await DelayWithJitter(5, token);
                 continue;
             }
@@ -440,6 +480,7 @@ public class ChatBridge : IDisposable
                 failureStage = "receive";
                 Linked?.Invoke();
                 StatusChanged?.Invoke(string.Empty);
+                ResetPermissionWarning();
                 _connectCount++;
                 if (_connectCount > 1) _reconnectCount++;
                 PluginServices.Instance?.Log.Info($"chat.ws connect count={_connectCount} reconnects={_reconnectCount}");
@@ -506,7 +547,7 @@ public class ChatBridge : IDisposable
 
             if (forbidden)
             {
-                _tokenManager.Clear("Invalid API key");
+                ShowPermissionWarning();
                 ResetState();
                 Unlinked?.Invoke();
                 _tokenValid = false;
@@ -519,7 +560,7 @@ public class ChatBridge : IDisposable
             _reconnectAttempt++;
             var backoff = GetReconnectDelay(_reconnectAttempt);
             StatusChanged?.Invoke(forbidden
-                ? "Forbidden – check API key/roles"
+                ? ForbiddenMessage
                 : $"Reconnecting in {backoff.TotalSeconds:0.#}s...");
             await DelayWithBackoff(backoff, token);
         }
@@ -777,15 +818,44 @@ public class ChatBridge : IDisposable
         return SendRaw(json);
     }
 
-    private async Task<bool> ValidateToken(CancellationToken token)
+    private enum TokenValidationResult
+    {
+        Success,
+        Unauthorized,
+        Forbidden,
+        Error
+    }
+
+    private async Task<TokenValidationResult> ValidateToken(CancellationToken token)
     {
         var pingService = PingService.Instance ?? new PingService(_httpClient, _config, _tokenManager);
         var response = await pingService.PingAsync(token);
-        if (response?.StatusCode == HttpStatusCode.NotFound)
+        if (response == null)
+        {
+            return TokenValidationResult.Error;
+        }
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
         {
             PluginServices.Instance?.Log.Error("Backend ping endpoints missing. Please update or restart the backend.");
         }
-        return response?.IsSuccessStatusCode ?? false;
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            return TokenValidationResult.Unauthorized;
+        }
+
+        if (response.StatusCode == HttpStatusCode.Forbidden)
+        {
+            return TokenValidationResult.Forbidden;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return TokenValidationResult.Error;
+        }
+
+        return TokenValidationResult.Success;
     }
 
     private async Task DelayWithJitter(int seconds, CancellationToken token)

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -548,11 +548,18 @@ public class Plugin : IDalamudPlugin
             ApiHelpers.AddAuthHeader(request, _tokenManager);
             log.Info($"Requesting roles from {url}");
             var response = await _httpClient.SendAsync(request);
-            if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 var responseBody = await response.Content.ReadAsStringAsync();
                 log.Error($"Failed to fetch roles: {response.StatusCode}. Response Body: {responseBody}");
                 _tokenManager.Clear("Authentication failed");
+                return false;
+            }
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                log.Error($"Failed to fetch roles: {response.StatusCode}. Response Body: {responseBody}");
+                PluginServices.Instance?.ToastGui.ShowError("Forbidden – check API key/roles");
                 return false;
             }
             if (!response.IsSuccessStatusCode)
@@ -575,11 +582,18 @@ public class Plugin : IDalamudPlugin
             try
             {
                 var channelResponse = await _httpClient.SendAsync(channelRequest);
-                if (channelResponse.StatusCode == HttpStatusCode.Unauthorized || channelResponse.StatusCode == HttpStatusCode.Forbidden)
+                if (channelResponse.StatusCode == HttpStatusCode.Unauthorized)
                 {
                     var responseBody = await channelResponse.Content.ReadAsStringAsync();
                     log.Error($"Failed to fetch channels: {channelResponse.StatusCode}. Response Body: {responseBody}");
                     _tokenManager.Clear("Authentication failed");
+                    return false;
+                }
+                if (channelResponse.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    var responseBody = await channelResponse.Content.ReadAsStringAsync();
+                    log.Error($"Failed to fetch channels: {channelResponse.StatusCode}. Response Body: {responseBody}");
+                    PluginServices.Instance?.ToastGui.ShowError("Forbidden – check API key/roles");
                     return false;
                 }
 

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -21,6 +21,8 @@ public class RequestWatcher : IDisposable
     private string? _lastErrorSignature;
     private DateTime _lastErrorLog;
     private static readonly TimeSpan ErrorLogThrottle = TimeSpan.FromSeconds(30);
+    private const string ForbiddenMessage = "Forbidden – check API key/roles";
+    private bool _permissionWarningShown;
 
     public RequestWatcher(Config config, HttpClient httpClient, TokenManager tokenManager)
     {
@@ -76,6 +78,10 @@ public class RequestWatcher : IDisposable
                     {
                         PluginServices.Instance!.Log.Error("Backend ping endpoints missing. Please update or restart the backend.");
                     }
+                    if (pingResponse?.StatusCode == HttpStatusCode.Forbidden)
+                    {
+                        ShowPermissionWarning();
+                    }
                     await DelayWithBackoff(baseDelay, token);
                     _retryAttempt = 0;
                     continue;
@@ -111,6 +117,7 @@ public class RequestWatcher : IDisposable
                 await _ws.ConnectAsync(uri!, token);
                 _retryAttempt = 0;
                 hadTransportError = false;
+                ResetPermissionWarning();
 
                 var buffer = new byte[1024];
                 while (_ws.State == WebSocketState.Open && !token.IsCancellationRequested)
@@ -123,10 +130,7 @@ public class RequestWatcher : IDisposable
 
                 if (_ws.CloseStatus == WebSocketCloseStatus.PolicyViolation)
                 {
-                    if (_tokenManager.IsReady())
-                    {
-                        _tokenManager.Clear("Authentication failed");
-                    }
+                    ShowPermissionWarning();
                     hadTransportError = true;
                 }
             }
@@ -143,12 +147,16 @@ public class RequestWatcher : IDisposable
             catch (HttpRequestException ex)
             {
                 hadTransportError = true;
-                if (ex.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized)
+                if (ex.StatusCode == HttpStatusCode.Unauthorized)
                 {
                     if (_tokenManager.IsReady())
                     {
                         _tokenManager.Clear("Authentication failed");
                     }
+                }
+                else if (ex.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    ShowPermissionWarning();
                 }
                 LogConnectionException(ex, "connect");
             }
@@ -157,10 +165,7 @@ public class RequestWatcher : IDisposable
                 hadTransportError = true;
                 if (_ws?.CloseStatus == WebSocketCloseStatus.PolicyViolation || ex.Message?.Contains("403", StringComparison.Ordinal) == true)
                 {
-                    if (_tokenManager.IsReady())
-                    {
-                        _tokenManager.Clear("Authentication failed");
-                    }
+                    ShowPermissionWarning();
                 }
                 LogConnectionException(ex, "connect");
             }
@@ -200,6 +205,25 @@ public class RequestWatcher : IDisposable
                 await DelayWithBackoff(baseDelay, token);
             }
         }
+    }
+
+    private void ShowPermissionWarning()
+    {
+        if (_permissionWarningShown)
+        {
+            return;
+        }
+
+        _permissionWarningShown = true;
+        _ = PluginServices.Instance?.Framework.RunOnTick(() =>
+        {
+            PluginServices.Instance?.ToastGui.ShowError(ForbiddenMessage);
+        });
+    }
+
+    private void ResetPermissionWarning()
+    {
+        _permissionWarningShown = false;
     }
 
     private void HandleMessage(string json)

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -37,6 +37,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
     private bool _channelWarningShown;
     private bool _channelSelectionWarningShown;
     private bool _embedWarningShown;
+    private bool _permissionWarningShown;
     private readonly SemaphoreSlim _connectGate = new(1, 1);
     private DateTime _lastSync;
     private int _failureCount;
@@ -57,6 +58,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
     private bool _presenceLoadAttempted;
     private static readonly Regex MentionRegex = new("<@!?([0-9]+)>", RegexOptions.Compiled);
     private const string DefaultWebSocketPath = "/ws/embeds";
+    private const string ForbiddenMessage = "Forbidden – check API key/roles";
 
     public UiRenderer(Config config, HttpClient httpClient, ChannelSelectionService channelSelection, EmojiManager emojiManager)
     {
@@ -318,11 +320,16 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
-            if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
-                PluginServices.Instance?.Log.Warning(
-                    $"Sync unauthorized (status={response.StatusCode}); clearing token");
+                PluginServices.Instance?.Log.Warning("Sync unauthorized; clearing token");
                 TokenManager.Instance?.Clear("Invalid API key");
+                return false;
+            }
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                PluginServices.Instance?.Log.Warning("Sync forbidden; check API key/roles");
+                ShowPermissionToast();
                 return false;
             }
             if (!response.IsSuccessStatusCode)
@@ -344,14 +351,20 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             });
             _failureCount = 0;
             _lastSync = DateTime.UtcNow;
+            ResetPermissionToast();
             PluginServices.Instance?.Log.Info($"Sync at {_lastSync:O}");
             return true;
         }
-        catch (HttpRequestException ex)
-            when (ex.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
         {
-            PluginServices.Instance?.Log.Warning(ex, $"Sync unauthorized ({ex.StatusCode}); clearing token");
+            PluginServices.Instance?.Log.Warning(ex, "Sync unauthorized; clearing token");
             TokenManager.Instance?.Clear("Invalid API key");
+            return false;
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
+        {
+            PluginServices.Instance?.Log.Warning(ex, "Sync forbidden; check API key/roles");
+            ShowPermissionToast();
             return false;
         }
         catch (OperationCanceledException ex) when (IsPollingShutdown(ex))
@@ -434,11 +447,16 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             {
                 var pingService = PingService.Instance ?? new PingService(_httpClient, _config, TokenManager.Instance!);
                 var pingResponse = await pingService.PingAsync(CancellationToken.None);
-                if (pingResponse?.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+                if (pingResponse?.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    PluginServices.Instance?.Log.Warning(
-                        $"WebSocket ping returned {pingResponse.StatusCode}; clearing token");
+                    PluginServices.Instance?.Log.Warning("WebSocket ping unauthorized; clearing token");
                     TokenManager.Instance?.Clear("Invalid API key");
+                    return;
+                }
+                if (pingResponse?.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    PluginServices.Instance?.Log.Warning("WebSocket ping forbidden; check API key/roles");
+                    ShowPermissionToast();
                     return;
                 }
 
@@ -466,6 +484,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 PluginServices.Instance!.Log.Information("Connecting WebSocket to {Uri}", wsUrl);
                 await _webSocket.ConnectAsync(wsUrl, CancellationToken.None);
                 PluginServices.Instance!.Log.Information("WebSocket connected successfully");
+                ResetPermissionToast();
 
                 ResetWebSocketBackoff();
                 StopPolling();
@@ -980,6 +999,22 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         }
     }
 
+    private void ShowPermissionToast()
+    {
+        if (_permissionWarningShown)
+        {
+            return;
+        }
+
+        _permissionWarningShown = true;
+        PluginServices.Instance?.ToastGui.ShowError(ForbiddenMessage);
+    }
+
+    private void ResetPermissionToast()
+    {
+        _permissionWarningShown = false;
+    }
+
     public void ResetChannels()
     {
         _channelsLoaded = false;
@@ -1017,12 +1052,26 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
             ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
-            if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 var responseBody = await response.Content.ReadAsStringAsync();
                 PluginServices.Instance!.Log.Warning(
                     $"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}. Clearing token");
                 TokenManager.Instance?.Clear("Invalid API key");
+                return;
+            }
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                PluginServices.Instance!.Log.Warning(
+                    $"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}.");
+                ShowPermissionToast();
+                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = ForbiddenMessage;
+                    _channelsLoaded = true;
+                });
                 return;
             }
             if (!response.IsSuccessStatusCode)
@@ -1094,25 +1143,36 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 _channelFetchFailed = false;
                 _channelErrorMessage = string.Empty;
             });
+            ResetPermissionToast();
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            PluginServices.Instance!.Log.Warning(
+                ex,
+                "Failed to fetch channels due to authorization failure; clearing token");
+            TokenManager.Instance?.Clear("Invalid API key");
+            return;
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
+        {
+            PluginServices.Instance!.Log.Warning(
+                ex,
+                "Failed to fetch channels due to forbidden response");
+            ShowPermissionToast();
+            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+            {
+                _channelFetchFailed = true;
+                _channelErrorMessage = ForbiddenMessage;
+                _channelsLoaded = true;
+            });
         }
         catch (HttpRequestException ex)
         {
-            if (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
-            {
-                PluginServices.Instance!.Log.Warning(
-                    ex,
-                    "Failed to fetch channels due to authorization failure; clearing token");
-                TokenManager.Instance?.Clear("Invalid API key");
-                return;
-            }
-
             PluginServices.Instance!.Log.Warning($"Failed to fetch channels. Status: {ex.StatusCode}");
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channelFetchFailed = true;
-                _channelErrorMessage = ex.StatusCode == HttpStatusCode.Forbidden
-                    ? "Forbidden \u2013 check API key/roles"
-                    : "Failed to load channels";
+                _channelErrorMessage = "Failed to load channels";
                 _channelsLoaded = true;
             });
         }


### PR DESCRIPTION
## Summary
- ensure UiRenderer leaves the API token intact on 403 responses and surfaces a toast warning while resetting the notice after successful syncs
- update ChannelWatcher, RequestWatcher, and ChatBridge to treat policy violations/forbidden errors as permission warnings instead of clearing stored credentials
- adjust RefreshRoles to only clear tokens on 401s and notify the user when role updates are forbidden

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d088a7892c83289d5993ae5c045d4c