### PR TITLE
Prevent disposing shared presence service

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -188,6 +188,7 @@ public class ChatWindow : IDisposable
 
     public virtual void StartNetworking()
     {
+        _presence?.SetPresenceReady(true);
         _bridge.Start();
         var chan = CurrentChannelId;
         if (!string.IsNullOrEmpty(chan))
@@ -203,6 +204,7 @@ public class ChatWindow : IDisposable
     {
         _bridge.Stop();
         _presence?.Stop();
+        _presence?.SetPresenceReady(false);
         _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
     }
 

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -627,6 +627,8 @@ public class Plugin : IDalamudPlugin
         _chatWindow.StopNetworking();
         _officerChatWindow.StopNetworking();
         _officerWatcherRunning = false;
+        _presenceService?.SetPresenceReady(false);
+        _presenceService?.Stop();
         _ui.StopNetworking();
         _mainWindow.TemplatesWindow.StopNetworking();
         MembershipCache.Reset();
@@ -807,7 +809,8 @@ public class Plugin : IDalamudPlugin
                         {
                             _services.Log.Info("Stopping chat window networking");
                             _chatWindow.StopNetworking();
-                            _presenceService?.Dispose();
+                            _presenceService?.SetPresenceReady(false);
+                            _presenceService?.Stop();
                         }
 
                         if (startChannelWatcher)

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -154,7 +154,9 @@ public class SettingsWindow : IDisposable
                 else
                 {
                     ChatWindow.StopNetworking();
-                    ChatWindow.Presence?.Dispose();
+                    var presenceService = ChatWindow.Presence ?? OfficerChatWindow?.Presence;
+                    presenceService?.SetPresenceReady(false);
+                    presenceService?.Stop();
                 }
             }
         }
@@ -495,8 +497,12 @@ public class SettingsWindow : IDisposable
         SafeInvoke(() =>
         {
             var presence = ChatWindow?.Presence ?? OfficerChatWindow?.Presence;
-            presence?.Dispose();
-        }, "Failed to dispose presence service.");
+            if (presence != null)
+            {
+                presence.SetPresenceReady(false);
+                presence.Stop();
+            }
+        }, "Failed to stop presence service.");
     }
 
     private void ClearRuntimeCaches()
@@ -601,6 +607,7 @@ public class SettingsWindow : IDisposable
     {
         var framework = PluginServices.Instance?.Framework;
         var presence = ChatWindow?.Presence ?? OfficerChatWindow?.Presence;
+        var presenceRestarted = false;
 
         void UpdateStatus(string status)
         {
@@ -791,6 +798,7 @@ public class SettingsWindow : IDisposable
             {
                 presence?.Reset();
                 presence?.Reload();
+                presenceRestarted = presence != null;
             }
             catch (Exception ex)
             {
@@ -826,7 +834,7 @@ public class SettingsWindow : IDisposable
         }
         finally
         {
-            presence?.SetPresenceReady(true);
+            presence?.SetPresenceReady(presenceRestarted);
             lock (_hardReloadLock)
             {
                 _hardReloadTask = null;

--- a/tests/PresenceServiceLifecycleTests.cs
+++ b/tests/PresenceServiceLifecycleTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
+using DemiCatPlugin;
+using Moq;
+using Xunit;
+
+public class PresenceServiceLifecycleTests : IDisposable
+{
+    private readonly PluginServices? _previousServices;
+    private readonly TokenManager? _previousTokenManager;
+    private readonly PingService? _previousPingService;
+
+    public PresenceServiceLifecycleTests()
+    {
+        _previousServices = PluginServices.Instance;
+        _previousTokenManager = TokenManager.Instance;
+        _previousPingService = PingService.Instance;
+
+        var services = new PluginServices();
+        SetServiceProperty(services, "Framework", new ImmediateFramework());
+        SetServiceProperty(services, "Log", new TestLog());
+        SetPluginServicesInstance(services);
+    }
+
+    [Fact]
+    public void StopAllWatchersAndPresence_MarksServiceNotReady()
+    {
+        var config = new Config { ApiBaseUrl = "https://example.invalid" };
+        using var httpClient = new HttpClient(new StubPresenceHandler());
+        var tokenManager = new TokenManager();
+        var presence = new DiscordPresenceService(config, httpClient);
+        presence.SetPresenceReady(true);
+        var channelService = new ChannelService(config, httpClient, tokenManager);
+
+        var settingsWindow = new SettingsWindow(
+            config,
+            tokenManager,
+            httpClient,
+            () => Task.FromResult(true),
+            () => Task.CompletedTask,
+            new TestLog(),
+            Mock.Of<IDalamudPluginInterface>());
+
+        settingsWindow.ChatWindow = new ChatWindow(config, httpClient, presence, tokenManager, channelService);
+
+        var method = typeof(SettingsWindow).GetMethod(
+            "StopAllWatchersAndPresence",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        method!.Invoke(settingsWindow, Array.Empty<object>());
+
+        Assert.False(presence.IsPresenceReady);
+    }
+
+    [Fact]
+    public void ChatWindow_StartAndStopTogglePresenceReady()
+    {
+        var config = new Config { ApiBaseUrl = "https://example.invalid" };
+        using var httpClient = new HttpClient(new StubPresenceHandler());
+        var tokenManager = new TokenManager();
+        var presence = new DiscordPresenceService(config, httpClient);
+        var channelService = new ChannelService(config, httpClient, tokenManager);
+
+        PingService.Instance = new PingService(httpClient, config, tokenManager);
+
+        presence.SetPresenceReady(false);
+        var window = new ChatWindow(config, httpClient, presence, tokenManager, channelService);
+
+        window.StartNetworking();
+        Assert.True(presence.IsPresenceReady);
+
+        window.StopNetworking();
+        Assert.False(presence.IsPresenceReady);
+    }
+
+    public void Dispose()
+    {
+        SetPluginServicesInstance(_previousServices);
+        SetTokenManagerInstance(_previousTokenManager);
+        PingService.Instance = _previousPingService;
+    }
+
+    private static void SetServiceProperty(PluginServices services, string propertyName, object value)
+        => typeof(PluginServices)
+            .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, value);
+
+    private static void SetPluginServicesInstance(PluginServices? instance)
+        => typeof(PluginServices)
+            .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetSetMethod(true)!
+            .Invoke(null, new object?[] { instance });
+
+    private static void SetTokenManagerInstance(TokenManager? instance)
+        => typeof(TokenManager)
+            .GetProperty("Instance", BindingFlags.Static | BindingFlags.Public)!
+            .GetSetMethod(true)!
+            .Invoke(null, new object?[] { instance });
+
+    private sealed class StubPresenceHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Head)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+
+            if (request.Method == HttpMethod.Get && request.RequestUri != null &&
+                request.RequestUri.AbsolutePath.EndsWith("/api/users", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{}")
+            });
+        }
+    }
+
+    private sealed class ImmediateFramework : IFramework
+    {
+        public event FrameworkUpdateDelegate? Update { add { } remove { } }
+
+        public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
+
+        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+            => action();
+    }
+
+    private sealed class TestLog : IPluginLog
+    {
+        public void Verbose(string message) { }
+        public void Verbose(string message, Exception exception) { }
+        public void Debug(string message) { }
+        public void Debug(string message, Exception exception) { }
+        public void Info(string message) { }
+        public void Info(string message, Exception exception) { }
+        public void Warning(string message) { }
+        public void Warning(string message, Exception exception) { }
+        public void Error(string message) { }
+        public void Error(Exception exception, string message) { }
+        public void Fatal(string message) { }
+        public void Fatal(Exception exception, string message) { }
+    }
+}


### PR DESCRIPTION
## Summary
- stop disposing the shared Discord presence service when shutting down watchers so it can be restarted safely
- ensure hard reload only marks the presence service ready after attempting to reset/reload and teach chat windows to toggle readiness on start/stop
- update watcher stop logic to call the presence service stop helpers and add lifecycle tests for the new behaviour

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b4caf50483288dfb43ab99998d72