### PR TITLE
Stop refreshing roles when opening officer tab

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net.Http;
 using System.Numerics;
-using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using DemiCatPlugin.Emoji;
 
@@ -21,9 +20,6 @@ public class MainWindow : IDisposable
     private bool _syncshellEnabled;
     private bool _templatesTabActive;
     private readonly HttpClient _httpClient;
-    private readonly Func<Task<bool>> _refreshRoles;
-    private bool _checkingOfficer;
-    private bool _officerChecked;
     private const float FadeAlphaTolerance = 0.001f;
     private const float MinimumFadeDuration = 0.001f;
     private float _timeSinceLastInteraction;
@@ -44,7 +40,6 @@ public class MainWindow : IDisposable
         HttpClient httpClient,
         ChannelService channelService,
         ChannelSelectionService channelSelection,
-        Func<Task<bool>> refreshRoles,
         EmojiManager emojiManager)
     {
         _config = config;
@@ -53,7 +48,6 @@ public class MainWindow : IDisposable
         _officer = officer;
         _settings = settings;
         _httpClient = httpClient;
-        _refreshRoles = refreshRoles;
         _create = new EventCreateWindow(config, httpClient, channelService, channelSelection, emojiManager);
         _templates = new TemplatesWindow(config, httpClient, channelService, channelSelection, emojiManager);
         _requestBoard = new RequestBoardWindow(config, httpClient);
@@ -284,21 +278,6 @@ public class MainWindow : IDisposable
                                 ImGui.PushStyleVar(ImGuiStyleVar.Alpha, officerAlpha);
                             }
 
-                            if (!_officerChecked && !_checkingOfficer)
-                            {
-                                _officerChecked = true;
-                                _checkingOfficer = true;
-                                _ = Task.Run(async () =>
-                                {
-                                    await _refreshRoles();
-                                    PluginServices.Instance?.Framework.RunOnTick(() =>
-                                    {
-                                        _checkingOfficer = false;
-                                        if (!HasOfficerRole)
-                                            ImGui.SetTabItemClosed("Officer");
-                                    });
-                                });
-                            }
                             ImGui.BeginChild("##officerChatArea", ImGui.GetContentRegionAvail(), false);
                             _officer.Draw();
                             ImGui.EndChild();
@@ -308,10 +287,6 @@ public class MainWindow : IDisposable
                             {
                                 ImGui.PopStyleVar();
                             }
-                        }
-                        else
-                        {
-                            _officerChecked = false;
                         }
                     }
                 }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -107,7 +107,6 @@ public class Plugin : IDalamudPlugin
             _httpClient,
             _channelService,
             _channelSelection,
-            () => RefreshRoles(_services.Log),
             _emojiManager
         );
 


### PR DESCRIPTION
## Summary
- stop invoking role refresh when the Officer tab opens
- remove the Officer tab focus bookkeeping that supported the forced refresh
- rely on Plugin.RefreshRoles to keep MainWindow.HasOfficerRole up to date

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a7aef4e883288d684fc0e6afbc23