### PR TITLE
Guard guild binding when selecting channels

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -933,28 +933,54 @@ public class ChatWindow : IDisposable
         }
     }
 
-    public void SetChannels(List<ChannelDto> channels)
+    protected List<ChannelDto> PrepareChannelsForDisplay(IEnumerable<ChannelDto> channels)
+    {
+        var channelList = channels?.ToList() ?? new List<ChannelDto>();
+        var hasStoredGuild = !ChannelKeyHelper.IsDefaultGuild(_config.GuildId);
+        var normalizedStoredGuild = ChannelKeyHelper.NormalizeGuildId(_config.GuildId);
+
+        if (!hasStoredGuild)
+        {
+            var channelWithGuild = channelList.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c.GuildId));
+            if (channelWithGuild != null && !string.IsNullOrWhiteSpace(channelWithGuild.GuildId))
+            {
+                normalizedStoredGuild = ChannelKeyHelper.NormalizeGuildId(channelWithGuild.GuildId);
+                _config.GuildId = normalizedStoredGuild;
+                SaveConfig();
+                hasStoredGuild = true;
+            }
+        }
+
+        if (hasStoredGuild)
+        {
+            channelList = channelList
+                .Where(c =>
+                    string.IsNullOrWhiteSpace(c.GuildId) ||
+                    string.Equals(
+                        ChannelKeyHelper.NormalizeGuildId(c.GuildId),
+                        normalizedStoredGuild,
+                        StringComparison.Ordinal))
+                .ToList();
+        }
+
+        return ChannelDtoExtensions.SortForDisplay(channelList);
+    }
+
+    public void SetChannels(IEnumerable<ChannelDto> channels)
+    {
+        var prepared = PrepareChannelsForDisplay(channels);
+        ApplyPreparedChannels(prepared);
+    }
+
+    protected void ApplyPreparedChannels(List<ChannelDto> channels)
     {
         _channels.Clear();
-        _channels.AddRange(ChannelDtoExtensions.SortForDisplay(channels));
+        _channels.AddRange(channels);
         if (_channels.Count == 0)
         {
             _selectedIndex = 0;
             _channelSelection.SetChannel(_channelKind, _config.GuildId, string.Empty);
             return;
-        }
-
-        var storedNormalizedGuild = ChannelKeyHelper.NormalizeGuildId(_config.GuildId);
-        string? normalizedGuildFromChannels = null;
-        var channelWithGuild = _channels.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c.GuildId));
-        if (channelWithGuild != null && !string.IsNullOrWhiteSpace(channelWithGuild.GuildId))
-        {
-            normalizedGuildFromChannels = ChannelKeyHelper.NormalizeGuildId(channelWithGuild.GuildId);
-            if (!string.Equals(normalizedGuildFromChannels, storedNormalizedGuild, StringComparison.Ordinal))
-            {
-                _config.GuildId = normalizedGuildFromChannels;
-                PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
-            }
         }
 
         var current = CurrentChannelId;
@@ -970,11 +996,6 @@ public class ChatWindow : IDisposable
 
         var newId = _channels[_selectedIndex].Id;
         _channelSelection.SetChannel(_channelKind, _config.GuildId, newId);
-
-        if (normalizedGuildFromChannels != null)
-        {
-            OnGuildUpdated();
-        }
     }
 
     internal void OnGuildUpdated()
@@ -2041,7 +2062,7 @@ public class ChatWindow : IDisposable
 
     protected void SaveConfig()
     {
-        PluginServices.Instance!.PluginInterface.SavePluginConfig(_config);
+        PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
     }
 
     public Task RefreshChannels()

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -312,7 +312,8 @@ public class OfficerChatWindow : ChatWindow
             }
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
-                SetChannels(channels);
+                var preparedChannels = PrepareChannelsForDisplay(channels);
+                ApplyPreparedChannels(preparedChannels);
                 _channelsLoaded = true;
                 _channelFetchFailed = false;
                 _channelErrorMessage = string.Empty;

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -252,10 +252,10 @@ public class Plugin : IDalamudPlugin
 
     private async void HandleChannelSelectionValidation(string kind, string guildId, string oldId, string newId)
     {
-        await ValidateChannelSelectionAsync(kind, guildId, newId);
+        await ValidateChannelSelectionAsync(kind, guildId, newId, oldId);
     }
 
-    private async Task ValidateChannelSelectionAsync(string kind, string guildId, string channelId)
+    private async Task ValidateChannelSelectionAsync(string kind, string guildId, string channelId, string? previousChannelId = null)
     {
         if (string.IsNullOrWhiteSpace(channelId))
         {
@@ -286,16 +286,42 @@ public class Plugin : IDalamudPlugin
             if (!string.IsNullOrWhiteSpace(response.GuildId))
             {
                 var normalizedResponseGuild = ChannelKeyHelper.NormalizeGuildId(response.GuildId);
-                var guildChanged = !string.Equals(normalizedStoredGuild, normalizedResponseGuild, StringComparison.Ordinal);
+                var hasStoredGuild = !ChannelKeyHelper.IsDefaultGuild(_config.GuildId);
 
-                _config.GuildId = normalizedResponseGuild;
-                _services.PluginInterface.SavePluginConfig(_config);
-
-                _chatWindow.OnGuildUpdated();
-                _officerChatWindow.OnGuildUpdated();
-
-                if (guildChanged)
+                if (hasStoredGuild &&
+                    !string.Equals(normalizedStoredGuild, normalizedResponseGuild, StringComparison.Ordinal))
                 {
+                    void RejectSelection()
+                    {
+                        var restoreChannelId = string.IsNullOrWhiteSpace(previousChannelId) ? string.Empty : previousChannelId;
+                        _channelSelection.SetChannel(kind, _config.GuildId, restoreChannelId);
+                        PluginServices.Instance?.ToastGui.ShowError(
+                            "Cannot select a channel from a different Discord server without unlinking first."
+                        );
+                    }
+
+                    var framework = PluginServices.Instance?.Framework;
+                    if (framework != null)
+                    {
+                        framework.RunOnTick(RejectSelection);
+                    }
+                    else
+                    {
+                        RejectSelection();
+                    }
+
+                    return;
+                }
+
+                if (!hasStoredGuild)
+                {
+                    var guildChanged = !string.Equals(normalizedStoredGuild, normalizedResponseGuild, StringComparison.Ordinal);
+                    _config.GuildId = normalizedResponseGuild;
+                    _services.PluginInterface.SavePluginConfig(_config);
+
+                    _chatWindow.OnGuildUpdated();
+                    _officerChatWindow.OnGuildUpdated();
+
                     await HandleGuildChangedAsync(normalizedResponseGuild, kind).ConfigureAwait(false);
                 }
             }
@@ -402,7 +428,8 @@ public class Plugin : IDalamudPlugin
                 continue;
             }
 
-            await ValidateChannelSelectionAsync(targetKind, normalizedGuildId, selectedChannel).ConfigureAwait(false);
+            await ValidateChannelSelectionAsync(targetKind, normalizedGuildId, selectedChannel, selectedChannel)
+                .ConfigureAwait(false);
         }
     }
 

--- a/tests/ChatWindowChannelFetchTests.cs
+++ b/tests/ChatWindowChannelFetchTests.cs
@@ -6,8 +6,10 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 using DemiCatPlugin;
+using Moq;
 using Xunit;
 
 public class ChatWindowChannelFetchTests
@@ -69,6 +71,40 @@ public class ChatWindowChannelFetchTests
         window.Dispose();
     }
 
+    [Fact]
+    public void SetChannels_FiltersMismatchedGuildEntries()
+    {
+        SetupServices();
+        var config = new Config
+        {
+            ApiBaseUrl = "http://localhost",
+            GuildId = "guild-a"
+        };
+        using var client = new HttpClient(new HttpClientHandler());
+        var tokenManager = new TokenManager();
+        var channelService = new ChannelService(config, client, tokenManager);
+        var window = new ChatWindow(config, client, null, tokenManager, channelService);
+
+        var channels = new List<ChannelDto>
+        {
+            new() { Id = "1", Name = "General", GuildId = "guild-a" },
+            new() { Id = "2", Name = "Other", GuildId = "guild-b" }
+        };
+
+        window.SetChannels(channels);
+
+        Assert.Equal("guild-a", config.GuildId);
+
+        var storedChannels = (List<ChannelDto>)typeof(ChatWindow)
+            .GetField("_channels", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!;
+
+        Assert.Single(storedChannels);
+        Assert.Equal("1", storedChannels[0].Id);
+
+        window.Dispose();
+    }
+
     private static string SerializeChannels(params (string Id, string Name)[] channels)
     {
         var list = new List<object>();
@@ -91,6 +127,8 @@ public class ChatWindowChannelFetchTests
         var log = new TestLog();
         typeof(PluginServices).GetProperty("Framework", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, framework);
         typeof(PluginServices).GetProperty("Log", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, log);
+        var pluginInterface = new Mock<IDalamudPluginInterface>();
+        typeof(PluginServices).GetProperty("PluginInterface", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, pluginInterface.Object);
     }
 
     private sealed class SequenceHandler : HttpMessageHandler

--- a/tests/PluginChannelValidationTests.cs
+++ b/tests/PluginChannelValidationTests.cs
@@ -128,7 +128,7 @@ public class PluginChannelValidationTests
 
         try
         {
-            await (Task)method.Invoke(plugin, new object?[] { ChannelKind.Chat, string.Empty, "123456" })!;
+            await (Task)method.Invoke(plugin, new object?[] { ChannelKind.Chat, string.Empty, "123456", null })!;
 
             Assert.Equal("guild-123", config.GuildId);
             pluginInterfaceMock.Verify(pi => pi.SavePluginConfig(config), Times.AtLeastOnce());


### PR DESCRIPTION
## Summary
- ensure chat windows derive a shared guild-aware channel preparation helper so selections stay scoped to the stored guild
- reject channel validation responses that drift to another guild and only persist the guild binding when it is first established
- add coverage proving SetChannels ignores cross-guild channels and update the validation test harness for the new API signature

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: `dotnet` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f3b7b8fc83288357d664116172f9