### PR TITLE
Fix chat pagination order and merging

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1846,12 +1846,24 @@ public class ChatWindow : IDisposable
                     break;
                 }
 
-                all.InsertRange(0, msgs);
+                var oldestMessageId = msgs[^1].Id;
+                all.AddRange(msgs);
                 if (all.Count >= MaxMessages || msgs.Count < PageSize)
                 {
                     break;
                 }
-                before = msgs[0].Id;
+
+                if (string.IsNullOrEmpty(oldestMessageId))
+                {
+                    break;
+                }
+
+                before = oldestMessageId;
+            }
+
+            if (all.Count > 1)
+            {
+                all.Reverse();
             }
 
             if (all.Count > MaxMessages)


### PR DESCRIPTION
## Summary
- accumulate fetched message pages in chronological order and keep the newest window limited to 100 entries
- paginate using the ID of the oldest message from the previous batch so older history loads correctly
- preserve incremental merge behaviour so new messages append properly before trimming

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3342aa7a08328aaad45e35e20d14c