### PR TITLE
Add bridge message header with membership metadata

### DIFF
--- a/DemiCatPlugin/BridgeMessageFormatter.cs
+++ b/DemiCatPlugin/BridgeMessageFormatter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -74,6 +75,21 @@ public static class BridgeMessageFormatter
         var content = resolution.Content;
         var displayContent = ChatWindow.ReplaceMentionTokens(content, resolution.Mentions);
         displayContent = displayContent.Replace("@\u200B", "@");
+
+        var header = BuildHeaderLine(options);
+        if (!string.IsNullOrEmpty(header))
+        {
+            if (!string.IsNullOrEmpty(content))
+            {
+                content = string.Concat(header, "\n", content);
+                displayContent = string.Concat(header, "\n", displayContent);
+            }
+            else
+            {
+                content = header;
+                displayContent = header;
+            }
+        }
 
         var warnings = new List<string>();
         var errors = new List<string>();
@@ -184,6 +200,36 @@ public static class BridgeMessageFormatter
             _ => 0x5865F2 // Discord blurple
         };
     }
+
+    private static string BuildHeaderLine(BridgeFormatterOptions options)
+    {
+        var displayName = string.IsNullOrWhiteSpace(options.AuthorName)
+            ? "You"
+            : options.AuthorName!.Trim();
+
+        var segments = new List<string> { displayName };
+        if (options.UseCharacterName)
+        {
+            if (!string.IsNullOrWhiteSpace(options.CharacterName))
+            {
+                segments.Add(options.CharacterName.Trim());
+                if (!string.IsNullOrWhiteSpace(options.WorldName))
+                {
+                    segments.Add(options.WorldName.Trim());
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(options.WorldName))
+            {
+                segments.Add(options.WorldName.Trim());
+            }
+        }
+
+        var timestamp = FormatTimestamp(options.Timestamp);
+        return $"Message Sent by: {string.Join(" / ", segments)} @ {timestamp}";
+    }
+
+    private static string FormatTimestamp(DateTimeOffset timestamp)
+        => timestamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
 
     private static IReadOnlyList<string> SplitIntoEmbedChunks(
         string displayContent,

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -930,8 +930,8 @@ public class ChatWindow : IDisposable
 
     private BridgeMessageFormatter.BridgeFormattedMessage GetFormattedMessage()
     {
-        UpdatePreviewMessage();
-        return _previewMessage;
+        var options = BuildFormatterOptions();
+        return BridgeMessageFormatter.Format(_input, _attachments, options);
     }
 
     private BridgeMessageFormatter.BridgeFormatterOptions BuildFormatterOptions()
@@ -950,6 +950,16 @@ public class ChatWindow : IDisposable
             }
         }
 
+        var authorName = MembershipCache.DisplayName;
+        if (string.IsNullOrWhiteSpace(authorName))
+        {
+            authorName = MembershipCache.DiscordUserId;
+        }
+        if (string.IsNullOrWhiteSpace(authorName))
+        {
+            authorName = "You";
+        }
+
         return new BridgeMessageFormatter.BridgeFormatterOptions
         {
             UseCharacterName = _useCharacterName,
@@ -957,7 +967,7 @@ public class ChatWindow : IDisposable
             Presences = presences,
             Roles = RoleCache.Roles,
             AllowedRoleIds = _config.MentionRoleIds,
-            AuthorName = _useCharacterName ? characterName : characterName ?? "You",
+            AuthorName = authorName,
             CharacterName = characterName,
             WorldName = worldName,
             Timestamp = DateTimeOffset.UtcNow

--- a/DemiCatPlugin/MembershipCache.cs
+++ b/DemiCatPlugin/MembershipCache.cs
@@ -9,6 +9,7 @@ internal static class MembershipCache
 {
     private static readonly object SyncRoot = new();
     private static string? _displayName;
+    private static string? _discordUserId;
     private static bool _loading;
 
     internal static string? DisplayName
@@ -22,11 +23,23 @@ internal static class MembershipCache
         }
     }
 
+    internal static string? DiscordUserId
+    {
+        get
+        {
+            lock (SyncRoot)
+            {
+                return _discordUserId;
+            }
+        }
+    }
+
     internal static void Reset()
     {
         lock (SyncRoot)
         {
             _displayName = null;
+            _discordUserId = null;
             _loading = false;
         }
     }
@@ -65,13 +78,28 @@ internal static class MembershipCache
 
             await using var stream = await response.Content.ReadAsStreamAsync();
             using var doc = await JsonDocument.ParseAsync(stream);
-            if (doc.RootElement.TryGetProperty("displayName", out var displayNameElement))
+            void SetValue(ref string? field, string? value)
             {
-                var value = displayNameElement.GetString();
                 lock (SyncRoot)
                 {
-                    _displayName = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+                    field = string.IsNullOrWhiteSpace(value) ? null : value.Trim();
                 }
+            }
+
+            if (doc.RootElement.TryGetProperty("displayName", out var displayNameElement))
+            {
+                SetValue(ref _displayName, displayNameElement.GetString());
+            }
+
+            if (doc.RootElement.TryGetProperty("discordUserId", out var discordUserIdElement))
+            {
+                string? idValue = discordUserIdElement.ValueKind switch
+                {
+                    JsonValueKind.String => discordUserIdElement.GetString(),
+                    JsonValueKind.Number => discordUserIdElement.GetRawText(),
+                    _ => null
+                };
+                SetValue(ref _discordUserId, idValue);
             }
         }
         catch

--- a/demibot/demibot/bridge.py
+++ b/demibot/demibot/bridge.py
@@ -67,6 +67,18 @@ def _determine_author_name(
     return str(user.discord_user_id)
 
 
+def _determine_display_name(*, user: User, membership: Membership | None) -> str:
+    if membership and membership.nickname:
+        nickname = membership.nickname.strip()
+        if nickname:
+            return nickname
+    if user.global_name:
+        global_name = user.global_name.strip()
+        if global_name:
+            return global_name
+    return str(user.discord_user_id)
+
+
 def _normalize_content(content: str) -> str:
     return content.replace("\r\n", "\n").replace("\r", "\n")
 
@@ -136,6 +148,7 @@ def build_bridge_message(
     use_character_name: bool = False,
     attachments: Sequence[tuple[str, bytes, str | None]] | None = None,
     nonce: str | None = None,
+    timestamp: datetime | None = None,
 ) -> tuple[str, list[discord.Embed], list[BridgeUpload], str]:
     """Construct the Discord payload for a bridge message."""
 
@@ -151,13 +164,28 @@ def build_bridge_message(
             if image_filename is None and _is_image(filename, content_type):
                 image_filename = filename
 
+    timestamp = timestamp or datetime.now(timezone.utc)
+    display_name = _determine_display_name(user=user, membership=membership)
+    character_name = user.character_name if use_character_name else None
+    world_name = user.world if use_character_name else None
+    header = _format_header_line(
+        display_name=display_name,
+        use_character_name=use_character_name,
+        character_name=character_name,
+        world_name=world_name,
+        timestamp=timestamp,
+    )
+    if normalized:
+        normalized = f"{header}\n{normalized}"
+    else:
+        normalized = header
+
     chunks = _split_embed_text(normalized)
     if not chunks:
         chunks = [""]
 
     embed_nonce = nonce or uuid.uuid4().hex
     footer = f"DemiCat • {_tab_label(channel_kind)} • {BRIDGE_MARKER}{embed_nonce}"
-    timestamp = datetime.now(timezone.utc)
     author_name = _determine_author_name(
         user=user, membership=membership, use_character_name=use_character_name
     )
@@ -178,6 +206,31 @@ def build_bridge_message(
 
     discord_content = normalized[:DISCORD_CONTENT_LIMIT]
     return discord_content, embeds, uploads, embed_nonce
+
+
+def _format_header_line(
+    *,
+    display_name: str,
+    use_character_name: bool,
+    character_name: str | None,
+    world_name: str | None,
+    timestamp: datetime,
+) -> str:
+    name = display_name.strip() or "You"
+    segments = [name]
+    if use_character_name:
+        char = (character_name or "").strip()
+        world = (world_name or "").strip()
+        if char:
+            segments.append(char)
+            if world:
+                segments.append(world)
+        elif world:
+            segments.append(world)
+    formatted_timestamp = timestamp.astimezone(timezone.utc).strftime(
+        "%Y-%m-%d %H:%M:%S UTC"
+    )
+    return f"Message Sent by: {' / '.join(segments)} @ {formatted_timestamp}"
 
 
 def extract_bridge_nonce_from_footer(text: str | None) -> str | None:

--- a/demibot/demibot/http/routes/users.py
+++ b/demibot/demibot/http/routes/users.py
@@ -231,9 +231,12 @@ async def get_my_profile(
         )
     base_name = compute_creator_base_name(ctx, nickname)
     creator_label = build_creator_label(base_name)
+    discord_user_id = getattr(getattr(ctx, "user", None), "discord_user_id", None)
+    discord_user_id_str = str(discord_user_id) if discord_user_id is not None else None
     return {
         "displayName": base_name,
         "creatorLabel": creator_label,
         "nickname": nickname,
         "globalName": ctx.user.global_name,
+        "discordUserId": discord_user_id_str,
     }

--- a/tests/BridgeMessageFormatterTests.cs
+++ b/tests/BridgeMessageFormatterTests.cs
@@ -5,6 +5,8 @@ using Xunit;
 
 public class BridgeMessageFormatterTests
 {
+    private static readonly DateTimeOffset FixedTimestamp = new(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
+
     private static BridgeMessageFormatter.BridgeFormatterOptions CreateOptions()
         => new()
         {
@@ -12,11 +14,13 @@ public class BridgeMessageFormatterTests
             ChannelKind = ChannelKind.FcChat,
             Presences = Array.Empty<PresenceDto>(),
             Roles = Array.Empty<RoleDto>(),
-            Timestamp = DateTimeOffset.UtcNow,
+            Timestamp = FixedTimestamp,
             AuthorName = "You",
             CharacterName = "Tester",
             WorldName = "World"
         };
+
+    private static string ExpectedHeader() => "Message Sent by: You @ 2024-01-02 03:04:05 UTC";
 
     [Fact]
     public void Format_LongContentProducesError()
@@ -24,6 +28,7 @@ public class BridgeMessageFormatterTests
         var input = new string('x', 2100);
         var result = BridgeMessageFormatter.Format(input, Array.Empty<string>(), CreateOptions());
 
+        Assert.StartsWith(ExpectedHeader(), result.Content);
         Assert.Contains(result.Errors, e => e.Contains("2000"));
     }
 
@@ -36,6 +41,7 @@ public class BridgeMessageFormatterTests
         Assert.True(result.Embeds.Count >= 2);
         Assert.True(result.Embeds[0].Description!.Length <= 4096);
         Assert.Contains(result.Warnings, w => w.Contains("split"));
+        Assert.StartsWith(ExpectedHeader(), result.Embeds[0].Description!);
     }
 
     [Fact]
@@ -46,7 +52,8 @@ public class BridgeMessageFormatterTests
 
         var result = BridgeMessageFormatter.Format("Hello @Alice", Array.Empty<string>(), options);
 
-        Assert.Equal("Hello <@1>", result.Content);
+        Assert.Equal($"{ExpectedHeader()}\nHello <@1>", result.Content);
+        Assert.StartsWith(ExpectedHeader(), result.DisplayContent);
         Assert.Contains("@Alice", result.DisplayContent);
         Assert.Single(result.Mentions);
         Assert.Equal("1", result.Mentions[0].Id);

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -10,10 +10,12 @@ if str(ROOT) not in sys.path:
 from demibot.bridge import (
     BRIDGE_MARKER,
     BridgeUpload,
+    DISCORD_CONTENT_LIMIT,
     build_bridge_message,
     extract_bridge_nonce_from_payload,
 )
 from demibot.db.models import ChannelKind, Membership, User
+from datetime import datetime, timezone
 
 
 @pytest.fixture()
@@ -23,6 +25,7 @@ def sample_user():
         discord_user_id=111,
         global_name="Sample",
         character_name="Hero",
+        world="Eorzea",
     )
 
 
@@ -40,6 +43,7 @@ def sample_membership():
 def test_build_bridge_message_populates_embed_footer(sample_user, sample_membership):
     content = "Hello from DemiCat"
     attachments = [("screenshot.png", b"bytes", "image/png")]
+    fixed_time = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
 
     discord_content, embeds, uploads, nonce = build_bridge_message(
         content=content,
@@ -47,15 +51,22 @@ def test_build_bridge_message_populates_embed_footer(sample_user, sample_members
         membership=sample_membership,
         channel_kind=ChannelKind.FC_CHAT,
         attachments=attachments,
+        timestamp=fixed_time,
     )
 
-    assert discord_content == content
+    expected_header = "Message Sent by: Nick @ 2024-01-02 03:04:05 UTC"
+    header, body = discord_content.split("\n", 1)
+    assert header == expected_header
+    assert body == content
     assert nonce
     assert len(embeds) == 1
 
     embed_dict = embeds[0].to_dict()
     footer_text = embed_dict.get("footer", {}).get("text")
     assert footer_text and footer_text.endswith(f"{BRIDGE_MARKER}{nonce}")
+    description = embed_dict.get("description", "")
+    assert description.startswith(expected_header)
+    assert description.split("\n", 1)[1] == content
     assert embed_dict.get("author", {}).get("name") == sample_membership.nickname
     assert embed_dict.get("author", {}).get("icon_url") == sample_membership.avatar_url
 
@@ -74,18 +85,29 @@ def test_build_bridge_message_populates_embed_footer(sample_user, sample_members
 
 def test_build_bridge_message_splits_long_content(sample_user, sample_membership):
     long_content = "A" * 7000
+    fixed_time = datetime(2024, 5, 6, 7, 8, 9, tzinfo=timezone.utc)
 
     discord_content, embeds, uploads, nonce = build_bridge_message(
         content=long_content,
         user=sample_user,
         membership=sample_membership,
         channel_kind=ChannelKind.FC_CHAT,
+        timestamp=fixed_time,
     )
 
-    assert discord_content == long_content[:2000]
+    expected_header = "Message Sent by: Nick @ 2024-05-06 07:08:09 UTC"
+    assert discord_content.startswith(f"{expected_header}\n")
+    header_len = len(expected_header) + 1
+    assert (
+        discord_content[header_len:]
+        == long_content[: DISCORD_CONTENT_LIMIT - header_len]
+    )
     assert not uploads
     assert nonce
     assert len(embeds) >= 2
+
+    first_description = embeds[0].to_dict().get("description", "")
+    assert first_description.startswith(expected_header)
 
     total_length = 0
     for embed in embeds:
@@ -100,3 +122,26 @@ def test_build_bridge_message_splits_long_content(sample_user, sample_membership
 
     payload = {"embeds": [embed.to_dict() for embed in embeds]}
     assert extract_bridge_nonce_from_payload(payload) == nonce
+
+
+def test_build_bridge_message_includes_character_when_enabled(
+    sample_user, sample_membership
+):
+    fixed_time = datetime(2024, 7, 8, 9, 10, 11, tzinfo=timezone.utc)
+
+    discord_content, embeds, uploads, nonce = build_bridge_message(
+        content="Hi",
+        user=sample_user,
+        membership=sample_membership,
+        channel_kind=ChannelKind.FC_CHAT,
+        use_character_name=True,
+        timestamp=fixed_time,
+    )
+
+    expected_header = (
+        "Message Sent by: Nick / Hero / Eorzea @ 2024-07-08 09:10:11 UTC"
+    )
+    assert discord_content.startswith(f"{expected_header}\n")
+    assert embeds[0].to_dict().get("description", "").startswith(expected_header)
+    assert not uploads
+    assert nonce

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -268,9 +268,14 @@ def test_get_my_profile_returns_creator_label():
             db.add(Membership(id=10, guild_id=1, user_id=10, nickname='ProfileNick'))
             await db.commit()
             ctx = StubContext(1)
-            ctx.user = types.SimpleNamespace(id=10, global_name='ProfileUser')
+            ctx.user = types.SimpleNamespace(
+                id=10,
+                global_name='ProfileUser',
+                discord_user_id=100,
+            )
             res = await get_my_profile(ctx=ctx, db=db)
             assert res['displayName'] == 'ProfileNick'
             assert res['creatorLabel'] == 'Event created by ProfileNick'
+            assert res['discordUserId'] == '100'
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- source bridge formatter options from membership profile metadata and ensure messages format a shared header line
- prepend the header line to both plugin previews and Discord bridge payloads while formatting timestamps in UTC
- extend tests to cover the new header format and expose the Discord user id from the profile API

## Testing
- pytest tests/test_bridge.py tests/test_users.py

------
https://chatgpt.com/codex/tasks/task_e_68d135a3a4f483288618e8c42b1d3aff