### PR TITLE
Fix channel selection fallback for uppercase kinds

### DIFF
--- a/DemiCatPlugin/ChannelSelectionService.cs
+++ b/DemiCatPlugin/ChannelSelectionService.cs
@@ -7,6 +7,9 @@ public class ChannelSelectionService
 {
     private const string EventSelectionPrefix = "Event:";
     private static readonly string NormalizedEventKind = ChannelKeyHelper.NormalizeKind(ChannelKind.Event);
+    private static readonly string NormalizedFcKind = ChannelKeyHelper.NormalizeKind(ChannelKind.FcChat);
+    private static readonly string NormalizedOfficerKind = ChannelKeyHelper.NormalizeKind(ChannelKind.OfficerChat);
+    private static readonly string NormalizedChatKind = ChannelKeyHelper.NormalizeKind(ChannelKind.Chat);
     private readonly Config _config;
 
     public ChannelSelectionService(Config config)
@@ -52,14 +55,27 @@ public class ChannelSelectionService
             return string.Empty;
         }
 
-        return (kind switch
+        if (normalizedKind == NormalizedEventKind)
         {
-            ChannelKind.Event => _config.EventChannelId,
-            ChannelKind.FcChat => _config.FcChannelId,
-            ChannelKind.OfficerChat => _config.OfficerChannelId,
-            ChannelKind.Chat => _config.ChatChannelId,
-            _ => string.Empty
-        }) ?? string.Empty;
+            return _config.EventChannelId ?? string.Empty;
+        }
+
+        if (normalizedKind == NormalizedFcKind)
+        {
+            return _config.FcChannelId ?? string.Empty;
+        }
+
+        if (normalizedKind == NormalizedOfficerKind)
+        {
+            return _config.OfficerChannelId ?? string.Empty;
+        }
+
+        if (normalizedKind == NormalizedChatKind)
+        {
+            return _config.ChatChannelId ?? string.Empty;
+        }
+
+        return string.Empty;
     }
 
     public void SetChannel(string kind, string? guildId, string id)

--- a/tests/ChatWindowWebSocketTests.cs
+++ b/tests/ChatWindowWebSocketTests.cs
@@ -196,6 +196,23 @@ public class ChatWindowWebSocketTests
     }
 
     [Fact]
+    public void OfficerChatResync_UsesStoredSelectionForUppercaseKind()
+    {
+        var config = new Config
+        {
+            Officer = true,
+            OfficerChannelId = "42"
+        };
+        var selection = new ChannelSelectionService(config);
+
+        // Simulate the websocket resync path passing an uppercased kind from the server.
+        var channel = selection.GetChannel("OFFICER_CHAT", config.GuildId, out var hasStoredSelection);
+
+        Assert.False(hasStoredSelection);
+        Assert.Equal("42", channel);
+    }
+
+    [Fact]
     public async Task WebSocket_ReconnectPersistsCursor()
     {
         int firstSince = -1;


### PR DESCRIPTION
## Summary
- ensure ChannelSelectionService fallback matches normalized channel kinds so defaults work with upper-cased inputs
- add websocket regression test that covers officer channel resync retrieving stored selection

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d09e80696883288c85168813800f0f