### PR TITLE
Fix emoji InputText call for Dalamud API 13

### DIFF
--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -67,9 +67,8 @@ public class SignupOptionEditor
             ImGui.InputText(
                 "Emoji",
                 emojiBuf,
-                (uint)emojiBuf.Length,
                 ImGuiInputTextFlags.CallbackAlways,
-                new ImGui.ImGuiInputTextCallbackDelegate(OnEmojiEdited)
+                OnEmojiEdited
             );
             var emoji = ImGuiTextUtil.ReadUtf8Buffer(emojiBuf);
             if (_working.Emoji != emoji)
@@ -178,7 +177,7 @@ public class SignupOptionEditor
         _focusEmojiNextFrame = true;
     }
 
-    private int OnEmojiEdited(ref ImGuiInputTextCallbackData data)
+    private int OnEmojiEdited(scoped ref ImGuiInputTextCallbackData data)
     {
         _emojiSelectionStart = data.SelectionStart;
         _emojiSelectionEnd = data.SelectionEnd;


### PR DESCRIPTION
## Summary
- update the emoji input field to use the new Dalamud InputText overload that no longer requires a manual buffer length
- adjust the callback signature to align with the latest ImGui input text delegate requirements

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68d68417585883289f855dd25adea409