### PR TITLE
Fix async invocation warnings

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1795,7 +1795,6 @@ public class ChatWindow : IDisposable
                 messageState.hasMatchingChannel &&
                 !messageState.hasConflictingChannel;
 
-            var firstPage = true;
             var appliedStoredCursor = false;
             while (all.Count < MaxMessages)
             {
@@ -1852,7 +1851,6 @@ public class ChatWindow : IDisposable
                 {
                     break;
                 }
-                firstPage = false;
                 before = msgs[0].Id;
             }
 
@@ -1959,7 +1957,7 @@ public class ChatWindow : IDisposable
         if (framework != null)
         {
             var tcs = new TaskCompletionSource<(bool, bool, bool)>(TaskCreationOptions.RunContinuationsAsynchronously);
-            framework.RunOnTick(() =>
+            _ = framework.RunOnTick(() =>
             {
                 try
                 {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -303,7 +303,7 @@ public class Plugin : IDalamudPlugin
                     var framework = PluginServices.Instance?.Framework;
                     if (framework != null)
                     {
-                        framework.RunOnTick(RejectSelection);
+                        _ = framework.RunOnTick(RejectSelection);
                     }
                     else
                     {

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -546,7 +546,7 @@ public class SettingsWindow : IDisposable
             {
                 try
                 {
-                    framework.RunOnTick(ApplyOfficerAccess);
+                    _ = framework.RunOnTick(ApplyOfficerAccess);
                 }
                 catch (Exception ex)
                 {
@@ -932,7 +932,7 @@ public class SettingsWindow : IDisposable
                 {
                     try
                     {
-                        framework.RunOnTick(() => MainWindow.IsOpen = true);
+                        _ = framework.RunOnTick(() => MainWindow.IsOpen = true);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
## Summary
- explicitly discard framework RunOnTick calls where the returned task is intentionally fire-and-forget
- remove an unused pagination flag from the chat refresh routine to silence CS0219

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d31cf006c0832883199bc03f15eeaf