### PR TITLE
Add officer claim flag and update gating

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -50,7 +50,7 @@ public class ChannelWatcher : IDisposable
 
     public async Task Start()
     {
-        if (!_config.Events && !_config.SyncedChat && !_config.Roles.Contains("officer"))
+        if (!_config.Events && !_config.SyncedChat && !OfficerPermissions.HasAccess(_config))
         {
             return;
         }
@@ -385,7 +385,7 @@ public class ChannelWatcher : IDisposable
         _ = SafeRefresh(_templatesWindow.RefreshChannels);
         if (_config.SyncedChat && _config.EnableFcChat)
             _ = SafeRefresh(_chatWindow.RefreshChannels);
-        if (_config.Roles.Contains("officer"))
+        if (OfficerPermissions.HasAccess(_config))
             _ = SafeRefresh(_officerChatWindow.RefreshChannels);
 
         _lastRefresh = DateTime.UtcNow;

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -9,7 +9,7 @@ namespace DemiCatPlugin;
 public class Config : IPluginConfiguration
 {
     // Required by Dalamud
-    public int Version { get; set; } = 8;
+    public int Version { get; set; } = 9;
 
     public bool Enabled { get; set; } = true;
     public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
@@ -46,6 +46,8 @@ public class Config : IPluginConfiguration
     public bool Requests { get; set; } = true;
     [JsonPropertyName("officer")]
     public bool Officer { get; set; } = true;
+    [JsonPropertyName("isOfficerToken")]
+    public bool IsOfficerToken { get; set; }
     [JsonPropertyName("fcSyncShell")]
     public bool FCSyncShell { get; set; } = false;
     public bool UseCharacterName { get; set; } = false;
@@ -248,6 +250,12 @@ public class Config : IPluginConfiguration
             ChatInputSplitRatio = Math.Clamp(ChatInputSplitRatio, 0.2f, 0.8f);
 
             Version = 8;
+            ExtensionData = null;
+        }
+        if (Version < 9)
+        {
+            IsOfficerToken = false;
+            Version = 9;
             ExtensionData = null;
         }
     }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -26,7 +26,7 @@ public class MainWindow : IDisposable
     private float _fadeAlpha = 1f;
 
     public bool IsOpen;
-    public bool HasOfficerRole { get; set; }
+    public bool HasOfficerAccess { get; set; }
     public UiRenderer Ui => _ui;
     public EventCreateWindow EventCreateWindow => _create;
     public TemplatesWindow TemplatesWindow => _templates;
@@ -258,7 +258,7 @@ public class MainWindow : IDisposable
                     }
                 }
 
-                if (HasOfficerRole)
+                if (HasOfficerAccess)
                 {
                     if (!linked)
                     {

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -79,31 +79,53 @@ public class OfficerChatWindow : ChatWindow
 
     public override void StartNetworking()
     {
+        if (!OfficerPermissions.HasAccess(_config))
+        {
+            MarkNetworkingStopped();
+            _bridge.Stop();
+            _presence?.SetPresenceReady(false);
+
+            var message = "Officer tools require an officer-enabled key.";
+            var services = PluginServices.Instance;
+            var framework = services?.Framework;
+
+            if (framework != null)
+            {
+                try
+                {
+                    framework.RunOnTick(() => _statusMessage = message);
+                }
+                catch (Exception ex)
+                {
+                    services?.Log.Warning(ex, "Failed to update officer status message on framework thread.");
+                    _statusMessage = message;
+                }
+            }
+            else
+            {
+                _statusMessage = message;
+            }
+
+            _subscribed = false;
+            return;
+        }
+
         MarkNetworkingStarted();
+        _presence?.SetPresenceReady(true);
         _bridge.Start();
-        if (_config.Roles.Contains("officer"))
-        {
-            Subscribe();
-        }
-        else
-        {
-            TryRefreshRoles();
-        }
+        Subscribe();
+        TryRefreshRoles();
+        _presence?.Reset();
     }
 
     public override void Draw()
     {
-        if (!_config.Roles.Contains("officer"))
+        if (!OfficerPermissions.HasAccess(_config))
         {
-            TryRefreshRoles();
-            if (!string.IsNullOrEmpty(_statusMessage))
-            {
-                ImGui.TextUnformatted(_statusMessage);
-            }
-            else
-            {
-                ImGui.TextUnformatted("Link DemiCat…");
-            }
+            var message = string.IsNullOrEmpty(_statusMessage)
+                ? "Officer tools require an officer-enabled key."
+                : _statusMessage;
+            ImGui.TextUnformatted(message);
             return;
         }
 
@@ -412,9 +434,6 @@ public class OfficerChatWindow : ChatWindow
                 : new List<string>();
             filteredRoles.RemoveAll(r => string.Equals(r, "chat", StringComparison.Ordinal));
 
-            var hadOfficer = _config.Roles.Contains("officer");
-            var hasOfficer = filteredRoles.Contains("officer");
-
             if (filteredRoles.Count == 0)
             {
                 services?.Log.Warning("Received empty role list while refreshing officer roles.");
@@ -425,13 +444,6 @@ public class OfficerChatWindow : ChatWindow
                 return;
             }
 
-            if (!hasOfficer && hadOfficer)
-            {
-                services?.Log.Warning("Officer role missing from refresh response; retaining cached permissions.");
-                services?.ToastGui?.ShowError("Officer role missing from refresh; keeping cached permissions.");
-                return;
-            }
-
             void ApplyRoles()
             {
                 _config.Roles = filteredRoles;
@@ -439,7 +451,7 @@ public class OfficerChatWindow : ChatWindow
                 var mainWindow = MainWindow.Instance;
                 if (mainWindow != null)
                 {
-                    mainWindow.HasOfficerRole = hasOfficer;
+                    mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
                 }
             }
 

--- a/DemiCatPlugin/OfficerPermissions.cs
+++ b/DemiCatPlugin/OfficerPermissions.cs
@@ -1,0 +1,9 @@
+namespace DemiCatPlugin;
+
+internal static class OfficerPermissions
+{
+    internal static bool HasAccess(Config config)
+    {
+        return config.Officer && config.IsOfficerToken;
+    }
+}

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -121,7 +121,7 @@ public class Plugin : IDalamudPlugin
         _settings.ChannelWatcher = _channelWatcher;
         _settings.RequestWatcher = _requestWatcher;
 
-        _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
+        _mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
 
         _ = RoleCache.EnsureLoaded(_httpClient, _config);
 
@@ -466,6 +466,14 @@ public class Plugin : IDalamudPlugin
         {
             StopWatchers();
 
+            var hadOfficerAccess = _config.IsOfficerToken;
+            _config.IsOfficerToken = false;
+            _mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
+            if (hadOfficerAccess)
+            {
+                _services.PluginInterface?.SavePluginConfig(_config);
+            }
+
             if (IsAuthenticationFailure(reason))
             {
                 ShowInvalidTokenToast();
@@ -533,8 +541,8 @@ public class Plugin : IDalamudPlugin
             _requestWatcher.Start();
         }
 
-        var hasOfficerRole = _config.Roles.Contains("officer");
-        if (_config.Events || _config.SyncedChat || hasOfficerRole)
+        var hasOfficerAccess = OfficerPermissions.HasAccess(_config);
+        if (_config.Events || _config.SyncedChat || hasOfficerAccess)
         {
             _services.Log.Info("Starting channel watcher");
             _ = _channelWatcher.Start();
@@ -546,7 +554,7 @@ public class Plugin : IDalamudPlugin
             _chatWindow.StartNetworking();
         }
 
-        if (hasOfficerRole)
+        if (hasOfficerAccess)
         {
             if (!_officerWatcherRunning)
             {
@@ -760,7 +768,6 @@ public class Plugin : IDalamudPlugin
 
             _ = _services.Framework.RunOnTick(() =>
             {
-                var hadOfficerRole = _config.Roles.Contains("officer");
                 var officerWatcherWasRunning = _officerWatcherRunning;
                 var channelWatcherWasRunning = _channelWatcher.IsRunning;
                 var requestWatcherWasRunning = _requestWatcher.IsRunning;
@@ -768,8 +775,8 @@ public class Plugin : IDalamudPlugin
 
                 dto.Roles.RemoveAll(r => r == "chat");
                 _config.Roles = dto.Roles;
-                var hasOfficerRole = _config.Roles.Contains("officer");
-                _mainWindow.HasOfficerRole = hasOfficerRole;
+                var hasOfficerAccess = OfficerPermissions.HasAccess(_config);
+                _mainWindow.HasOfficerAccess = hasOfficerAccess;
 
                 var stopChat = false;
                 var startChat = false;
@@ -798,11 +805,11 @@ public class Plugin : IDalamudPlugin
                     log.Warning("Skipping FC chat updates because channels could not be fetched.");
                 }
 
-                var shouldRunChannelWatcher = _config.Events || _config.SyncedChat || hasOfficerRole;
+                var shouldRunChannelWatcher = _config.Events || _config.SyncedChat || hasOfficerAccess;
                 var shouldRunRequestWatcher = _config.Requests;
 
-                var stopOfficer = officerWatcherWasRunning && !hasOfficerRole;
-                var startOfficer = !officerWatcherWasRunning && hasOfficerRole;
+                var stopOfficer = officerWatcherWasRunning && !hasOfficerAccess;
+                var startOfficer = !officerWatcherWasRunning && hasOfficerAccess;
                 var stopChannelWatcher = channelWatcherWasRunning && !shouldRunChannelWatcher;
                 var startChannelWatcher = !channelWatcherWasRunning && shouldRunChannelWatcher;
                 var stopRequestWatcher = requestWatcherWasRunning && !shouldRunRequestWatcher;
@@ -877,7 +884,7 @@ public class Plugin : IDalamudPlugin
                         _watcherRestartLock.Release();
                         _ = _services.Framework.RunOnTick(() =>
                         {
-                            _mainWindow.HasOfficerRole = _config.Roles.Contains("officer");
+                            _mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
                         });
                     }
                 });

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -468,6 +468,103 @@ public class SettingsWindow : IDisposable
         }
     }
 
+    private async Task UpdateIdentityAsync(IFramework? framework)
+    {
+        try
+        {
+            if (_httpClient == null || !_tokenManager.IsReady() || !ApiHelpers.ValidateApiBaseUrl(_config))
+                return;
+
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me";
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
+            var response = await _httpClient.SendAsync(request);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                _log.Warning($"Failed to load user identity: {response.StatusCode}. Response Body: {responseBody}");
+                return;
+            }
+
+            using var stream = await response.Content.ReadAsStreamAsync();
+            using var doc = await JsonDocument.ParseAsync(stream);
+
+            string? newGuildId = null;
+            bool? officerClaim = null;
+
+            if (doc.RootElement.TryGetProperty("guildId", out var guildProperty) && guildProperty.ValueKind == JsonValueKind.String)
+            {
+                newGuildId = guildProperty.GetString();
+            }
+
+            if (doc.RootElement.TryGetProperty("isOfficer", out var officerProperty))
+            {
+                officerClaim = officerProperty.ValueKind switch
+                {
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.Number when officerProperty.TryGetInt32(out var numeric) => numeric != 0,
+                    _ => officerClaim
+                };
+            }
+
+            var configChanged = false;
+
+            if (newGuildId != null)
+            {
+                var normalizedGuild = string.IsNullOrWhiteSpace(newGuildId)
+                    ? string.Empty
+                    : ChannelKeyHelper.NormalizeGuildId(newGuildId);
+                if (!string.Equals(_config.GuildId, normalizedGuild, StringComparison.Ordinal))
+                {
+                    _config.GuildId = normalizedGuild;
+                    configChanged = true;
+                }
+            }
+
+            if (officerClaim.HasValue && _config.IsOfficerToken != officerClaim.Value)
+            {
+                _config.IsOfficerToken = officerClaim.Value;
+                configChanged = true;
+            }
+
+            if (configChanged)
+            {
+                SaveConfig();
+            }
+
+            void ApplyOfficerAccess()
+            {
+                if (MainWindow != null)
+                {
+                    MainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
+                }
+            }
+
+            if (framework != null)
+            {
+                try
+                {
+                    framework.RunOnTick(ApplyOfficerAccess);
+                }
+                catch (Exception ex)
+                {
+                    _log.Warning(ex, "Failed to apply officer access update on framework thread.");
+                    ApplyOfficerAccess();
+                }
+            }
+            else
+            {
+                ApplyOfficerAccess();
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to update user identity");
+        }
+    }
+
     private void StopAllWatchersAndPresence()
     {
         void SafeInvoke(Action action, string context)
@@ -563,6 +660,7 @@ public class SettingsWindow : IDisposable
         _config.ChatCursors.Clear();
         _config.RestChatCursors.Clear();
         _config.Roles.Clear();
+        _config.IsOfficerToken = false;
         _config.MentionRoleIds.Clear();
         _config.SignupPresets.Clear();
         _config.TemplateData.Clear();
@@ -583,6 +681,8 @@ public class SettingsWindow : IDisposable
         {
             OfficerChatWindow.ChannelsLoaded = false;
         }
+
+        MainWindow?.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
     }
 
     internal Task HardReloadIdentityAndStartAsync(bool openMainWindow = false)
@@ -671,6 +771,8 @@ public class SettingsWindow : IDisposable
                 return;
             }
 
+            await UpdateIdentityAsync(framework);
+
             if (_refreshRoles != null)
             {
                 try
@@ -748,7 +850,10 @@ public class SettingsWindow : IDisposable
 
             try
             {
-                OfficerChatWindow?.StartNetworking();
+                if (OfficerPermissions.HasAccess(_config))
+                {
+                    OfficerChatWindow?.StartNetworking();
+                }
             }
             catch (Exception ex)
             {
@@ -761,7 +866,10 @@ public class SettingsWindow : IDisposable
                 {
                     _ = ChatWindow?.RefreshChannels();
                 }
-                _ = OfficerChatWindow?.RefreshChannels();
+                if (OfficerPermissions.HasAccess(_config))
+                {
+                    _ = OfficerChatWindow?.RefreshChannels();
+                }
                 _ = MainWindow?.EventCreateWindow.RefreshChannels();
                 _ = MainWindow?.TemplatesWindow.RefreshChannels();
             }
@@ -776,7 +884,10 @@ public class SettingsWindow : IDisposable
                 {
                     _ = ChatWindow?.RefreshMessages();
                 }
-                _ = OfficerChatWindow?.RefreshMessages();
+                if (OfficerPermissions.HasAccess(_config))
+                {
+                    _ = OfficerChatWindow?.RefreshMessages();
+                }
             }
             catch (Exception ex)
             {

--- a/tests/ChatWindowChannelFetchTests.cs
+++ b/tests/ChatWindowChannelFetchTests.cs
@@ -50,7 +50,8 @@ public class ChatWindowChannelFetchTests
         {
             ApiBaseUrl = "http://localhost",
             GuildId = "guild",
-            Roles = new[] { "officer" }
+            Roles = new[] { "officer" },
+            IsOfficerToken = true
         };
         var handler = new SequenceHandler();
         handler.EnqueueResponse(SerializeChannels(("1", "officer")));

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -14,6 +14,7 @@ public class ConfigDefaultsTests
         Assert.True(cfg.Templates);
         Assert.True(cfg.Requests);
         Assert.True(cfg.Officer);
+        Assert.False(cfg.IsOfficerToken);
         Assert.False(cfg.FCSyncShell);
     }
 

--- a/tests/OfficerChatWindowTests.cs
+++ b/tests/OfficerChatWindowTests.cs
@@ -21,7 +21,8 @@ public class OfficerChatWindowTests
             Officer = true,
             Roles = new[] { "officer" },
             ApiBaseUrl = "http://localhost",
-            OfficerChannelId = "42"
+            OfficerChannelId = "42",
+            IsOfficerToken = true
         };
         var handler = new SequenceHandler();
         using var client = new HttpClient(handler);
@@ -53,7 +54,8 @@ public class OfficerChatWindowTests
             Officer = true,
             Roles = new[] { "officer" },
             ApiBaseUrl = "http://localhost",
-            OfficerChannelId = "42"
+            OfficerChannelId = "42",
+            IsOfficerToken = true
         };
         var handler = new TestHandler();
         using var client = new HttpClient(handler);
@@ -81,7 +83,8 @@ public class OfficerChatWindowTests
             Officer = true,
             Roles = new[] { "officer" },
             ApiBaseUrl = "https://example.com/base",
-            OfficerChannelId = "42"
+            OfficerChannelId = "42",
+            IsOfficerToken = true
         };
         using var client = new HttpClient(new EmojiStubHandler());
         var tm = new TokenManager();
@@ -92,6 +95,30 @@ public class OfficerChatWindowTests
         var uri = (Uri)method.Invoke(window, null)!;
 
         Assert.Equal("wss://example.com/base/ws/chat", uri.ToString());
+    }
+
+    [Fact]
+    public void StartNetworkingWithoutOfficerClaimShowsMessage()
+    {
+        SetupServices();
+        var config = new Config
+        {
+            Officer = true,
+            ApiBaseUrl = "http://localhost",
+            OfficerChannelId = "42"
+        };
+        using var client = new HttpClient(new EmojiStubHandler());
+        var tm = new TokenManager();
+        var channelService = new ChannelService(config, client, tm);
+        var window = new OfficerChatWindow(config, client, null, tm, channelService);
+
+        window.StartNetworking();
+
+        var statusMessage = (string)typeof(ChatWindow)
+            .GetField("_statusMessage", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!;
+
+        Assert.Contains("officer", statusMessage, StringComparison.OrdinalIgnoreCase);
     }
 
     private static List<DiscordMessageDto> GetMessages(ChatWindow window)

--- a/tests/SettingsWindowIdentityTests.cs
+++ b/tests/SettingsWindowIdentityTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
+using DemiCatPlugin;
+using Moq;
+using Xunit;
+
+public class SettingsWindowIdentityTests
+{
+    [Fact]
+    public async Task UpdateIdentityStoresOfficerClaim()
+    {
+        typeof(PluginServices)
+            .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!
+            .SetValue(null, null);
+        var services = new PluginServices();
+
+        var frameworkMock = new Mock<IFramework>();
+        frameworkMock
+            .Setup(f => f.RunOnTick(It.IsAny<Action>(), It.IsAny<FrameworkUpdatePriority>()))
+            .Callback<Action, FrameworkUpdatePriority>((action, _) => action());
+
+        var pluginInterfaceMock = new Mock<IDalamudPluginInterface>();
+        pluginInterfaceMock.Setup(pi => pi.SavePluginConfig(It.IsAny<IPluginConfiguration>()));
+
+        typeof(PluginServices)
+            .GetProperty("Framework", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, frameworkMock.Object);
+        typeof(PluginServices)
+            .GetProperty("PluginInterface", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, pluginInterfaceMock.Object);
+
+        var logMock = new Mock<IPluginLog>();
+        typeof(PluginServices)
+            .GetProperty("Log", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, logMock.Object);
+
+        var config = new Config
+        {
+            ApiBaseUrl = "https://example.com",
+            Officer = true
+        };
+
+        var handler = new IdentityHandler();
+        using var httpClient = new HttpClient(handler);
+        var tokenManager = new TokenManager();
+
+        var settings = new SettingsWindow(
+            config,
+            tokenManager,
+            httpClient,
+            () => Task.FromResult(true),
+            () => Task.CompletedTask,
+            logMock.Object,
+            pluginInterfaceMock.Object);
+
+        var mainWindow = (MainWindow)FormatterServices.GetUninitializedObject(typeof(MainWindow));
+        settings.MainWindow = mainWindow;
+
+        var method = typeof(SettingsWindow)
+            .GetMethod("UpdateIdentityAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        await (Task)method.Invoke(settings, new object?[] { frameworkMock.Object })!;
+
+        Assert.Equal("guild-123", config.GuildId);
+        Assert.True(config.IsOfficerToken);
+        Assert.True(settings.MainWindow!.HasOfficerAccess);
+
+        pluginInterfaceMock.Verify(pi => pi.SavePluginConfig(config), Times.AtLeastOnce());
+
+        typeof(PluginServices)
+            .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!
+            .SetValue(null, null);
+    }
+
+    private sealed class IdentityHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/api/users/me")
+            {
+                var payload = JsonSerializer.Serialize(new { guildId = "guild-123", isOfficer = true });
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an IsOfficerToken flag to the configuration with a helper for checking officer access
- fetch /api/users/me during hard reload to store the guild id and officer claim and gate officer networking on the helper
- simplify officer role refresh usage and add regression tests around officer access and identity updates

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3016c529883288d432235b168679d