### PR TITLE
Add membership banner and accent support

### DIFF
--- a/DemiCatPlugin/ColorUtils.cs
+++ b/DemiCatPlugin/ColorUtils.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Numerics;
 
 namespace DemiCatPlugin;
@@ -31,5 +32,39 @@ public static class ColorUtils
 
     public static uint VectorToImGui(Vector3 color)
         => ((uint)(color.X * 255)) | ((uint)(color.Y * 255) << 8) | ((uint)(color.Z * 255) << 16) | 0xFF000000;
+
+    public static Vector4 RgbToVector4(uint rgb, float alpha = 1f)
+        => new(
+            ((rgb >> 16) & 0xFF) / 255f,
+            ((rgb >> 8) & 0xFF) / 255f,
+            (rgb & 0xFF) / 255f,
+            alpha);
+
+    public static uint Vector4ToImGui(Vector4 color)
+        => VectorToImGui(new Vector3(color.X, color.Y, color.Z));
+
+    public static uint MixRgb(uint source, uint target, float amount)
+    {
+        var t = Math.Clamp(amount, 0f, 1f);
+        static byte MixChannel(uint s, uint t, float factor)
+        {
+            var blended = s * (1f - factor) + t * factor;
+            var rounded = (int)Math.Round(blended);
+            return (byte)Math.Clamp(rounded, 0, 255);
+        }
+
+        var sr = (source >> 16) & 0xFF;
+        var sg = (source >> 8) & 0xFF;
+        var sb = source & 0xFF;
+        var tr = (target >> 16) & 0xFF;
+        var tg = (target >> 8) & 0xFF;
+        var tb = target & 0xFF;
+
+        var r = MixChannel(sr, tr, t);
+        var g = MixChannel(sg, tg, t);
+        var b = MixChannel(sb, tb, t);
+
+        return ((uint)r << 16) | ((uint)g << 8) | b;
+    }
 }
 

--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -390,27 +390,46 @@ public class DiscordPresenceService : IDisposable
             if (dto != null)
             {
                 _ = PluginServices.Instance!.Framework.RunOnTick(() =>
-                {
-                    var idx = _presences.FindIndex(p => p.Id == dto.Id);
-                    if (idx >= 0)
-                    {
-                        var existing = _presences[idx];
-                        dto.AvatarUrl ??= existing.AvatarUrl;
-                        dto.AvatarTexture = existing.AvatarTexture;
-                        if (dto.Roles.Count == 0)
-                            dto.Roles = existing.Roles;
-                        if (dto.RoleDetails.Count == 0 && existing.RoleDetails.Count > 0)
-                            dto.RoleDetails = existing.RoleDetails;
-                        if (string.IsNullOrWhiteSpace(dto.StatusText) && !string.IsNullOrWhiteSpace(existing.StatusText))
-                            dto.StatusText = existing.StatusText;
-                        _presences[idx] = dto;
-                    }
-                    else
-                    {
-                        _presences.Add(dto);
-                    }
-                });
+                    ApplyPresenceUpdate(dto));
             }
+        }
+    }
+
+    internal void ApplyPresenceUpdate(PresenceDto dto)
+    {
+        var idx = _presences.FindIndex(p => p.Id == dto.Id);
+        if (idx >= 0)
+        {
+            var existing = _presences[idx];
+            dto.AvatarUrl ??= existing.AvatarUrl;
+            dto.AvatarTexture ??= existing.AvatarTexture;
+            var existingBannerUrl = existing.BannerUrl;
+            if (string.IsNullOrWhiteSpace(dto.BannerUrl) && !string.IsNullOrWhiteSpace(existingBannerUrl))
+            {
+                dto.BannerUrl = existingBannerUrl;
+            }
+            else if (!string.IsNullOrWhiteSpace(dto.BannerUrl) && !string.IsNullOrWhiteSpace(existingBannerUrl) &&
+                     !string.Equals(dto.BannerUrl, existingBannerUrl, StringComparison.Ordinal))
+            {
+                dto.BannerTexture = null;
+            }
+            if (dto.BannerTexture == null && string.Equals(dto.BannerUrl, existingBannerUrl, StringComparison.Ordinal))
+            {
+                dto.BannerTexture = existing.BannerTexture;
+            }
+            if (!dto.AccentColorValue.HasValue && existing.AccentColorValue.HasValue)
+                dto.AccentColorValue = existing.AccentColorValue;
+            if (dto.Roles.Count == 0)
+                dto.Roles = existing.Roles;
+            if (dto.RoleDetails.Count == 0 && existing.RoleDetails.Count > 0)
+                dto.RoleDetails = existing.RoleDetails;
+            if (string.IsNullOrWhiteSpace(dto.StatusText) && !string.IsNullOrWhiteSpace(existing.StatusText))
+                dto.StatusText = existing.StatusText;
+            _presences[idx] = dto;
+        }
+        else
+        {
+            _presences.Add(dto);
         }
     }
 

--- a/DemiCatPlugin/PresenceDto.cs
+++ b/DemiCatPlugin/PresenceDto.cs
@@ -1,5 +1,6 @@
-using System.Text.Json.Serialization;
 using System.Collections.Generic;
+using System.Numerics;
+using System.Text.Json.Serialization;
 using Dalamud.Interface.Textures;
 
 namespace DemiCatPlugin;
@@ -12,6 +13,20 @@ public class PresenceDto
     [JsonPropertyName("status_text")] public string? StatusText { get; set; }
     [JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; }
     [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
+    [JsonPropertyName("banner_url")] public string? BannerUrl { get; set; }
+    [JsonIgnore] public ISharedImmediateTexture? BannerTexture { get; set; }
+    private uint? _accentColorValue;
+    [JsonPropertyName("accent_color")]
+    public uint? AccentColorValue
+    {
+        get => _accentColorValue;
+        set
+        {
+            _accentColorValue = value;
+            AccentColor = value.HasValue ? ColorUtils.RgbToVector4(value.Value) : null;
+        }
+    }
+    [JsonIgnore] public Vector4? AccentColor { get; private set; }
     [JsonPropertyName("roles")] public List<string> Roles { get; set; } = new();
     [JsonPropertyName("role_details")] public List<PresenceRoleDto> RoleDetails { get; set; } = new();
 }

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -244,12 +244,18 @@ public class PresenceSidebar : IDisposable
     private void DrawPresence(PresenceDto p)
     {
         ImGui.PushID(p.Id);
-        ImGui.BeginGroup();
+        var drawList = ImGui.GetWindowDrawList();
 
         const float rowHeight = 40f;
+        var backgroundMin = ImGui.GetCursorScreenPos();
+        var availableWidth = MathF.Max(0f, ImGui.GetContentRegionAvail().X);
+        var backgroundMax = new Vector2(backgroundMin.X + availableWidth, backgroundMin.Y + rowHeight);
+        DrawPresenceBackground(drawList, backgroundMin, backgroundMax, p);
+
+        ImGui.BeginGroup();
+
         var avatarSize = new Vector2(36f, 36f);
         var color = GetStatusColor(p.Status);
-        var drawList = ImGui.GetWindowDrawList();
 
         var groupStartY = ImGui.GetCursorPosY();
         var avatarOffsetY = MathF.Max(0f, (rowHeight - avatarSize.Y) * 0.5f);
@@ -357,6 +363,63 @@ public class PresenceSidebar : IDisposable
 
         ImGui.EndGroup();
         ImGui.PopID();
+    }
+
+    protected virtual void DrawPresenceBackground(ImDrawListPtr drawList, Vector2 min, Vector2 max, PresenceDto presence)
+    {
+        if (max.X <= min.X || max.Y <= min.Y)
+        {
+            if (TextureLoader != null && !string.IsNullOrEmpty(presence.BannerUrl) && presence.BannerTexture == null)
+            {
+                TextureLoader(presence.BannerUrl, t => presence.BannerTexture = t);
+            }
+            return;
+        }
+
+        var bannerDrawn = false;
+        if (presence.BannerTexture != null)
+        {
+            try
+            {
+                var wrap = presence.BannerTexture.GetWrapOrEmpty();
+                drawList.AddImage(wrap.Handle, min, max);
+                bannerDrawn = true;
+            }
+            catch (ObjectDisposedException)
+            {
+                presence.BannerTexture = null;
+            }
+        }
+
+        if (!bannerDrawn && TextureLoader != null && !string.IsNullOrEmpty(presence.BannerUrl) && presence.BannerTexture == null)
+        {
+            TextureLoader(presence.BannerUrl, t => presence.BannerTexture = t);
+        }
+
+        if (!bannerDrawn)
+        {
+            var gradient = presence.AccentColorValue.HasValue
+                ? ComputeAccentGradient(presence.AccentColorValue.Value)
+                : null;
+            if (gradient.HasValue)
+            {
+                var (top, bottom) = gradient.Value;
+                drawList.AddRectFilledMultiColor(min, max, top, top, bottom, bottom);
+            }
+        }
+    }
+
+    internal static (uint Top, uint Bottom)? ComputeAccentGradient(uint accentRgb)
+    {
+        var topRgb = ColorUtils.MixRgb(accentRgb, 0xFFFFFF, 0.35f);
+        var bottomRgb = ColorUtils.MixRgb(accentRgb, 0x000000, 0.45f);
+        var topColor = ColorUtils.RgbToImGui(topRgb);
+        var bottomColor = ColorUtils.RgbToImGui(bottomRgb);
+        if (topColor == bottomColor)
+        {
+            bottomColor = ColorUtils.RgbToImGui(ColorUtils.MixRgb(accentRgb, 0x000000, 0.6f));
+        }
+        return (topColor, bottomColor);
     }
 
     private static void DrawRoleBadge(ImDrawListPtr drawList, string text)

--- a/demibot/demibot/db/migrations/versions/0048_add_membership_banner_and_accent.py
+++ b/demibot/demibot/db/migrations/versions/0048_add_membership_banner_and_accent.py
@@ -1,0 +1,33 @@
+"""add membership banner and accent fields
+
+Revision ID: 0048_add_membership_banner_and_accent
+Revises: 0047_add_role_metadata_fields
+Create Date: 2025-03-15 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0048_add_membership_banner_and_accent"
+down_revision: str = "0047_add_role_metadata_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "memberships",
+        sa.Column("banner_url", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "memberships",
+        sa.Column("accent_color", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("memberships", "accent_color")
+    op.drop_column("memberships", "banner_url")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -170,6 +170,8 @@ class Membership(Base):
     user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), ForeignKey("users.id"))
     nickname: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     avatar_url: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    banner_url: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    accent_color: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
 
 class Role(Base):

--- a/demibot/demibot/discordbot/cogs/presence.py
+++ b/demibot/demibot/discordbot/cogs/presence.py
@@ -69,6 +69,43 @@ class PresenceTracker(commands.Cog):
         ]
         display_name = member.display_name or member.name
         avatar_url = str(member.display_avatar.url)
+        banner_url: str | None = None
+        banner_asset = getattr(member, "banner", None)
+        if banner_asset is not None:
+            asset_url = getattr(banner_asset, "url", None)
+            banner_url = str(asset_url or banner_asset)
+
+        def _extract_accent(value: object | None) -> int | None:
+            if value is None:
+                return None
+            raw = getattr(value, "value", None)
+            if isinstance(raw, int):
+                return raw
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+
+        accent_color_value = _extract_accent(getattr(member, "accent_color", None))
+
+        if banner_url is None or accent_color_value is None:
+            fallback_user: discord.abc.User | None = self.bot.get_user(member.id)
+            if fallback_user is None:
+                try:
+                    fallback_user = await self.bot.fetch_user(member.id)
+                except Exception:
+                    fallback_user = None
+            if fallback_user is not None:
+                if banner_url is None:
+                    fb_banner = getattr(fallback_user, "banner", None)
+                    if fb_banner is not None:
+                        asset_url = getattr(fb_banner, "url", None)
+                        banner_url = str(asset_url or fb_banner)
+                if accent_color_value is None:
+                    accent_color_value = _extract_accent(
+                        getattr(fallback_user, "accent_color", None)
+                    )
+
         status_text = self._status_text(member)
         data = StorePresence(
             id=member.id,
@@ -77,6 +114,8 @@ class PresenceTracker(commands.Cog):
             avatar_url=avatar_url,
             roles=role_ids,
             status_text=status_text,
+            banner_url=banner_url,
+            accent_color=accent_color_value,
         )
         set_presence(member.guild.id, data)
         async with get_session() as db:
@@ -130,6 +169,8 @@ class PresenceTracker(commands.Cog):
                 db.add(mem)
             mem.nickname = display_name
             mem.avatar_url = avatar_url
+            mem.banner_url = banner_url
+            mem.accent_color = accent_color_value
 
             cfg_res = await db.execute(
                 select(GuildConfig).where(GuildConfig.guild_id == guild_row.id)
@@ -213,6 +254,8 @@ class PresenceTracker(commands.Cog):
             "roles": [str(r) for r in role_ids],
             "status_text": data.status_text,
             "role_details": role_details,
+            "banner_url": banner_url,
+            "accent_color": accent_color_value,
         }
 
     @commands.Cog.listener()

--- a/demibot/demibot/discordbot/presence_store.py
+++ b/demibot/demibot/discordbot/presence_store.py
@@ -12,6 +12,8 @@ class Presence:
     avatar_url: str | None = None
     roles: list[int] = field(default_factory=list)
     status_text: str | None = None
+    banner_url: str | None = None
+    accent_color: int | None = None
 
 
 _presences: Dict[int, Dict[int, Presence]] = {}
@@ -25,6 +27,10 @@ def set_presence(guild_id: int, presence: Presence) -> None:
             presence.avatar_url = existing.avatar_url
         if presence.status_text is None:
             presence.status_text = existing.status_text
+        if presence.banner_url is None:
+            presence.banner_url = existing.banner_url
+        if presence.accent_color is None:
+            presence.accent_color = existing.accent_color
     guild[presence.id] = presence
 
 

--- a/demibot/demibot/http/routes/presences.py
+++ b/demibot/demibot/http/routes/presences.py
@@ -45,6 +45,8 @@ async def list_presences(
                     User,
                     Role.discord_role_id,
                     Role.name,
+                    Membership.banner_url,
+                    Membership.accent_color,
                 )
                 .join(User, User.discord_user_id == DbPresence.user_id, isouter=True)
                 .join(
@@ -76,18 +78,20 @@ async def list_presences(
                             for r in guild.roles
                             if r.name != "@everyone"
                         }
-                    for p, _, _, _ in rows:
+                    for p, _, _, _, _, _ in rows:
                         member = guild.get_member(p.user_id) if guild else None
                         if member and member.display_avatar:
                             avatars[p.user_id] = str(member.display_avatar.url)
                 user_map: dict[int, dict[str, object]] = {}
-                for p, u, rid, role_name in rows:
+                for p, u, rid, role_name, banner, accent in rows:
                     entry = user_map.setdefault(
                         p.user_id,
                         {
                             "presence": p,
                             "user": u,
                             "roles": {},
+                            "banner": banner,
+                            "accent_color": accent,
                         },
                     )
                     if rid is not None:
@@ -97,7 +101,7 @@ async def list_presences(
                         else:
                             roles_dict.setdefault(rid, None)
                 db_presences = []
-                for data in user_map.values():
+                for uid, data in user_map.items():
                     p = data["presence"]  # type: ignore[assignment]
                     u = data["user"]  # type: ignore[assignment]
                     raw_status = getattr(p, "status", None)
@@ -119,6 +123,8 @@ async def list_presences(
                             "roles": [str(rid) for rid in role_map],
                             "status_text": getattr(p, "status_text", None),
                             "role_details": role_details,
+                            "banner_url": data.get("banner"),
+                            "accent_color": data.get("accent_color"),
                         }
                     )
     except RuntimeError:
@@ -150,6 +156,8 @@ async def list_presences(
                 }
                 for rid in p.roles
             ],
+            "banner_url": p.banner_url,
+            "accent_color": p.accent_color,
         }
         for p in presences
     ]

--- a/demibot/demibot/http/routes/users.py
+++ b/demibot/demibot/http/routes/users.py
@@ -62,6 +62,8 @@ async def get_users(
             Role.discord_role_id,
             Role.name,
             Membership.avatar_url,
+            Membership.banner_url,
+            Membership.accent_color,
         )
         .join(Membership, Membership.user_id == User.id)
         .join(
@@ -85,7 +87,7 @@ async def get_users(
     cache = {p.id: p for p in get_presences(ctx.guild.id)}
 
     user_map: dict[int, dict[str, object]] = {}
-    for u, n, s, st, rid, role_name, avatar in rows:
+    for u, n, s, st, rid, role_name, avatar, banner, accent in rows:
         entry = user_map.setdefault(
             u.discord_user_id,
             {
@@ -95,6 +97,8 @@ async def get_users(
                 "status_text": st,
                 "roles": {},
                 "avatar": avatar,
+                "banner": banner,
+                "accent_color": accent,
             },
         )
         if entry["status"] is None and s is not None:
@@ -105,6 +109,10 @@ async def get_users(
             entry["nickname"] = n
         if entry["avatar"] is None and avatar is not None:
             entry["avatar"] = avatar
+        if entry["banner"] is None and banner is not None:
+            entry["banner"] = banner
+        if entry["accent_color"] is None and accent is not None:
+            entry["accent_color"] = accent
         if rid is not None:
             roles_dict = entry["roles"]  # type: ignore[assignment]
             if role_name is not None:
@@ -116,6 +124,10 @@ async def get_users(
         presence = cache.get(uid)
         if presence and presence.avatar_url and not data.get("avatar"):
             data["avatar"] = presence.avatar_url
+        if presence and presence.banner_url and not data.get("banner"):
+            data["banner"] = presence.banner_url
+        if presence and presence.accent_color is not None and data.get("accent_color") is None:
+            data["accent_color"] = presence.accent_color
 
     avatars: dict[int, str] = {}
     for uid, data in user_map.items():
@@ -223,6 +235,8 @@ async def get_users(
                 "roles": role_ids,
                 "status_text": status_text,
                 "role_details": role_details,
+                "banner_url": data.get("banner"),
+                "accent_color": data.get("accent_color"),
             }
         )
     return users

--- a/tests/ColorConversionTests.cs
+++ b/tests/ColorConversionTests.cs
@@ -54,6 +54,31 @@ public class ColorConversionTests
         Assert.Equal(rgb, back);
     }
 
+    [Theory]
+    [InlineData(0x123456)]
+    [InlineData(0xABCDEF)]
+    [InlineData(0x000000)]
+    [InlineData(0xFFFFFF)]
+    public void RgbToVector4MatchesComponents(uint rgb)
+    {
+        var vec = ColorUtils.RgbToVector4(rgb);
+        Assert.Equal(((rgb >> 16) & 0xFF) / 255f, vec.X, 5);
+        Assert.Equal(((rgb >> 8) & 0xFF) / 255f, vec.Y, 5);
+        Assert.Equal((rgb & 0xFF) / 255f, vec.Z, 5);
+        Assert.Equal(1f, vec.W, 5);
+    }
+
+    [Theory]
+    [InlineData(0x000000, 0xFFFFFF, 0f, 0x000000)]
+    [InlineData(0x000000, 0xFFFFFF, 1f, 0xFFFFFF)]
+    [InlineData(0x000000, 0xFFFFFF, 0.5f, 0x808080)]
+    [InlineData(0x123456, 0x654321, 0.25f, 0x273849)]
+    public void MixRgbInterpolates(uint source, uint target, float amount, uint expected)
+    {
+        var result = ColorUtils.MixRgb(source, target, amount);
+        Assert.Equal(expected, result);
+    }
+
     private class StubHandler : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/tests/DiscordPresenceServiceTests.cs
+++ b/tests/DiscordPresenceServiceTests.cs
@@ -7,7 +7,9 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using DemiCatPlugin;
+using Dalamud.Interface.Textures;
 using Dalamud.Plugin.Services;
+using Moq;
 using Xunit;
 
 public class DiscordPresenceServiceTests
@@ -342,6 +344,88 @@ public class DiscordPresenceServiceTests
             var instanceProp = typeof(TokenManager).GetProperty("Instance", BindingFlags.Static | BindingFlags.Public)!;
             instanceProp.GetSetMethod(true)!.Invoke(null, new object?[] { previousToken });
         }
+    }
+
+    [Fact]
+    public void ApplyPresenceUpdate_PreservesExistingVisuals()
+    {
+        var config = new Config { ApiBaseUrl = "http://unit-test" };
+        using var httpClient = new HttpClient(new StubPresenceHandler());
+        var service = new DiscordPresenceService(config, httpClient);
+
+        var field = typeof(DiscordPresenceService).GetField("_presences", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (List<PresenceDto>)field.GetValue(service)!;
+
+        var existingTexture = Mock.Of<ISharedImmediateTexture>();
+        var existing = new PresenceDto
+        {
+            Id = "42",
+            Name = "Existing",
+            Status = "online",
+            AvatarUrl = "https://example.com/avatar.png",
+            BannerUrl = "https://example.com/banner.png",
+            StatusText = "Hello"
+        };
+        existing.BannerTexture = existingTexture;
+        existing.AccentColorValue = 0x112233;
+        existing.Roles.Add("1");
+        existing.RoleDetails.Add(new PresenceRoleDto { Id = "1", Name = "Role" });
+        list.Add(existing);
+
+        var update = new PresenceDto
+        {
+            Id = "42",
+            Name = "Existing",
+            Status = "online",
+        };
+
+        service.ApplyPresenceUpdate(update);
+
+        Assert.Single(list);
+        var updated = list[0];
+        Assert.Equal("https://example.com/avatar.png", updated.AvatarUrl);
+        Assert.Equal("https://example.com/banner.png", updated.BannerUrl);
+        Assert.Same(existingTexture, updated.BannerTexture);
+        Assert.Equal((uint)0x112233, updated.AccentColorValue);
+        Assert.Equal("Hello", updated.StatusText);
+        Assert.Equal(existing.Roles, updated.Roles);
+        Assert.Equal(existing.RoleDetails, updated.RoleDetails);
+    }
+
+    [Fact]
+    public void ApplyPresenceUpdate_NewBannerClearsOldTexture()
+    {
+        var config = new Config { ApiBaseUrl = "http://unit-test" };
+        using var httpClient = new HttpClient(new StubPresenceHandler());
+        var service = new DiscordPresenceService(config, httpClient);
+
+        var field = typeof(DiscordPresenceService).GetField("_presences", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (List<PresenceDto>)field.GetValue(service)!;
+
+        var existingTexture = Mock.Of<ISharedImmediateTexture>();
+        var existing = new PresenceDto
+        {
+            Id = "43",
+            Name = "Existing",
+            Status = "online",
+            BannerUrl = "https://example.com/old.png"
+        };
+        existing.BannerTexture = existingTexture;
+        list.Add(existing);
+
+        var update = new PresenceDto
+        {
+            Id = "43",
+            Name = "Existing",
+            Status = "online",
+            BannerUrl = "https://example.com/new.png"
+        };
+
+        service.ApplyPresenceUpdate(update);
+
+        var updated = list[0];
+        Assert.Equal("https://example.com/new.png", updated.BannerUrl);
+        Assert.Null(updated.BannerTexture);
     }
 
     private static void ConfigurePluginServices(PluginServices services, IFramework framework, IPluginLog log)

--- a/tests/PresenceSidebarTests.cs
+++ b/tests/PresenceSidebarTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Net.Http;
+using System.Numerics;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DemiCatPlugin;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Textures;
+using Moq;
+using Xunit;
+
+public class PresenceSidebarTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+    }
+
+    private sealed class ImGuiContextScope : IDisposable
+    {
+        public ImGuiContextScope()
+        {
+            ImGui.CreateContext();
+            var io = ImGui.GetIO();
+            io.DisplaySize = new Vector2(800f, 600f);
+        }
+
+        public void BeginFrame()
+        {
+            ImGui.NewFrame();
+            ImGui.Begin("test", ImGuiWindowFlags.NoSavedSettings);
+        }
+
+        public void EndFrame()
+        {
+            ImGui.End();
+            ImGui.Render();
+        }
+
+        public void Dispose()
+        {
+            ImGui.DestroyContext();
+        }
+    }
+
+    private static PresenceSidebar CreateSidebar()
+    {
+        var config = new Config();
+        var httpClient = new HttpClient(new StubHandler());
+        var service = new DiscordPresenceService(config, httpClient);
+        return new PresenceSidebar(service);
+    }
+
+    private static void InvokeDrawPresence(PresenceSidebar sidebar, PresenceDto presence)
+    {
+        var method = typeof(PresenceSidebar).GetMethod("DrawPresence", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        method.Invoke(sidebar, new object[] { presence });
+    }
+
+    [Fact]
+    public void DrawPresence_LoadsBannerTextureWhenMissing()
+    {
+        using var scope = new ImGuiContextScope();
+        var sidebar = CreateSidebar();
+        var presence = new PresenceDto
+        {
+            Id = "1",
+            Name = "Tester",
+            Status = "online",
+            BannerUrl = "https://example.com/banner.png"
+        };
+
+        var texture = Mock.Of<ISharedImmediateTexture>();
+        var loaderCalled = false;
+        sidebar.TextureLoader = (url, assign) =>
+        {
+            loaderCalled = true;
+            assign(texture);
+        };
+
+        scope.BeginFrame();
+        InvokeDrawPresence(sidebar, presence);
+        scope.EndFrame();
+
+        Assert.True(loaderCalled);
+        Assert.Same(texture, presence.BannerTexture);
+    }
+
+    [Fact]
+    public void DrawPresence_DoesNotRequestBannerWithoutUrl()
+    {
+        using var scope = new ImGuiContextScope();
+        var sidebar = CreateSidebar();
+        var presence = new PresenceDto
+        {
+            Id = "2",
+            Name = "NoBanner",
+            Status = "online",
+        };
+        presence.AccentColorValue = 0x336699;
+
+        var loaderCalled = false;
+        sidebar.TextureLoader = (url, assign) => loaderCalled = true;
+
+        scope.BeginFrame();
+        InvokeDrawPresence(sidebar, presence);
+        scope.EndFrame();
+
+        Assert.False(loaderCalled);
+    }
+
+    [Fact]
+    public void ComputeAccentGradient_ReturnsDistinctColors()
+    {
+        var gradient = PresenceSidebar.ComputeAccentGradient(0x336699);
+        Assert.True(gradient.HasValue);
+        var (top, bottom) = gradient.Value;
+        Assert.NotEqual(top, bottom);
+    }
+}

--- a/tests/test_presences.py
+++ b/tests/test_presences.py
@@ -68,6 +68,8 @@ def test_list_presences_returns_data():
                 avatar_url="https://example.com/a.png",
                 roles=[100],
                 status_text="Working",
+                banner_url="https://example.com/a-banner.png",
+                accent_color=0x123456,
             ),
         )
         set_presence(
@@ -79,6 +81,8 @@ def test_list_presences_returns_data():
                 avatar_url="https://example.com/b.png",
                 roles=[],
                 status_text=None,
+                banner_url=None,
+                accent_color=None,
             ),
         )
         ctx = StubContext(1)
@@ -90,10 +94,14 @@ def test_list_presences_returns_data():
         assert data["10"]["role_details"] == [
             {"id": "100", "name": "100"}
         ]
+        assert data["10"]["banner_url"] == "https://example.com/a-banner.png"
+        assert data["10"]["accent_color"] == 0x123456
         assert data["20"]["status"] == "offline"
         assert data["20"]["status_text"] is None
         assert data["20"]["roles"] == []
         assert data["20"]["role_details"] == []
+        assert data["20"]["banner_url"] is None
+        assert data["20"]["accent_color"] is None
 
     asyncio.run(_run())
 
@@ -116,6 +124,10 @@ def test_list_presences_reads_from_db():
         assert data["10"]["status"] == "online"
         assert data["10"]["status_text"] is None
         assert data["10"]["roles"] == []
+        assert data["10"]["banner_url"] is None
+        assert data["10"]["accent_color"] is None
         assert data["20"]["status"] == "offline"
         assert data["20"]["status_text"] is None
+        assert data["20"]["banner_url"] is None
+        assert data["20"]["accent_color"] is None
     asyncio.run(_run())

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -56,6 +56,17 @@ def _header(default=None, *args, **kwargs):
     return default
 
 
+class WebSocketDisconnect(Exception):
+    pass
+
+
+class WebSocket:
+    scope: dict[str, object]
+
+    def __init__(self):
+        self.scope = {}
+
+
 class HTTPException(Exception):
     def __init__(self, status_code: int, detail: str | None = None):
         super().__init__(detail)
@@ -81,6 +92,8 @@ fastapi_pkg.Header = _header
 fastapi_pkg.HTTPException = HTTPException
 fastapi_pkg.status = _StatusModule()
 fastapi_pkg.Request = Request
+fastapi_pkg.WebSocket = WebSocket
+fastapi_pkg.WebSocketDisconnect = WebSocketDisconnect
 sys.modules.setdefault('fastapi', fastapi_pkg)
 
 from demibot.http.routes.users import get_users, get_my_profile, get_me
@@ -128,6 +141,8 @@ def test_get_users_includes_status_from_cache():
                     status='online',
                     status_text='Working',
                     roles=[100],
+                    banner_url='https://example.com/banner.png',
+                    accent_color=0x112233,
                 ),
             )
             set_presence(1, StorePresence(id=20, name='Bob', status='offline'))
@@ -138,9 +153,13 @@ def test_get_users_includes_status_from_cache():
             assert data['10']['status_text'] == 'Working'
             assert tuple(data['10']['roles']) == ('100',)
             assert data['10']['role_details'] == [{'id': '100', 'name': 'Officer'}]
+            assert data['10']['banner_url'] == 'https://example.com/banner.png'
+            assert data['10']['accent_color'] == 0x112233
             assert data['20']['status'] == 'offline'
             assert data['20']['status_text'] is None
             assert tuple(data['20']['roles']) == ()
+            assert data['20']['banner_url'] is None
+            assert data['20']['accent_color'] is None
     asyncio.run(_run())
 
 
@@ -173,6 +192,8 @@ def test_get_users_uses_cached_avatars_without_discord():
                     name='PresenceUser',
                     status='online',
                     avatar_url='https://example.com/presence.png',
+                    banner_url='https://example.com/presence-banner.png',
+                    accent_color=0x445566,
                 ),
             )
             users_route.discord_client = None
@@ -181,6 +202,9 @@ def test_get_users_uses_cached_avatars_without_discord():
             data = {u['id']: u for u in res}
             assert data['110']['avatar_url'] == 'https://example.com/avatar.png'
             assert data['120']['avatar_url'] == 'https://example.com/presence.png'
+            assert data['110']['banner_url'] is None
+            assert data['120']['banner_url'] == 'https://example.com/presence-banner.png'
+            assert data['120']['accent_color'] == 0x445566
 
     asyncio.run(_run())
 
@@ -208,6 +232,10 @@ def test_get_users_reads_presence_from_db():
             assert data['30']['status'] == 'idle'
             assert data['30']['status_text'] == 'Away'
             assert data['40']['status'] == 'dnd'
+            assert data['30']['banner_url'] is None
+            assert data['40']['banner_url'] is None
+            assert data['30']['accent_color'] is None
+            assert data['40']['accent_color'] is None
     asyncio.run(_run())
 
 


### PR DESCRIPTION
## Summary
- add a migration and ORM columns for membership banner URLs and accent colors【F:demibot/demibot/db/migrations/versions/0048_add_membership_banner_and_accent.py†L1-L33】【F:demibot/demibot/db/models.py†L170-L174】
- persist Discord banner/accent data in the presence tracker and expose them through cached APIs【F:demibot/demibot/discordbot/cogs/presence.py†L70-L173】【F:demibot/demibot/discordbot/presence_store.py†L7-L34】【F:demibot/demibot/http/routes/users.py†L60-L241】【F:demibot/demibot/http/routes/presences.py†L35-L162】
- extend the plugin presence DTO/service and sidebar renderer to support banners, gradients, and accent-aware colors, with updated helpers and tests【F:DemiCatPlugin/PresenceDto.cs†L1-L32】【F:DemiCatPlugin/DiscordPresenceService.cs†L351-L434】【F:DemiCatPlugin/PresenceSidebar.cs†L244-L423】【F:DemiCatPlugin/ColorUtils.cs†L1-L69】【F:tests/PresenceSidebarTests.cs†L1-L122】【F:tests/DiscordPresenceServiceTests.cs†L349-L429】【F:tests/ColorConversionTests.cs†L57-L105】
- verify the new fields through expanded API tests for users and presences【F:tests/test_users.py†L120-L206】【F:tests/test_presences.py†L55-L132】

## Testing
- `pytest tests/test_users.py tests/test_presences.py`【21e9b7†L1-L12】
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: dotnet command unavailable in container)*【4aa48f†L1-L2】

------
https://chatgpt.com/codex/tasks/task_e_68d5e6b933208328a8022bb366ee01f7