### PR TITLE
Prevent duplicate plain text next to embeds

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -482,8 +482,6 @@ public class ChatWindow : IDisposable
 
                 ImGui.BeginGroup();
                 ImGui.TextUnformatted(msg.Author?.Name ?? "Unknown");
-                ImGui.SameLine();
-                ImGui.TextUnformatted(msg.Timestamp.ToLocalTime().ToString());
 
                 if (msg.Reference?.MessageId != null)
                 {
@@ -499,10 +497,19 @@ public class ChatWindow : IDisposable
                     }
                 }
 
-                FormatContent(msg);
+                var plainText = GetMessagePlainText(msg);
+                var hasPlainText = !string.IsNullOrEmpty(plainText);
+                if (hasPlainText)
+                {
+                    FormatContent(msg, plainText);
+                }
+
                 if (msg.EditedTimestamp != null)
                 {
-                    ImGui.SameLine();
+                    if (hasPlainText)
+                    {
+                        ImGui.SameLine();
+                    }
                     ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.6f, 0.6f, 0.6f, 1f));
                     ImGui.TextUnformatted("(edited)");
                     ImGui.PopStyleColor();
@@ -1106,10 +1113,10 @@ public class ChatWindow : IDisposable
         return new Vector2(width * scale, height * scale);
     }
 
-    protected void FormatContent(DiscordMessageDto msg)
+    protected void FormatContent(DiscordMessageDto msg, string? textOverride = null)
     {
         using var emojiFont = _emojiManager.PushEmojiFont();
-        var text = msg.Content ?? string.Empty;
+        var text = textOverride ?? msg.Content ?? string.Empty;
         text = ReplaceMentionTokens(text, msg.Mentions);
         text = MarkdownFormatter.Format(text);
         var parts = Regex.Split(text, "(<a?:[a-zA-Z0-9_]+:\\d+>)");
@@ -1304,6 +1311,24 @@ public class ChatWindow : IDisposable
         }
 
         return null;
+    }
+
+    internal static string? GetMessagePlainText(DiscordMessageDto message)
+    {
+        var content = message.Content ?? string.Empty;
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        var embeds = (IReadOnlyList<EmbedDto>?)message.Embeds ?? Array.Empty<EmbedDto>();
+        if (embeds.Count == 0)
+        {
+            return content;
+        }
+
+        var remainder = GetUnrepresentedPlainText(content, embeds);
+        return string.IsNullOrEmpty(remainder) ? null : remainder;
     }
 
     private static string GetUnrepresentedPlainText(string displayContent, IReadOnlyList<EmbedDto> embeds)

--- a/tests/ChatWindowPreviewTests.cs
+++ b/tests/ChatWindowPreviewTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using DemiCatPlugin;
 using DiscordHelper;
@@ -58,5 +59,46 @@ public class ChatWindowPreviewTests
         var preview = ChatWindow.GetPreviewPlainText(message);
 
         Assert.Equal("Plain preview", preview);
+    }
+
+    [Fact]
+    public void GetMessagePlainText_ReturnsNull_WhenEmbedsCoverContent()
+    {
+        var message = new DiscordMessageDto
+        {
+            Content = "Embed text",
+            Embeds = new List<EmbedDto> { new() { Description = "Embed text" } }
+        };
+
+        var preview = ChatWindow.GetMessagePlainText(message);
+
+        Assert.Null(preview);
+    }
+
+    [Fact]
+    public void GetMessagePlainText_ReturnsRemainder_WhenEmbedsDoNotCoverContent()
+    {
+        var message = new DiscordMessageDto
+        {
+            Content = "Embed text and more",
+            Embeds = new List<EmbedDto> { new() { Description = "Embed text" } }
+        };
+
+        var preview = ChatWindow.GetMessagePlainText(message);
+
+        Assert.Equal(" and more", preview);
+    }
+
+    [Fact]
+    public void GetMessagePlainText_ReturnsContent_WhenNoEmbeds()
+    {
+        var message = new DiscordMessageDto
+        {
+            Content = "Plain message"
+        };
+
+        var preview = ChatWindow.GetMessagePlainText(message);
+
+        Assert.Equal("Plain message", preview);
     }
 }


### PR DESCRIPTION
## Summary
- stop rendering the timestamp row for chat messages and reuse embed remainder logic for plain text
- add a helper to skip plain text when embed descriptions cover the message and apply it to FC/Officer previews
- extend chat window preview tests to cover message plain text scenarios

## Testing
- dotnet test DemiCat/tests/DemiCatPlugin.Tests.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d298dd288328a4b54f384cd89935