### PR TITLE
Fix SettingsWindow compile error when updating officer access

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -682,7 +682,10 @@ public class SettingsWindow : IDisposable
             OfficerChatWindow.ChannelsLoaded = false;
         }
 
-        MainWindow?.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
+        if (MainWindow != null)
+        {
+            MainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
+        }
     }
 
     internal Task HardReloadIdentityAndStartAsync(bool openMainWindow = false)


### PR DESCRIPTION
## Summary
- replace the null-conditional assignment when updating officer access with an explicit null check to restore buildability

## Testing
- dotnet build -c Release *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d31b8b553c83289315cb9be347b8ee