### PR TITLE
Persist guild ID from validation and refresh consumers

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -262,13 +262,10 @@ public class Plugin : IDalamudPlugin
             return;
         }
 
-        if (
-            !string.Equals(
-                ChannelKeyHelper.NormalizeGuildId(guildId),
-                ChannelKeyHelper.NormalizeGuildId(_config.GuildId),
-                StringComparison.Ordinal
-            )
-        )
+        var normalizedRequestedGuild = ChannelKeyHelper.NormalizeGuildId(guildId);
+        var normalizedStoredGuild = ChannelKeyHelper.NormalizeGuildId(_config.GuildId);
+
+        if (!string.Equals(normalizedRequestedGuild, normalizedStoredGuild, StringComparison.Ordinal))
         {
             return;
         }
@@ -284,6 +281,20 @@ public class Plugin : IDalamudPlugin
             if (response == null)
             {
                 return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(response.GuildId))
+            {
+                var normalizedResponseGuild = ChannelKeyHelper.NormalizeGuildId(response.GuildId);
+                var guildChanged = !string.Equals(normalizedStoredGuild, normalizedResponseGuild, StringComparison.Ordinal);
+
+                _config.GuildId = normalizedResponseGuild;
+                _services.PluginInterface.SavePluginConfig(_config);
+
+                if (guildChanged)
+                {
+                    await HandleGuildChangedAsync(normalizedResponseGuild, kind).ConfigureAwait(false);
+                }
             }
 
             if (response.Ok)
@@ -327,6 +338,82 @@ public class Plugin : IDalamudPlugin
                 channelId,
                 kind
             );
+        }
+    }
+
+    private async Task HandleGuildChangedAsync(string normalizedGuildId, string changedKind)
+    {
+        try
+        {
+            await RevalidateChannelSelectionsAsync(normalizedGuildId, changedKind).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _services.Log.Warning(
+                ex,
+                $"Failed to revalidate channel selections after guild change to {normalizedGuildId}"
+            );
+        }
+
+        try
+        {
+            await RestartWatchersAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _services.Log.Warning(ex, "Failed to restart watchers after guild change");
+        }
+
+        try
+        {
+            await _emojiManager.RefreshCustomAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _services.Log.Warning(ex, "Failed to refresh custom emoji after guild change");
+        }
+    }
+
+    private async Task RevalidateChannelSelectionsAsync(string normalizedGuildId, string changedKind)
+    {
+        var normalizedChangedKind = ChannelKeyHelper.NormalizeKind(changedKind);
+        var kindsToValidate = new[]
+        {
+            ChannelKind.Chat,
+            ChannelKind.Event,
+            ChannelKind.FcChat,
+            ChannelKind.OfficerChat
+        };
+
+        foreach (var targetKind in kindsToValidate)
+        {
+            var normalizedTargetKind = ChannelKeyHelper.NormalizeKind(targetKind);
+            if (string.Equals(normalizedTargetKind, normalizedChangedKind, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var selectedChannel = _channelSelection.GetChannel(targetKind, normalizedGuildId);
+            if (string.IsNullOrWhiteSpace(selectedChannel))
+            {
+                continue;
+            }
+
+            await ValidateChannelSelectionAsync(targetKind, normalizedGuildId, selectedChannel).ConfigureAwait(false);
+        }
+    }
+
+    private async Task RestartWatchersAsync()
+    {
+        await _watcherRestartLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            StopWatchers();
+            await StartWatchersAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _watcherRestartLock.Release();
         }
     }
 

--- a/tests/PluginChannelValidationTests.cs
+++ b/tests/PluginChannelValidationTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
+using DemiCatPlugin;
+using DemiCatPlugin.Emoji;
+using Moq;
+using Xunit;
+
+public class PluginChannelValidationTests
+{
+    [Fact]
+    public async Task ValidationResponseStoresGuildAndEnablesCustomEmoji()
+    {
+        Cleanup();
+        PingService.Instance = null;
+
+        var plugin = (Plugin)FormatterServices.GetUninitializedObject(typeof(Plugin));
+        var services = new PluginServices();
+
+        var pluginInterfaceMock = new Mock<IDalamudPluginInterface>();
+        pluginInterfaceMock
+            .Setup(p => p.SavePluginConfig(It.IsAny<Config>()));
+
+        var logMock = new Mock<IPluginLog>();
+        logMock.Setup(l => l.Info(It.IsAny<string>()));
+        logMock.Setup(l => l.Warning(It.IsAny<string>()));
+        logMock.Setup(l => l.Warning(It.IsAny<Exception>(), It.IsAny<string>()));
+        logMock.Setup(l => l.Error(It.IsAny<string>()));
+
+        var frameworkMock = new Mock<IFramework>();
+        frameworkMock
+            .Setup(f => f.RunOnTick(It.IsAny<Action>(), It.IsAny<FrameworkUpdatePriority>()))
+            .Callback<Action, FrameworkUpdatePriority>((action, _) => action());
+
+        var toastMock = new Mock<IToastGui>();
+
+        SetPluginService(services, "PluginInterface", pluginInterfaceMock.Object);
+        SetPluginService(services, "Log", logMock.Object);
+        SetPluginService(services, "Framework", frameworkMock.Object);
+        SetPluginService(services, "ToastGui", toastMock.Object);
+
+        var config = new Config
+        {
+            ApiBaseUrl = "https://example.com",
+            Requests = false,
+            Events = false,
+            SyncedChat = false,
+            EnableFcChat = false
+        };
+        config.Roles.Clear();
+
+        var tokenManager = new TokenManager();
+        var handler = new ValidationTestHandler();
+        var httpClient = new HttpClient(handler);
+
+        var channelService = new ChannelService(config, httpClient, tokenManager);
+        var channelSelection = new ChannelSelectionService(config);
+        var emojiManager = new EmojiManager(httpClient, tokenManager, config);
+        var ui = new UiRenderer(config, httpClient, channelSelection, emojiManager);
+        var requestWatcher = new RequestWatcher(config, httpClient, tokenManager);
+        var chatWindow = new ChatWindow(config, httpClient, null, tokenManager, channelService);
+        var officerChatWindow = new OfficerChatWindow(config, httpClient, null, tokenManager, channelService);
+        var settingsWindow = new SettingsWindow(
+            config,
+            tokenManager,
+            httpClient,
+            () => Task.FromResult(true),
+            () => Task.CompletedTask,
+            logMock.Object,
+            pluginInterfaceMock.Object
+        );
+        var mainWindow = new MainWindow(
+            config,
+            ui,
+            chatWindow,
+            officerChatWindow,
+            settingsWindow,
+            httpClient,
+            channelService,
+            channelSelection,
+            emojiManager
+        );
+        var channelWatcher = new ChannelWatcher(
+            config,
+            ui,
+            mainWindow.EventCreateWindow,
+            mainWindow.TemplatesWindow,
+            chatWindow,
+            officerChatWindow,
+            tokenManager,
+            httpClient
+        );
+
+        settingsWindow.MainWindow = mainWindow;
+        settingsWindow.ChatWindow = chatWindow;
+        settingsWindow.OfficerChatWindow = officerChatWindow;
+        settingsWindow.ChannelWatcher = channelWatcher;
+        settingsWindow.RequestWatcher = requestWatcher;
+
+        SetPrivateField(plugin, "_services", services);
+        SetPrivateField(plugin, "_config", config);
+        SetPrivateField(plugin, "_tokenManager", tokenManager);
+        SetPrivateField(plugin, "_httpClient", httpClient);
+        SetPrivateField(plugin, "_channelService", channelService);
+        SetPrivateField(plugin, "_channelSelection", channelSelection);
+        SetPrivateField(plugin, "_emojiManager", emojiManager);
+        SetPrivateField(plugin, "_ui", ui);
+        SetPrivateField(plugin, "_settings", settingsWindow);
+        SetPrivateField(plugin, "_chatWindow", chatWindow);
+        SetPrivateField(plugin, "_officerChatWindow", officerChatWindow);
+        SetPrivateField(plugin, "_mainWindow", mainWindow);
+        SetPrivateField(plugin, "_channelWatcher", channelWatcher);
+        SetPrivateField(plugin, "_requestWatcher", requestWatcher);
+
+        PingService.Instance = new PingService(httpClient, config, tokenManager);
+
+        Assert.False(emojiManager.CanLoadCustom);
+
+        var method = typeof(Plugin)
+            .GetMethod("ValidateChannelSelectionAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        try
+        {
+            await (Task)method.Invoke(plugin, new object?[] { ChannelKind.Chat, string.Empty, "123456" })!;
+
+            Assert.Equal("guild-123", config.GuildId);
+            pluginInterfaceMock.Verify(pi => pi.SavePluginConfig(config), Times.AtLeastOnce());
+            Assert.True(emojiManager.CanLoadCustom);
+            Assert.Contains(
+                handler.Requests,
+                request => request.Method == HttpMethod.Head && request.Uri?.AbsolutePath == "/api/ping"
+            );
+        }
+        finally
+        {
+            Cleanup();
+        }
+    }
+
+    private static void SetPrivateField(object instance, string fieldName, object value)
+    {
+        instance.GetType()
+            .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(instance, value);
+    }
+
+    private static void SetPluginService(PluginServices services, string propertyName, object value)
+    {
+        typeof(PluginServices)
+            .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, value);
+    }
+
+    private static void Cleanup()
+    {
+        PingService.Instance = null;
+        var instanceProperty = typeof(PluginServices)
+            .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+        instanceProperty?.SetValue(null, null);
+    }
+
+    private sealed class ValidationTestHandler : HttpMessageHandler
+    {
+        public List<(HttpMethod Method, Uri? Uri)> Requests { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add((request.Method, request.RequestUri));
+
+            if (request.Method == HttpMethod.Head && request.RequestUri?.AbsolutePath == "/api/ping")
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/api/emojis/unicode")
+            {
+                return Task.FromResult(CreateJsonResponse("[]"));
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/api/emojis/guilds/guild-123")
+            {
+                return Task.FromResult(CreateJsonResponse("[]"));
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/api/channels/123456/validate")
+            {
+                return Task.FromResult(CreateJsonResponse("{\"ok\":true,\"guildId\":\"guild-123\",\"kind\":\"chat\",\"name\":\"General\"}"));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+
+        private static HttpResponseMessage CreateJsonResponse(string json)
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json)
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- persist the guild id returned by channel validation and restart guild-scoped consumers when it changes
- add a plugin unit test that verifies the stored guild id enables custom emoji loading

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68d21824dbd483289c3bb1607564b2b0