### PR TITLE
Avoid updating deselected channel messages

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1413,6 +1413,7 @@ public class ChatWindow : IDisposable
 
         try
         {
+            var requestedChannelId = channelId;
             const int PageSize = 50;
             var all = new List<DiscordMessageDto>();
             string? before = null;
@@ -1474,6 +1475,11 @@ public class ChatWindow : IDisposable
 
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
+                if (!string.Equals(requestedChannelId, CurrentChannelId, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
                 if (since == 0)
                 {
                     _messages.Clear();


### PR DESCRIPTION
## Summary
- capture the channel id used during refresh requests
- skip RunOnTick updates when the current channel changes mid-refresh

## Testing
- ⚠️ `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0cc27c2888328a9464833ba4a7afb