### PR TITLE
Handle stale Discord webhooks in chat ws

### DIFF
--- a/demibot/demibot/http/ws_chat.py
+++ b/demibot/demibot/http/ws_chat.py
@@ -47,6 +47,8 @@ MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024  # 25MB
 RETRY_BASE = 1.0  # seconds
 MAX_SEND_ATTEMPTS = 5
 
+FATAL_WEBHOOK_STATUSES = {401, 403, 404}
+
 HISTORY_LIMIT = 200
 HISTORY_CHANNEL_CAP = 500
 HISTORY_TTL_SECONDS = 10 * 60  # 10 minutes
@@ -845,9 +847,131 @@ class ChatConnectionManager:
         finally:
             self._webhook_supervisor = None
 
+    async def _finalize_webhook_success(
+        self,
+        msg: PendingWebhookMessage,
+        sent: discord.Message,
+        *,
+        started_at: float,
+    ) -> None:
+        latency_ms = (time.perf_counter() - started_at) * 1000
+        self._send_count += 1
+        logger.info(
+            "chat.ws send channel=%s latency_ms=%.1f count=%s",
+            msg.channel_id,
+            latency_ms,
+            self._send_count,
+        )
+        dto, _ = serialize_message(sent)
+        await emit_event(
+            {
+                "channel": str(msg.channel_id),
+                "op": "mc",
+                "d": dto.model_dump(by_alias=True, exclude_none=True),
+            }
+        )
+
+    async def _recover_stale_webhook(
+        self, msg: PendingWebhookMessage, meta: ChannelMeta | None
+    ) -> tuple[bool, float]:
+        _channel_webhooks.pop(msg.channel_id, None)
+        guild_id = meta.guild_id if meta is not None else None
+        discord_guild_id = meta.discord_guild_id if meta is not None else None
+        channel_kind: ChannelKind | None = None
+        if meta is not None and meta.kind:
+            try:
+                channel_kind = ChannelKind(meta.kind.lower())
+            except ValueError:
+                channel_kind = None
+        should_commit = False
+        created = None
+        created_url: str | None = None
+        creation_errors: list[str] = []
+        async with get_session() as db:
+            stmt = select(GuildChannel).where(
+                GuildChannel.channel_id == msg.channel_id
+            )
+            if guild_id is not None:
+                stmt = stmt.where(GuildChannel.guild_id == guild_id)
+            result = await db.execute(stmt)
+            rows = result.scalars().all()
+            for row in rows:
+                if row.webhook_url and (
+                    msg.webhook_url is None or row.webhook_url == msg.webhook_url
+                ):
+                    row.webhook_url = None
+                    should_commit = True
+                if guild_id is None:
+                    guild_id = row.guild_id
+                if channel_kind is None and getattr(row, "kind", None) is not None:
+                    channel_kind = row.kind
+            if guild_id is None:
+                if should_commit:
+                    await db.commit()
+                else:
+                    await db.rollback()
+                return False, 0.0
+            created, created_url, creation_errors = await create_webhook_for_channel(
+                channel=None,
+                channel_id=msg.channel_id,
+                guild_id=guild_id,
+                guild_discord_id=discord_guild_id,
+                db=db,
+                channel_kind=channel_kind,
+                configured_channel_id=msg.channel_id,
+            )
+            if creation_errors:
+                logger.warning(
+                    "chat.ws webhook recreate errors channel=%s errors=%s",
+                    msg.channel_id,
+                    creation_errors,
+                )
+            if created_url:
+                msg.webhook_url = created_url
+                should_commit = True
+            elif created is not None:
+                should_commit = True
+            if should_commit:
+                await db.commit()
+            else:
+                await db.rollback()
+        if created is None:
+            return False, 0.0
+        retry_start = time.perf_counter()
+        try:
+            sent = await created.send(
+                msg.content,
+                username=msg.username,
+                avatar_url=msg.avatar_url,
+                files=[upload.to_discord_file() for upload in msg.uploads] or None,
+                embeds=list(msg.embeds) if msg.embeds else None,
+                wait=True,
+            )
+        except discord.HTTPException as e:
+            headers = getattr(getattr(e, "response", None), "headers", {}) or {}
+            retry_after = headers.get("Retry-After") or headers.get(
+                "X-RateLimit-Reset-After"
+            )
+            retry_after_s = float(retry_after) if retry_after is not None else 0.0
+            logger.warning(
+                "chat.ws webhook resend error channel=%s status=%s attempt=%s",
+                msg.channel_id,
+                getattr(e, "status", None),
+                msg.attempts + 1,
+            )
+            return False, retry_after_s
+        except Exception:
+            logger.exception(
+                "chat.ws webhook resend failed channel=%s attempt=%s",
+                msg.channel_id,
+                msg.attempts + 1,
+            )
+            return False, 0.0
+        await self._finalize_webhook_success(msg, sent, started_at=retry_start)
+        return True, 0.0
+
     async def _send_webhook(self, msg: PendingWebhookMessage) -> tuple[bool, float]:
         webhook = discord.Webhook.from_url(msg.webhook_url, client=discord_client)
-        files = [upload.to_discord_file() for upload in msg.uploads]
         start = time.perf_counter()
         channel_str = str(msg.channel_id)
         meta = await self._ensure_channel_meta(channel_str)
@@ -867,7 +991,7 @@ class ChatConnectionManager:
                 msg.content,
                 username=msg.username,
                 avatar_url=msg.avatar_url,
-                files=files or None,
+                files=[upload.to_discord_file() for upload in msg.uploads] or None,
                 embeds=list(msg.embeds) if msg.embeds else None,
                 wait=True,
             )
@@ -877,10 +1001,19 @@ class ChatConnectionManager:
                 "X-RateLimit-Reset-After"
             )
             retry_after_s = float(retry_after) if retry_after is not None else 0.0
+            status = getattr(e, "status", None)
+            if status in FATAL_WEBHOOK_STATUSES:
+                logger.warning(
+                    "chat.ws webhook stale channel=%s status=%s attempt=%s",
+                    msg.channel_id,
+                    status,
+                    msg.attempts + 1,
+                )
+                return await self._recover_stale_webhook(msg, meta)
             logger.warning(
                 "chat.ws webhook send error channel=%s status=%s attempt=%s",
                 msg.channel_id,
-                getattr(e, "status", None),
+                status,
                 msg.attempts + 1,
             )
             return False, retry_after_s
@@ -891,22 +1024,7 @@ class ChatConnectionManager:
                 msg.attempts + 1,
             )
             return False, 0.0
-        latency_ms = (time.perf_counter() - start) * 1000
-        self._send_count += 1
-        logger.info(
-            "chat.ws send channel=%s latency_ms=%.1f count=%s",
-            msg.channel_id,
-            latency_ms,
-            self._send_count,
-        )
-        dto, _ = serialize_message(sent)
-        await emit_event(
-            {
-                "channel": str(msg.channel_id),
-                "op": "mc",
-                "d": dto.model_dump(by_alias=True, exclude_none=True),
-            }
-        )
+        await self._finalize_webhook_success(msg, sent, started_at=start)
         return True, 0.0
 
     async def _send_subscription_ack(

--- a/tests/test_chat_ws.py
+++ b/tests/test_chat_ws.py
@@ -114,7 +114,7 @@ class StubWebSocket:
 class DummySession:
     async def execute(self, *args, **kwargs):
         return types.SimpleNamespace(
-            all=lambda: [(1, 1, "CHAT", 1)]
+            all=lambda: [(1, 1, ws_chat.OFFICER_CHAT_KIND, 1)]
         )
 
     async def close(self):  # pragma: no cover - trivial
@@ -470,6 +470,186 @@ def test_chat_ws_officer_send_requires_role(monkeypatch):
 
         assert queued == []
         assert 1 not in ws_chat._channel_webhooks
+
+    _run(scenario())
+
+
+def test_chat_ws_recovers_from_stale_webhook(monkeypatch):
+    async def scenario():
+        ws_chat._channel_webhooks.clear()
+        manager = ws_chat.ChatConnectionManager()
+        channel_id = 9876
+        manager._channel_meta[str(channel_id)] = ws_chat.ChannelMeta(
+            guild_id=5, discord_guild_id=50, kind="CHAT"
+        )
+
+        class FakeSession:
+            def __init__(self):
+                self.commit_called = False
+                self.rollback_called = False
+                self.cleared = False
+                self.row = self._make_row()
+
+            def _make_row(self):
+                session = self
+
+                class Row:
+                    def __init__(self) -> None:
+                        self.guild_id = 5
+                        self.channel_id = channel_id
+                        self.kind = ws_chat.ChannelKind.CHAT
+                        self._webhook_url = "https://example.invalid/stale"
+
+                    @property
+                    def webhook_url(self):
+                        return self._webhook_url
+
+                    @webhook_url.setter
+                    def webhook_url(self, value):
+                        if value is None:
+                            session.cleared = True
+                        self._webhook_url = value
+
+                return Row()
+
+            async def execute(self, *args, **kwargs):
+                return types.SimpleNamespace(
+                    scalars=lambda: types.SimpleNamespace(all=lambda: [self.row])
+                )
+
+            async def commit(self):
+                self.commit_called = True
+
+            async def rollback(self):
+                self.rollback_called = True
+
+            async def close(self):  # pragma: no cover - close not triggered
+                pass
+
+        fake_session = FakeSession()
+
+        @asynccontextmanager
+        async def fake_get_session():
+            yield fake_session
+
+        events: list[dict] = []
+
+        async def fake_emit_event(event):
+            events.append(event)
+
+        counter = itertools.count(100)
+
+        class DummyDiscordMessage:
+            def __init__(self):
+                self.id = next(counter)
+                self.attachments = []
+
+            def model_dump(self, **kwargs):  # pragma: no cover - defensive
+                return {"id": self.id}
+
+        class FreshWebhook:
+            def __init__(self) -> None:
+                self.calls: list[tuple] = []
+
+            async def send(
+                self,
+                content,
+                *,
+                username=None,
+                avatar_url=None,
+                files=None,
+                embeds=None,
+                wait=True,
+            ):
+                self.calls.append((content, username, avatar_url, files, embeds, wait))
+                return DummyDiscordMessage()
+
+        fresh_webhook = FreshWebhook()
+
+        class FailingWebhook:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def send(self, *args, **kwargs):
+                self.calls += 1
+                exc = ws_chat.discord.HTTPException("gone")
+                exc.status = 404
+                exc.response = types.SimpleNamespace(headers={})
+                raise exc
+
+        failing_webhook = FailingWebhook()
+        created_urls: list[str] = []
+
+        async def fake_create_webhook_for_channel(**kwargs):
+            created_urls.append("https://example.invalid/fresh")
+            fake_session.row.webhook_url = "https://example.invalid/fresh"
+            ws_chat._channel_webhooks[channel_id] = "https://example.invalid/fresh"
+            return fresh_webhook, "https://example.invalid/fresh", []
+
+        def fake_from_url(url, client=None):
+            if url == "https://example.invalid/stale":
+                return failing_webhook
+            assert url == "https://example.invalid/fresh"
+            return fresh_webhook
+
+        def fake_serialize(message):
+            class DummyDto:
+                def model_dump(self, **kwargs):
+                    return {"id": message.id}
+
+            return DummyDto(), []
+
+        monkeypatch.setattr(ws_chat, "get_session", fake_get_session)
+        monkeypatch.setattr(ws_chat, "emit_event", fake_emit_event)
+        monkeypatch.setattr(ws_chat, "create_webhook_for_channel", fake_create_webhook_for_channel)
+        monkeypatch.setattr(ws_chat.discord.Webhook, "from_url", staticmethod(fake_from_url))
+        monkeypatch.setattr(ws_chat, "serialize_message", fake_serialize)
+
+        ws_chat._channel_webhooks[channel_id] = "https://example.invalid/stale"
+
+        msg = ws_chat.PendingWebhookMessage(
+            channel_id=channel_id,
+            webhook_url="https://example.invalid/stale",
+            content="hello",
+            username="Tester",
+            avatar_url=None,
+            uploads=[],
+            embeds=[],
+            nonce="nonce",
+            payload={"op": "mc"},
+        )
+
+        success, retry_after = await manager._send_webhook(msg)
+
+        assert success is True
+        assert retry_after == 0.0
+        assert msg.webhook_url == "https://example.invalid/fresh"
+        assert ws_chat._channel_webhooks[channel_id] == "https://example.invalid/fresh"
+        assert fake_session.cleared is True
+        assert fake_session.commit_called is True
+        assert created_urls == ["https://example.invalid/fresh"]
+        assert fresh_webhook.calls, "expected fresh webhook to be used"
+        assert failing_webhook.calls == 1
+        assert events and events[0]["channel"] == str(channel_id)
+
+        msg2 = ws_chat.PendingWebhookMessage(
+            channel_id=channel_id,
+            webhook_url=msg.webhook_url,
+            content="hello again",
+            username="Tester",
+            avatar_url=None,
+            uploads=[],
+            embeds=[],
+            nonce="nonce2",
+            payload={"op": "mc"},
+        )
+
+        success2, retry_after2 = await manager._send_webhook(msg2)
+
+        assert success2 is True
+        assert retry_after2 == 0.0
+        assert len(created_urls) == 1, "webhook creation should only occur once"
+        assert len(fresh_webhook.calls) == 2
 
     _run(scenario())
 


### PR DESCRIPTION
## Summary
- treat 401/403/404 webhook responses as fatal, purge stale URLs, and try to recreate the webhook before failing
- add helpers that clear cached/persisted webhook URLs and reuse them after successful recreation
- extend chat websocket tests to cover stale webhook recovery and cached URL reuse

## Testing
- pytest tests/test_chat_ws.py


------
https://chatgpt.com/codex/tasks/task_e_68d338e093a48328bbabfb97c5766522