### PR TITLE
Avoid duplicate plain-text previews in chat preview

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -649,14 +649,12 @@ public class ChatWindow : IDisposable
         {
             UpdatePreviewMessage();
 
+            var plainTextPreview = GetPreviewPlainText(_previewMessage);
+
             ImGui.BeginChild("##inputPreview", new Vector2(0, ImGui.GetTextLineHeight() * 6), true);
-            if (!string.IsNullOrEmpty(_previewMessage.DisplayContent))
+            if (!string.IsNullOrEmpty(plainTextPreview))
             {
-                ImGui.TextWrapped(_previewMessage.DisplayContent);
-            }
-            else if (!string.IsNullOrEmpty(_previewMessage.Content))
-            {
-                ImGui.TextWrapped(ChatWindow.ReplaceMentionTokens(_previewMessage.Content, _previewMessage.Mentions));
+                ImGui.TextWrapped(plainTextPreview);
             }
 
             foreach (var embed in _previewMessage.Embeds)
@@ -926,6 +924,59 @@ public class ChatWindow : IDisposable
         _previewMessage = BridgeMessageFormatter.Format(_input, _attachments, options);
         _previewKey = key;
         CleanupAttachmentPreviews(_previewMessage.Attachments.Select(a => a.Path));
+    }
+
+    internal static string? GetPreviewPlainText(BridgeMessageFormatter.BridgeFormattedMessage message)
+    {
+        var displayContent = message.DisplayContent ?? string.Empty;
+        var embeds = message.Embeds ?? Array.Empty<EmbedDto>();
+        var hasEmbedChunks = embeds.Any(e => !string.IsNullOrEmpty(e?.Description));
+
+        if (hasEmbedChunks)
+        {
+            var remainder = GetUnrepresentedPlainText(displayContent, embeds);
+            return string.IsNullOrEmpty(remainder) ? null : remainder;
+        }
+
+        if (!string.IsNullOrEmpty(displayContent))
+        {
+            return displayContent;
+        }
+
+        if (!string.IsNullOrEmpty(message.Content))
+        {
+            var fallback = ReplaceMentionTokens(message.Content, message.Mentions);
+            return string.IsNullOrEmpty(fallback) ? null : fallback;
+        }
+
+        return null;
+    }
+
+    private static string GetUnrepresentedPlainText(string displayContent, IReadOnlyList<EmbedDto> embeds)
+    {
+        if (string.IsNullOrEmpty(displayContent))
+            return string.Empty;
+
+        var index = 0;
+        foreach (var embed in embeds)
+        {
+            var description = embed?.Description;
+            if (string.IsNullOrEmpty(description))
+                continue;
+
+            var remaining = displayContent.AsSpan(index);
+            var desc = description.AsSpan();
+
+            if (remaining.Length < desc.Length || !remaining.StartsWith(desc, StringComparison.Ordinal))
+                return string.Empty;
+
+            index += desc.Length;
+        }
+
+        if (index >= displayContent.Length)
+            return string.Empty;
+
+        return displayContent[index..];
     }
 
     private BridgeMessageFormatter.BridgeFormattedMessage GetFormattedMessage()

--- a/tests/ChatWindowPreviewTests.cs
+++ b/tests/ChatWindowPreviewTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using DemiCatPlugin;
+using DiscordHelper;
+using Xunit;
+
+public class ChatWindowPreviewTests
+{
+    private static readonly DateTimeOffset FixedTimestamp = new(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void GetPreviewPlainText_ReturnsNull_WhenEmbedsCoverContent()
+    {
+        var options = new BridgeMessageFormatter.BridgeFormatterOptions
+        {
+            AuthorName = "Tester",
+            Timestamp = FixedTimestamp
+        };
+        var message = BridgeMessageFormatter.Format("Hello world", Array.Empty<string>(), options);
+
+        var preview = ChatWindow.GetPreviewPlainText(message);
+
+        Assert.Null(preview);
+    }
+
+    [Fact]
+    public void GetPreviewPlainText_ReturnsRemainder_WhenEmbedsDoNotCoverContent()
+    {
+        var options = new BridgeMessageFormatter.BridgeFormatterOptions
+        {
+            AuthorName = "Tester",
+            Timestamp = FixedTimestamp
+        };
+        var longBody = new string('A', 50000);
+        var message = BridgeMessageFormatter.Format(longBody, Array.Empty<string>(), options);
+
+        var embedText = string.Concat(message.Embeds.Select(e => e.Description ?? string.Empty));
+        Assert.True(embedText.Length <= message.DisplayContent.Length);
+        var expected = message.DisplayContent[embedText.Length..];
+
+        Assert.NotEqual(0, expected.Length);
+
+        var preview = ChatWindow.GetPreviewPlainText(message);
+
+        Assert.Equal(expected, preview);
+    }
+
+    [Fact]
+    public void GetPreviewPlainText_ReturnsDisplayContent_WhenNoEmbeds()
+    {
+        var message = new BridgeMessageFormatter.BridgeFormattedMessage
+        {
+            Content = "Plain preview",
+            DisplayContent = "Plain preview",
+            Embeds = Array.Empty<EmbedDto>()
+        };
+
+        var preview = ChatWindow.GetPreviewPlainText(message);
+
+        Assert.Equal("Plain preview", preview);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid rendering the plain-text preview when embed chunks already cover the message content
- surface any extra plain text that is not represented inside embeds so long inputs still show the remainder once
- add unit tests for the preview text extraction helper

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d13d8cb7908328b3adbbb8d5557bd7