### PR TITLE
Remove stale guild channels when names cannot be resolved

### DIFF
--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -159,15 +159,13 @@ async def get_channels(
                 ctx.guild.id,
             )
             await db.execute(
-                update(GuildChannel)
-                .where(
+                delete(GuildChannel).where(
                     GuildChannel.guild_id == ctx.guild.id,
                     GuildChannel.channel_id == channel_id,
                     GuildChannel.kind == channel_kind,
                 )
-                .values(name=None)
             )
-            return {"id": str(channel_id), "name": str(channel_id)}, True
+            return None, True
         if new_name != name:
             await db.execute(
                 update(GuildChannel)

--- a/tests/test_channels_endpoint.py
+++ b/tests/test_channels_endpoint.py
@@ -52,7 +52,7 @@ def _setup_db(
     asyncio.run(populate())
 
 
-def test_get_channels_returns_placeholder_and_flags_retry(monkeypatch):
+def test_get_channels_removes_unresolved_channel(monkeypatch):
     _setup_db("test_channels.db")
 
     async def fake_ensure_channel_name(*args, **kwargs):
@@ -60,8 +60,11 @@ def test_get_channels_returns_placeholder_and_flags_retry(monkeypatch):
 
     monkeypatch.setattr(channel_routes, "ensure_channel_name", fake_ensure_channel_name)
 
+    broadcast_called = False
+
     async def dummy_broadcast(*args, **kwargs):
-        return None
+        nonlocal broadcast_called
+        broadcast_called = True
 
     monkeypatch.setattr(channel_routes.manager, "broadcast_text", dummy_broadcast)
 
@@ -82,12 +85,13 @@ def test_get_channels_returns_placeholder_and_flags_retry(monkeypatch):
                         GuildChannel.kind == ChannelKind.EVENT,
                     )
                 )
-            ).scalar_one()
-            return data, row.name
+            ).scalar_one_or_none()
+            return data, row
 
-    data, name = asyncio.run(run())
-    assert data[ChannelKind.EVENT.value][0]["name"] == "100"
-    assert name is None
+    data, row = asyncio.run(run())
+    assert data[ChannelKind.EVENT.value] == []
+    assert row is None
+    assert broadcast_called
 
 
 def test_get_channels_kind_event(monkeypatch):


### PR DESCRIPTION
## Summary
- delete guild channel mappings when a channel name cannot be resolved
- keep websocket broadcasts after deletions so clients refresh channel lists
- update channel endpoint tests to cover removal of unresolved channels

## Testing
- PYTHONPATH=demibot pytest tests/test_channels_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68d1ee514e648328a09981a837b49e17