### PR TITLE
Prevent redundant channel reload on reselect

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -238,11 +238,28 @@ public class ChatWindow : IDisposable
         if (_channels.Count > 0)
         {
             var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
+            var previousIndex = _selectedIndex;
+            var activeChannelId = CurrentChannelId;
+            string? selectedChannelId = null;
+
             if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
             {
-                var newId = _channels[_selectedIndex].Id;
+                selectedChannelId = _channels[_selectedIndex].Id;
+                if (string.Equals(selectedChannelId, activeChannelId, StringComparison.Ordinal))
+                {
+                    if (previousIndex != _selectedIndex)
+                    {
+                        _selectedIndex = previousIndex;
+                    }
+
+                    selectedChannelId = null;
+                }
+            }
+
+            if (selectedChannelId != null)
+            {
                 ClearTextureCache();
-                _channelSelection.SetChannel(_channelKind, _config.GuildId, newId);
+                _channelSelection.SetChannel(_channelKind, _config.GuildId, selectedChannelId);
             }
         }
         else


### PR DESCRIPTION
## Summary
- cache the currently active channel id before rendering the channel combo
- avoid clearing textures or re-setting the channel when the existing channel is reselected

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c57354948328b42caf54dc0bf887