### PR TITLE
Handle websocket ping fallback and add tests

### DIFF
--- a/demibot/demibot/http/ws.py
+++ b/demibot/demibot/http/ws.py
@@ -1,6 +1,6 @@
-
 from __future__ import annotations
 import asyncio
+import inspect
 from dataclasses import dataclass
 from typing import Dict
 
@@ -14,6 +14,7 @@ from .deps import RequestContext, api_key_auth
 PING_INTERVAL = 30.0
 PING_TIMEOUT = 60.0
 SEND_TIMEOUT = 5.0
+HEARTBEAT_PAYLOAD = "{\"op\":\"ping\"}"
 
 # Mapping of websocket paths to roles required to access them.
 # Additional entries can be added as new protected paths are introduced.
@@ -97,13 +98,61 @@ class ConnectionManager:
                 dead: list[WebSocket] = []
                 for ws in list(self.connections.keys()):
                     try:
-                        await asyncio.wait_for(ws.ping(), PING_TIMEOUT)
+                        alive = await self._probe_connection(ws)
+                    except asyncio.CancelledError:
+                        raise
                     except Exception:
+                        alive = False
+                    if not alive:
                         dead.append(ws)
                 for ws in dead:
                     self.disconnect(ws)
         except asyncio.CancelledError:
             pass
+
+    async def _probe_connection(self, ws: WebSocket) -> bool:
+        ping = getattr(ws, "ping", None)
+        supports_ping = callable(ping)
+        if supports_ping:
+            try:
+                result = ping()
+            except NotImplementedError:
+                supports_ping = False
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                return False
+            else:
+                if result is not None and inspect.isawaitable(result):
+                    try:
+                        await asyncio.wait_for(result, PING_TIMEOUT)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        return False
+            if supports_ping:
+                return True
+
+        send_text = getattr(ws, "send_text", None)
+        if callable(send_text):
+            try:
+                result = send_text(HEARTBEAT_PAYLOAD)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                return False
+            if result is not None and inspect.isawaitable(result):
+                try:
+                    await asyncio.wait_for(result, SEND_TIMEOUT)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    return False
+            return True
+
+        # Without ping or the ability to send a heartbeat, assume the socket
+        # remains healthy and let other send paths detect failures.
+        return True
 
 manager = ConnectionManager()
 

--- a/demibot/demibot/http/ws_chat.py
+++ b/demibot/demibot/http/ws_chat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import inspect
 import json
 import logging
 import random
@@ -36,6 +37,8 @@ BATCH_MAX = 0.08
 
 PING_INTERVAL = 30.0
 PING_TIMEOUT = 60.0
+HEARTBEAT_TIMEOUT = 5.0
+HEARTBEAT_PAYLOAD = "{\"op\":\"ping\"}"
 
 MAX_ATTACHMENTS = 10
 MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024  # 25MB
@@ -156,14 +159,60 @@ class ChatConnectionManager:
                 dead: list[WebSocket] = []
                 for ws in list(self.connections.keys()):
                     try:
-                        await asyncio.wait_for(ws.ping(), PING_TIMEOUT)
+                        alive = await self._probe_connection(ws)
+                    except asyncio.CancelledError:
+                        raise
                     except Exception:
+                        alive = False
+                    if not alive:
                         dead.append(ws)
                 for ws in dead:
                     self.disconnect(ws)
                 self._purge_idle_channels()
         except asyncio.CancelledError:
             pass
+
+    async def _probe_connection(self, ws: WebSocket) -> bool:
+        ping = getattr(ws, "ping", None)
+        supports_ping = callable(ping)
+        if supports_ping:
+            try:
+                result = ping()
+            except NotImplementedError:
+                supports_ping = False
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                return False
+            else:
+                if result is not None and inspect.isawaitable(result):
+                    try:
+                        await asyncio.wait_for(result, PING_TIMEOUT)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        return False
+            if supports_ping:
+                return True
+
+        send_text = getattr(ws, "send_text", None)
+        if callable(send_text):
+            try:
+                result = send_text(HEARTBEAT_PAYLOAD)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                return False
+            if result is not None and inspect.isawaitable(result):
+                try:
+                    await asyncio.wait_for(result, HEARTBEAT_TIMEOUT)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    return False
+            return True
+
+        return True
 
     def _release_connection_channels(self, info: ChatConnection) -> None:
         for channel in list(info.channels):

--- a/tests/test_chat_ws.py
+++ b/tests/test_chat_ws.py
@@ -11,6 +11,72 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "demibot"))
 
+discord_stub = types.ModuleType("discord")
+discord_stub.Embed = type("Embed", (), {})
+discord_stub.HTTPException = type("HTTPException", (Exception,), {})
+discord_stub.Forbidden = type("Forbidden", (Exception,), {})
+discord_stub.NotFound = type("NotFound", (Exception,), {})
+discord_stub.Webhook = type(
+    "Webhook",
+    (),
+    {
+        "from_url": staticmethod(
+            lambda url, client: types.SimpleNamespace(send=lambda *args, **kwargs: None)
+        )
+    },
+)
+discord_stub.abc = types.SimpleNamespace(Messageable=object)
+discord_commands_stub = types.ModuleType("discord.ext.commands")
+discord_commands_stub.Bot = type("Bot", (), {})
+discord_ext_stub = types.ModuleType("discord.ext")
+discord_ext_stub.commands = discord_commands_stub
+discord_stub.ext = discord_ext_stub
+sys.modules.setdefault("discord", discord_stub)
+sys.modules.setdefault("discord.ext", discord_ext_stub)
+sys.modules.setdefault("discord.ext.commands", discord_commands_stub)
+
+structlog_stub = types.ModuleType("structlog")
+structlog_stub.get_logger = lambda *args, **kwargs: None
+sys.modules.setdefault("structlog", structlog_stub)
+
+alembic_stub = types.ModuleType("alembic")
+alembic_command_stub = types.ModuleType("alembic.command")
+alembic_command_stub.upgrade = lambda *args, **kwargs: None
+alembic_stub.command = alembic_command_stub
+sys.modules.setdefault("alembic", alembic_stub)
+sys.modules.setdefault("alembic.command", alembic_command_stub)
+
+class _AlembicConfig:
+    def __init__(self):
+        self.options: dict[str, str] = {}
+
+    def set_main_option(self, key: str, value: str) -> None:
+        self.options[key] = value
+
+
+alembic_config_stub = types.ModuleType("alembic.config")
+alembic_config_stub.Config = _AlembicConfig
+sys.modules.setdefault("alembic.config", alembic_config_stub)
+
+messages_common_stub = types.ModuleType("demibot.http.routes._messages_common")
+messages_common_stub._channel_webhooks = {}
+messages_common_stub.create_webhook_for_channel = lambda *args, **kwargs: None
+routes_stub = types.ModuleType("demibot.http.routes")
+routes_stub.__path__ = []
+routes_stub._messages_common = messages_common_stub
+sys.modules.setdefault("demibot.http.routes", routes_stub)
+sys.modules.setdefault("demibot.http.routes._messages_common", messages_common_stub)
+
+discord_helpers_stub = types.ModuleType("demibot.http.discord_helpers")
+discord_helpers_stub.serialize_message = lambda message: (message, [])
+sys.modules.setdefault("demibot.http.discord_helpers", discord_helpers_stub)
+
+discord_client_stub = types.ModuleType("demibot.http.discord_client")
+discord_client_stub.discord_client = None
+discord_client_stub.set_discord_client = lambda client: None
+discord_client_stub.is_discord_client_ready = lambda client=None: False
+sys.modules.setdefault("demibot.http.discord_client", discord_client_stub)
+
 from demibot.http import ws_chat
 from demibot.http.deps import RequestContext
 
@@ -88,6 +154,35 @@ def test_chat_ws_role_access(monkeypatch):
 
     _run(scenario(["officer"], True))
     _run(scenario([], False))
+
+
+def test_chat_ws_ping_fallback_sends_heartbeat():
+    async def scenario():
+        manager = ws_chat.ChatConnectionManager()
+
+        class NoPingWebSocket:
+            def __init__(self) -> None:
+                self.scope = {"path": "/ws/chat"}
+                self.sent: list[str] = []
+
+            async def send_text(self, message: str) -> None:
+                self.sent.append(message)
+
+        ws = NoPingWebSocket()
+        ctx = RequestContext(
+            user=types.SimpleNamespace(id=1, discord_user_id=1, character_name="Tester"),
+            guild=types.SimpleNamespace(id=1, discord_guild_id=1),
+            key=None,
+            roles=[],
+        )
+        manager.connections[ws] = ws_chat.ChatConnection(ctx=ctx)
+
+        alive = await manager._probe_connection(ws)
+
+        assert alive is True
+        assert ws.sent == [ws_chat.HEARTBEAT_PAYLOAD]
+
+    _run(scenario())
 
 
 def test_chat_ws_invalid_token(monkeypatch):

--- a/tests/test_template_ws.py
+++ b/tests/test_template_ws.py
@@ -47,7 +47,7 @@ fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (Exception,), {})
 fastapi_stub.HTTPException = type("HTTPException", (Exception,), {})
 sys.modules.setdefault("fastapi", fastapi_stub)
 
-from demibot.http.ws import ConnectionManager
+from demibot.http.ws import ConnectionInfo, ConnectionManager, HEARTBEAT_PAYLOAD
 
 
 class StubWebSocket:
@@ -86,5 +86,28 @@ def test_templates_updates_broadcast_to_all():
 
         assert ws_officer.sent == [msg]
         assert ws_member.sent == [msg]
+
+    asyncio.run(_run())
+
+
+def test_templates_ping_fallback_sends_heartbeat():
+    async def _run():
+        manager = ConnectionManager()
+
+        class NoPingWebSocket:
+            def __init__(self) -> None:
+                self.scope = {"path": "/ws/templates"}
+                self.sent: list[str] = []
+
+            async def send_text(self, message: str) -> None:
+                self.sent.append(message)
+
+        ws = NoPingWebSocket()
+        manager.connections[ws] = ConnectionInfo(guild_id=1, roles=[], path="/ws/templates")
+
+        alive = await manager._probe_connection(ws)
+
+        assert alive is True
+        assert ws.sent == [HEARTBEAT_PAYLOAD]
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add heartbeat payloads and `_probe_connection` helpers so websocket ping loops fall back to a text heartbeat when `ping` is unavailable
- update the websocket ping loops to rely on the new helper logic instead of assuming a ping coroutine exists
- extend the websocket tests with stubs and coverage that exercises the new heartbeat behaviour

## Testing
- pytest tests/test_template_ws.py
- pytest tests/test_chat_ws.py

------
https://chatgpt.com/codex/tasks/task_e_68d0afddf3848328a4debe9edcbd62e3