### PR TITLE
Await officer role refresh scheduling

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -432,9 +432,10 @@ public class OfficerChatWindow : ChatWindow
                 }
             }
 
-            if (services?.Framework != null)
+            var framework = services?.Framework;
+            if (framework != null)
             {
-                services.Framework.RunOnTick(ApplyRoles);
+                await framework.RunOnTick(ApplyRoles);
             }
             else
             {


### PR DESCRIPTION
## Summary
- await the framework RunOnTick scheduling when applying refreshed officer roles so the task is observed

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0bd960174832882e80beaefc2f91f