### PR TITLE
Remove redundant System.IO import in ChannelWatcher

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -6,7 +6,6 @@ using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
-using System.IO;
 
 namespace DemiCatPlugin;
 


### PR DESCRIPTION
## Summary
- remove the duplicate System.IO using directive from ChannelWatcher so it is imported once

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e77a57c083289c1c1abc9c07d1ef