### PR TITLE
Clear chat window messages between refreshes

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1481,13 +1481,25 @@ public class ChatWindow : IDisposable
                     return;
                 }
 
-                if (since == 0)
+                foreach (var message in _messages)
                 {
-                    _messages.Clear();
+                    DisposeMessageTextures(message);
                 }
-                foreach (var m in all)
+
+                _messages.Clear();
+
+                if (all.Count > 0)
                 {
-                    _messages.Add(m);
+                    var seenIds = new HashSet<string>(StringComparer.Ordinal);
+                    foreach (var m in all)
+                    {
+                        if (!string.IsNullOrEmpty(m.Id) && !seenIds.Add(m.Id))
+                        {
+                            continue;
+                        }
+
+                        _messages.Add(m);
+                    }
                 }
                 TrimMessages();
             });

--- a/tests/ChatWindowMessageLimitTests.cs
+++ b/tests/ChatWindowMessageLimitTests.cs
@@ -42,8 +42,8 @@ public class ChatWindowMessageLimitTests
         await window.RefreshMessages();
 
         msgs = GetMessages(window);
-        Assert.Equal(100, msgs.Count);
-        Assert.Equal("31", msgs[0].Id);
+        Assert.Equal(10, msgs.Count);
+        Assert.Equal("121", msgs[0].Id);
         Assert.Equal("130", msgs[^1].Id);
         Assert.Equal(130, config.RestChatCursors[cursorKey]);
         Assert.False(config.ChatCursors.ContainsKey(cursorKey));
@@ -70,6 +70,30 @@ public class ChatWindowMessageLimitTests
         Assert.DoesNotContain("after=", handler.Requests[0].Query);
         Assert.Equal(20, config.RestChatCursors[cursorKey]);
         Assert.False(config.ChatCursors.ContainsKey(cursorKey));
+    }
+
+    [Fact]
+    public async Task RefreshMessages_ReplacesMessagesForActiveChannel()
+    {
+        SetupServices();
+        var config = new Config { ApiBaseUrl = "http://localhost", ChatChannelId = "1" };
+        var handler = new SequenceHandler();
+        using var client = new HttpClient(handler);
+        var tm = new TokenManager();
+        var channelService = new ChannelService(config, client, tm);
+        var window = new ChatWindow(config, client, null, tm, channelService);
+
+        handler.EnqueueResponse(SerializeMessages(1, 20));
+        await window.RefreshMessages();
+
+        handler.EnqueueResponse(SerializeMessages(201, 203));
+        await window.RefreshMessages();
+
+        var msgs = GetMessages(window);
+        Assert.Collection(msgs,
+            m => Assert.Equal("201", m.Id),
+            m => Assert.Equal("202", m.Id),
+            m => Assert.Equal("203", m.Id));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- rebuild the in-memory message list for the active channel on every refresh and dispose textures for the cleared entries
- deduplicate fetched messages by id before trimming and persisting the cursor
- update the message limit tests and add coverage that the refreshed list replaces the previous channel history

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj --filter ChatWindowMessageLimitTests` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d44309208328990a7b6b4a2fc647