### PR TITLE
Support Discord thread webhooks in chat WS

### DIFF
--- a/demibot/demibot/http/ws_chat.py
+++ b/demibot/demibot/http/ws_chat.py
@@ -102,6 +102,7 @@ class PendingWebhookMessage:
     embeds: List[discord.Embed]
     nonce: str
     payload: dict
+    thread_id: int | None = None
     attempts: int = 0
 
 
@@ -939,16 +940,20 @@ class ChatConnectionManager:
         if created is None:
             return False, 0.0
         retry_start = time.perf_counter()
+        files = [upload.to_discord_file() for upload in msg.uploads] or None
+        embeds = list(msg.embeds) if msg.embeds else None
+        send_kwargs = {
+            "username": msg.username,
+            "avatar_url": msg.avatar_url,
+            "files": files,
+            "embeds": embeds,
+            "wait": True,
+            "allowed_mentions": ALLOWED_MENTIONS,
+        }
+        if msg.thread_id is not None:
+            send_kwargs["thread"] = discord.Object(id=msg.thread_id)
         try:
-            sent = await created.send(
-                msg.content,
-                username=msg.username,
-                avatar_url=msg.avatar_url,
-                files=[upload.to_discord_file() for upload in msg.uploads] or None,
-                embeds=list(msg.embeds) if msg.embeds else None,
-                wait=True,
-                allowed_mentions=ALLOWED_MENTIONS,
-            )
+            sent = await created.send(msg.content, **send_kwargs)
         except discord.HTTPException as e:
             headers = getattr(getattr(e, "response", None), "headers", {}) or {}
             retry_after = headers.get("Retry-After") or headers.get(
@@ -988,16 +993,20 @@ class ChatConnectionManager:
             msg.channel_id,
             total_bytes,
         )
+        files = [upload.to_discord_file() for upload in msg.uploads] or None
+        embeds = list(msg.embeds) if msg.embeds else None
+        send_kwargs = {
+            "username": msg.username,
+            "avatar_url": msg.avatar_url,
+            "files": files,
+            "embeds": embeds,
+            "wait": True,
+            "allowed_mentions": ALLOWED_MENTIONS,
+        }
+        if msg.thread_id is not None:
+            send_kwargs["thread"] = discord.Object(id=msg.thread_id)
         try:
-            sent = await webhook.send(
-                msg.content,
-                username=msg.username,
-                avatar_url=msg.avatar_url,
-                files=[upload.to_discord_file() for upload in msg.uploads] or None,
-                embeds=list(msg.embeds) if msg.embeds else None,
-                wait=True,
-                allowed_mentions=ALLOWED_MENTIONS,
-            )
+            sent = await webhook.send(msg.content, **send_kwargs)
         except discord.HTTPException as e:
             headers = getattr(getattr(e, "response", None), "headers", {}) or {}
             retry_after = headers.get("Retry-After") or headers.get(
@@ -1161,6 +1170,18 @@ class ChatConnectionManager:
             payload.get("useCharacterName") or payload.get("use_character_name")
         )
 
+        channel_obj: discord.abc.Messageable | discord.Thread | None = None
+        thread_id: int | None = None
+        thread_cls = getattr(discord, "Thread", None)
+        if discord_client:
+            channel_obj = discord_client.get_channel(channel_id)
+            if thread_cls is not None and isinstance(channel_obj, thread_cls):
+                thread_identifier = getattr(channel_obj, "id", None)
+                try:
+                    thread_id = int(thread_identifier) if thread_identifier is not None else channel_id
+                except (TypeError, ValueError):
+                    thread_id = channel_id
+
         def _normalize_channel_kind(value: object | None) -> ChannelKind:
             if isinstance(value, ChannelKind):
                 return value
@@ -1195,13 +1216,27 @@ class ChatConnectionManager:
                         channel_id,
                     )
                     return
-                channel_obj = discord_client.get_channel(channel_id)
+                channel_obj = channel_obj or discord_client.get_channel(channel_id)
                 if not isinstance(channel_obj, discord.abc.Messageable):
                     logger.warning(
                         "chat.ws missing webhook channel=%s reason=no_channel",
                         channel_id,
                     )
                     return
+                if (
+                    thread_id is None
+                    and thread_cls is not None
+                    and isinstance(channel_obj, thread_cls)
+                ):
+                    thread_identifier = getattr(channel_obj, "id", None)
+                    try:
+                        thread_id = (
+                            int(thread_identifier)
+                            if thread_identifier is not None
+                            else channel_id
+                        )
+                    except (TypeError, ValueError):
+                        thread_id = channel_id
                 try:
                     _, created_url, creation_errors = await create_webhook_for_channel(
                         channel=channel_obj,
@@ -1298,6 +1333,7 @@ class ChatConnectionManager:
             embeds=embed_objects,
             nonce=nonce,
             payload=payload_with_nonce,
+            thread_id=thread_id,
         )
         await self._queue_webhook(msg)
 

--- a/tests/test_chat_ws.py
+++ b/tests/test_chat_ws.py
@@ -26,6 +26,22 @@ discord_stub.Webhook = type(
         )
     },
 )
+class _ThreadStub:
+    def __init__(self, *, id=0, parent=None, archived=False):
+        self.id = id
+        self.parent = parent
+        self.archived = archived
+
+
+class _ObjectStub:
+    def __init__(self, id=None, **kwargs):
+        if id is None:
+            id = kwargs.get("id")
+        self.id = id
+
+
+discord_stub.Thread = _ThreadStub
+discord_stub.Object = _ObjectStub
 discord_stub.abc = types.SimpleNamespace(Messageable=object)
 discord_commands_stub = types.ModuleType("discord.ext.commands")
 discord_commands_stub.Bot = type("Bot", (), {})
@@ -364,6 +380,152 @@ def test_chat_ws_send_uses_channel_field(monkeypatch):
         message = queued[0]
         assert message.channel_id == 12345
         assert ws_chat._channel_webhooks[12345] == "https://example.invalid/webhook"
+
+    _run(scenario())
+
+
+def test_chat_ws_thread_send_includes_thread_param(monkeypatch):
+    async def scenario():
+        ws_chat._channel_webhooks.clear()
+        manager = ws_chat.ChatConnectionManager()
+        ws = StubWebSocket()
+        thread_channel_id = 54321
+        ctx = RequestContext(
+            user=types.SimpleNamespace(
+                id=42,
+                discord_user_id=4242,
+                character_name="Tester",
+            ),
+            guild=types.SimpleNamespace(id=9, discord_guild_id=9090),
+            key=None,
+            roles=[],
+        )
+        manager.connections[ws] = ws_chat.ChatConnection(ctx=ctx)
+        info = manager.connections[ws]
+        info.channels.add(str(thread_channel_id))
+        meta = ws_chat.ChannelMeta(
+            guild_id=ctx.guild.id,
+            discord_guild_id=ctx.guild.discord_guild_id,
+            kind="CHAT",
+        )
+        info.metadata[str(thread_channel_id)] = meta
+        manager._channel_meta[str(thread_channel_id)] = meta
+
+        parent_channel = types.SimpleNamespace(id=9876)
+        thread_obj = ws_chat.discord.Thread(id=thread_channel_id, parent=parent_channel)
+
+        class DummyDiscordClient:
+            def get_channel(self, cid):
+                assert cid == thread_channel_id
+                return thread_obj
+
+        monkeypatch.setattr(ws_chat, "discord_client", DummyDiscordClient())
+
+        class FakeSession:
+            def __init__(self):
+                self.commit_called = False
+
+            async def execute(self, *args, **kwargs):
+                return types.SimpleNamespace(
+                    one_or_none=lambda: (None, ws_chat.ChannelKind.CHAT)
+                )
+
+            async def scalar(self, *args, **kwargs):
+                return None
+
+            async def commit(self):
+                self.commit_called = True
+
+            async def close(self):  # pragma: no cover - trivial
+                pass
+
+        fake_session = FakeSession()
+
+        @asynccontextmanager
+        async def fake_get_session():
+            yield fake_session
+
+        def fake_build_bridge_message(
+            *,
+            content,
+            user,
+            membership,
+            channel_kind,
+            use_character_name=False,
+            attachments=None,
+            nonce=None,
+        ):
+            return content, [], [], nonce or "nonce"
+
+        async def fake_create_webhook_for_channel(**kwargs):
+            return None, "https://example.invalid/thread-webhook", []
+
+        queued: list[ws_chat.PendingWebhookMessage] = []
+
+        async def fake_queue_webhook(self, msg):
+            queued.append(msg)
+
+        events: list[dict] = []
+
+        async def fake_emit_event(payload):
+            events.append(payload)
+
+        monkeypatch.setattr(ws_chat, "get_session", fake_get_session)
+        monkeypatch.setattr(ws_chat, "build_bridge_message", fake_build_bridge_message)
+        monkeypatch.setattr(
+            ws_chat, "create_webhook_for_channel", fake_create_webhook_for_channel
+        )
+        monkeypatch.setattr(
+            manager,
+            "_queue_webhook",
+            types.MethodType(fake_queue_webhook, manager),
+        )
+
+        await manager._handle_send(
+            ws,
+            {
+                "channel": thread_channel_id,
+                "payload": {"content": "hello thread"},
+            },
+        )
+
+        assert queued, "expected webhook message to be queued"
+        message = queued[0]
+        assert message.thread_id == thread_channel_id
+        assert message.webhook_url == "https://example.invalid/thread-webhook"
+        assert fake_session.commit_called is True
+
+        webhook_calls: list[dict] = []
+
+        class DummyWebhook:
+            async def send(self, content, **kwargs):
+                webhook_calls.append({"content": content, **kwargs})
+
+                class DummyMessage:
+                    id = 777
+
+                    def model_dump(self, **kwargs):  # pragma: no cover - simple stub
+                        return {"id": str(self.id)}
+
+                return DummyMessage()
+
+        def fake_from_url(url, client=None):
+            assert url == "https://example.invalid/thread-webhook"
+            return DummyWebhook()
+
+        monkeypatch.setattr(
+            ws_chat.discord.Webhook, "from_url", staticmethod(fake_from_url)
+        )
+        monkeypatch.setattr(ws_chat, "emit_event", fake_emit_event)
+
+        success, retry_after = await manager._send_webhook(message)
+
+        assert success is True
+        assert retry_after == 0.0
+        assert webhook_calls, "expected webhook send to be invoked"
+        call = webhook_calls[-1]
+        assert call["thread"].id == thread_channel_id
+        assert events, "expected emit_event to be called"
 
     _run(scenario())
 


### PR DESCRIPTION
## Summary
- capture the destination Discord thread when queuing websocket webhook sends
- pass the stored thread identifier when sending or recreating webhooks so messages land in the thread
- add regression coverage ensuring thread webhook sends include the thread parameter

## Testing
- pytest tests/test_chat_ws.py

------
https://chatgpt.com/codex/tasks/task_e_68d3579706848328b3fd8a61e31937e5