### PR TITLE
Ensure websocket JSON dumps preserve Unicode

### DIFF
--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -269,7 +269,10 @@ class Mirror(commands.Cog):
                     )
                     await manager.broadcast_text(
                         json.dumps(
-                            dto.model_dump(mode="json", by_alias=True, exclude_none=True)
+                            dto.model_dump(
+                                mode="json", by_alias=True, exclude_none=True
+                            ),
+                            ensure_ascii=False,
                         ),
                         guild_id,
                         officer_only=is_officer,
@@ -424,7 +427,10 @@ class Mirror(commands.Cog):
 
                 await manager.broadcast_text(
                     json.dumps(
-                        dto.model_dump(mode="json", by_alias=True, exclude_none=True)
+                        dto.model_dump(
+                            mode="json", by_alias=True, exclude_none=True
+                        ),
+                        ensure_ascii=False,
                     ),
                     guild_id,
                     officer_only=is_officer,
@@ -588,7 +594,9 @@ class Mirror(commands.Cog):
                     await db.commit()
 
                     await manager.broadcast_text(
-                        json.dumps({"deletedId": str(message.id)}),
+                        json.dumps(
+                            {"deletedId": str(message.id)}, ensure_ascii=False
+                        ),
                         guild_id,
                         officer_only=is_officer,
                         path="/ws/embeds",
@@ -607,7 +615,9 @@ class Mirror(commands.Cog):
                         await db.commit()
 
                     await manager.broadcast_text(
-                        json.dumps({"deletedId": str(message.id)}),
+                        json.dumps(
+                            {"deletedId": str(message.id)}, ensure_ascii=False
+                        ),
                         guild_id,
                         officer_only=is_officer,
                         path="/ws/messages",
@@ -626,7 +636,9 @@ class Mirror(commands.Cog):
                     await db.commit()
 
                 await manager.broadcast_text(
-                    json.dumps({"deletedId": str(message.id)}),
+                    json.dumps(
+                        {"deletedId": str(message.id)}, ensure_ascii=False
+                    ),
                     guild_id,
                     officer_only=is_officer,
                     path="/ws/messages",

--- a/demibot/demibot/discordbot/cogs/presence.py
+++ b/demibot/demibot/discordbot/cogs/presence.py
@@ -227,7 +227,9 @@ class PresenceTracker(commands.Cog):
     ) -> None:
         payload = await self._update(after)
         await manager.broadcast_text(
-            json.dumps(payload), after.guild.id, path="/ws/presences"
+            json.dumps(payload, ensure_ascii=False),
+            after.guild.id,
+            path="/ws/presences",
         )
 
     @commands.Cog.listener()
@@ -236,7 +238,9 @@ class PresenceTracker(commands.Cog):
     ) -> None:
         payload = await self._update(after)
         await manager.broadcast_text(
-            json.dumps(payload), after.guild.id, path="/ws/presences"
+            json.dumps(payload, ensure_ascii=False),
+            after.guild.id,
+            path="/ws/presences",
         )
 
 

--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -1457,7 +1457,7 @@ async def save_message(
 
     payload = dto.model_dump(mode="json", by_alias=True, exclude_none=True)
     await manager.broadcast_text(
-        json.dumps(payload),
+        json.dumps(payload, ensure_ascii=False),
         ctx.guild.id,
         officer_only=is_officer,
         path="/ws/officer-messages" if is_officer else "/ws/messages",
@@ -1664,7 +1664,7 @@ async def edit_message(
     )
     payload = dto.model_dump(mode="json", by_alias=True, exclude_none=True)
     await manager.broadcast_text(
-        json.dumps(payload),
+        json.dumps(payload, ensure_ascii=False),
         ctx.guild.id,
         officer_only=is_officer,
         path="/ws/officer-messages" if is_officer else "/ws/messages",
@@ -1732,7 +1732,7 @@ async def delete_message(
                     pass
     payload = {"id": str(message_id), "channelId": str(cid), "deleted": True}
     await manager.broadcast_text(
-        json.dumps(payload),
+        json.dumps(payload, ensure_ascii=False),
         ctx.guild.id,
         officer_only=is_officer,
         path="/ws/officer-messages" if is_officer else "/ws/messages",

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -538,7 +538,7 @@ async def create_event(
     payload = dto.model_dump(mode="json", by_alias=True, exclude_none=True)
     try:
         await manager.broadcast_text(
-            json.dumps(payload),
+            json.dumps(payload, ensure_ascii=False),
             ctx.guild.id,
             officer_only=kind == ChannelKind.OFFICER_CHAT,
             path="/ws/embeds",
@@ -714,7 +714,7 @@ async def rsvp_event(
     ).scalar_one_or_none()
     try:
         await manager.broadcast_text(
-            json.dumps(payload),
+            json.dumps(payload, ensure_ascii=False),
             embed.guild_id,
             officer_only=kind == ChannelKind.OFFICER_CHAT,
             path="/ws/embeds",

--- a/demibot/demibot/http/routes/interactions.py
+++ b/demibot/demibot/http/routes/interactions.py
@@ -129,7 +129,7 @@ async def post_interaction(
             )
         ).scalar_one_or_none()
         await manager.broadcast_text(
-            json.dumps(payload),
+            json.dumps(payload, ensure_ascii=False),
             embed.guild_id,
             officer_only=kind == ChannelKind.OFFICER_CHAT,
             path="/ws/embeds",

--- a/demibot/demibot/http/routes/requests.py
+++ b/demibot/demibot/http/routes/requests.py
@@ -98,9 +98,11 @@ async def _load_request_with_children(
 
 
 async def _broadcast(guild_id: int, request_id: int, delta: dict[str, Any]) -> None:
-    payload = json.dumps({"topic": "requests.stream", "payload": delta})
+    payload = json.dumps({"topic": "requests.stream", "payload": delta}, ensure_ascii=False)
     await manager.broadcast_text(payload, guild_id, path="/ws/requests")
-    payload = json.dumps({"topic": f"request.{request_id}", "payload": delta})
+    payload = json.dumps(
+        {"topic": f"request.{request_id}", "payload": delta}, ensure_ascii=False
+    )
     await manager.broadcast_text(payload, guild_id, path="/ws/requests")
 
 

--- a/demibot/demibot/http/routes/templates.py
+++ b/demibot/demibot/http/routes/templates.py
@@ -140,7 +140,8 @@ async def create_template(
                     "payload": dto.model_dump(
                         mode="json", by_alias=True, exclude_none=True
                     ),
-                }
+                },
+                ensure_ascii=False,
             ),
             ctx.guild.id,
             path="/ws/templates",
@@ -258,7 +259,8 @@ async def update_template(
                     "payload": dto.model_dump(
                         mode="json", by_alias=True, exclude_none=True
                     ),
-                }
+                },
+                ensure_ascii=False,
             ),
             ctx.guild.id,
             path="/ws/templates",
@@ -315,7 +317,8 @@ async def delete_template(
                     {
                         "topic": "templates.updated",
                         "payload": {"id": str(tid), "deleted": True},
-                    }
+                    },
+                    ensure_ascii=False,
                 ),
                 ctx.guild.id,
                 path="/ws/templates",

--- a/demibot/demibot/http/ws_chat.py
+++ b/demibot/demibot/http/ws_chat.py
@@ -509,7 +509,7 @@ class ChatConnectionManager:
                     "kind": meta.kind,
                     "messages": history,
                 }
-                await websocket.send_text(json.dumps(payload))
+                await websocket.send_text(json.dumps(payload, ensure_ascii=False))
         for channel_id in sync_channels:
             meta = info.metadata.get(channel_id)
             if meta is None:
@@ -722,7 +722,7 @@ class ChatConnectionManager:
             "kind": meta.kind,
             "messages": queue,
         }
-        message = json.dumps(payload)
+        message = json.dumps(payload, ensure_ascii=False)
         targets: list[WebSocket] = []
         for ws, info in self.connections.items():
             if channel not in info.channels:
@@ -925,7 +925,7 @@ class ChatConnectionManager:
             meta.kind,
             channel,
         )
-        await websocket.send_text(json.dumps(payload))
+        await websocket.send_text(json.dumps(payload, ensure_ascii=False))
 
     async def _send_resync(
         self,
@@ -955,7 +955,8 @@ class ChatConnectionManager:
                     "kind": meta.kind,
                     "channel": channel,
                     "cursor": cursor,
-                }
+                },
+                ensure_ascii=False,
             )
         )
 


### PR DESCRIPTION
## Summary
- ensure chat websocket payloads use `json.dumps(..., ensure_ascii=False)` so history batches, ack messages, and resyncs keep Unicode characters intact
- update message, event, template, request, presence, and mirror broadcasters to serialize JSON with `ensure_ascii=False` before fanning out over websockets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1f9c5533c8328986131315ae6b915