### PR TITLE
Fix message pagination ordering

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1900,8 +1900,15 @@ public class ChatWindow : IDisposable
                     break;
                 }
 
-                var oldestMessageId = msgs[^1].Id;
-                all.AddRange(msgs);
+                var oldestMessageId = msgs[0].Id;
+                if (all.Count == 0)
+                {
+                    all.AddRange(msgs);
+                }
+                else
+                {
+                    all.InsertRange(0, msgs);
+                }
                 if (all.Count >= MaxMessages || msgs.Count < PageSize)
                 {
                     break;
@@ -1913,11 +1920,6 @@ public class ChatWindow : IDisposable
                 }
 
                 before = oldestMessageId;
-            }
-
-            if (all.Count > 1)
-            {
-                all.Reverse();
             }
 
             if (all.Count > MaxMessages)


### PR DESCRIPTION
## Summary
- keep paginated message results in the order returned by the API by inserting older pages at the front of the aggregate list
- drop the redundant reversal step now that the API already provides chronological ordering

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: missing Dalamud installation / assemblies in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cbc1fd7c8328b782f97b40e2edc8