### PR TITLE
Fix pagination cursor usage in chat refresh

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1619,7 +1619,8 @@ public class ChatWindow : IDisposable
                 {
                     url += $"&before={before}";
                 }
-                var after = !firstPage ? storedAfter : null;
+                // The "after" cursor is only for incremental refreshes; pagination uses "before" alone.
+                var after = firstPage && before == null ? storedAfter : null;
                 if (after != null)
                 {
                     url += $"&after={after}";


### PR DESCRIPTION
## Summary
- ensure the REST chat refresh only applies the `after` cursor on the initial request so pagination can fetch older messages
- document that incremental refreshes rely on `after` while paging uses `before`

## Testing
- not run (dotnet CLI not available in container)
- not run (manual Discord pagination test requires live game environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2080900ec8328a16975d20225874b