### PR TITLE
Ensure bridge content only carries leftover text

### DIFF
--- a/demibot/demibot/bridge.py
+++ b/demibot/demibot/bridge.py
@@ -83,15 +83,24 @@ def _normalize_content(content: str) -> str:
     return content.replace("\r\n", "\n").replace("\r", "\n")
 
 
-def _split_embed_text(text: str) -> list[str]:
-    """Split ``text`` into chunks that satisfy Discord's embed limits."""
+def _split_embed_text(text: str) -> tuple[list[str], int]:
+    """Split ``text`` into chunks that satisfy Discord's embed limits.
+
+    Returns
+    -------
+    tuple[list[str], int]
+        A tuple containing the resulting embed description chunks and the
+        number of characters from ``text`` that are represented in those
+        chunks (excluding any ellipsis added to signal truncation).
+    """
 
     if not text:
-        return []
+        return [], 0
 
     chunks: list[str] = []
     remaining = text
     total = 0
+    consumed = 0
     while (
         remaining
         and len(chunks) < DISCORD_EMBED_COUNT_LIMIT
@@ -118,13 +127,16 @@ def _split_embed_text(text: str) -> list[str]:
         chunks.append(slice_text)
         remaining = remaining[actual:]
         total += actual
+        consumed += actual
 
     if remaining:
         # Append an ellipsis to signal truncation while respecting limits.
+        removed_from_last = 0
         if chunks:
             last = chunks[-1]
             if len(last) >= DISCORD_EMBED_DESCRIPTION_LIMIT:
                 last = last[:-1]
+                removed_from_last += 1
             else:
                 space_available = min(
                     DISCORD_EMBED_DESCRIPTION_LIMIT - len(last),
@@ -132,11 +144,15 @@ def _split_embed_text(text: str) -> list[str]:
                 )
                 if space_available <= 0 and len(last) > 0:
                     last = last[:-1]
+                    removed_from_last += 1
             chunks[-1] = f"{last}…" if last else "…"
+            consumed -= removed_from_last
         else:
             truncated = remaining[: DISCORD_EMBED_DESCRIPTION_LIMIT - 1]
             chunks.append(f"{truncated}…")
-    return chunks
+            consumed += len(truncated)
+        consumed = max(consumed, 0)
+    return chunks, consumed
 
 
 def build_bridge_message(
@@ -184,7 +200,7 @@ def build_bridge_message(
             normalized = header
 
 
-    chunks = _split_embed_text(normalized)
+    chunks, represented = _split_embed_text(normalized)
     if not chunks:
         chunks = [""]
 
@@ -208,7 +224,10 @@ def build_bridge_message(
             embed.set_image(url=f"attachment://{image_filename}")
         embeds.append(embed)
 
-    discord_content = normalized[:DISCORD_CONTENT_LIMIT]
+    leftover = normalized[represented:]
+    if leftover.startswith("\n"):
+        leftover = leftover[1:]
+    discord_content = leftover[:DISCORD_CONTENT_LIMIT]
     return discord_content, embeds, uploads, embed_nonce
 
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -55,9 +55,7 @@ def test_build_bridge_message_populates_embed_footer(sample_user, sample_members
     )
 
     expected_header = "Message Sent by: Nick @ 2024-01-02 03:04:05 UTC"
-    header, body = discord_content.split("\n", 1)
-    assert header == expected_header
-    assert body == content
+    assert discord_content == ""
     assert nonce
     assert len(embeds) == 1
 
@@ -96,18 +94,22 @@ def test_build_bridge_message_splits_long_content(sample_user, sample_membership
     )
 
     expected_header = "Message Sent by: Nick @ 2024-05-06 07:08:09 UTC"
-    assert discord_content.startswith(f"{expected_header}\n")
-    header_len = len(expected_header) + 1
-    assert (
-        discord_content[header_len:]
-        == long_content[: DISCORD_CONTENT_LIMIT - header_len]
-    )
+    assert discord_content
     assert not uploads
     assert nonce
     assert len(embeds) >= 2
 
     first_description = embeds[0].to_dict().get("description", "")
     assert first_description.startswith(expected_header)
+
+    embed_descriptions = [
+        embed.to_dict().get("description", "") for embed in embeds
+    ]
+    combined = "".join(embed_descriptions)
+    assert combined.startswith(expected_header)
+    body_in_embeds = combined[len(expected_header):]
+    if body_in_embeds.startswith("\n"):
+        body_in_embeds = body_in_embeds[1:]
 
     total_length = 0
     for embed in embeds:
@@ -118,7 +120,18 @@ def test_build_bridge_message_splits_long_content(sample_user, sample_membership
         assert data.get("footer", {}).get("text", "").endswith(f"{BRIDGE_MARKER}{nonce}")
 
     assert total_length <= 6000
-    assert embeds[-1].to_dict().get("description", "").endswith("…")
+    last_description = embeds[-1].to_dict().get("description", "")
+    assert last_description.endswith("…")
+    if body_in_embeds.endswith("…"):
+        body_in_embeds_without_ellipsis = body_in_embeds[:-1]
+    else:
+        body_in_embeds_without_ellipsis = body_in_embeds
+
+    expected_leftover = long_content[len(body_in_embeds_without_ellipsis) :]
+    assert (
+        discord_content
+        == expected_leftover[: DISCORD_CONTENT_LIMIT]
+    )
 
     payload = {"embeds": [embed.to_dict() for embed in embeds]}
     assert extract_bridge_nonce_from_payload(payload) == nonce
@@ -141,7 +154,7 @@ def test_build_bridge_message_includes_character_when_enabled(
     expected_header = (
         "Message Sent by: Nick / Hero / Eorzea @ 2024-07-08 09:10:11 UTC"
     )
-    assert discord_content.startswith(f"{expected_header}\n")
+    assert discord_content == ""
     assert embeds[0].to_dict().get("description", "").startswith(expected_header)
     assert not uploads
     assert nonce
@@ -161,8 +174,7 @@ def test_build_bridge_message_preserves_existing_header(sample_user, sample_memb
         timestamp=server_timestamp,
     )
 
-    assert discord_content == preformatted
-    assert discord_content.count("Message Sent by:") == 1
+    assert discord_content == ""
     assert not uploads
     assert nonce
 


### PR DESCRIPTION
## Summary
- update bridge message construction so Discord content only contains text not shown in the embeds while keeping headers inside the embed payload
- track how much source text is represented in embed descriptions to surface any leftover text in the message content field
- refresh bridge tests to assert the new content behaviour and validate leftover handling for truncated messages

## Testing
- pytest *(fails: missing optional dependencies such as httpx, sqlalchemy, fastapi, discord)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ce9a9f148328b3db6737fc490269