### PR TITLE
Protect officer channel sends via ws

### DIFF
--- a/demibot/demibot/http/ws_chat.py
+++ b/demibot/demibot/http/ws_chat.py
@@ -961,6 +961,20 @@ class ChatConnectionManager:
                 data.get("channel"),
             )
             return
+        channel = str(channel_id)
+        if channel not in info.channels:
+            logger.warning(
+                "chat.ws send drop reason=not_subscribed channel=%s",
+                channel_id,
+            )
+            return
+        meta = info.metadata.get(channel)
+        if meta is None:
+            logger.warning(
+                "chat.ws send drop reason=missing_meta channel=%s",
+                channel_id,
+            )
+            return
         payload = data.get("d") or data.get("payload") or {}
         content = payload.get("content", "")
         attachments = payload.get("attachments") or []
@@ -968,6 +982,23 @@ class ChatConnectionManager:
         use_character_name_flag = bool(
             payload.get("useCharacterName") or payload.get("use_character_name")
         )
+
+        def _normalize_channel_kind(value: object | None) -> ChannelKind:
+            if isinstance(value, ChannelKind):
+                return value
+            if isinstance(value, str):
+                lowered = value.lower()
+                try:
+                    return ChannelKind(lowered)
+                except ValueError:
+                    try:
+                        return ChannelKind(value)
+                    except ValueError:
+                        return ChannelKind.FC_CHAT
+            return ChannelKind.FC_CHAT
+
+        raw_channel_kind_value: object | None = None
+        normalized_channel_kind: ChannelKind = ChannelKind.FC_CHAT
         async with get_session() as db:
             result = await db.execute(
                 select(GuildChannel.webhook_url, GuildChannel.kind).where(
@@ -977,7 +1008,8 @@ class ChatConnectionManager:
             )
             row = result.one_or_none()
             webhook_url = row[0] if row else None
-            channel_kind_value = row[1] if row else None
+            raw_channel_kind_value = row[1] if row else None
+            normalized_channel_kind = _normalize_channel_kind(raw_channel_kind_value)
             if not webhook_url:
                 if not discord_client:
                     logger.warning(
@@ -998,7 +1030,7 @@ class ChatConnectionManager:
                         channel_id=channel_id,
                         guild_id=info.ctx.guild.id,
                         db=db,
-                        channel_kind=channel_kind_value or ChannelKind.FC_CHAT,
+                        channel_kind=normalized_channel_kind,
                         configured_channel_id=channel_id,
                     )
                 except HTTPException:
@@ -1026,7 +1058,21 @@ class ChatConnectionManager:
                     Membership.user_id == info.ctx.user.id,
                 )
             )
-        channel_kind_value = channel_kind_value or ChannelKind.FC_CHAT
+        channel_kind_value = normalized_channel_kind
+        if raw_channel_kind_value is None and meta.kind:
+            try:
+                channel_kind_value = ChannelKind(meta.kind.lower())
+            except ValueError:
+                pass
+        if (
+            channel_kind_value == ChannelKind.OFFICER_CHAT
+            and "officer" not in info.ctx.roles
+        ):
+            logger.warning(
+                "chat.ws send drop reason=officer_required channel=%s",
+                channel_id,
+            )
+            return
         if not webhook_url:
             logger.warning("chat.ws missing webhook channel=%s", channel_id)
             return

--- a/tests/test_chat_ws.py
+++ b/tests/test_chat_ws.py
@@ -16,6 +16,7 @@ discord_stub.Embed = type("Embed", (), {})
 discord_stub.HTTPException = type("HTTPException", (Exception,), {})
 discord_stub.Forbidden = type("Forbidden", (Exception,), {})
 discord_stub.NotFound = type("NotFound", (Exception,), {})
+discord_stub.ClientException = type("ClientException", (Exception,), {})
 discord_stub.Webhook = type(
     "Webhook",
     (),
@@ -276,6 +277,13 @@ def test_chat_ws_send_uses_channel_field(monkeypatch):
             roles=[],
         )
         manager.connections[ws] = ws_chat.ChatConnection(ctx=ctx)
+        info = manager.connections[ws]
+        info.channels.add("12345")
+        info.metadata["12345"] = ws_chat.ChannelMeta(
+            guild_id=ctx.guild.id,
+            discord_guild_id=ctx.guild.discord_guild_id,
+            kind="FC_CHAT",
+        )
 
         class FakeSession:
             def __init__(self):
@@ -340,6 +348,128 @@ def test_chat_ws_send_uses_channel_field(monkeypatch):
         message = queued[0]
         assert message.channel_id == 12345
         assert ws_chat._channel_webhooks[12345] == "https://example.invalid/webhook"
+
+    _run(scenario())
+
+
+def test_chat_ws_send_requires_subscription(monkeypatch):
+    async def scenario():
+        ws_chat._channel_webhooks.clear()
+        manager = ws_chat.ChatConnectionManager()
+        ws = StubWebSocket()
+        ctx = RequestContext(
+            user=types.SimpleNamespace(
+                id=7, discord_user_id=77, character_name="Tester"
+            ),
+            guild=types.SimpleNamespace(id=3, discord_guild_id=333),
+            key=None,
+            roles=[],
+        )
+        manager.connections[ws] = ws_chat.ChatConnection(ctx=ctx)
+
+        get_session_called = False
+
+        @asynccontextmanager
+        async def fake_get_session():
+            nonlocal get_session_called
+            get_session_called = True
+            yield types.SimpleNamespace()
+
+        async def fake_queue_webhook(self, msg):  # pragma: no cover - not expected
+            raise AssertionError("queue should not be called")
+
+        monkeypatch.setattr(ws_chat, "get_session", fake_get_session)
+        monkeypatch.setattr(
+            manager,
+            "_queue_webhook",
+            types.MethodType(fake_queue_webhook, manager),
+        )
+
+        await manager._handle_send(
+            ws,
+            {
+                "channel": 12345,
+                "payload": {"content": "hello"},
+            },
+        )
+
+        assert get_session_called is False
+
+    _run(scenario())
+
+
+def test_chat_ws_officer_send_requires_role(monkeypatch):
+    async def scenario():
+        ws_chat._channel_webhooks.clear()
+        manager = ws_chat.ChatConnectionManager()
+        ws = StubWebSocket()
+        ctx = RequestContext(
+            user=types.SimpleNamespace(
+                id=7, discord_user_id=77, character_name="Tester"
+            ),
+            guild=types.SimpleNamespace(id=3, discord_guild_id=333),
+            key=None,
+            roles=[],
+        )
+        manager.connections[ws] = ws_chat.ChatConnection(ctx=ctx)
+        info = manager.connections[ws]
+        info.channels.add("1")
+        info.metadata["1"] = ws_chat.ChannelMeta(
+            guild_id=ctx.guild.id,
+            discord_guild_id=ctx.guild.discord_guild_id,
+            kind=ws_chat.OFFICER_CHAT_KIND,
+        )
+
+        class DummySession:
+            async def execute(self, *args, **kwargs):
+                return types.SimpleNamespace(
+                    one_or_none=lambda: (
+                        "https://example.invalid/webhook",
+                        ws_chat.ChannelKind.OFFICER_CHAT,
+                    )
+                )
+
+            async def scalar(self, *args, **kwargs):
+                return None
+
+            async def commit(self):  # pragma: no cover - commit not expected
+                raise AssertionError("commit should not be called")
+
+            async def close(self):  # pragma: no cover - trivial
+                pass
+
+        session = DummySession()
+
+        @asynccontextmanager
+        async def fake_get_session():
+            yield session
+
+        def fake_build_bridge_message(**kwargs):  # pragma: no cover - not expected
+            raise AssertionError("build_bridge_message should not be called")
+
+        queued: list[ws_chat.PendingWebhookMessage] = []
+
+        async def fake_queue_webhook(self, msg):
+            queued.append(msg)
+
+        monkeypatch.setattr(ws_chat, "get_session", fake_get_session)
+        monkeypatch.setattr(ws_chat, "build_bridge_message", fake_build_bridge_message)
+        monkeypatch.setattr(
+            manager,
+            "_queue_webhook",
+            types.MethodType(fake_queue_webhook, manager),
+        )
+
+        await manager._handle_send(
+            ws,
+            {
+                "channel": 1,
+                "payload": {"content": "hello"},
+            },
+        )
+
+        assert queued == []
+        assert 1 not in ws_chat._channel_webhooks
 
     _run(scenario())
 

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -560,6 +560,13 @@ def test_ws_handle_send_creates_webhook(monkeypatch):
         manager = ws_chat.ChatConnectionManager()
         websocket = object()
         manager.connections[websocket] = ws_chat.ChatConnection(ctx=ctx)
+        info = manager.connections[websocket]
+        info.channels.add("555")
+        info.metadata["555"] = ws_chat.ChannelMeta(
+            guild_id=guild.id,
+            discord_guild_id=guild.discord_guild_id,
+            kind="CHAT",
+        )
 
         monkeypatch.setattr(mc, "_channel_webhooks", {})
         monkeypatch.setattr(ws_chat, "_channel_webhooks", mc._channel_webhooks)

--- a/tests/test_ws_retry.py
+++ b/tests/test_ws_retry.py
@@ -47,6 +47,13 @@ def test_webhook_retry_success(monkeypatch):
         manager = ws_chat.ChatConnectionManager()
         ws = object()
         manager.connections[ws] = ws_chat.ChatConnection(ctx)
+        info = manager.connections[ws]
+        info.channels.add("123")
+        info.metadata["123"] = ws_chat.ChannelMeta(
+            guild_id=ctx.guild.id,
+            discord_guild_id=getattr(ctx.guild, "discord_guild_id", None),
+            kind="FC_CHAT",
+        )
 
         @asynccontextmanager
         async def fake_get_session():
@@ -153,6 +160,13 @@ def test_webhook_retry_failure(monkeypatch):
         manager = ws_chat.ChatConnectionManager()
         ws = object()
         manager.connections[ws] = ws_chat.ChatConnection(ctx)
+        info = manager.connections[ws]
+        info.channels.add("123")
+        info.metadata["123"] = ws_chat.ChannelMeta(
+            guild_id=ctx.guild.id,
+            discord_guild_id=getattr(ctx.guild, "discord_guild_id", None),
+            kind="FC_CHAT",
+        )
 
         @asynccontextmanager
         async def fake_get_session():


### PR DESCRIPTION
## Summary
- ensure WebSocket send operations only proceed for subscribed channels with cached metadata
- normalize channel kind lookups, fall back to metadata, and require the officer role before queueing officer chat messages
- extend chat websocket tests for unauthorized sends and update related suites to provide subscription metadata

## Testing
- PYTHONPATH=demibot pytest tests/test_chat_ws.py -k "send_requires_subscription or officer_send_requires_role"
- pytest tests/test_ws_retry.py
- PYTHONPATH=demibot pytest tests/test_messages_common.py::test_ws_handle_send_creates_webhook

------
https://chatgpt.com/codex/tasks/task_e_68d0b6aed54c8328b7f387b028002273