### PR TITLE
Align chat auto-scroll to bottom

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -669,8 +669,11 @@ public class ChatWindow : IDisposable
 
         if (shouldAutoScroll)
         {
-            ImGui.Dummy(Vector2.Zero);
-            ImGui.SetScrollHereY(1f);
+            var maxScrollY = ImGui.GetScrollMaxY();
+            if (maxScrollY > 0f)
+            {
+                ImGui.SetScrollY(maxScrollY);
+            }
             _pendingInitialScroll = false;
         }
 


### PR DESCRIPTION
## Summary
- replace the chat auto-scroll placeholder with logic that sets the view to the maximum Y position so new messages are aligned to the bottom

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6779e6bac8328a9f9abe226f2bc2e