### PR TITLE
Add chat appearance scaling controls

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -490,6 +490,14 @@ public class ChatWindow : IDisposable
         const float ScrollTolerance = 1f;
         ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), true);
 
+        var fontScale = _config.ChatFontScale;
+        if (!float.IsFinite(fontScale) || fontScale <= 0f)
+        {
+            fontScale = 1f;
+        }
+        fontScale = Math.Clamp(fontScale, Config.MinChatFontScale, Config.MaxChatFontScale);
+        ImGui.SetWindowFontScale(fontScale);
+
         var io = ImGui.GetIO();
         var hoverFlags = ImGuiHoveredFlags.AllowWhenBlockedByPopup | ImGuiHoveredFlags.AllowWhenBlockedByActiveItem;
         var chatHovered = ImGui.IsWindowHovered(hoverFlags);
@@ -1195,18 +1203,49 @@ public class ChatWindow : IDisposable
         return ImGuiMouseCursor.ResizeAll;
     }
 
-    private static Vector2 CalculateAttachmentDisplaySize(Vector2 originalSize, Vector2 maxSize)
+    private Vector2 CalculateAttachmentDisplaySize(Vector2 originalSize, Vector2 maxSize)
     {
         var width = MathF.Max(1f, originalSize.X);
         var height = MathF.Max(1f, originalSize.Y);
         var maxWidth = MathF.Max(1f, maxSize.X);
         var maxHeight = MathF.Max(1f, maxSize.Y);
 
-        var widthScale = maxWidth / width;
-        var heightScale = maxHeight / height;
-        var scale = MathF.Min(1f, MathF.Min(widthScale, heightScale));
+        if (_config.ChatImageAutoStretch)
+        {
+            var widthScale = maxWidth / width;
+            var heightScale = maxHeight / height;
+            var scale = MathF.Min(1f, MathF.Min(widthScale, heightScale));
 
-        return new Vector2(width * scale, height * scale);
+            return new Vector2(width * scale, height * scale);
+        }
+
+        var manualScale = _config.ChatImageManualScale;
+        if (!float.IsFinite(manualScale) || manualScale <= 0f)
+        {
+            manualScale = 1f;
+        }
+
+        manualScale = Math.Clamp(manualScale, Config.MinChatImageScale, Config.MaxChatImageScale);
+
+        var scaledWidth = width * manualScale;
+        var scaledHeight = height * manualScale;
+
+        var widthClamp = maxWidth / MathF.Max(1f, scaledWidth);
+        var heightClamp = maxHeight / MathF.Max(1f, scaledHeight);
+        var clampScale = MathF.Min(1f, MathF.Min(widthClamp, heightClamp));
+
+        if (clampScale < 1f)
+        {
+            scaledWidth *= clampScale;
+            scaledHeight *= clampScale;
+        }
+
+        return new Vector2(scaledWidth, scaledHeight);
+    }
+
+    public virtual void OnAppearanceSettingsChanged()
+    {
+        _pendingInitialScroll = true;
     }
 
     protected void FormatContent(DiscordMessageDto msg)

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -8,8 +8,13 @@ namespace DemiCatPlugin;
 
 public class Config : IPluginConfiguration
 {
+    public const float MinChatFontScale = 0.75f;
+    public const float MaxChatFontScale = 1.5f;
+    public const float MinChatImageScale = 0.5f;
+    public const float MaxChatImageScale = 3f;
+
     // Required by Dalamud
-    public int Version { get; set; } = 9;
+    public int Version { get; set; } = 10;
 
     public bool Enabled { get; set; } = true;
     public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
@@ -32,6 +37,10 @@ public class Config : IPluginConfiguration
     public bool ChatFadeOutEnabled { get; set; } = false;
     public int ChatFadeOutDelaySeconds { get; set; } = 10;
     public float ChatFadeOutMinimumAlpha { get; set; } = 0.3f;
+
+    public float ChatFontScale { get; set; } = 1f;
+    public bool ChatImageAutoStretch { get; set; } = true;
+    public float ChatImageManualScale { get; set; } = 1f;
 
     [JsonPropertyName("chatInputSplitRatio")]
     public float ChatInputSplitRatio { get; set; } = 0.35f;
@@ -256,6 +265,25 @@ public class Config : IPluginConfiguration
         {
             IsOfficerToken = false;
             Version = 9;
+            ExtensionData = null;
+        }
+        if (Version < 10)
+        {
+            if (!float.IsFinite(ChatFontScale) || ChatFontScale <= 0f)
+            {
+                ChatFontScale = 1f;
+            }
+            ChatFontScale = Math.Clamp(ChatFontScale, MinChatFontScale, MaxChatFontScale);
+
+            ChatImageAutoStretch = true;
+
+            if (!float.IsFinite(ChatImageManualScale) || ChatImageManualScale <= 0f)
+            {
+                ChatImageManualScale = 1f;
+            }
+            ChatImageManualScale = Math.Clamp(ChatImageManualScale, MinChatImageScale, MaxChatImageScale);
+
+            Version = 10;
             ExtensionData = null;
         }
     }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -270,6 +270,48 @@ public class SettingsWindow : IDisposable
     {
         var fadeOutEnabled = _config.ChatFadeOutEnabled;
 
+        ImGui.TextUnformatted("Chat Options");
+        ImGui.Spacing();
+
+        var chatFontScale = _config.ChatFontScale;
+        if (ImGui.SliderFloat("Chat Font Scale", ref chatFontScale, Config.MinChatFontScale, Config.MaxChatFontScale, "%.2fx"))
+        {
+            chatFontScale = Math.Clamp(chatFontScale, Config.MinChatFontScale, Config.MaxChatFontScale);
+            if (Math.Abs(chatFontScale - _config.ChatFontScale) > 0.0001f)
+            {
+                _config.ChatFontScale = chatFontScale;
+                SaveConfig();
+                RefreshChatWindows();
+            }
+        }
+
+        var autoStretch = _config.ChatImageAutoStretch;
+        if (ImGui.Checkbox("Auto-stretch chat images", ref autoStretch))
+        {
+            _config.ChatImageAutoStretch = autoStretch;
+            SaveConfig();
+            RefreshChatWindows();
+        }
+
+        var manualImageScale = _config.ChatImageManualScale;
+        ImGui.BeginDisabled(autoStretch);
+        var manualScaleChanged = ImGui.SliderFloat("Manual Image Scale", ref manualImageScale, Config.MinChatImageScale, Config.MaxChatImageScale, "%.2fx");
+        ImGui.EndDisabled();
+        if (autoStretch && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+            ImGui.SetTooltip("Disable auto-stretch to adjust manual image scale.");
+        if (manualScaleChanged)
+        {
+            manualImageScale = Math.Clamp(manualImageScale, Config.MinChatImageScale, Config.MaxChatImageScale);
+            if (Math.Abs(manualImageScale - _config.ChatImageManualScale) > 0.0001f)
+            {
+                _config.ChatImageManualScale = manualImageScale;
+                SaveConfig();
+                RefreshChatWindows();
+            }
+        }
+
+        ImGui.Spacing();
+
         ImGui.BeginDisabled(fadeOutEnabled);
         var fcOpacity = _config.FcChatOpacity * 100f;
         if (ImGui.SliderFloat("FC Chat Opacity", ref fcOpacity, 0f, 100f, "%.0f%%"))
@@ -294,6 +336,7 @@ public class SettingsWindow : IDisposable
         if (fadeOutEnabled && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
             ImGui.SetTooltip("Disable fade-out to adjust per-tab opacity.");
 
+        ImGui.NewLine();
         ImGui.Separator();
 
         if (ImGui.Checkbox("Enable fade-out", ref fadeOutEnabled))
@@ -342,6 +385,12 @@ public class SettingsWindow : IDisposable
         ImGui.SameLine();
         DrawFadePreview("##fadePreview", _config.ChatFadeOutMinimumAlpha);
         ImGui.EndDisabled();
+    }
+
+    private void RefreshChatWindows()
+    {
+        ChatWindow?.OnAppearanceSettingsChanged();
+        OfficerChatWindow?.OnAppearanceSettingsChanged();
     }
 
     private static void DrawFadePreview(string id, float alpha)


### PR DESCRIPTION
## Summary
- add configuration defaults and migration support for chat font and image scaling options
- surface new chat font and image controls in the appearance settings and refresh open chat windows when they change
- respect the configurable font scale and image scaling behaviour during chat rendering

## Testing
- Not Run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d750cf2da88328b0e6680dec6d4f7e