### PR TITLE
Clear chat messages before repopulating

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1420,6 +1420,7 @@ public class ChatWindow : IDisposable
             var hasCursor = _config.RestChatCursors.TryGetValue(cursorKey, out var since);
             var storedAfter = hasCursor ? since.ToString() : null;
             var firstPage = true;
+            var backfillSucceeded = true;
             while (all.Count < MaxMessages)
             {
                 var url = $"{_config.ApiBaseUrl.TrimEnd('/')}{MessagesPath}/{channelId}?limit={PageSize}";
@@ -1446,6 +1447,7 @@ public class ChatWindow : IDisposable
                         _ = PluginServices.Instance!.Framework.RunOnTick(() =>
                             _statusMessage = "Forbidden – check API key/roles");
                     }
+                    backfillSucceeded = false;
                     break;
                 }
 
@@ -1472,13 +1474,20 @@ public class ChatWindow : IDisposable
                 all = all.Skip(all.Count - MaxMessages).ToList();
             }
 
+            if (!backfillSucceeded)
+            {
+                return;
+            }
+
+            var messagesToApply = all;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
-                if (since == 0)
+                foreach (var existing in _messages)
                 {
-                    _messages.Clear();
+                    DisposeMessageTextures(existing);
                 }
-                foreach (var m in all)
+                _messages.Clear();
+                foreach (var m in messagesToApply)
                 {
                     _messages.Add(m);
                 }

--- a/tests/ChatWindowMessageLimitTests.cs
+++ b/tests/ChatWindowMessageLimitTests.cs
@@ -42,8 +42,8 @@ public class ChatWindowMessageLimitTests
         await window.RefreshMessages();
 
         msgs = GetMessages(window);
-        Assert.Equal(100, msgs.Count);
-        Assert.Equal("31", msgs[0].Id);
+        Assert.Equal(10, msgs.Count);
+        Assert.Equal("121", msgs[0].Id);
         Assert.Equal("130", msgs[^1].Id);
         Assert.Equal(130, config.RestChatCursors[cursorKey]);
         Assert.False(config.ChatCursors.ContainsKey(cursorKey));


### PR DESCRIPTION
## Summary
- replace the chat window message cache with the latest REST backfill on every successful refresh
- dispose textures for removed messages before rebuilding the cache
- update the cursor/limit test to expect the new refresh behavior

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0cce18a348328b81393a9b8708ec0