### PR TITLE
Handle structured mention tokens in resolver

### DIFF
--- a/DemiCatPlugin/MentionResolver.cs
+++ b/DemiCatPlugin/MentionResolver.cs
@@ -7,6 +7,7 @@ namespace DemiCatPlugin;
 public static class MentionResolver
 {
     private static readonly char[] TrimChars = ['!', '.', ',', '?', ';', ':', ')', ']', '}', '>', '\'', '"'];
+    private const char MetadataMarker = '\u2063';
 
     private static string Normalize(string name) => name.Trim().ToLowerInvariant();
 
@@ -29,6 +30,7 @@ public static class MentionResolver
         IEnumerable<string>? allowedRoleIds = null)
     {
         var lookup = new Dictionary<string, (string Replacement, DiscordMentionDto? Mention)>(StringComparer.OrdinalIgnoreCase);
+        var mentionsById = new Dictionary<string, DiscordMentionDto>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var u in presences)
         {
@@ -36,6 +38,7 @@ public static class MentionResolver
                 continue;
             var mention = new DiscordMentionDto { Id = u.Id, Name = u.Name, Type = "user" };
             lookup[Normalize(u.Name)] = ($"<@{u.Id}>", mention);
+            mentionsById[u.Id] = mention;
         }
 
         HashSet<string>? allowed = null;
@@ -50,21 +53,27 @@ public static class MentionResolver
                 continue;
             var mention = new DiscordMentionDto { Id = r.Id, Name = r.Name, Type = "role" };
             lookup[Normalize(r.Name)] = ($"<@&{r.Id}>", mention);
+            mentionsById[r.Id] = mention;
         }
 
         // Discord special mentions
-        lookup[Normalize("everyone")] = ("<@everyone>", new DiscordMentionDto
+        var everyoneMention = new DiscordMentionDto
         {
             Id = "everyone",
             Name = "everyone",
             Type = "keyword"
-        });
-        lookup[Normalize("here")] = ("<@here>", new DiscordMentionDto
+        };
+        lookup[Normalize("everyone")] = ("<@everyone>", everyoneMention);
+        mentionsById[everyoneMention.Id] = everyoneMention;
+
+        var hereMention = new DiscordMentionDto
         {
             Id = "here",
             Name = "here",
             Type = "keyword"
-        });
+        };
+        lookup[Normalize("here")] = ("<@here>", hereMention);
+        mentionsById[hereMention.Id] = hereMention;
 
         var sb = new StringBuilder(content.Length);
         var mentions = new List<DiscordMentionDto>();
@@ -72,43 +81,21 @@ public static class MentionResolver
 
         for (var i = 0; i < content.Length;)
         {
+            if (TryConsumeStructuredMention(content, ref i, sb, mentions, seen, mentionsById))
+            {
+                continue;
+            }
+
             if (content[i] == '@')
             {
-                var start = i + 1;
-                var j = start;
-                while (j < content.Length && !char.IsWhiteSpace(content[j]))
+                if (TryConsumeAtMention(content, lookup, mentionsById, sb, mentions, seen, ref i))
                 {
-                    j++;
+                    continue;
                 }
-
-                var token = content.Substring(start, j - start);
-                var name = token.TrimEnd(TrimChars);
-                var suffix = token.Substring(name.Length);
-                var key = Normalize(name);
-
-                if (lookup.TryGetValue(key, out var replacement))
-                {
-                    sb.Append(replacement.Replacement);
-                    sb.Append(suffix);
-
-                    if (replacement.Mention != null && seen.Add(replacement.Mention.Id))
-                    {
-                        mentions.Add(replacement.Mention);
-                    }
-                }
-                else
-                {
-                    sb.Append("@\u200B");
-                    sb.Append(token);
-                }
-
-                i = j;
             }
-            else
-            {
-                sb.Append(content[i]);
-                i++;
-            }
+
+            sb.Append(content[i]);
+            i++;
         }
 
         return new MentionResolution(sb.ToString(), mentions);
@@ -121,5 +108,175 @@ public static class MentionResolver
         IEnumerable<string>? allowedRoleIds = null)
     {
         return ResolveDetailed(content, presences, roles, allowedRoleIds).Content;
+    }
+
+    private static bool TryConsumeStructuredMention(
+        string content,
+        ref int index,
+        StringBuilder sb,
+        List<DiscordMentionDto> mentions,
+        HashSet<string> seen,
+        Dictionary<string, DiscordMentionDto> mentionsById)
+    {
+        var span = content.AsSpan(index);
+        if (!TryParseStructuredMention(span, mentionsById, out var consumed, out var mention))
+        {
+            return false;
+        }
+
+        sb.Append(span.Slice(0, consumed));
+        if (mention != null && seen.Add(mention.Id))
+        {
+            mentions.Add(mention);
+        }
+
+        index += consumed;
+        return true;
+    }
+
+    private static bool TryConsumeAtMention(
+        string content,
+        Dictionary<string, (string Replacement, DiscordMentionDto? Mention)> lookup,
+        Dictionary<string, DiscordMentionDto> mentionsById,
+        StringBuilder sb,
+        List<DiscordMentionDto> mentions,
+        HashSet<string> seen,
+        ref int index)
+    {
+        var start = index + 1;
+        var j = start;
+        while (j < content.Length && !char.IsWhiteSpace(content[j]))
+        {
+            j++;
+        }
+
+        var token = content.Substring(start, j - start);
+
+        if (TryResolveMetadataMention(token, mentionsById, sb, mentions, seen))
+        {
+            index = j;
+            return true;
+        }
+
+        var name = token.TrimEnd(TrimChars);
+        var suffix = token.Substring(name.Length);
+        var key = Normalize(name);
+
+        if (lookup.TryGetValue(key, out var replacement))
+        {
+            sb.Append(replacement.Replacement);
+            sb.Append(suffix);
+
+            if (replacement.Mention != null && seen.Add(replacement.Mention.Id))
+            {
+                mentions.Add(replacement.Mention);
+            }
+        }
+        else
+        {
+            sb.Append("@\u200B");
+            sb.Append(token);
+        }
+
+        index = j;
+        return true;
+    }
+
+    private static bool TryResolveMetadataMention(
+        string token,
+        Dictionary<string, DiscordMentionDto> mentionsById,
+        StringBuilder sb,
+        List<DiscordMentionDto> mentions,
+        HashSet<string> seen)
+    {
+        var metadataIndex = token.IndexOf(MetadataMarker);
+        if (metadataIndex < 0)
+        {
+            return false;
+        }
+
+        var metadataSpan = token.AsSpan(metadataIndex + 1);
+        if (!TryParseStructuredMention(metadataSpan, mentionsById, out var consumed, out var mention))
+        {
+            return false;
+        }
+
+        sb.Append(metadataSpan.Slice(0, consumed));
+        var suffix = metadataSpan.Slice(consumed);
+        if (!suffix.IsEmpty)
+        {
+            sb.Append(suffix);
+        }
+
+        if (mention != null && seen.Add(mention.Id))
+        {
+            mentions.Add(mention);
+        }
+
+        return true;
+    }
+
+    private static bool TryParseStructuredMention(
+        ReadOnlySpan<char> span,
+        Dictionary<string, DiscordMentionDto> mentionsById,
+        out int consumed,
+        out DiscordMentionDto? mention)
+    {
+        consumed = 0;
+        mention = null;
+
+        if (span.Length < 3 || span[0] != '<' || span[1] != '@')
+        {
+            return false;
+        }
+
+        var index = 2;
+        var prefix = '\0';
+        if (index < span.Length && (span[index] == '&' || span[index] == '!'))
+        {
+            prefix = span[index];
+            index++;
+        }
+
+        var idStart = index;
+        while (index < span.Length && span[index] != '>')
+        {
+            index++;
+        }
+
+        if (index >= span.Length)
+        {
+            return false;
+        }
+
+        var idSpan = span.Slice(idStart, index - idStart);
+        if (idSpan.IsEmpty)
+        {
+            return false;
+        }
+
+        consumed = index + 1;
+        var id = idSpan.ToString();
+
+        if (!mentionsById.TryGetValue(id, out var resolved))
+        {
+            var type = prefix == '&'
+                ? "role"
+                : id.Equals("everyone", StringComparison.OrdinalIgnoreCase) || id.Equals("here", StringComparison.OrdinalIgnoreCase)
+                    ? "keyword"
+                    : "user";
+
+            resolved = new DiscordMentionDto
+            {
+                Id = id,
+                Name = id,
+                Type = type
+            };
+
+            mentionsById[id] = resolved;
+        }
+
+        mention = resolved;
+        return true;
     }
 }

--- a/tests/ChatWindowTests.cs
+++ b/tests/ChatWindowTests.cs
@@ -68,4 +68,43 @@ public class ChatWindowTests
 
         Assert.Equal("Hello @​Admin", result);
     }
+
+    [Fact]
+    public void MentionResolver_RecognizesExistingMentionTokens()
+    {
+        var presences = new[] { new PresenceDto { Id = "1", Name = "Alice" } };
+        var roles = new[] { new RoleDto { Id = "2", Name = "Admin" } };
+        var input = "Hello <@1> and <@&2> and <@1>";
+
+        var result = MentionResolver.ResolveDetailed(input, presences, roles);
+
+        Assert.Equal(input, result.Content);
+        Assert.Collection(result.Mentions,
+            mention =>
+            {
+                Assert.Equal("1", mention.Id);
+                Assert.Equal("user", mention.Type);
+            },
+            mention =>
+            {
+                Assert.Equal("2", mention.Id);
+                Assert.Equal("role", mention.Type);
+            });
+    }
+
+    [Fact]
+    public void MentionResolver_UsesMetadataWhenPresent()
+    {
+        var presences = new[] { new PresenceDto { Id = "1", Name = "Alice" } };
+        var roles = new[] { new RoleDto { Id = "2", Name = "Admin" } };
+        const char metadata = '\u2063';
+        var input = $"Hello @Alice{metadata}<@1> and @Admin{metadata}<@&2>.";
+
+        var result = MentionResolver.ResolveDetailed(input, presences, roles);
+
+        Assert.Equal("Hello <@1> and <@&2>.", result.Content);
+        Assert.Collection(result.Mentions,
+            mention => Assert.Equal("1", mention.Id),
+            mention => Assert.Equal("2", mention.Id));
+    }
 }


### PR DESCRIPTION
## Summary
- recognize structured Discord mention tokens and metadata markers before falling back to name-based lookup
- keep a shared mention lookup by id so detected mentions are added without altering existing tokens
- add unit tests covering existing tokens, metadata-driven replacements, and duplicate handling

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d74d696a6c8328867fd0417819fc27