### PR TITLE
Preserve chat messages when cursor refresh returns empty

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1678,8 +1678,11 @@ public class ChatWindow : IDisposable
                 }
 
                 var hadExistingMessages = _messages.Count > 0;
+                var hasMatchingChannel = _messages.Any(m => string.Equals(m.ChannelId, requestedChannelId, StringComparison.Ordinal));
+                var hasConflictingChannel = _messages.Any(m => !string.IsNullOrEmpty(m.ChannelId) && !string.Equals(m.ChannelId, requestedChannelId, StringComparison.Ordinal));
+                var canMergeIncremental = usedStoredCursor && hadExistingMessages && hasMatchingChannel && !hasConflictingChannel;
 
-                if (usedStoredCursor && hadExistingMessages)
+                if (canMergeIncremental)
                 {
                     if (all.Count == 0)
                     {

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1609,8 +1609,13 @@ public class ChatWindow : IDisposable
             var all = new List<DiscordMessageDto>();
             string? before = null;
             var cursorKey = ChannelKeyHelper.BuildCursorKey(_config.GuildId, _channelKind, channelId);
-            var hasCursor = _config.RestChatCursors.TryGetValue(cursorKey, out var since);
-            var storedAfter = hasCursor ? since.ToString() : null;
+            string? storedAfter = null;
+            var usedStoredCursor = false;
+            if (_config.RestChatCursors.TryGetValue(cursorKey, out var since))
+            {
+                storedAfter = since.ToString();
+                usedStoredCursor = true;
+            }
             var firstPage = true;
             while (all.Count < MaxMessages)
             {
@@ -1669,6 +1674,48 @@ public class ChatWindow : IDisposable
             {
                 if (!string.Equals(requestedChannelId, CurrentChannelId, StringComparison.Ordinal))
                 {
+                    return;
+                }
+
+                var hadExistingMessages = _messages.Count > 0;
+
+                if (usedStoredCursor && hadExistingMessages)
+                {
+                    if (all.Count == 0)
+                    {
+                        return;
+                    }
+
+                    var existingIndices = new Dictionary<string, int>(StringComparer.Ordinal);
+                    for (var i = 0; i < _messages.Count; i++)
+                    {
+                        var id = _messages[i].Id;
+                        if (!string.IsNullOrEmpty(id) && !existingIndices.ContainsKey(id))
+                        {
+                            existingIndices[id] = i;
+                        }
+                    }
+
+                    foreach (var message in all)
+                    {
+                        if (string.IsNullOrEmpty(message.Id))
+                        {
+                            continue;
+                        }
+
+                        if (existingIndices.TryGetValue(message.Id, out var index))
+                        {
+                            DisposeMessageTextures(_messages[index]);
+                            _messages[index] = message;
+                        }
+                        else
+                        {
+                            _messages.Add(message);
+                            existingIndices[message.Id] = _messages.Count - 1;
+                        }
+                    }
+
+                    TrimMessages();
                     return;
                 }
 

--- a/tests/ChatWindowMessageLimitTests.cs
+++ b/tests/ChatWindowMessageLimitTests.cs
@@ -131,6 +131,40 @@ public class ChatWindowMessageLimitTests
     }
 
     [Fact]
+    public async Task RefreshMessages_SwitchChannelsWithCursorAndEmptyResponse_ClearsPreviousMessages()
+    {
+        SetupServices();
+        var config = new Config { ApiBaseUrl = "http://localhost", ChatChannelId = "1" };
+        var handler = new SequenceHandler();
+        using var client = new HttpClient(handler);
+        var tm = new TokenManager();
+        var channelService = new ChannelService(config, client, tm);
+        var window = new ChatWindow(config, client, null, tm, channelService);
+
+        handler.EnqueueResponse(SerializeMessages(1, 3));
+        await window.RefreshMessages();
+
+        var initial = GetMessages(window);
+        Assert.Equal(3, initial.Count);
+        Assert.All(initial, m => Assert.Equal("1", m.ChannelId));
+
+        var selectionKey = ChannelKeyHelper.BuildSelectionKey(config.GuildId, ChannelKind.Chat);
+        config.ChannelSelections[selectionKey] = "2";
+        var cursorKey = ChannelKeyHelper.BuildCursorKey(config.GuildId, ChannelKind.Chat, "2");
+        config.RestChatCursors[cursorKey] = 42;
+
+        handler.Requests.Clear();
+        handler.EnqueueResponse("[]");
+        await window.RefreshMessages();
+
+        var refreshed = GetMessages(window);
+        Assert.Empty(refreshed);
+        Assert.Single(handler.Requests);
+        Assert.Contains("/api/messages/2", handler.Requests[0].AbsolutePath);
+        Assert.Contains("after=42", handler.Requests[0].Query);
+    }
+
+    [Fact]
     public async Task RefreshMessages_ReappliesCursorWhenPaginating()
     {
         SetupServices();

--- a/tests/ChatWindowMessageLimitTests.cs
+++ b/tests/ChatWindowMessageLimitTests.cs
@@ -42,13 +42,13 @@ public class ChatWindowMessageLimitTests
         await window.RefreshMessages();
 
         msgs = GetMessages(window);
-        Assert.Equal(10, msgs.Count);
-        Assert.Equal("121", msgs[0].Id);
+        Assert.Equal(100, msgs.Count);
+        Assert.Equal("31", msgs[0].Id);
         Assert.Equal("130", msgs[^1].Id);
         Assert.Equal(130, config.RestChatCursors[cursorKey]);
         Assert.False(config.ChatCursors.ContainsKey(cursorKey));
         Assert.Single(handler.Requests);
-        Assert.DoesNotContain("after=", handler.Requests[0].Query);
+        Assert.Contains("after=120", handler.Requests[0].Query);
     }
 
     [Fact]
@@ -90,10 +90,44 @@ public class ChatWindowMessageLimitTests
         await window.RefreshMessages();
 
         var msgs = GetMessages(window);
-        Assert.Collection(msgs,
+        Assert.Equal(23, msgs.Count);
+        var tail = msgs.GetRange(msgs.Count - 3, 3);
+        Assert.Collection(tail,
             m => Assert.Equal("201", m.Id),
             m => Assert.Equal("202", m.Id),
             m => Assert.Equal("203", m.Id));
+    }
+
+    [Fact]
+    public async Task RefreshMessages_WithCursorAndEmptyResponse_RetainsMessages()
+    {
+        SetupServices();
+        var config = new Config { ApiBaseUrl = "http://localhost", ChatChannelId = "1" };
+        var handler = new SequenceHandler();
+        using var client = new HttpClient(handler);
+        var tm = new TokenManager();
+        var channelService = new ChannelService(config, client, tm);
+        var window = new ChatWindow(config, client, null, tm, channelService);
+        var cursorKey = ChannelKeyHelper.BuildCursorKey(config.GuildId, ChannelKind.Chat, "1");
+
+        handler.EnqueueResponse(SerializeMessages(1, 5));
+        await window.RefreshMessages();
+
+        var initial = GetMessages(window);
+        Assert.Equal(5, initial.Count);
+        Assert.Equal("5", initial[^1].Id);
+
+        handler.Requests.Clear();
+        handler.EnqueueResponse("[]");
+        await window.RefreshMessages();
+
+        var refreshed = GetMessages(window);
+        Assert.Equal(5, refreshed.Count);
+        Assert.Equal("1", refreshed[0].Id);
+        Assert.Equal("5", refreshed[^1].Id);
+        Assert.Equal(5, config.RestChatCursors[cursorKey]);
+        Assert.Single(handler.Requests);
+        Assert.Contains("after=5", handler.Requests[0].Query);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- merge REST refreshes that rely on stored cursors into the existing message list so empty responses keep previously loaded content
- retain cursor trimming only when messages exist and update incremental merge logic to prevent clearing messages without new data
- extend chat window tests to cover empty REST responses with cursors and adjust expectations for incremental pagination

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj --filter ChatWindowMessageLimitTests *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68d21d14d78c832896d562d6eb2b5033