### PR TITLE
Add asset metadata fields to events and templates

### DIFF
--- a/demibot/demibot/http/discord_helpers.py
+++ b/demibot/demibot/http/discord_helpers.py
@@ -35,6 +35,7 @@ def attachment_to_dto(attachment: discord.Attachment) -> AttachmentDto:
         url=attachment.url,
         filename=attachment.filename,
         content_type=attachment.content_type,
+        size=getattr(attachment, "size", None),
     )
 
 

--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -971,6 +971,7 @@ async def _send_via_webhook(
                 url=a.url,
                 filename=a.filename,
                 content_type=a.content_type,
+                size=getattr(a, "size", None),
             )
             for a in sent.attachments
         ]
@@ -1391,6 +1392,7 @@ async def save_message(
                             url=a.url,
                             filename=a.filename,
                             content_type=a.content_type,
+                            size=getattr(a, "size", None),
                         )
                         for a in sent.attachments
                     ]
@@ -1501,6 +1503,7 @@ async def save_message(
                                 content_type=(
                                     a.get("content_type") or a.get("contentType")
                                 ),
+                                size=a.get("size"),
                             )
                             for a in attachments_data
                             if isinstance(a, dict)
@@ -1612,7 +1615,10 @@ async def save_message(
             types.SimpleNamespace(
                 url=a.url,
                 filename=a.filename,
-                content_type=getattr(a, "content_type", getattr(a, "contentType", None)),
+                content_type=getattr(
+                    a, "content_type", getattr(a, "contentType", None)
+                ),
+                size=getattr(a, "size", None),
             )
             for a in (attachments or [])
         ],

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -93,7 +93,21 @@ class CreateEventBody(BaseModel):
     description: str
     url: Optional[str] = None
     image_url: Optional[str] = Field(default=None, alias="imageUrl")
+    image_id: Optional[str] = Field(default=None, alias="imageId")
+    image_filename: Optional[str] = Field(default=None, alias="imageFilename")
+    image_content_type: Optional[str] = Field(
+        default=None, alias="imageContentType"
+    )
+    image_size: Optional[int] = Field(default=None, alias="imageSize")
     thumbnail_url: Optional[str] = Field(default=None, alias="thumbnailUrl")
+    thumbnail_id: Optional[str] = Field(default=None, alias="thumbnailId")
+    thumbnail_filename: Optional[str] = Field(
+        default=None, alias="thumbnailFilename"
+    )
+    thumbnail_content_type: Optional[str] = Field(
+        default=None, alias="thumbnailContentType"
+    )
+    thumbnail_size: Optional[int] = Field(default=None, alias="thumbnailSize")
     color: Optional[int] = None
     fields: List[FieldBody] | None = None
     buttons: List[EmbedButtonDto] | None = None
@@ -437,6 +451,7 @@ async def create_event(
                         "url": a.url,
                         "filename": a.filename,
                         "contentType": a.content_type,
+                        "size": getattr(a, "size", None),
                     }
                     for a in sent.attachments
                 ]

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -83,6 +83,7 @@ class AttachmentDto(CamelModel):
     url: str
     filename: Optional[str] = None
     content_type: Optional[str] = Field(default=None, alias="contentType")
+    size: Optional[int] = None
 
 
 class ButtonComponentDto(CamelModel):
@@ -151,7 +152,21 @@ class TemplatePayload(CamelModel):
     description: str
     url: str | None = None
     image_url: str | None = Field(default=None, alias="imageUrl")
+    image_id: str | None = Field(default=None, alias="imageId")
+    image_filename: str | None = Field(default=None, alias="imageFilename")
+    image_content_type: str | None = Field(
+        default=None, alias="imageContentType"
+    )
+    image_size: int | None = Field(default=None, alias="imageSize")
     thumbnail_url: str | None = Field(default=None, alias="thumbnailUrl")
+    thumbnail_id: str | None = Field(default=None, alias="thumbnailId")
+    thumbnail_filename: str | None = Field(
+        default=None, alias="thumbnailFilename"
+    )
+    thumbnail_content_type: str | None = Field(
+        default=None, alias="thumbnailContentType"
+    )
+    thumbnail_size: int | None = Field(default=None, alias="thumbnailSize")
     color: int | None = None
     fields: List[EmbedFieldDto] | None = None
     buttons: List[EmbedButtonDto] | None = None


### PR DESCRIPTION
## Summary
- add asset identifiers and metadata fields to event creation payloads and template schemas
- capture attachment sizes when serialising Discord payloads for storage and responses

## Testing
- pytest tests/test_templates.py tests/test_create_event_source.py tests/test_messages_common.py *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68d73b52fd688328927decde6ad38d0f