### PR TITLE
Update channel refresh to persist renamed channels

### DIFF
--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -363,6 +363,15 @@ async def refresh_channels(
             updated = True
             continue
         if new_name != name:
+            await db.execute(
+                update(GuildChannel)
+                .where(
+                    GuildChannel.guild_id == ctx.guild.id,
+                    GuildChannel.channel_id == channel_id,
+                    GuildChannel.kind == kind,
+                )
+                .values(name=new_name)
+            )
             updated = True
     if updated:
         await db.commit()


### PR DESCRIPTION
## Summary
- ensure refresh_channels updates stored channel names before marking the database as changed

## Testing
- pytest tests/demibot -q *(fails: file or directory not found)*
- pytest -q *(fails: missing optional dependencies such as fastapi, sqlalchemy, discord)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b6374f0c8328a4936899f87936b2