### PR TITLE
Handle Discord client unavailability in message posting

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -144,6 +144,9 @@ CHANNEL_NOT_CONFIGURED_DETAIL = (
 )
 
 
+DISCORD_CLIENT_UNAVAILABLE_DETAIL = "Discord client unavailable"
+
+
 def _role_set(ctx: RequestContext | object) -> Set[str]:
     roles: Iterable[str] | str | None = getattr(ctx, "roles", None)
     if roles is None:
@@ -350,6 +353,10 @@ async def create_webhook_for_channel(
                     "fetch_channel(%s) failed during webhook creation: %s",
                     channel_id,
                     exc,
+                )
+                resolution_error = DISCORD_CLIENT_UNAVAILABLE_DETAIL
+                errors.append(
+                    f"Webhook creation failed: {DISCORD_CLIENT_UNAVAILABLE_DETAIL}"
                 )
             except Exception:  # pragma: no cover - network errors
                 logging.exception(
@@ -1334,14 +1341,31 @@ async def save_message(
                             "channelId": str(cid),
                         },
                     )
+                client_unavailable = False
                 if error_details:
-                    logging.error(
-                        "Failed to resolve channel due to Discord errors: %s",
-                        error_details,
-                        extra=log_extra,
+                    client_unavailable = any(
+                        DISCORD_CLIENT_UNAVAILABLE_DETAIL in detail
+                        for detail in error_details
                     )
+                    if client_unavailable:
+                        logging.warning(
+                            "Discord client unavailable while resolving channel: %s",
+                            error_details,
+                            extra=log_extra,
+                        )
+                    else:
+                        logging.error(
+                            "Failed to resolve channel due to Discord errors: %s",
+                            error_details,
+                            extra=log_extra,
+                        )
                 else:
                     logging.warning("Failed to resolve channel", extra=log_extra)
+                if client_unavailable:
+                    detail = {"message": DISCORD_CLIENT_UNAVAILABLE_DETAIL}
+                    if error_details:
+                        detail["discord"] = error_details
+                    raise HTTPException(status_code=503, detail=detail)
                 detail: dict[str, object] = {"message": "channel not found"}
                 if error_details:
                     detail["discord"] = error_details

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -2006,6 +2006,54 @@ def test_save_message_unresolved_channel_id(monkeypatch):
     asyncio.run(_run())
 
 
+def test_save_message_discord_client_unavailable(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
+            await db.execute(text("DELETE FROM messages"))
+            await db.execute(text("DELETE FROM memberships"))
+            await db.execute(text("DELETE FROM users"))
+            await db.execute(text("DELETE FROM guilds"))
+            await db.execute(text("DELETE FROM guild_channels"))
+            db.add(Guild(id=10, discord_guild_id=10, name="Guild"))
+            db.add(User(id=10, discord_user_id=100, global_name="Alice"))
+            db.add(GuildChannel(guild_id=10, channel_id=456, kind=ChannelKind.FC_CHAT))
+            await db.commit()
+            guild = await db.get(Guild, 10)
+            user = await db.get(User, 10)
+            ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=[])
+
+            class DummyClient:
+                def get_channel(self, cid: int):
+                    return None
+
+                async def fetch_channel(self, cid: int):
+                    raise mc.ClientException("client not ready")
+
+            monkeypatch.setattr(mc, "discord_client", DummyClient())
+            monkeypatch.setattr(mc, "_channel_webhooks", {})
+
+            body = mc.PostBody(channel_id="456", content="hi")
+            with pytest.raises(HTTPException) as ex:
+                await mc.save_message(body, ctx, db, channel_kind=ChannelKind.FC_CHAT)
+
+            assert ex.value.status_code == 503
+            detail = ex.value.detail
+            assert isinstance(detail, dict)
+            assert (
+                detail.get("message") == mc.DISCORD_CLIENT_UNAVAILABLE_DETAIL
+            )
+            discord_details = detail.get("discord")
+            assert isinstance(discord_details, list)
+            assert any(
+                mc.DISCORD_CLIENT_UNAVAILABLE_DETAIL in item
+                for item in discord_details
+            )
+
+    asyncio.run(_run())
+
+
 def test_save_message_http_fallback_failure(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")


### PR DESCRIPTION
## Summary
- add a shared constant and capture discord.ClientException errors during webhook creation so the error list reflects when the client is unavailable
- surface a 503 Discord client unavailable response from save_message when that error detail is present instead of falling back to a 404
- extend the message posting tests to cover the disconnected client scenario

## Testing
- PYTHONPATH=demibot pytest tests/test_messages_common.py::test_save_message_unresolved_channel_id tests/test_messages_common.py::test_save_message_discord_client_unavailable

------
https://chatgpt.com/codex/tasks/task_e_68d1fbde618083288b5647fdfe5bd0f4