### PR TITLE
Fix discord client registration proxy

### DIFF
--- a/demibot/demibot/http/discord_client.py
+++ b/demibot/demibot/http/discord_client.py
@@ -3,10 +3,42 @@ from __future__ import annotations
 from discord.ext import commands
 
 
-discord_client: commands.Bot | None = None
+class _DiscordClientProxy:
+    """Proxy object that always reflects the current Discord client.
+
+    HTTP route modules often import ``discord_client`` directly, meaning they
+    receive the value that existed at import time.  Reassigning the module level
+    ``discord_client`` would therefore leave those imports pointing at the old
+    object (usually ``None``) even after the bot is created.  The proxy keeps a
+    mutable reference to the underlying client so that existing imports stay in
+    sync when :func:`set_discord_client` updates the client.
+    """
+
+    __slots__ = ("_client",)
+
+    def __init__(self) -> None:
+        self._client: commands.Bot | None = None
+
+    def set(self, client: commands.Bot | None) -> None:
+        self._client = client
+
+    def get(self) -> commands.Bot | None:
+        return self._client
+
+    def __bool__(self) -> bool:
+        return self._client is not None
+
+    def __getattr__(self, name: str):  # pragma: no cover - passthrough
+        client = self._client
+        if client is None:
+            raise AttributeError(name)
+        return getattr(client, name)
 
 
-def set_discord_client(client: commands.Bot) -> None:
+discord_client = _DiscordClientProxy()
+
+
+def set_discord_client(client: commands.Bot | None) -> None:
     """Register the Discord client used for sending messages.
 
     The HTTP routes rely on this client to forward messages to Discord
@@ -14,11 +46,16 @@ def set_discord_client(client: commands.Bot) -> None:
     the running :class:`commands.Bot` instance.
     """
 
-    global discord_client
-    discord_client = client
+    discord_client.set(client)
 
 
-def is_discord_client_ready(client: commands.Bot | None = None) -> bool:
+def get_discord_client() -> commands.Bot | None:
+    """Return the currently registered Discord client, if any."""
+
+    return discord_client.get()
+
+
+def is_discord_client_ready(client: commands.Bot | _DiscordClientProxy | None = None) -> bool:
     """Return ``True`` when the Discord client is ready for API access.
 
     The helper performs defensive checks around the lifecycle helpers exposed
@@ -28,7 +65,11 @@ def is_discord_client_ready(client: commands.Bot | None = None) -> bool:
     syncing with Discord.
     """
 
-    client = client or discord_client
+    if isinstance(client, _DiscordClientProxy):
+        client = client.get()
+
+    if client is None:
+        client = discord_client.get()
     if client is None:
         return False
 

--- a/tests/test_discord_client_proxy.py
+++ b/tests/test_discord_client_proxy.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+if str(root) not in sys.path:
+    sys.path.append(str(root))
+
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+discord_pkg = types.ModuleType("discord")
+discord_ext_pkg = types.ModuleType("discord.ext")
+discord_commands_pkg = types.ModuleType("discord.ext.commands")
+
+
+class _DummyBot:
+    def __init__(self) -> None:
+        self.marker = "bot"
+
+
+discord_commands_pkg.Bot = _DummyBot
+discord_ext_pkg.commands = discord_commands_pkg
+discord_pkg.ext = discord_ext_pkg
+
+sys.modules.setdefault("discord", discord_pkg)
+sys.modules.setdefault("discord.ext", discord_ext_pkg)
+sys.modules.setdefault("discord.ext.commands", discord_commands_pkg)
+
+
+def test_set_discord_client_updates_existing_imports():
+    from demibot.http.discord_client import (
+        discord_client,
+        get_discord_client,
+        set_discord_client,
+    )
+
+    assert bool(discord_client) is False
+    assert get_discord_client() is None
+
+    bot = _DummyBot()
+    set_discord_client(bot)
+
+    assert bool(discord_client) is True
+    assert get_discord_client() is bot
+    assert discord_client.marker == "bot"
+
+
+def test_set_discord_client_accepts_none():
+    from demibot.http.discord_client import (
+        discord_client,
+        get_discord_client,
+        set_discord_client,
+    )
+
+    set_discord_client(None)
+
+    assert get_discord_client() is None
+    assert bool(discord_client) is False
+    with pytest.raises(AttributeError):
+        _ = discord_client.marker


### PR DESCRIPTION
## Summary
- keep http.discord_client exports synced with the running bot by replacing the module global with a proxy holder
- expose a helper to fetch the current client and update readiness checks to unwrap the proxy safely
- add regression tests proving that previously-imported references update when the bot registers and that clearing works

## Testing
- pytest tests/test_discord_client_proxy.py tests/test_discord_client_ready.py

------
https://chatgpt.com/codex/tasks/task_e_68d5292ae7a883289d4c0475d84f2647