### PR TITLE
Implement caret-aware emoji insertion

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -82,6 +82,7 @@ public class ChatWindow : IDisposable
     private float _chatTopPadding;
     private int _selectionStart;
     private int _selectionEnd;
+    private bool _focusComposerNextFrame;
     private BridgeMessageFormatter.BridgeFormattedMessage _previewMessage = BridgeMessageFormatter.BridgeFormattedMessage.Empty;
     private string _previewKey = string.Empty;
     private readonly Dictionary<string, ISharedImmediateTexture?> _attachmentPreviewTextures = new(StringComparer.OrdinalIgnoreCase);
@@ -631,8 +632,7 @@ public class ChatWindow : IDisposable
                         ImGui.SameLine();
                     }
                     ImGui.NewLine();
-                    var pick = string.Empty;
-                    _emojiPicker.Draw(ref pick);
+                    var pick = _emojiPicker.Draw();
                     if (!string.IsNullOrEmpty(pick))
                     {
                         _ = React(msg.Id, pick, false);
@@ -885,6 +885,11 @@ public class ChatWindow : IDisposable
         var newlineCount = string.IsNullOrEmpty(_input) ? 1 : _input.Count(c => c == '\n') + 1;
         var lineCount = Math.Clamp(Math.Max(newlineCount, wrapLineCount), MinInputLines, MaxInputLines);
         var inputHeight = lineCount * lineHeight + style.FramePadding.Y * 2f;
+        if (_focusComposerNextFrame)
+        {
+            ImGui.SetKeyboardFocusHere();
+            _focusComposerNextFrame = false;
+        }
         _ = ImGui.InputTextMultiline(
             "##chatInput",
             inputBuf,
@@ -931,7 +936,12 @@ public class ChatWindow : IDisposable
         }
         if (ImGui.BeginPopup("##dc_emoji_picker"))
         {
-            _emojiPicker.Draw(ref _input);
+            var inserted = _emojiPicker.Draw();
+            if (!string.IsNullOrEmpty(inserted))
+            {
+                InsertTextAtSelection(inserted);
+                ImGui.CloseCurrentPopup();
+            }
             ImGui.EndPopup();
         }
 
@@ -1251,6 +1261,38 @@ public class ChatWindow : IDisposable
         var input = _input;
         MarkdownSelectionHelper.WrapSelection(ref input, prefix, suffix, ref _selectionStart, ref _selectionEnd);
         _input = input ?? string.Empty;
+    }
+
+    private void InsertTextAtSelection(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        var value = _input ?? string.Empty;
+        var start = Math.Min(_selectionStart, _selectionEnd);
+        var end = Math.Max(_selectionStart, _selectionEnd);
+        start = Math.Clamp(start, 0, value.Length);
+        end = Math.Clamp(end, 0, value.Length);
+
+        var builder = new StringBuilder(value.Length + text.Length);
+        if (start > 0)
+        {
+            builder.Append(value.AsSpan(0, start));
+        }
+
+        builder.Append(text);
+
+        if (end < value.Length)
+        {
+            builder.Append(value.AsSpan(end));
+        }
+
+        _input = builder.ToString();
+        var caret = start + text.Length;
+        _selectionStart = _selectionEnd = caret;
+        _focusComposerNextFrame = true;
     }
 
     private void InvalidatePreview()

--- a/DemiCatPlugin/Emoji/EmojiFormatter.cs
+++ b/DemiCatPlugin/Emoji/EmojiFormatter.cs
@@ -7,21 +7,11 @@ public static class EmojiFormatter
     public const string CustomPrefix = "custom:";
     private const string DefaultCustomName = "emoji";
 
-    public static void InsertUnicode(ref string target, UnicodeEmoji emoji)
-        => InsertUnicode(ref target, emoji.Emoji);
+    public static string CreateUnicodeToken(UnicodeEmoji emoji) => CreateUnicodeToken(emoji.Emoji);
 
-    public static void InsertUnicode(ref string target, string emoji)
-    {
-        if (string.IsNullOrEmpty(emoji))
-        {
-            return;
-        }
+    public static string CreateUnicodeToken(string emoji) => string.IsNullOrEmpty(emoji) ? string.Empty : emoji;
 
-        target += emoji;
-    }
-
-    public static void InsertCustom(ref string target, CustomEmoji emoji)
-        => target += CreateCustomToken(emoji.Id);
+    public static string CreateCustomToken(CustomEmoji emoji) => CreateCustomToken(emoji.Id);
 
     public static string CreateCustomToken(string id) => string.Concat(CustomPrefix, id);
 

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -19,22 +19,23 @@ public sealed class EmojiPicker
 
     public EmojiPicker(EmojiManager manager) => _manager = manager;
 
-    public void Draw(ref string targetText, float buttonSize = 28f)
+    public string? Draw(float buttonSize = 28f)
     {
         var previous = _tab;
+        string? selected = null;
         if (ImGui.BeginTabBar("##dc_emoji_tabs"))
         {
             if (ImGui.BeginTabItem("Standard"))
             {
                 _tab = EmojiTab.Standard;
-                DrawStandard(ref targetText, buttonSize);
+                selected = DrawStandard(buttonSize);
                 ImGui.EndTabItem();
             }
 
             if (ImGui.BeginTabItem("Custom"))
             {
                 _tab = EmojiTab.Custom;
-                DrawCustom(ref targetText, buttonSize);
+                selected ??= DrawCustom(buttonSize);
                 ImGui.EndTabItem();
             }
 
@@ -45,9 +46,11 @@ public sealed class EmojiPicker
         {
             _search = string.Empty;
         }
+
+        return string.IsNullOrEmpty(selected) ? null : selected;
     }
 
-    private void DrawStandard(ref string targetText, float size)
+    private string? DrawStandard(float size)
     {
         ImGui.InputTextWithHint("##emoji_std_search", "Search…", ref _search, 64);
         ImGui.Separator();
@@ -55,7 +58,7 @@ public sealed class EmojiPicker
         if (!_manager.CanLoadStandard)
         {
             ImGui.TextDisabled("Link DemiCat to load emoji.");
-            return;
+            return null;
         }
 
         _ = _manager.EnsureUnicodeAsync();
@@ -92,13 +95,14 @@ public sealed class EmojiPicker
             {
                 ImGui.TextDisabled(string.IsNullOrWhiteSpace(_search) ? "No emoji available." : "No matches.");
             }
-            return;
+            return null;
         }
 
         ImGui.BeginChild("##emoji_std_grid", new Vector2(0, 220f), false);
         var avail = ImGui.GetContentRegionAvail().X;
         var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (size + 4f)));
         var column = 0;
+        string? selected = null;
 
         for (var i = 0; i < filtered.Count; i++)
         {
@@ -113,7 +117,7 @@ public sealed class EmojiPicker
             using var _ = _manager.PushEmojiFont();
             if (ImGui.Button(emoji.Emoji, new Vector2(size, size)))
             {
-                EmojiFormatter.InsertUnicode(ref targetText, emoji);
+                selected = EmojiFormatter.CreateUnicodeToken(emoji);
             }
             if (!string.IsNullOrEmpty(emoji.Name) && ImGui.IsItemHovered())
             {
@@ -126,12 +130,18 @@ public sealed class EmojiPicker
             {
                 ImGui.SameLine();
             }
+
+            if (!string.IsNullOrEmpty(selected))
+            {
+                break;
+            }
         }
 
         ImGui.EndChild();
+        return string.IsNullOrEmpty(selected) ? null : selected;
     }
 
-    private void DrawCustom(ref string targetText, float size)
+    private string? DrawCustom(float size)
     {
         ImGui.InputTextWithHint("##emoji_custom_search", "Search :name:", ref _search, 64);
         ImGui.SameLine();
@@ -147,7 +157,7 @@ public sealed class EmojiPicker
         if (!canLoad)
         {
             ImGui.TextDisabled("Set GuildId in config to enable server emoji.");
-            return;
+            return null;
         }
 
         _ = _manager.EnsureCustomAsync();
@@ -182,13 +192,14 @@ public sealed class EmojiPicker
             {
                 ImGui.TextDisabled(string.IsNullOrWhiteSpace(_search) ? "No server emoji found." : "No matches.");
             }
-            return;
+            return null;
         }
 
         ImGui.BeginChild("##emoji_custom_grid", new Vector2(0, 220f), false);
         var avail = ImGui.GetContentRegionAvail().X;
         var columns = Math.Max(1, (int)Math.Floor((avail + 6f) / (size + 6f)));
         var column = 0;
+        string? selected = null;
 
         foreach (var emoji in items)
         {
@@ -227,7 +238,7 @@ public sealed class EmojiPicker
 
             if (clicked)
             {
-                EmojiFormatter.InsertCustom(ref targetText, emoji);
+                selected = EmojiFormatter.CreateCustomToken(emoji);
             }
 
             column++;
@@ -235,9 +246,15 @@ public sealed class EmojiPicker
             {
                 ImGui.SameLine();
             }
+
+            if (!string.IsNullOrEmpty(selected))
+            {
+                break;
+            }
         }
 
         ImGui.EndChild();
+        return string.IsNullOrEmpty(selected) ? null : selected;
     }
 
     private static void DrawError(string message)

--- a/DemiCatPlugin/Emoji/EmojiPopup.cs
+++ b/DemiCatPlugin/Emoji/EmojiPopup.cs
@@ -28,8 +28,7 @@ public sealed class EmojiPopup
             return;
         }
 
-        var selected = string.Empty;
-        _picker.Draw(ref selected);
+        var selected = _picker.Draw();
         if (!string.IsNullOrEmpty(selected))
         {
             _onSelected?.Invoke(selected);

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -28,6 +28,7 @@ public class EventCreateWindow
     private string _description = string.Empty;
     private int _descriptionSelectionStart;
     private int _descriptionSelectionEnd;
+    private bool _focusDescriptionNextFrame;
     private string _time = DateTime.UtcNow.ToString("O");
     private string _imageUrl = string.Empty;
     private string _url = string.Empty;
@@ -37,6 +38,7 @@ public class EventCreateWindow
     private string? _lastResult;
     private readonly List<Template.TemplateButton> _buttons = new();
     private readonly SignupOptionEditor _optionEditor;
+    private readonly EmojiPopup _descriptionEmojiPopup;
     private int _editingButtonIndex = -1;
     private int _selectedPreset = -1;
     private string _presetName = string.Empty;
@@ -70,6 +72,7 @@ public class EventCreateWindow
         _emojiManager = emojiManager;
         _channelSelection = channelSelection;
         _optionEditor = new SignupOptionEditor(config, httpClient, emojiManager);
+        _descriptionEmojiPopup = new EmojiPopup(emojiManager, "EventDescriptionEmoji");
         ResetDefaultButtons();
         _channelSelection.ChannelChanged += HandleChannelChanged;
     }
@@ -184,11 +187,24 @@ public class EventCreateWindow
                     if (ImGui.SmallButton("Spoiler##descSpoiler")) WrapDescription("||", "||");
                     ImGui.SameLine();
                     if (ImGui.SmallButton("Link##descLink")) WrapDescription("[", "](url)");
+                    ImGui.SameLine();
+                    using (var emojiFont = _emojiManager.PushEmojiFont())
+                    {
+                        if (ImGui.SmallButton("😊##descEmoji"))
+                        {
+                            _descriptionEmojiPopup.Open(InsertDescriptionText);
+                        }
+                    }
                     ImGui.Spacing();
 
                     var avail = ImGui.GetContentRegionAvail();
                     var descHeight = ImGui.GetTextLineHeight() * 6f;
                     var descBuf = ImGuiTextUtil.MakeUtf8Buffer(_description, 4096);
+                    if (_focusDescriptionNextFrame)
+                    {
+                        ImGui.SetKeyboardFocusHere();
+                        _focusDescriptionNextFrame = false;
+                    }
                     ImGui.InputTextMultiline(
                         "##Description",
                         descBuf,
@@ -197,6 +213,7 @@ public class EventCreateWindow
                         new ImGui.ImGuiInputTextCallbackDelegate(OnDescriptionEdited)
                     );
                     _description = ImGuiTextUtil.ReadUtf8Buffer(descBuf);
+                    _descriptionEmojiPopup.Draw();
                 },
                 alignLabel: false,
                 setFullWidth: false);
@@ -847,6 +864,38 @@ public class EventCreateWindow
         var description = _description;
         MarkdownSelectionHelper.WrapSelection(ref description, prefix, suffix, ref _descriptionSelectionStart, ref _descriptionSelectionEnd);
         _description = description ?? string.Empty;
+    }
+
+    private void InsertDescriptionText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        var value = _description ?? string.Empty;
+        var start = Math.Min(_descriptionSelectionStart, _descriptionSelectionEnd);
+        var end = Math.Max(_descriptionSelectionStart, _descriptionSelectionEnd);
+        start = Math.Clamp(start, 0, value.Length);
+        end = Math.Clamp(end, 0, value.Length);
+
+        var builder = new StringBuilder(value.Length + text.Length);
+        if (start > 0)
+        {
+            builder.Append(value.AsSpan(0, start));
+        }
+
+        builder.Append(text);
+
+        if (end < value.Length)
+        {
+            builder.Append(value.AsSpan(end));
+        }
+
+        _description = builder.ToString();
+        var caret = start + text.Length;
+        _descriptionSelectionStart = _descriptionSelectionEnd = caret;
+        _focusDescriptionNextFrame = true;
     }
 
     private int OnDescriptionEdited(ref ImGuiInputTextCallbackData data)

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -3,6 +3,7 @@ using Dalamud.Bindings.ImGui;
 using DiscordHelper;
 using System.Numerics;
 using System.Net.Http;
+using System.Text;
 using DemiCat.UI;
 using DemiCatPlugin.Emoji;
 
@@ -15,6 +16,9 @@ public class SignupOptionEditor
     private Action<Template.TemplateButton>? _onSave;
     private readonly EmojiPopup _emojiPopup;
     private readonly EmojiManager _emojiManager;
+    private int _emojiSelectionStart;
+    private int _emojiSelectionEnd;
+    private bool _focusEmojiNextFrame;
 
     public SignupOptionEditor(Config config, HttpClient httpClient, EmojiManager emojiManager)
     {
@@ -35,6 +39,8 @@ public class SignupOptionEditor
             MaxSignups = button.MaxSignups,
             Width = button.Width
         };
+        _emojiSelectionStart = _emojiSelectionEnd = _working.Emoji?.Length ?? 0;
+        _focusEmojiNextFrame = false;
         _onSave = onSave;
         _open = true;
     }
@@ -52,13 +58,30 @@ public class SignupOptionEditor
             var label = _working.Label;
             if (ImGui.InputText("Label", ref label, 64))
                 _working.Label = label;
-            var emoji = _working.Emoji;
-            if (ImGui.InputText("Emoji", ref emoji, 16))
+            var emojiBuf = ImGuiTextUtil.MakeUtf8Buffer(_working.Emoji ?? string.Empty, 64);
+            if (_focusEmojiNextFrame)
+            {
+                ImGui.SetKeyboardFocusHere();
+                _focusEmojiNextFrame = false;
+            }
+            ImGui.InputText(
+                "Emoji",
+                emojiBuf,
+                (uint)emojiBuf.Length,
+                ImGuiInputTextFlags.CallbackAlways,
+                new ImGui.ImGuiInputTextCallbackDelegate(OnEmojiEdited)
+            );
+            var emoji = ImGuiTextUtil.ReadUtf8Buffer(emojiBuf);
+            if (_working.Emoji != emoji)
+            {
                 _working.Emoji = emoji;
+                _emojiSelectionStart = Math.Clamp(_emojiSelectionStart, 0, _working.Emoji.Length);
+                _emojiSelectionEnd = Math.Clamp(_emojiSelectionEnd, 0, _working.Emoji.Length);
+            }
             ImGui.SameLine();
             if (ImGui.Button("Pick"))
             {
-                _emojiPopup.Open(e => _working.Emoji = e);
+                _emojiPopup.Open(InsertEmojiText);
             }
 
             if (!string.IsNullOrWhiteSpace(_working.Emoji))
@@ -120,5 +143,45 @@ public class SignupOptionEditor
             ImGui.EndPopup();
         }
         if (!open) _open = false;
+    }
+
+    private void InsertEmojiText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        var value = _working.Emoji ?? string.Empty;
+        var start = Math.Min(_emojiSelectionStart, _emojiSelectionEnd);
+        var end = Math.Max(_emojiSelectionStart, _emojiSelectionEnd);
+        start = Math.Clamp(start, 0, value.Length);
+        end = Math.Clamp(end, 0, value.Length);
+
+        var builder = new StringBuilder(value.Length + text.Length);
+        if (start > 0)
+        {
+            builder.Append(value.AsSpan(0, start));
+        }
+
+        builder.Append(text);
+
+        if (end < value.Length)
+        {
+            builder.Append(value.AsSpan(end));
+        }
+
+        var result = builder.ToString();
+        _working.Emoji = result;
+        var caret = start + text.Length;
+        _emojiSelectionStart = _emojiSelectionEnd = caret;
+        _focusEmojiNextFrame = true;
+    }
+
+    private int OnEmojiEdited(ref ImGuiInputTextCallbackData data)
+    {
+        _emojiSelectionStart = data.SelectionStart;
+        _emojiSelectionEnd = data.SelectionEnd;
+        return 0;
     }
 }

--- a/tests/ChatWindowFormattingTests.cs
+++ b/tests/ChatWindowFormattingTests.cs
@@ -99,6 +99,30 @@ public class ChatWindowFormattingTests
         Assert.Equal("[click](url)", GetInput(window));
     }
 
+    [Fact]
+    public void InsertTextAtSelection_ReplacesSelection()
+    {
+        var window = CreateWindow();
+        SetInput(window, "hello world", 6, 11);
+        InsertAtSelection(window, ":smile:");
+        Assert.Equal("hello :smile:", GetInput(window));
+        var (start, end) = GetSelection(window);
+        Assert.Equal(13, start);
+        Assert.Equal(13, end);
+    }
+
+    [Fact]
+    public void InsertTextAtSelection_AppendsWhenCollapsedAtEnd()
+    {
+        var window = CreateWindow();
+        SetInput(window, "hello", 5, 5);
+        InsertAtSelection(window, "🙂");
+        Assert.Equal("hello🙂", GetInput(window));
+        var (start, end) = GetSelection(window);
+        Assert.Equal(6, start);
+        Assert.Equal(6, end);
+    }
+
     private static ChatWindow CreateWindow()
     {
         SetupServices();
@@ -123,9 +147,24 @@ public class ChatWindowFormattingTests
             .Invoke(window, new object[] { prefix, suffix });
     }
 
+    private static void InsertAtSelection(ChatWindow window, string text)
+    {
+        typeof(ChatWindow).GetMethod("InsertTextAtSelection", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(window, new object[] { text });
+    }
+
     private static string GetInput(ChatWindow window)
     {
         return (string)typeof(ChatWindow).GetField("_input", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(window)!;
+    }
+
+    private static (int Start, int End) GetSelection(ChatWindow window)
+    {
+        var start = (int)typeof(ChatWindow).GetField("_selectionStart", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!;
+        var end = (int)typeof(ChatWindow).GetField("_selectionEnd", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!;
+        return (start, end);
     }
 
     private class DummyHandler : HttpMessageHandler

--- a/tests/ColorConversionTests.cs
+++ b/tests/ColorConversionTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using DemiCatPlugin;
+using DemiCatPlugin.Emoji;
 using DiscordHelper;
 using Xunit;
 
@@ -94,9 +95,11 @@ public class ColorConversionTests
     {
         var config = new Config();
         var http = new HttpClient(new StubHandler());
-        var channelService = new ChannelService(config, http, new TokenManager());
+        var tokenManager = new TokenManager();
+        var channelService = new ChannelService(config, http, tokenManager);
         var selection = new ChannelSelectionService(config);
-        var window = new EventCreateWindow(config, http, channelService, selection);
+        var emojiManager = new EmojiManager(http, tokenManager, config);
+        var window = new EventCreateWindow(config, http, channelService, selection, emojiManager);
         typeof(EventCreateWindow).GetField("_color", BindingFlags.NonPublic | BindingFlags.Instance)!
             .SetValue(window, ColorUtils.RgbToImGui(rgb));
         var preview = (EmbedDto)typeof(EventCreateWindow).GetMethod("BuildPreview", BindingFlags.NonPublic | BindingFlags.Instance)!

--- a/tests/EventButtonWidthTests.cs
+++ b/tests/EventButtonWidthTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DemiCatPlugin;
 using DemiCat.UI;
+using DemiCatPlugin.Emoji;
 using DiscordHelper;
 using Xunit;
 
@@ -21,9 +22,11 @@ public class EventButtonWidthTests
     {
         var config = new Config();
         var http = new HttpClient(new StubHandler());
-        var channelService = new ChannelService(config, http, new TokenManager());
+        var tokenManager = new TokenManager();
+        var channelService = new ChannelService(config, http, tokenManager);
         var selection = new ChannelSelectionService(config);
-        var window = new EventCreateWindow(config, http, channelService, selection);
+        var emojiManager = new EmojiManager(http, tokenManager, config);
+        var window = new EventCreateWindow(config, http, channelService, selection, emojiManager);
         var buttonsField = typeof(EventCreateWindow).GetField("_buttons", BindingFlags.NonPublic | BindingFlags.Instance)!;
         buttonsField.SetValue(window, new List<Template.TemplateButton>
         {

--- a/tests/EventCreateWindowFormattingTests.cs
+++ b/tests/EventCreateWindowFormattingTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using DemiCatPlugin;
+using DemiCatPlugin.Emoji;
 using Xunit;
 
 public class EventCreateWindowFormattingTests
@@ -30,9 +31,11 @@ public class EventCreateWindowFormattingTests
         var config = new Config();
         var handler = new DummyHandler();
         var http = new HttpClient(handler);
-        var channelService = new ChannelService(config, http, new TokenManager());
+        var tokenManager = new TokenManager();
+        var channelService = new ChannelService(config, http, tokenManager);
         var selection = new ChannelSelectionService(config);
-        return new EventCreateWindow(config, http, channelService, selection);
+        var emojiManager = new EmojiManager(http, tokenManager, config);
+        return new EventCreateWindow(config, http, channelService, selection, emojiManager);
     }
 
     private static void SetDescription(EventCreateWindow window, string text, int start, int end)


### PR DESCRIPTION
## Summary
- refactor the emoji picker/popup to return tokens instead of mutating strings
- add caret-aware insertion helpers in chat, event creation, and signup editors and trigger them from emoji popups
- extend formatting tests to cover caret insertion scenarios

## Testing
- `dotnet test` *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d680deccd8832898e4b77091db4ba8