### PR TITLE
Ensure websocket webhooks include allowed mentions

### DIFF
--- a/demibot/demibot/http/discord_allowed_mentions.py
+++ b/demibot/demibot/http/discord_allowed_mentions.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import discord
+
+
+try:  # pragma: no cover - optional dependency in tests
+    ALLOWED_MENTIONS = discord.AllowedMentions(users=True, roles=True, everyone=False)
+except AttributeError:  # pragma: no cover - fallback for stub discord module
+    class _AllowedMentionsFallback:
+        users = True
+        roles = True
+        everyone = False
+
+        def to_dict(self) -> dict[str, object]:
+            return {"users": [], "roles": [], "everyone": False}
+
+    ALLOWED_MENTIONS = _AllowedMentionsFallback()
+
+
+__all__ = ["ALLOWED_MENTIONS"]

--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -67,6 +67,7 @@ from ..schemas import (
     EmbedDto,
     MessageReferenceDto,
 )
+from ..discord_allowed_mentions import ALLOWED_MENTIONS
 from ..discord_helpers import serialize_message
 from ...bridge import BridgeUpload, build_bridge_message
 
@@ -417,23 +418,6 @@ async def create_webhook_for_channel(
         channel_kind=channel_kind,
     )
     return created, webhook_url, errors
-
-
-# Restrict everyone mentions but allow user and role pings
-try:  # pragma: no cover - optional dependency in tests
-    ALLOWED_MENTIONS = discord.AllowedMentions(
-        users=True, roles=True, everyone=False
-    )
-except AttributeError:  # pragma: no cover - fallback for stub discord module
-    class _AllowedMentionsFallback:
-        users = True
-        roles = True
-        everyone = False
-
-        def to_dict(self) -> dict[str, object]:
-            return {"users": [], "roles": [], "everyone": False}
-
-    ALLOWED_MENTIONS = _AllowedMentionsFallback()
 
 
 def _discord_error(exc: discord.HTTPException) -> str:

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -33,7 +33,8 @@ from ...db.models import (
     Membership,
 )
 from ._user_display import compute_creator_base_name, build_creator_label
-from ._messages_common import _send_via_webhook, ALLOWED_MENTIONS, _role_set
+from ..discord_allowed_mentions import ALLOWED_MENTIONS
+from ._messages_common import _send_via_webhook, _role_set
 from models.event import Event
 
 router = APIRouter(prefix="/api")

--- a/demibot/demibot/http/ws_chat.py
+++ b/demibot/demibot/http/ws_chat.py
@@ -22,6 +22,7 @@ from .chat_events import emit_event
 from .deps import RequestContext, api_key_auth
 from .discord_client import discord_client
 from .discord_helpers import serialize_message
+from .discord_allowed_mentions import ALLOWED_MENTIONS
 from .routes._messages_common import create_webhook_for_channel, _channel_webhooks
 from ..bridge import (
     BridgeUpload,
@@ -946,6 +947,7 @@ class ChatConnectionManager:
                 files=[upload.to_discord_file() for upload in msg.uploads] or None,
                 embeds=list(msg.embeds) if msg.embeds else None,
                 wait=True,
+                allowed_mentions=ALLOWED_MENTIONS,
             )
         except discord.HTTPException as e:
             headers = getattr(getattr(e, "response", None), "headers", {}) or {}
@@ -994,6 +996,7 @@ class ChatConnectionManager:
                 files=[upload.to_discord_file() for upload in msg.uploads] or None,
                 embeds=list(msg.embeds) if msg.embeds else None,
                 wait=True,
+                allowed_mentions=ALLOWED_MENTIONS,
             )
         except discord.HTTPException as e:
             headers = getattr(getattr(e, "response", None), "headers", {}) or {}

--- a/tests/test_chat_ws.py
+++ b/tests/test_chat_ws.py
@@ -59,9 +59,25 @@ alembic_config_stub = types.ModuleType("alembic.config")
 alembic_config_stub.Config = _AlembicConfig
 sys.modules.setdefault("alembic.config", alembic_config_stub)
 
+allowed_mentions_stub = types.ModuleType("demibot.http.discord_allowed_mentions")
+
+
+class _AllowedMentionsStub:
+    users = True
+    roles = True
+    everyone = False
+
+    def to_dict(self) -> dict[str, object]:  # pragma: no cover - simple stub
+        return {"users": [], "roles": [], "everyone": False}
+
+
+allowed_mentions_stub.ALLOWED_MENTIONS = _AllowedMentionsStub()
+sys.modules.setdefault("demibot.http.discord_allowed_mentions", allowed_mentions_stub)
+
 messages_common_stub = types.ModuleType("demibot.http.routes._messages_common")
 messages_common_stub._channel_webhooks = {}
 messages_common_stub.create_webhook_for_channel = lambda *args, **kwargs: None
+messages_common_stub.ALLOWED_MENTIONS = allowed_mentions_stub.ALLOWED_MENTIONS
 routes_stub = types.ModuleType("demibot.http.routes")
 routes_stub.__path__ = []
 routes_stub._messages_common = messages_common_stub
@@ -549,7 +565,7 @@ def test_chat_ws_recovers_from_stale_webhook(monkeypatch):
 
         class FreshWebhook:
             def __init__(self) -> None:
-                self.calls: list[tuple] = []
+                self.calls: list[dict[str, object]] = []
 
             async def send(
                 self,
@@ -560,8 +576,19 @@ def test_chat_ws_recovers_from_stale_webhook(monkeypatch):
                 files=None,
                 embeds=None,
                 wait=True,
+                allowed_mentions=None,
             ):
-                self.calls.append((content, username, avatar_url, files, embeds, wait))
+                self.calls.append(
+                    {
+                        "content": content,
+                        "username": username,
+                        "avatar_url": avatar_url,
+                        "files": files,
+                        "embeds": embeds,
+                        "wait": wait,
+                        "allowed_mentions": allowed_mentions,
+                    }
+                )
                 return DummyDiscordMessage()
 
         fresh_webhook = FreshWebhook()
@@ -650,6 +677,10 @@ def test_chat_ws_recovers_from_stale_webhook(monkeypatch):
         assert retry_after2 == 0.0
         assert len(created_urls) == 1, "webhook creation should only occur once"
         assert len(fresh_webhook.calls) == 2
+        assert all(
+            call["allowed_mentions"] is ws_chat.ALLOWED_MENTIONS
+            for call in fresh_webhook.calls
+        )
 
     _run(scenario())
 


### PR DESCRIPTION
## Summary
- extract the Discord allowed mentions helper into a shared module for reuse
- update chat websocket webhook sends to pass the shared allowed mentions settings
- expand the websocket test doubles to assert the allowed mentions are forwarded

## Testing
- pytest tests/test_chat_ws.py


------
https://chatgpt.com/codex/tasks/task_e_68d33c5253c083289b46111717e203b2