### PR TITLE
Ensure emoji font available across Discord text surfaces

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -248,17 +248,20 @@ public class ChatWindow : IDisposable
             var activeChannelId = CurrentChannelId;
             string? selectedChannelId = null;
 
-            if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
             {
-                selectedChannelId = _channels[_selectedIndex].Id;
-                if (string.Equals(selectedChannelId, activeChannelId, StringComparison.Ordinal))
+                using var emojiFont = _emojiManager.PushEmojiFont();
+                if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
                 {
-                    if (previousIndex != _selectedIndex)
+                    selectedChannelId = _channels[_selectedIndex].Id;
+                    if (string.Equals(selectedChannelId, activeChannelId, StringComparison.Ordinal))
                     {
-                        _selectedIndex = previousIndex;
-                    }
+                        if (previousIndex != _selectedIndex)
+                        {
+                            _selectedIndex = previousIndex;
+                        }
 
-                    selectedChannelId = null;
+                        selectedChannelId = null;
+                    }
                 }
             }
 
@@ -311,6 +314,7 @@ public class ChatWindow : IDisposable
             {
                 var msg = _messages[i];
                 ImGui.PushID(msg.Id);
+                using var emojiFont = _emojiManager.PushEmojiFont();
                 ImGui.BeginGroup();
                 if (msg.Author != null && msg.AvatarTexture == null && _avatarCache != null)
                 {
@@ -452,7 +456,6 @@ public class ChatWindow : IDisposable
 
                         if (!handled)
                         {
-                            using var emojiFont = _emojiManager.PushEmojiFont();
                             if (ImGui.SmallButton($"{reaction.Emoji} {reaction.Count}##{msg.Id}{reaction.Emoji}"))
                             {
                                 _ = React(msg.Id, reaction.Emoji, reaction.Me);
@@ -472,7 +475,6 @@ public class ChatWindow : IDisposable
                     ImGui.TextUnformatted("Pick an emoji:");
                     foreach (var emoji in DefaultReactions)
                     {
-                        using var emojiFont = _emojiManager.PushEmojiFont();
                         if (ImGui.Button($"{emoji}##pick{msg.Id}{emoji}"))
                         {
                             _ = React(msg.Id, emoji, false);
@@ -513,7 +515,6 @@ public class ChatWindow : IDisposable
                 }
 
                 ImGui.PopID();
-                ImGui.EndGroup();
             }
         }
         clipper.End();
@@ -568,7 +569,10 @@ public class ChatWindow : IDisposable
             {
                 var preview = refMsg.Content ?? string.Empty;
                 if (preview.Length > 50) preview = preview.Substring(0, 50) + "...";
-                ImGui.TextUnformatted($"Replying to {refMsg.Author?.Name ?? "Unknown"}: {preview}");
+                {
+                    using var emojiFont = _emojiManager.PushEmojiFont();
+                    ImGui.TextUnformatted($"Replying to {refMsg.Author?.Name ?? "Unknown"}: {preview}");
+                }
                 ImGui.SameLine();
                 if (ImGui.SmallButton("Cancel Reply"))
                 {
@@ -639,7 +643,10 @@ public class ChatWindow : IDisposable
         }
         foreach (var att in _attachments.ToArray())
         {
-            ImGui.TextUnformatted(Path.GetFileName(att));
+            {
+                using var emojiFont = _emojiManager.PushEmojiFont();
+                ImGui.TextUnformatted(Path.GetFileName(att));
+            }
             ImGui.SameLine();
             if (ImGui.SmallButton($"X##{att}"))
             {
@@ -657,7 +664,10 @@ public class ChatWindow : IDisposable
         {
             var names = string.Join(", ", _typingUsers.Values.Select(v => v.Name));
             var verb = _typingUsers.Count > 1 ? "are" : "is";
-            ImGui.TextUnformatted($"{names} {verb} typing...");
+            {
+                using var emojiFont = _emojiManager.PushEmojiFont();
+                ImGui.TextUnformatted($"{names} {verb} typing...");
+            }
         }
 
         if (ImGui.SmallButton("B")) WrapSelection("**", "**");
@@ -754,23 +764,26 @@ public class ChatWindow : IDisposable
 
             var plainTextPreview = GetPreviewPlainText(_previewMessage);
 
-            ImGui.BeginChild("##inputPreview", new Vector2(0, ImGui.GetTextLineHeight() * 6), true);
-            if (!string.IsNullOrEmpty(plainTextPreview))
+            using (var emojiFont = _emojiManager.PushEmojiFont())
             {
-                ImGui.TextWrapped(plainTextPreview);
-            }
+                ImGui.BeginChild("##inputPreview", new Vector2(0, ImGui.GetTextLineHeight() * 6), true);
+                if (!string.IsNullOrEmpty(plainTextPreview))
+                {
+                    ImGui.TextWrapped(plainTextPreview);
+                }
 
-            foreach (var embed in _previewMessage.Embeds)
-            {
-                EmbedPreviewRenderer.Draw(embed, LoadTexture, _emojiManager);
-            }
+                foreach (var embed in _previewMessage.Embeds)
+                {
+                    EmbedPreviewRenderer.Draw(embed, LoadTexture, _emojiManager);
+                }
 
-            foreach (var att in _previewMessage.Attachments)
-            {
-                RenderAttachmentPreview(att);
-            }
+                foreach (var att in _previewMessage.Attachments)
+                {
+                    RenderAttachmentPreview(att);
+                }
 
-            ImGui.EndChild();
+                ImGui.EndChild();
+            }
 
             foreach (var warning in _previewMessage.Warnings)
             {
@@ -858,6 +871,7 @@ public class ChatWindow : IDisposable
 
     protected void FormatContent(DiscordMessageDto msg)
     {
+        using var emojiFont = _emojiManager.PushEmojiFont();
         var text = msg.Content ?? string.Empty;
         text = ReplaceMentionTokens(text, msg.Mentions);
         text = MarkdownFormatter.Format(text);
@@ -1131,6 +1145,7 @@ public class ChatWindow : IDisposable
     private void RenderAttachmentPreview(BridgeMessageFormatter.BridgeFormattedAttachment attachment)
     {
         var icon = attachment.IsImage ? "🖼️" : "📎";
+        using var emojiFont = _emojiManager.PushEmojiFont();
         ImGui.TextUnformatted($"{icon} {attachment.FileName}");
         if (!attachment.IsImage)
             return;

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -15,6 +15,7 @@ public static class EmbedPreviewRenderer
 
     public static void Draw(EmbedDto dto, Action<string?, Action<ISharedImmediateTexture?>> loadTexture, EmojiManager emojiManager, Action<string>? onButtonClick = null)
     {
+        using var emojiFont = emojiManager.PushEmojiFont();
         const float stripeWidth = 4f;
         const float contentPadding = 8f;
         const float verticalPadding = 4f;

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -16,6 +16,7 @@ public static class EmbedRenderer
 
     public static void Draw(EmbedDto dto, Action<string?, Action<ISharedImmediateTexture?>> loadTexture, EmojiManager emojiManager, Action<string>? onButtonClick = null)
     {
+        using var emojiFont = emojiManager.PushEmojiFont();
         if (!string.IsNullOrEmpty(dto.Title))
         {
             ImGui.TextUnformatted(dto.Title);

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -126,10 +126,13 @@ public class EventCreateWindow
         if (_channels.Count > 0)
         {
             var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
-            if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
             {
-                var newId = _channels[_selectedIndex].Id;
-                _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, newId);
+                using var emojiFont = _emojiManager.PushEmojiFont();
+                if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
+                {
+                    var newId = _channels[_selectedIndex].Id;
+                    _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, newId);
+                }
             }
         }
         else
@@ -229,6 +232,7 @@ public class EventCreateWindow
                     {
                         if (_roles.Count > 0)
                         {
+                            using var emojiFont = _emojiManager.PushEmojiFont();
                             var selectedRoleNames = _roles.Where(r => _mentions.Contains(r.Id)).Select(r => r.Name).ToList();
                             var previewLabel = selectedRoleNames.Count > 0 ? string.Join(", ", selectedRoleNames) : "Select roles";
                             var maxTextWidth = ImGui.CalcTextSize(previewLabel).X;
@@ -326,7 +330,10 @@ public class EventCreateWindow
                 EmojiRenderer.Draw(button.Emoji, _emojiManager);
                 ImGui.SameLine();
             }
-            ImGui.TextUnformatted($"{button.Label} ({button.Tag})");
+            {
+                using var emojiFont = _emojiManager.PushEmojiFont();
+                ImGui.TextUnformatted($"{button.Label} ({button.Tag})");
+            }
             ImGui.SameLine();
             if (ImGui.Button("Edit"))
             {
@@ -362,6 +369,7 @@ public class EventCreateWindow
             var preview = _selectedPreset >= 0 && _selectedPreset < presets.Count
                 ? presets[_selectedPreset].Name
                 : string.Empty;
+            using var emojiFont = _emojiManager.PushEmojiFont();
             if (ImGui.BeginCombo("Presets", preview))
             {
                 for (var i = 0; i < presets.Count; i++)
@@ -452,7 +460,10 @@ public class EventCreateWindow
             for (var i = 0; i < _schedules.Count; i++)
             {
                 var s = _schedules[i];
-                ImGui.TextUnformatted($"{s.Title} ({s.Repeat}) next {s.Next}");
+                {
+                    using var emojiFont = _emojiManager.PushEmojiFont();
+                    ImGui.TextUnformatted($"{s.Title} ({s.Repeat}) next {s.Next}");
+                }
                 ImGui.SameLine();
                 if (ImGui.Button($"Cancel##{i}"))
                 {
@@ -484,9 +495,15 @@ public class EventCreateWindow
         if (_confirmCreate && ImGui.BeginPopupModal("Confirm Event Create", ref openConfirm, ImGuiWindowFlags.AlwaysAutoResize))
         {
             var channelName = _channels.FirstOrDefault(c => c.Id == ChannelId)?.Name ?? ChannelId;
-            ImGui.TextUnformatted($"Channel: {channelName}");
+            {
+                using var emojiFont = _emojiManager.PushEmojiFont();
+                ImGui.TextUnformatted($"Channel: {channelName}");
+            }
             var roleNames = _roles.Where(r => _mentions.Contains(r.Id)).Select(r => r.Name).ToList();
-            ImGui.TextUnformatted("Roles: " + (roleNames.Count > 0 ? string.Join(", ", roleNames) : "None"));
+            {
+                using var emojiFont = _emojiManager.PushEmojiFont();
+                ImGui.TextUnformatted("Roles: " + (roleNames.Count > 0 ? string.Join(", ", roleNames) : "None"));
+            }
             if (ImGui.Button("Confirm"))
             {
                 _ = CreateEvent();

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -132,6 +132,7 @@ public class EventView : IDisposable
 
     public void Draw(float? availableHeight)
     {
+        using var emojiFont = _emojiManager.PushEmojiFont();
         var dto = _dto;
         var cursorStart = ImGui.GetCursorPosY();
 
@@ -204,6 +205,7 @@ public class EventView : IDisposable
 
     private void DrawEmbed(EmbedDto dto, float? availableHeight)
     {
+        using var emojiFont = _emojiManager.PushEmojiFont();
         const float stripeWidth = 4f;
         const float contentPadding = 8f;
         const float verticalPadding = 4f;
@@ -483,6 +485,7 @@ public class EventView : IDisposable
 
     public void DrawButtons()
     {
+        using var emojiFont = _emojiManager.PushEmojiFont();
         if (Buttons != null && Buttons.Count > 0)
         {
             foreach (var row in Buttons

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -148,10 +148,13 @@ public class TemplatesWindow
         if (_channels.Count > 0)
         {
             var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
-            if (ImGui.Combo("Channel", ref _channelIndex, channelNames, channelNames.Length))
             {
-                var newId = _channels[_channelIndex].Id;
-                _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, newId);
+                using var emojiFont = _emojiManager.PushEmojiFont();
+                if (ImGui.Combo("Channel", ref _channelIndex, channelNames, channelNames.Length))
+                {
+                    var newId = _channels[_channelIndex].Id;
+                    _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, newId);
+                }
             }
         }
         else
@@ -160,13 +163,16 @@ public class TemplatesWindow
         }
 
         ImGui.BeginChild("TemplateList", new Vector2(150, 0), true);
-        for (var i = 0; i < _templates.Count; i++)
         {
-            var tmplItem = _templates[i];
-            var name = tmplItem.Template.Name;
-            if (ImGui.Selectable(name, _selectedIndex == i))
+            using var emojiFont = _emojiManager.PushEmojiFont();
+            for (var i = 0; i < _templates.Count; i++)
             {
-                SelectTemplate(i, tmplItem.Template);
+                var tmplItem = _templates[i];
+                var name = tmplItem.Template.Name;
+                if (ImGui.Selectable(name, _selectedIndex == i))
+                {
+                    SelectTemplate(i, tmplItem.Template);
+                }
             }
         }
         ImGui.EndChild();
@@ -200,13 +206,16 @@ public class TemplatesWindow
                 {
                     ImGui.Separator();
                     ImGui.Text("Mention Roles");
-                    foreach (var role in _roles)
                     {
-                        var roleId = role.Id;
-                        var sel = _mentions.Contains(roleId);
-                        if (ImGui.Checkbox($"{role.Name}##role{role.Id}", ref sel))
+                        using var emojiFont = _emojiManager.PushEmojiFont();
+                        foreach (var role in _roles)
                         {
-                            if (sel) _mentions.Add(roleId); else _mentions.Remove(roleId);
+                            var roleId = role.Id;
+                            var sel = _mentions.Contains(roleId);
+                            if (ImGui.Checkbox($"{role.Name}##role{role.Id}", ref sel))
+                            {
+                                if (sel) _mentions.Add(roleId); else _mentions.Remove(roleId);
+                            }
                         }
                     }
                 }
@@ -224,9 +233,15 @@ public class TemplatesWindow
             if (_confirmPost && ImGui.BeginPopupModal("Confirm Template Post", ref openConfirm, ImGuiWindowFlags.AlwaysAutoResize))
             {
             var channelName = _channels.FirstOrDefault(c => c.Id == ChannelId)?.Name ?? ChannelId;
-                ImGui.TextUnformatted($"Channel: {channelName}");
+                {
+                    using var emojiFont = _emojiManager.PushEmojiFont();
+                    ImGui.TextUnformatted($"Channel: {channelName}");
+                }
                 var roleNames = _roles.Where(r => _mentions.Contains(r.Id)).Select(r => r.Name).ToList();
-                ImGui.TextUnformatted("Roles: " + (roleNames.Count > 0 ? string.Join(", ", roleNames) : "None"));
+                {
+                    using var emojiFont = _emojiManager.PushEmojiFont();
+                    ImGui.TextUnformatted("Roles: " + (roleNames.Count > 0 ? string.Join(", ", roleNames) : "None"));
+                }
                 var buttonsCount = _buttonRows.FlattenNonEmpty().Count();
                 bool canConfirm = !string.IsNullOrWhiteSpace(ChannelId)
                     && DiscordValidation.IsImageUrlAllowed(tmpl.ImageUrl)

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -909,17 +909,25 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             comboIndex = Math.Clamp(comboIndex, 0, channelNames.Length - 1);
         }
 
-        if (ImGui.Combo("Channel", ref comboIndex, channelNames, channelNames.Length))
         {
-            if (comboIndex >= 0 && comboIndex < _channels.Count)
+            using var emojiFont = _emojiManager.PushEmojiFont();
+            if (ImGui.Combo("Channel", ref comboIndex, channelNames, channelNames.Length))
             {
-                var selectedChannel = _channels[comboIndex];
-                if (!string.IsNullOrEmpty(selectedChannel?.Id))
+                if (comboIndex >= 0 && comboIndex < _channels.Count)
                 {
-                    _selectedIndex = comboIndex;
-                    _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, selectedChannel.Id);
-                    _ = RefreshChannels();
-                    _ = RefreshEmbeds();
+                    var selectedChannel = _channels[comboIndex];
+                    if (!string.IsNullOrEmpty(selectedChannel?.Id))
+                    {
+                        _selectedIndex = comboIndex;
+                        _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, selectedChannel.Id);
+                        _ = RefreshChannels();
+                        _ = RefreshEmbeds();
+                    }
+                    else
+                    {
+                        ShowWarningOrToast("Select a valid channel to view events.", ref _channelSelectionWarningShown);
+                        return;
+                    }
                 }
                 else
                 {
@@ -929,13 +937,8 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             }
             else
             {
-                ShowWarningOrToast("Select a valid channel to view events.", ref _channelSelectionWarningShown);
-                return;
+                _selectedIndex = comboIndex;
             }
-        }
-        else
-        {
-            _selectedIndex = comboIndex;
         }
 
         if (_selectedIndex < 0 || _selectedIndex >= _channels.Count)


### PR DESCRIPTION
## Summary
- ensure channel selectors across chat and event windows push the emoji font before rendering Discord-provided names
- wrap chat message headers, attachment labels, typing indicators, and composer preview text in emoji font scopes so Unicode emoji display correctly
- use the emoji font when rendering event/template confirmations and embed content to cover all Discord-provided text surfaces

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d148c320a083289c688294fd75aa25