### PR TITLE
Refresh chat messages when networking starts

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -188,6 +188,7 @@ public class ChatWindow : IDisposable
         {
             _bridge.Unsubscribe(chan);
             _bridge.Subscribe(chan, _config.GuildId, _channelKind);
+            _ = PluginServices.Instance!.Framework.RunOnTick(async () => await RefreshMessages());
         }
         _presence?.Reset();
     }


### PR DESCRIPTION
## Summary
- refresh the chat window once a channel subscription is established so REST data is shown even if the websocket is not ready

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d38f4a7c832882ba36f9120f57d2