### PR TITLE
Fix duplicate io declaration in chat window

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -902,7 +902,7 @@ public class ChatWindow : IDisposable
         );
         _input = ImGuiTextUtil.ReadUtf8Buffer(inputBuf);
 
-        var io = ImGui.GetIO();
+        io = ImGui.GetIO();
         var send = false;
         if (ImGui.IsItemActive() && ImGui.IsKeyPressed(ImGuiKey.Enter))
         {


### PR DESCRIPTION
## Summary
- reuse the existing ImGui IO pointer when handling chat input to avoid duplicate local declarations

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d731da227c83289b3082ef935c7fc0