### PR TITLE
Simplify bridge embeds and store nonce metadata

### DIFF
--- a/demibot/demibot/bridge.py
+++ b/demibot/demibot/bridge.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Iterable, Mapping, Sequence
 
 import discord
@@ -65,19 +65,6 @@ def _determine_author_name(
     if user.character_name:
         return user.character_name
     return str(user.discord_user_id)
-
-
-def _determine_display_name(*, user: User, membership: Membership | None) -> str:
-    if membership and membership.nickname:
-        nickname = membership.nickname.strip()
-        if nickname:
-            return nickname
-    if user.global_name:
-        global_name = user.global_name.strip()
-        if global_name:
-            return global_name
-    return str(user.discord_user_id)
-
 
 def _normalize_content(content: str) -> str:
     return content.replace("\r\n", "\n").replace("\r", "\n")
@@ -180,32 +167,12 @@ def build_bridge_message(
             if image_filename is None and _is_image(filename, content_type):
                 image_filename = filename
 
-    timestamp = timestamp or datetime.now(timezone.utc)
-    display_name = _determine_display_name(user=user, membership=membership)
-    character_name = user.character_name if use_character_name else None
-    world_name = user.world if use_character_name else None
-
-    header_present = _has_existing_header(normalized)
-    if not header_present:
-        header = _format_header_line(
-            display_name=display_name,
-            use_character_name=use_character_name,
-            character_name=character_name,
-            world_name=world_name,
-            timestamp=timestamp,
-        )
-        if normalized:
-            normalized = f"{header}\n{normalized}"
-        else:
-            normalized = header
-
 
     chunks, represented = _split_embed_text(normalized)
     if not chunks:
         chunks = [""]
 
     embed_nonce = nonce or uuid.uuid4().hex
-    footer = f"DemiCat • {_tab_label(channel_kind)} • {BRIDGE_MARKER}{embed_nonce}"
     author_name = _determine_author_name(
         user=user, membership=membership, use_character_name=use_character_name
     )
@@ -217,9 +184,14 @@ def build_bridge_message(
 
     embeds: list[discord.Embed] = []
     for index, chunk in enumerate(chunks):
-        embed = discord.Embed(description=chunk or None, timestamp=timestamp, color=color)
-        embed.set_footer(text=footer)
+        embed = discord.Embed(description=chunk, color=color)
         embed.set_author(name=author_name, icon_url=author_icon)
+        provider_name = f"{BRIDGE_MARKER}{embed_nonce}"
+        # ``discord.Embed`` does not expose a public setter for provider metadata, so
+        # assign to the private slot that backs :meth:`discord.Embed.to_dict`.  This
+        # keeps the bridge nonce outside of visible embed elements while remaining
+        # discoverable in webhook payloads for deduplication purposes.
+        embed._provider = {"name": provider_name}  # type: ignore[attr-defined]
         if index == 0 and image_filename:
             embed.set_image(url=f"attachment://{image_filename}")
         embeds.append(embed)
@@ -229,53 +201,6 @@ def build_bridge_message(
         leftover = leftover[1:]
     discord_content = leftover[:DISCORD_CONTENT_LIMIT]
     return discord_content, embeds, uploads, embed_nonce
-
-
-def _format_header_line(
-    *,
-    display_name: str,
-    use_character_name: bool,
-    character_name: str | None,
-    world_name: str | None,
-    timestamp: datetime,
-) -> str:
-    name = display_name.strip() or "You"
-    segments = [name]
-    if use_character_name:
-        char = (character_name or "").strip()
-        world = (world_name or "").strip()
-        if char:
-            segments.append(char)
-            if world:
-                segments.append(world)
-        elif world:
-            segments.append(world)
-    formatted_timestamp = timestamp.astimezone(timezone.utc).strftime(
-        "%Y-%m-%d %H:%M:%S UTC"
-    )
-    return f"Message Sent by: {' / '.join(segments)} @ {formatted_timestamp}"
-
-
-
-def _has_existing_header(content: str) -> bool:
-    if not content:
-        return False
-    first_line, _, _ = content.partition("\n")
-    line = first_line.strip()
-    if not line.startswith("Message Sent by:"):
-        return False
-    parts = line.rsplit("@", 1)
-    if len(parts) != 2:
-        return False
-    timestamp_text = parts[1].strip()
-    if not timestamp_text:
-        return False
-    try:
-        datetime.strptime(timestamp_text, "%Y-%m-%d %H:%M:%S UTC")
-    except ValueError:
-        return False
-    return True
-
 
 
 def extract_bridge_nonce_from_footer(text: str | None) -> str | None:
@@ -299,6 +224,18 @@ def extract_bridge_nonce_from_footer(text: str | None) -> str | None:
 
 
 def extract_bridge_nonce_from_embed_dict(embed: Mapping[str, object]) -> str | None:
+    provider = embed.get("provider")
+    if isinstance(provider, Mapping):
+        name = provider.get("name")
+        if isinstance(name, str):
+            marker = BRIDGE_MARKER.lower()
+            lower = name.lower()
+            idx = lower.find(marker)
+            if idx != -1:
+                remainder = name[idx + len(marker) :]
+                nonce = remainder.strip()
+                if nonce:
+                    return nonce
     footer_text = embed.get("footerText")
     if isinstance(footer_text, str):
         nonce = extract_bridge_nonce_from_footer(footer_text)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -40,7 +40,7 @@ def sample_membership():
     )
 
 
-def test_build_bridge_message_populates_embed_footer(sample_user, sample_membership):
+def test_build_bridge_message_populates_embed_metadata(sample_user, sample_membership):
     content = "Hello from DemiCat"
     attachments = [("screenshot.png", b"bytes", "image/png")]
     fixed_time = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
@@ -54,17 +54,15 @@ def test_build_bridge_message_populates_embed_footer(sample_user, sample_members
         timestamp=fixed_time,
     )
 
-    expected_header = "Message Sent by: Nick @ 2024-01-02 03:04:05 UTC"
     assert discord_content == ""
     assert nonce
     assert len(embeds) == 1
 
     embed_dict = embeds[0].to_dict()
-    footer_text = embed_dict.get("footer", {}).get("text")
-    assert footer_text and footer_text.endswith(f"{BRIDGE_MARKER}{nonce}")
+    provider_text = embed_dict.get("provider", {}).get("name")
+    assert provider_text == f"{BRIDGE_MARKER}{nonce}"
     description = embed_dict.get("description", "")
-    assert description.startswith(expected_header)
-    assert description.split("\n", 1)[1] == content
+    assert description == content
     assert embed_dict.get("author", {}).get("name") == sample_membership.nickname
     assert embed_dict.get("author", {}).get("icon_url") == sample_membership.avatar_url
 
@@ -93,23 +91,16 @@ def test_build_bridge_message_splits_long_content(sample_user, sample_membership
         timestamp=fixed_time,
     )
 
-    expected_header = "Message Sent by: Nick @ 2024-05-06 07:08:09 UTC"
     assert discord_content
     assert not uploads
     assert nonce
     assert len(embeds) >= 2
 
-    first_description = embeds[0].to_dict().get("description", "")
-    assert first_description.startswith(expected_header)
-
     embed_descriptions = [
         embed.to_dict().get("description", "") for embed in embeds
     ]
     combined = "".join(embed_descriptions)
-    assert combined.startswith(expected_header)
-    body_in_embeds = combined[len(expected_header):]
-    if body_in_embeds.startswith("\n"):
-        body_in_embeds = body_in_embeds[1:]
+    body_in_embeds = combined
 
     total_length = 0
     for embed in embeds:
@@ -117,7 +108,7 @@ def test_build_bridge_message_splits_long_content(sample_user, sample_membership
         description = data.get("description", "")
         assert len(description) <= 4096
         total_length += len(description)
-        assert data.get("footer", {}).get("text", "").endswith(f"{BRIDGE_MARKER}{nonce}")
+        assert data.get("provider", {}).get("name") == f"{BRIDGE_MARKER}{nonce}"
 
     assert total_length <= 6000
     last_description = embeds[-1].to_dict().get("description", "")
@@ -151,11 +142,11 @@ def test_build_bridge_message_includes_character_when_enabled(
         timestamp=fixed_time,
     )
 
-    expected_header = (
-        "Message Sent by: Nick / Hero / Eorzea @ 2024-07-08 09:10:11 UTC"
-    )
     assert discord_content == ""
-    assert embeds[0].to_dict().get("description", "").startswith(expected_header)
+    embed_dict = embeds[0].to_dict()
+    assert embed_dict.get("description", "") == "Hi"
+    assert embed_dict.get("author", {}).get("name") == sample_user.character_name
+    assert embed_dict.get("provider", {}).get("name", "").startswith(BRIDGE_MARKER)
     assert not uploads
     assert nonce
 

--- a/tests/test_ws_nonce.py
+++ b/tests/test_ws_nonce.py
@@ -70,7 +70,11 @@ if "discord" not in sys.modules:
             self._data.setdefault("image", {}).update(kwargs)
 
         def to_dict(self):
-            return self._data.copy()
+            data = self._data.copy()
+            provider = getattr(self, "_provider", None)
+            if provider is not None:
+                data["provider"] = provider
+            return data
 
     discord_module = types.ModuleType("discord")
     discord_module.HTTPException = _DummyHTTPException
@@ -251,8 +255,19 @@ if "demibot.bridge" not in sys.modules:
         return "", [], [], ""
 
     def _extract_bridge_nonce_stub(payload):
-        nonce = payload.get("nonce") if isinstance(payload, dict) else None
-        return str(nonce) if nonce is not None else None
+        if isinstance(payload, dict):
+            nonce = payload.get("nonce")
+            if nonce is not None:
+                return str(nonce)
+            embeds = payload.get("embeds")
+            if isinstance(embeds, list):
+                for embed in embeds:
+                    provider = embed.get("provider") if isinstance(embed, dict) else None
+                    if isinstance(provider, dict):
+                        name = provider.get("name")
+                        if isinstance(name, str) and name.startswith(BRIDGE_MARKER):
+                            return name[len(BRIDGE_MARKER) :]
+        return None
 
     sys.modules["demibot.bridge"] = types.SimpleNamespace(
         BridgeUpload=_DummyBridgeUpload,
@@ -287,7 +302,7 @@ def test_should_drop_due_to_nonce_and_cleanup(monkeypatch):
             "nonce": "abc123",
             "embeds": [
                 {
-                    "footer": {"text": f"DemiCat • Chat • {BRIDGE_MARKER}abc123"},
+                    "provider": {"name": f"{BRIDGE_MARKER}abc123"},
                 }
             ],
         },


### PR DESCRIPTION
## Summary
- stop adding visible headers/footers to bridge embeds while storing the nonce in provider metadata
- keep embed descriptions equal to the user content and continue applying author identity details
- refresh nonce extraction helpers and associated bridge/websocket tests for the new metadata layout

## Testing
- pytest tests/test_bridge.py tests/test_ws_nonce.py

------
https://chatgpt.com/codex/tasks/task_e_68d5da38440c8328b4bb27f5a0249f99