### PR TITLE
Handle disposed presence avatars when switching channels

### DIFF
--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -261,12 +261,26 @@ public class PresenceSidebar : IDisposable
         }
 
         var avatarPos = ImGui.GetCursorScreenPos();
+        var drewAvatar = false;
         if (p.AvatarTexture != null)
         {
-            var wrap = p.AvatarTexture.GetWrapOrEmpty();
-            ImGui.Image(wrap.Handle, avatarSize);
+            try
+            {
+                var wrap = p.AvatarTexture.GetWrapOrEmpty();
+                ImGui.Image(wrap.Handle, avatarSize);
+                drewAvatar = true;
+            }
+            catch (ObjectDisposedException)
+            {
+                p.AvatarTexture = null;
+                if (TextureLoader != null && !string.IsNullOrEmpty(p.AvatarUrl))
+                {
+                    TextureLoader(p.AvatarUrl, t => p.AvatarTexture = t);
+                }
+            }
         }
-        else
+
+        if (!drewAvatar)
         {
             ImGui.Dummy(avatarSize);
         }


### PR DESCRIPTION
## Summary
- prevent the FC chat presence sidebar from crashing when avatar textures have been disposed
- reload avatar textures after disposal so the sidebar can redraw without errors

## Testing
- not run (dotnet tooling not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d34726f3b88328a3c311f314ba1aac