### PR TITLE
Handle officer access gating for non-officer tokens

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -18,6 +18,7 @@ namespace DemiCatPlugin;
 
 public class OfficerChatWindow : ChatWindow
 {
+    private const string NoOfficerAccessMessage = "No officer access for this key.";
     private DateTime _lastRolesRefresh = DateTime.MinValue;
     private bool _subscribed;
     private readonly PresenceSidebar? _presenceSidebar;
@@ -85,7 +86,7 @@ public class OfficerChatWindow : ChatWindow
             _bridge.Stop();
             _presence?.SetPresenceReady(false);
 
-            var message = "Officer tools require an officer-enabled key.";
+            var message = NoOfficerAccessMessage;
             var services = PluginServices.Instance;
             var framework = services?.Framework;
 
@@ -123,7 +124,7 @@ public class OfficerChatWindow : ChatWindow
         if (!OfficerPermissions.HasAccess(_config))
         {
             var message = string.IsNullOrEmpty(_statusMessage)
-                ? "Officer tools require an officer-enabled key."
+                ? NoOfficerAccessMessage
                 : _statusMessage;
             ImGui.TextUnformatted(message);
             return;

--- a/tests/SettingsWindowIdentityTests.cs
+++ b/tests/SettingsWindowIdentityTests.cs
@@ -79,13 +79,89 @@ public class SettingsWindowIdentityTests
             .SetValue(null, null);
     }
 
+    [Fact]
+    public async Task UpdateIdentityWithoutOfficerClaimDisablesOfficerAccess()
+    {
+        typeof(PluginServices)
+            .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!
+            .SetValue(null, null);
+        var services = new PluginServices();
+
+        var frameworkMock = new Mock<IFramework>();
+        frameworkMock
+            .Setup(f => f.RunOnTick(It.IsAny<Action>(), It.IsAny<FrameworkUpdatePriority>()))
+            .Callback<Action, FrameworkUpdatePriority>((action, _) => action());
+
+        var pluginInterfaceMock = new Mock<IDalamudPluginInterface>();
+        pluginInterfaceMock.Setup(pi => pi.SavePluginConfig(It.IsAny<IPluginConfiguration>()));
+
+        typeof(PluginServices)
+            .GetProperty("Framework", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, frameworkMock.Object);
+        typeof(PluginServices)
+            .GetProperty("PluginInterface", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, pluginInterfaceMock.Object);
+
+        var logMock = new Mock<IPluginLog>();
+        typeof(PluginServices)
+            .GetProperty("Log", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, logMock.Object);
+
+        var config = new Config
+        {
+            ApiBaseUrl = "https://example.com",
+            Officer = true,
+            IsOfficerToken = true
+        };
+
+        var handler = new IdentityHandler(isOfficer: false);
+        using var httpClient = new HttpClient(handler);
+        var tokenManager = new TokenManager();
+
+        var settings = new SettingsWindow(
+            config,
+            tokenManager,
+            httpClient,
+            () => Task.FromResult(true),
+            () => Task.CompletedTask,
+            logMock.Object,
+            pluginInterfaceMock.Object);
+
+        var mainWindow = (MainWindow)FormatterServices.GetUninitializedObject(typeof(MainWindow));
+        mainWindow.HasOfficerAccess = true;
+        settings.MainWindow = mainWindow;
+
+        var method = typeof(SettingsWindow)
+            .GetMethod("UpdateIdentityAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        await (Task)method.Invoke(settings, new object?[] { frameworkMock.Object })!;
+
+        Assert.Equal("guild-123", config.GuildId);
+        Assert.False(config.IsOfficerToken);
+        Assert.False(settings.MainWindow!.HasOfficerAccess);
+
+        pluginInterfaceMock.Verify(pi => pi.SavePluginConfig(config), Times.AtLeastOnce());
+
+        typeof(PluginServices)
+            .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!
+            .SetValue(null, null);
+    }
+
     private sealed class IdentityHandler : HttpMessageHandler
     {
+        private readonly bool _isOfficer;
+        private readonly string _guildId;
+
+        public IdentityHandler(bool isOfficer = true, string guildId = "guild-123")
+        {
+            _isOfficer = isOfficer;
+            _guildId = guildId;
+        }
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if (request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/api/users/me")
             {
-                var payload = JsonSerializer.Serialize(new { guildId = "guild-123", isOfficer = true });
+                var payload = JsonSerializer.Serialize(new { guildId = _guildId, isOfficer = _isOfficer });
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(payload, Encoding.UTF8, "application/json")


### PR DESCRIPTION
## Summary
- show a consistent "No officer access for this key" message whenever officer networking is disabled
- extend the identity tests to cover non-officer tokens and ensure the officer tab remains disabled

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj --filter SettingsWindowIdentityTests *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d318a977048328898f8e978aed13e5