### PR TITLE
Expand emoji font glyph coverage

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -220,6 +220,8 @@ public class Plugin : IDalamudPlugin
                 {
                     var baseFont = pre.AddDalamudDefaultFont(fontSize);
                     var glyphRanges = default(FluentGlyphRangeBuilder)
+                        .With(0x2000, 0x27FF) // general punctuation, arrows, dingbats, enclosed & geometric symbols
+                        .With(0x2B00, 0x2BFF) // misc symbols and arrows (e.g. stars, triangles)
                         .With(0xD83C, 0xD83E) // high-surrogates covering U+1F000-U+1FAFF
                         .With(0xDC00, 0xDFFF) // low-surrogates for the same range
                         .With(0x200D, 0x200D) // zero width joiner for multi-glyph emoji sequences


### PR DESCRIPTION
## Summary
- expand the emoji font glyph ranges to include the BMP punctuation, symbol, and dingbat blocks alongside miscellaneous arrows so Noto Color Emoji is merged for those code points

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d20629aaa483289fa85884f2f88ee4