### PR TITLE
Gate officer UI by token claims and harden channel revalidation

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -50,7 +50,7 @@ public class ChannelWatcher : IDisposable
 
     public async Task Start()
     {
-        if (!_config.Events && !_config.SyncedChat && !_config.Roles.Contains("officer"))
+        if (!_config.Events && !_config.SyncedChat && !(_config.Officer && _config.IsOfficerToken))
         {
             return;
         }
@@ -385,7 +385,7 @@ public class ChannelWatcher : IDisposable
         _ = SafeRefresh(_templatesWindow.RefreshChannels);
         if (_config.SyncedChat && _config.EnableFcChat)
             _ = SafeRefresh(_chatWindow.RefreshChannels);
-        if (_config.Roles.Contains("officer"))
+        if (_config.Officer && _config.IsOfficerToken)
             _ = SafeRefresh(_officerChatWindow.RefreshChannels);
 
         _lastRefresh = DateTime.UtcNow;

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -933,28 +933,54 @@ public class ChatWindow : IDisposable
         }
     }
 
-    public void SetChannels(List<ChannelDto> channels)
+    protected List<ChannelDto> PrepareChannelsForDisplay(IEnumerable<ChannelDto> channels)
+    {
+        var channelList = channels?.ToList() ?? new List<ChannelDto>();
+        var hasStoredGuild = !ChannelKeyHelper.IsDefaultGuild(_config.GuildId);
+        var normalizedStoredGuild = ChannelKeyHelper.NormalizeGuildId(_config.GuildId);
+
+        if (!hasStoredGuild)
+        {
+            var channelWithGuild = channelList.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c.GuildId));
+            if (channelWithGuild != null && !string.IsNullOrWhiteSpace(channelWithGuild.GuildId))
+            {
+                normalizedStoredGuild = ChannelKeyHelper.NormalizeGuildId(channelWithGuild.GuildId);
+                _config.GuildId = normalizedStoredGuild;
+                SaveConfig();
+                hasStoredGuild = true;
+            }
+        }
+
+        if (hasStoredGuild)
+        {
+            channelList = channelList
+                .Where(c =>
+                    string.IsNullOrWhiteSpace(c.GuildId) ||
+                    string.Equals(
+                        ChannelKeyHelper.NormalizeGuildId(c.GuildId),
+                        normalizedStoredGuild,
+                        StringComparison.Ordinal))
+                .ToList();
+        }
+
+        return ChannelDtoExtensions.SortForDisplay(channelList);
+    }
+
+    public void SetChannels(IEnumerable<ChannelDto> channels)
+    {
+        var prepared = PrepareChannelsForDisplay(channels);
+        ApplyPreparedChannels(prepared);
+    }
+
+    protected void ApplyPreparedChannels(List<ChannelDto> channels)
     {
         _channels.Clear();
-        _channels.AddRange(ChannelDtoExtensions.SortForDisplay(channels));
+        _channels.AddRange(channels);
         if (_channels.Count == 0)
         {
             _selectedIndex = 0;
             _channelSelection.SetChannel(_channelKind, _config.GuildId, string.Empty);
             return;
-        }
-
-        var storedNormalizedGuild = ChannelKeyHelper.NormalizeGuildId(_config.GuildId);
-        string? normalizedGuildFromChannels = null;
-        var channelWithGuild = _channels.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c.GuildId));
-        if (channelWithGuild != null && !string.IsNullOrWhiteSpace(channelWithGuild.GuildId))
-        {
-            normalizedGuildFromChannels = ChannelKeyHelper.NormalizeGuildId(channelWithGuild.GuildId);
-            if (!string.Equals(normalizedGuildFromChannels, storedNormalizedGuild, StringComparison.Ordinal))
-            {
-                _config.GuildId = normalizedGuildFromChannels;
-                PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
-            }
         }
 
         var current = CurrentChannelId;
@@ -970,11 +996,6 @@ public class ChatWindow : IDisposable
 
         var newId = _channels[_selectedIndex].Id;
         _channelSelection.SetChannel(_channelKind, _config.GuildId, newId);
-
-        if (normalizedGuildFromChannels != null)
-        {
-            OnGuildUpdated();
-        }
     }
 
     internal void OnGuildUpdated()
@@ -2041,7 +2062,21 @@ public class ChatWindow : IDisposable
 
     protected void SaveConfig()
     {
-        PluginServices.Instance!.PluginInterface.SavePluginConfig(_config);
+        var services = PluginServices.Instance;
+        if (services?.PluginInterface == null)
+        {
+            return;
+        }
+
+        var framework = services.Framework;
+        if (framework != null)
+        {
+            framework.RunOnTick(() => services.PluginInterface!.SavePluginConfig(_config));
+        }
+        else
+        {
+            services.PluginInterface.SavePluginConfig(_config);
+        }
     }
 
     public Task RefreshChannels()

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -46,6 +46,7 @@ public class Config : IPluginConfiguration
     public bool Requests { get; set; } = true;
     [JsonPropertyName("officer")]
     public bool Officer { get; set; } = true;
+    public bool IsOfficerToken { get; set; }
     [JsonPropertyName("fcSyncShell")]
     public bool FCSyncShell { get; set; } = false;
     public bool UseCharacterName { get; set; } = false;

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -22,6 +22,10 @@ public class OfficerChatWindow : ChatWindow
     private bool _subscribed;
     private readonly PresenceSidebar? _presenceSidebar;
     private float _presenceWidth = 200f;
+    private const string NoOfficerAccessStatus = "No officer access for this key.";
+
+    private static bool HasOfficerAccess(Config config)
+        => config.Officer && config.IsOfficerToken;
 
     public OfficerChatWindow(
         Config config,
@@ -81,29 +85,24 @@ public class OfficerChatWindow : ChatWindow
     {
         MarkNetworkingStarted();
         _bridge.Start();
-        if (_config.Roles.Contains("officer"))
+        if (HasOfficerAccess(_config))
         {
+            _statusMessage = string.Empty;
             Subscribe();
         }
         else
         {
+            _statusMessage = NoOfficerAccessStatus;
             TryRefreshRoles();
         }
     }
 
     public override void Draw()
     {
-        if (!_config.Roles.Contains("officer"))
+        if (!HasOfficerAccess(_config))
         {
-            TryRefreshRoles();
-            if (!string.IsNullOrEmpty(_statusMessage))
-            {
-                ImGui.TextUnformatted(_statusMessage);
-            }
-            else
-            {
-                ImGui.TextUnformatted("Link DemiCat…");
-            }
+            var message = string.IsNullOrEmpty(_statusMessage) ? NoOfficerAccessStatus : _statusMessage;
+            ImGui.TextUnformatted(message);
             return;
         }
 
@@ -312,7 +311,8 @@ public class OfficerChatWindow : ChatWindow
             }
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
-                SetChannels(channels);
+                var preparedChannels = PrepareChannelsForDisplay(channels);
+                ApplyPreparedChannels(preparedChannels);
                 _channelsLoaded = true;
                 _channelFetchFailed = false;
                 _channelErrorMessage = string.Empty;
@@ -438,7 +438,7 @@ public class OfficerChatWindow : ChatWindow
                 var mainWindow = MainWindow.Instance;
                 if (mainWindow != null)
                 {
-                    mainWindow.HasOfficerRole = hasOfficer;
+                    mainWindow.HasOfficerRole = HasOfficerAccess(_config);
                 }
             }
 

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -121,7 +121,7 @@ public class Plugin : IDalamudPlugin
         _settings.ChannelWatcher = _channelWatcher;
         _settings.RequestWatcher = _requestWatcher;
 
-        _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
+        _mainWindow.HasOfficerRole = HasOfficerAccess(_config);
 
         _ = RoleCache.EnsureLoaded(_httpClient, _config);
 
@@ -252,10 +252,10 @@ public class Plugin : IDalamudPlugin
 
     private async void HandleChannelSelectionValidation(string kind, string guildId, string oldId, string newId)
     {
-        await ValidateChannelSelectionAsync(kind, guildId, newId);
+        await ValidateChannelSelectionAsync(kind, guildId, newId, oldId);
     }
 
-    private async Task ValidateChannelSelectionAsync(string kind, string guildId, string channelId)
+    private async Task ValidateChannelSelectionAsync(string kind, string guildId, string channelId, string? previousChannelId = null)
     {
         if (string.IsNullOrWhiteSpace(channelId))
         {
@@ -286,16 +286,42 @@ public class Plugin : IDalamudPlugin
             if (!string.IsNullOrWhiteSpace(response.GuildId))
             {
                 var normalizedResponseGuild = ChannelKeyHelper.NormalizeGuildId(response.GuildId);
-                var guildChanged = !string.Equals(normalizedStoredGuild, normalizedResponseGuild, StringComparison.Ordinal);
+                var hasStoredGuild = !ChannelKeyHelper.IsDefaultGuild(_config.GuildId);
 
-                _config.GuildId = normalizedResponseGuild;
-                _services.PluginInterface.SavePluginConfig(_config);
-
-                _chatWindow.OnGuildUpdated();
-                _officerChatWindow.OnGuildUpdated();
-
-                if (guildChanged)
+                if (hasStoredGuild &&
+                    !string.Equals(normalizedStoredGuild, normalizedResponseGuild, StringComparison.Ordinal))
                 {
+                    void RejectSelection()
+                    {
+                        var restoreChannelId = string.IsNullOrWhiteSpace(previousChannelId) ? string.Empty : previousChannelId;
+                        _channelSelection.SetChannel(kind, _config.GuildId, restoreChannelId);
+                        PluginServices.Instance?.ToastGui.ShowError(
+                            "Cannot select a channel from a different Discord server without unlinking first."
+                        );
+                    }
+
+                    var framework = PluginServices.Instance?.Framework;
+                    if (framework != null)
+                    {
+                        framework.RunOnTick(RejectSelection);
+                    }
+                    else
+                    {
+                        RejectSelection();
+                    }
+
+                    return;
+                }
+
+                if (!hasStoredGuild)
+                {
+                    var guildChanged = !string.Equals(normalizedStoredGuild, normalizedResponseGuild, StringComparison.Ordinal);
+                    _config.GuildId = normalizedResponseGuild;
+                    _services.PluginInterface.SavePluginConfig(_config);
+
+                    _chatWindow.OnGuildUpdated();
+                    _officerChatWindow.OnGuildUpdated();
+
                     await HandleGuildChangedAsync(normalizedResponseGuild, kind).ConfigureAwait(false);
                 }
             }
@@ -402,7 +428,12 @@ public class Plugin : IDalamudPlugin
                 continue;
             }
 
-            await ValidateChannelSelectionAsync(targetKind, normalizedGuildId, selectedChannel).ConfigureAwait(false);
+            await ValidateChannelSelectionAsync(
+                targetKind,
+                normalizedGuildId,
+                selectedChannel,
+                previousChannelId: string.Empty)
+                .ConfigureAwait(false);
         }
     }
 
@@ -506,8 +537,8 @@ public class Plugin : IDalamudPlugin
             _requestWatcher.Start();
         }
 
-        var hasOfficerRole = _config.Roles.Contains("officer");
-        if (_config.Events || _config.SyncedChat || hasOfficerRole)
+        var hasOfficerAccess = HasOfficerAccess(_config);
+        if (_config.Events || _config.SyncedChat || hasOfficerAccess)
         {
             _services.Log.Info("Starting channel watcher");
             _ = _channelWatcher.Start();
@@ -519,7 +550,7 @@ public class Plugin : IDalamudPlugin
             _chatWindow.StartNetworking();
         }
 
-        if (hasOfficerRole)
+        if (hasOfficerAccess)
         {
             if (!_officerWatcherRunning)
             {
@@ -547,6 +578,9 @@ public class Plugin : IDalamudPlugin
     private static bool IsAuthenticationFailure(string? reason)
         => string.Equals(reason, "Invalid API key", StringComparison.Ordinal)
             || string.Equals(reason, "Authentication failed", StringComparison.Ordinal);
+
+    private static bool HasOfficerAccess(Config config)
+        => config.Officer && config.IsOfficerToken;
 
     private void ShowInvalidTokenToast()
     {
@@ -733,7 +767,6 @@ public class Plugin : IDalamudPlugin
 
             _ = _services.Framework.RunOnTick(() =>
             {
-                var hadOfficerRole = _config.Roles.Contains("officer");
                 var officerWatcherWasRunning = _officerWatcherRunning;
                 var channelWatcherWasRunning = _channelWatcher.IsRunning;
                 var requestWatcherWasRunning = _requestWatcher.IsRunning;
@@ -741,8 +774,8 @@ public class Plugin : IDalamudPlugin
 
                 dto.Roles.RemoveAll(r => r == "chat");
                 _config.Roles = dto.Roles;
-                var hasOfficerRole = _config.Roles.Contains("officer");
-                _mainWindow.HasOfficerRole = hasOfficerRole;
+                var officerAccessAfterUpdate = HasOfficerAccess(_config);
+                _mainWindow.HasOfficerRole = officerAccessAfterUpdate;
 
                 var stopChat = false;
                 var startChat = false;
@@ -771,11 +804,11 @@ public class Plugin : IDalamudPlugin
                     log.Warning("Skipping FC chat updates because channels could not be fetched.");
                 }
 
-                var shouldRunChannelWatcher = _config.Events || _config.SyncedChat || hasOfficerRole;
+                var shouldRunChannelWatcher = _config.Events || _config.SyncedChat || officerAccessAfterUpdate;
                 var shouldRunRequestWatcher = _config.Requests;
 
-                var stopOfficer = officerWatcherWasRunning && !hasOfficerRole;
-                var startOfficer = !officerWatcherWasRunning && hasOfficerRole;
+                var stopOfficer = officerWatcherWasRunning && !officerAccessAfterUpdate;
+                var startOfficer = !officerWatcherWasRunning && officerAccessAfterUpdate;
                 var stopChannelWatcher = channelWatcherWasRunning && !shouldRunChannelWatcher;
                 var startChannelWatcher = !channelWatcherWasRunning && shouldRunChannelWatcher;
                 var stopRequestWatcher = requestWatcherWasRunning && !shouldRunRequestWatcher;
@@ -850,7 +883,7 @@ public class Plugin : IDalamudPlugin
                         _watcherRestartLock.Release();
                         _ = _services.Framework.RunOnTick(() =>
                         {
-                            _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
+                            _mainWindow.HasOfficerRole = HasOfficerAccess(_config);
                         });
                     }
                 });

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -671,6 +671,8 @@ public class SettingsWindow : IDisposable
                 return;
             }
 
+            await FetchIdentityClaimsAsync().ConfigureAwait(false);
+
             if (_refreshRoles != null)
             {
                 try
@@ -973,6 +975,85 @@ public class SettingsWindow : IDisposable
         finally
         {
             _syncInProgress = false;
+        }
+    }
+
+    private sealed class MeDto
+    {
+        public string? guildId { get; set; }
+        public bool isOfficer { get; set; }
+    }
+
+    private async Task FetchIdentityClaimsAsync()
+    {
+        if (!_tokenManager.IsReady() || !ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            return;
+        }
+
+        try
+        {
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                _log.Warning("Failed to fetch /api/users/me. Status: {Status}", response.StatusCode);
+                return;
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync();
+            var me = await JsonSerializer.DeserializeAsync<MeDto>(
+                stream,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+            if (me == null)
+            {
+                return;
+            }
+
+            var normalizedGuild = ChannelKeyHelper.NormalizeGuildId(me.guildId ?? string.Empty);
+            var updated = false;
+
+            if (ChannelKeyHelper.IsDefaultGuild(_config.GuildId) && !string.IsNullOrEmpty(normalizedGuild))
+            {
+                _config.GuildId = normalizedGuild;
+                updated = true;
+            }
+
+            if (_config.IsOfficerToken != me.isOfficer)
+            {
+                _config.IsOfficerToken = me.isOfficer;
+                updated = true;
+            }
+
+            if (updated)
+            {
+                SaveConfig();
+            }
+
+            var framework = PluginServices.Instance?.Framework;
+            void ApplyOfficerState()
+            {
+                if (MainWindow != null)
+                {
+                    MainWindow.HasOfficerRole = _config.Officer && _config.IsOfficerToken;
+                }
+            }
+
+            if (framework != null)
+            {
+                framework.RunOnTick(ApplyOfficerState);
+            }
+            else
+            {
+                ApplyOfficerState();
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to fetch /api/users/me");
         }
     }
 

--- a/tests/ChatWindowChannelFetchTests.cs
+++ b/tests/ChatWindowChannelFetchTests.cs
@@ -6,8 +6,10 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 using DemiCatPlugin;
+using Moq;
 using Xunit;
 
 public class ChatWindowChannelFetchTests
@@ -69,6 +71,40 @@ public class ChatWindowChannelFetchTests
         window.Dispose();
     }
 
+    [Fact]
+    public void SetChannels_FiltersMismatchedGuildEntries()
+    {
+        SetupServices();
+        var config = new Config
+        {
+            ApiBaseUrl = "http://localhost",
+            GuildId = "guild-a"
+        };
+        using var client = new HttpClient(new HttpClientHandler());
+        var tokenManager = new TokenManager();
+        var channelService = new ChannelService(config, client, tokenManager);
+        var window = new ChatWindow(config, client, null, tokenManager, channelService);
+
+        var channels = new List<ChannelDto>
+        {
+            new() { Id = "1", Name = "General", GuildId = "guild-a" },
+            new() { Id = "2", Name = "Other", GuildId = "guild-b" }
+        };
+
+        window.SetChannels(channels);
+
+        Assert.Equal("guild-a", config.GuildId);
+
+        var storedChannels = (List<ChannelDto>)typeof(ChatWindow)
+            .GetField("_channels", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!;
+
+        Assert.Single(storedChannels);
+        Assert.Equal("1", storedChannels[0].Id);
+
+        window.Dispose();
+    }
+
     private static string SerializeChannels(params (string Id, string Name)[] channels)
     {
         var list = new List<object>();
@@ -91,6 +127,8 @@ public class ChatWindowChannelFetchTests
         var log = new TestLog();
         typeof(PluginServices).GetProperty("Framework", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, framework);
         typeof(PluginServices).GetProperty("Log", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, log);
+        var pluginInterface = new Mock<IDalamudPluginInterface>();
+        typeof(PluginServices).GetProperty("PluginInterface", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, pluginInterface.Object);
     }
 
     private sealed class SequenceHandler : HttpMessageHandler

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -14,6 +14,7 @@ public class ConfigDefaultsTests
         Assert.True(cfg.Templates);
         Assert.True(cfg.Requests);
         Assert.True(cfg.Officer);
+        Assert.False(cfg.IsOfficerToken);
         Assert.False(cfg.FCSyncShell);
     }
 

--- a/tests/PluginChannelValidationTests.cs
+++ b/tests/PluginChannelValidationTests.cs
@@ -128,7 +128,7 @@ public class PluginChannelValidationTests
 
         try
         {
-            await (Task)method.Invoke(plugin, new object?[] { ChannelKind.Chat, string.Empty, "123456" })!;
+            await (Task)method.Invoke(plugin, new object?[] { ChannelKind.Chat, string.Empty, "123456", null })!;
 
             Assert.Equal("guild-123", config.GuildId);
             pluginInterfaceMock.Verify(pi => pi.SavePluginConfig(config), Times.AtLeastOnce());


### PR DESCRIPTION
## Summary
- clear rejected channel revalidations by resetting the previous selection so the UI snaps back on cross-guild responses
- add an `IsOfficerToken` flag hydrated from `/api/users/me` and gate officer networking/UI off the token claim instead of Discord roles
- marshal chat window config saves onto the framework thread for safety while keeping officer/chat channel watchers in sync with the token-gated access state

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: `dotnet` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f3b7b8fc83288357d664116172f9