### PR TITLE
Eager load request relations for DTOs

### DIFF
--- a/demibot/demibot/http/routes/requests.py
+++ b/demibot/demibot/http/routes/requests.py
@@ -86,6 +86,17 @@ def _dto(req: DbRequest) -> dict[str, Any]:
     return dto.model_dump(mode="json", by_alias=True, exclude_none=True)
 
 
+async def _load_request_with_children(
+    db: AsyncSession, request_id: int
+) -> DbRequest | None:
+    result = await db.execute(
+        select(DbRequest)
+        .where(DbRequest.id == request_id)
+        .options(selectinload(DbRequest.items), selectinload(DbRequest.runs))
+    )
+    return result.scalars().one_or_none()
+
+
 async def _broadcast(guild_id: int, request_id: int, delta: dict[str, Any]) -> None:
     payload = json.dumps({"topic": "requests.stream", "payload": delta})
     await manager.broadcast_text(payload, guild_id, path="/ws/requests")
@@ -203,7 +214,9 @@ async def create_request(
     )
     db.add(req)
     await db.commit()
-    await db.refresh(req)
+    req = await _load_request_with_children(db, req.id)
+    if req is None:
+        raise HTTPException(status_code=500)
     await _broadcast(ctx.guild.id, req.id, _dto(req))
     await _notify(ctx.guild.id, req, "created", db, ctx.user)
     return {"id": str(req.id)}
@@ -215,7 +228,7 @@ async def get_request(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
-    req = await db.get(DbRequest, request_id)
+    req = await _load_request_with_children(db, request_id)
     if not req or req.guild_id != ctx.guild.id:
         raise HTTPException(status_code=404)
     return _dto(req)
@@ -238,7 +251,9 @@ async def update_request(
     if body.urgency is not None:
         req.urgency = body.urgency
     await db.commit()
-    await db.refresh(req)
+    req = await _load_request_with_children(db, req.id)
+    if req is None:
+        raise HTTPException(status_code=404)
     await _broadcast(ctx.guild.id, req.id, _dto(req))
     return {"ok": True}
 

--- a/tests/http/requests/test_request_eager_loading.py
+++ b/tests/http/requests/test_request_eager_loading.py
@@ -1,0 +1,63 @@
+import sys
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+root = Path(__file__).resolve().parents[3] / "demibot"
+if str(root) not in sys.path:
+    sys.path.append(str(root))
+
+from demibot.db.models import Guild, User
+from demibot.db.session import get_session, init_db
+from demibot.http.api import create_app
+from demibot.http.deps import RequestContext, api_key_auth, get_db
+
+
+@pytest.mark.asyncio
+async def test_create_request_eager_loads(monkeypatch):
+    await init_db("sqlite+aiosqlite://")
+
+    user = User(id=1, discord_user_id=1)
+    guild = Guild(id=1, discord_guild_id=1, name="Guild")
+
+    async with get_session() as db:
+        await db.merge(user)
+        await db.merge(guild)
+        await db.commit()
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("demibot.http.routes.requests._broadcast", _noop)
+    monkeypatch.setattr("demibot.http.routes.requests._notify", _noop)
+
+    app = create_app()
+
+    async def override_auth():
+        return RequestContext(user=user, guild=guild, key=None, roles=[])
+
+    async def override_db():
+        async with get_session() as session:
+            yield session
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/requests",
+            json={
+                "title": "Gather carrots",
+                "type": "item",
+                "urgency": "low",
+            },
+        )
+
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    assert "MissingGreenlet" not in resp.text
+    payload = resp.json()
+    assert payload["id"].isdigit()


### PR DESCRIPTION
## Summary
- add a helper to reload requests with their related items and runs eagerly populated
- update request creation, retrieval, and update handlers to use the eager-loaded entity before building DTOs
- add an async HTTP test that posts to `/api/requests` and verifies no `MissingGreenlet` error occurs

## Testing
- pytest tests/http/requests/test_request_eager_loading.py

------
https://chatgpt.com/codex/tasks/task_e_68d1344bc46883288d00fb621d1f61e4