### PR TITLE
Fix webhook kind persistence and add regeneration tests

### DIFF
--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -88,6 +88,20 @@ from ..discord_client import discord_client, is_discord_client_ready
 _channel_webhooks: dict[int, str] = {}
 
 
+def _format_kind(kind: ChannelKind | None) -> str | None:
+    return kind.value if kind is not None else None
+
+
+def _is_missing_webhook_error(exc: discord.HTTPException) -> bool:
+    if exc.status in {403, 404}:
+        text = (exc.text or "").lower()
+        if exc.status == 404:
+            return True
+        if "missing access" in text or "unknown webhook" in text:
+            return True
+    return False
+
+
 async def _cache_and_store_webhook_url(
     *,
     db: AsyncSession,
@@ -119,6 +133,13 @@ async def _cache_and_store_webhook_url(
     rows = result.scalars().all()
     seen_ids = {row.channel_id for row in rows}
     for row in rows:
+        if (
+            configured_channel_id is not None
+            and channel_kind is not None
+            and row.channel_id == configured_channel_id
+            and row.kind != channel_kind
+        ):
+            row.kind = channel_kind
         if row.webhook_url != webhook_url:
             row.webhook_url = webhook_url
     for cid, default_kind in targets.items():
@@ -132,6 +153,36 @@ async def _cache_and_store_webhook_url(
                 webhook_url=webhook_url,
             )
         )
+
+
+async def _purge_webhook_urls(
+    *, db: AsyncSession, guild_id: int, channel_ids: Iterable[int]
+) -> bool:
+    """Remove cached webhook URLs for the supplied channel ids.
+
+    Returns ``True`` when any cached or persisted entry was updated.
+    """
+
+    unique_ids = {cid for cid in channel_ids}
+    if not unique_ids:
+        return False
+
+    changed = False
+    for cid in unique_ids:
+        if _channel_webhooks.pop(cid, None) is not None:
+            changed = True
+
+    result = await db.execute(
+        select(GuildChannel).where(
+            GuildChannel.guild_id == guild_id,
+            GuildChannel.channel_id.in_(list(unique_ids)),
+        )
+    )
+    for row in result.scalars():
+        if row.webhook_url is not None:
+            row.webhook_url = None
+            changed = True
+    return changed
 
 MAX_ATTACHMENTS = 10
 MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024  # 25MB
@@ -375,6 +426,14 @@ async def create_webhook_for_channel(
             errors.append("Webhook creation failed: channel not available")
         return None, None, errors
 
+    logging.info(
+        "webhook: creating",
+        extra={
+            "guild_id": guild_id,
+            "channel_id": channel_id,
+            "kind": _format_kind(channel_kind),
+        },
+    )
     try:
         created = await resolved_channel.create_webhook(name="DemiCat Relay")
     except discord.Forbidden:
@@ -560,10 +619,12 @@ async def _send_via_webhook(
         candidate_ids.append(configured_channel_id)
 
     webhook_url: str | None = None
+    webhook_source: str | None = None
     for candidate in candidate_ids:
         cached_url = _channel_webhooks.get(candidate)
         if cached_url:
             webhook_url = cached_url
+            webhook_source = "cache"
             break
 
     if webhook_url and any(
@@ -588,6 +649,7 @@ async def _send_via_webhook(
             stmt = stmt.where(GuildChannel.kind == channel_kind)
         webhook_url = await db.scalar(stmt)
         if webhook_url:
+            webhook_source = "database"
             await _cache_and_store_webhook_url(
                 db=db,
                 guild_id=guild_id,
@@ -604,6 +666,7 @@ async def _send_via_webhook(
             )
             webhook_url = await db.scalar(fallback_stmt)
             if webhook_url:
+                webhook_source = "database"
                 await _cache_and_store_webhook_url(
                     db=db,
                     guild_id=guild_id,
@@ -627,6 +690,7 @@ async def _send_via_webhook(
             stmt = stmt.where(GuildChannel.kind == channel_kind)
         webhook_url = await db.scalar(stmt)
         if webhook_url:
+            webhook_source = "database"
             await _cache_and_store_webhook_url(
                 db=db,
                 guild_id=guild_id,
@@ -643,6 +707,7 @@ async def _send_via_webhook(
             )
             webhook_url = await db.scalar(fallback_stmt)
             if webhook_url:
+                webhook_source = "database"
                 await _cache_and_store_webhook_url(
                     db=db,
                     guild_id=guild_id,
@@ -654,6 +719,15 @@ async def _send_via_webhook(
 
     webhook = None
     if webhook_url:
+        logging.info(
+            "webhook: using cached",
+            extra={
+                "guild_id": guild_id,
+                "channel_id": channel_id,
+                "kind": _format_kind(channel_kind),
+                "webhook_source": webhook_source,
+            },
+        )
         try:
             webhook = discord.Webhook.from_url(webhook_url, client=discord_client)
         except Exception as e:  # pragma: no cover - network errors
@@ -712,16 +786,36 @@ async def _send_via_webhook(
                 )
             except Exception as e2:  # pragma: no cover - network errors
                 e = e2
+        stale_webhook = False
         if sent is None:
-            logging.exception(
-                "webhook.send failed for channel %s: %s %s",
-                channel_id,
-                e.status,
-                e.text,
-            )
-            errors.append(
-                f"Webhook send failed: {e.status} {e.text or _discord_error(e)}"
-            )
+            stale_webhook = _is_missing_webhook_error(e)
+            if stale_webhook:
+                logging.info(
+                    "webhook: recreating after %s",
+                    e.status,
+                    extra={
+                        "guild_id": guild_id,
+                        "channel_id": channel_id,
+                        "kind": _format_kind(channel_kind),
+                    },
+                )
+                await _purge_webhook_urls(
+                    db=db,
+                    guild_id=guild_id,
+                    channel_ids=candidate_ids,
+                )
+                webhook = None
+                webhook_url = None
+            else:
+                logging.exception(
+                    "webhook.send failed for channel %s: %s %s",
+                    channel_id,
+                    e.status,
+                    e.text,
+                )
+                errors.append(
+                    f"Webhook send failed: {e.status} {e.text or _discord_error(e)}"
+                )
     except Exception as e:  # pragma: no cover - network errors
         logging.exception("webhook.send failed for channel %s", channel_id)
         errors.append(f"Webhook send failed: {e}")

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -1471,6 +1471,224 @@ def test_send_via_webhook_reuses_existing_url(monkeypatch):
     asyncio.run(_run())
 
 
+def test_webhook_kind_persistence_when_ids_match(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
+            await db.execute(text("DELETE FROM messages"))
+            await db.execute(text("DELETE FROM memberships"))
+            await db.execute(text("DELETE FROM users"))
+            await db.execute(text("DELETE FROM guilds"))
+            await db.execute(text("DELETE FROM guild_channels"))
+
+            guild_id = 20
+            channel_id = 777
+            webhook_url = "https://example.com/officer-webhook"
+
+            db.add(Guild(id=guild_id, discord_guild_id=7720, name="Guild"))
+            await db.commit()
+
+            monkeypatch.setattr(mc, "_channel_webhooks", {})
+
+            class DummyChannel:
+                async def create_webhook(self, name: str):
+                    return types.SimpleNamespace(url=webhook_url)
+
+            monkeypatch.setattr(mc, "_channel_supports_webhooks", lambda *_: True)
+
+            created, stored_url, errors = await mc.create_webhook_for_channel(
+                channel=DummyChannel(),
+                channel_id=channel_id,
+                guild_id=guild_id,
+                db=db,
+                configured_channel_id=channel_id,
+                channel_kind=ChannelKind.OFFICER_CHAT,
+            )
+
+            assert errors == []
+            assert stored_url == webhook_url
+            assert created is not None
+            assert mc._channel_webhooks.get(channel_id) == webhook_url
+
+            result = await db.execute(
+                select(GuildChannel.kind, GuildChannel.webhook_url).where(
+                    GuildChannel.guild_id == guild_id,
+                    GuildChannel.channel_id == channel_id,
+                )
+            )
+            stored = {kind: url for kind, url in result.all()}
+            assert stored.get(ChannelKind.OFFICER_CHAT) == webhook_url
+            assert ChannelKind.CHAT not in stored
+
+    asyncio.run(_run())
+
+
+def test_fc_kind_persistence_when_ids_match(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
+            await db.execute(text("DELETE FROM messages"))
+            await db.execute(text("DELETE FROM memberships"))
+            await db.execute(text("DELETE FROM users"))
+            await db.execute(text("DELETE FROM guilds"))
+            await db.execute(text("DELETE FROM guild_channels"))
+
+            guild_id = 21
+            channel_id = 778
+            webhook_url = "https://example.com/fc-webhook"
+
+            db.add(Guild(id=guild_id, discord_guild_id=7721, name="Guild"))
+            await db.commit()
+
+            monkeypatch.setattr(mc, "_channel_webhooks", {})
+
+            class DummyChannel:
+                async def create_webhook(self, name: str):
+                    return types.SimpleNamespace(url=webhook_url)
+
+            monkeypatch.setattr(mc, "_channel_supports_webhooks", lambda *_: True)
+
+            created, stored_url, errors = await mc.create_webhook_for_channel(
+                channel=DummyChannel(),
+                channel_id=channel_id,
+                guild_id=guild_id,
+                db=db,
+                configured_channel_id=channel_id,
+                channel_kind=ChannelKind.FC_CHAT,
+            )
+
+            assert errors == []
+            assert stored_url == webhook_url
+            assert created is not None
+            assert mc._channel_webhooks.get(channel_id) == webhook_url
+
+            result = await db.execute(
+                select(GuildChannel.kind, GuildChannel.webhook_url).where(
+                    GuildChannel.guild_id == guild_id,
+                    GuildChannel.channel_id == channel_id,
+                )
+            )
+            stored = {kind: url for kind, url in result.all()}
+            assert stored.get(ChannelKind.FC_CHAT) == webhook_url
+            assert ChannelKind.CHAT not in stored
+
+    asyncio.run(_run())
+
+
+def test_webhook_recreation_on_404(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
+            await db.execute(text("DELETE FROM messages"))
+            await db.execute(text("DELETE FROM memberships"))
+            await db.execute(text("DELETE FROM users"))
+            await db.execute(text("DELETE FROM guilds"))
+            await db.execute(text("DELETE FROM guild_channels"))
+
+            guild_id = 22
+            channel_id = 779
+            old_url = "https://example.com/old-webhook"
+            new_url = "https://example.com/new-webhook"
+
+            db.add(Guild(id=guild_id, discord_guild_id=7722, name="Guild"))
+            db.add(
+                GuildChannel(
+                    guild_id=guild_id,
+                    channel_id=channel_id,
+                    kind=ChannelKind.FC_CHAT,
+                    webhook_url=old_url,
+                )
+            )
+            await db.commit()
+
+            monkeypatch.setattr(mc, "_channel_webhooks", {channel_id: old_url})
+
+            class DummyHTTPException(Exception):
+                def __init__(self, status: int, text: str):
+                    super().__init__(text)
+                    self.status = status
+                    self.text = text
+                    self.retry_after = 0
+
+            monkeypatch.setattr(mc.discord, "HTTPException", DummyHTTPException)
+
+            class DummyWebhook:
+                def __init__(self) -> None:
+                    self.calls = 0
+
+                async def send(self, *args, **kwargs):
+                    self.calls += 1
+                    if self.calls == 1:
+                        raise DummyHTTPException(404, "Unknown Webhook")
+                    return types.SimpleNamespace(id=555, attachments=[])
+
+            dummy_webhook = DummyWebhook()
+
+            class DummyWebhookCls:
+                @staticmethod
+                def from_url(url: str, client=None):
+                    assert url == old_url
+                    return dummy_webhook
+
+            monkeypatch.setattr(mc.discord, "Webhook", DummyWebhookCls)
+
+            created_payload: dict[str, object] = {}
+
+            class FreshWebhook:
+                async def send(self, *args, **kwargs):
+                    created_payload["kwargs"] = kwargs
+                    return types.SimpleNamespace(id=556, attachments=[])
+
+            async def fake_create_webhook_for_channel(**kwargs):
+                created_payload["called"] = True
+                created_payload["kwargs"] = kwargs
+                await mc._cache_and_store_webhook_url(
+                    db=kwargs["db"],
+                    guild_id=kwargs["guild_id"],
+                    webhook_url=new_url,
+                    channel_id=kwargs.get("channel_id"),
+                    configured_channel_id=kwargs.get("configured_channel_id"),
+                    channel_kind=kwargs.get("channel_kind"),
+                )
+                return FreshWebhook(), new_url, []
+
+            monkeypatch.setattr(mc, "create_webhook_for_channel", fake_create_webhook_for_channel)
+
+            msg_id, attachments, errors, used_url = await mc._send_via_webhook(
+                channel=None,
+                channel_id=channel_id,
+                guild_id=guild_id,
+                configured_channel_id=channel_id,
+                content="hello",
+                username="Tester",
+                avatar=None,
+                files=None,
+                channel_kind=ChannelKind.FC_CHAT,
+                db=db,
+                thread=None,
+            )
+
+            assert msg_id == 556
+            assert attachments is None
+            assert errors == []
+            assert used_url == new_url
+            assert mc._channel_webhooks.get(channel_id) == new_url
+            assert created_payload.get("called") is True
+
+            result = await db.execute(
+                select(GuildChannel.webhook_url).where(
+                    GuildChannel.guild_id == guild_id,
+                    GuildChannel.channel_id == channel_id,
+                    GuildChannel.kind == ChannelKind.FC_CHAT,
+                )
+            )
+            assert result.scalar_one() == new_url
+
+    asyncio.run(_run())
+
 def test_send_via_webhook_thread_reuses_cached_url(monkeypatch):
     async def _run():
         from demibot.db import session as db_session


### PR DESCRIPTION
## Summary
- ensure configured channel webhook persistence honors explicit channel kinds and logs cache usage/creation flows
- add webhook cache purging and retry logic for stale 404/403 responses
- cover officer/FC kind persistence and webhook recreation with new tests

## Testing
- PYTHONPATH=demibot pytest tests/test_messages_common.py::test_webhook_kind_persistence_when_ids_match tests/test_messages_common.py::test_fc_kind_persistence_when_ids_match tests/test_messages_common.py::test_webhook_recreation_on_404 -q


------
https://chatgpt.com/codex/tasks/task_e_68d475b883cc8328b4264108cde8815e