### PR TITLE
Add separators between chat messages

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -662,6 +662,11 @@ public class ChatWindow : IDisposable
                     ImGui.EndPopup();
                 }
 
+                if (i < _messages.Count - 1)
+                {
+                    ImGui.Separator();
+                }
+
                 ImGui.PopID();
             }
         }


### PR DESCRIPTION
## Summary
- insert an ImGui separator between chat messages so each message group has visible spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67c31fad88328bd792a8b838bd944