### PR TITLE
Handle null-safe mention insertion

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1835,9 +1835,10 @@ public class ChatWindow : IDisposable
         _selectionEnd = end;
         InsertTextAtSelection(mentionText);
 
-        if (!needsSpace && _selectionEnd < _input.Length && char.IsWhiteSpace(_input[_selectionEnd]))
+        var updatedInput = _input ?? string.Empty;
+        if (!needsSpace && _selectionEnd < updatedInput.Length && char.IsWhiteSpace(updatedInput[_selectionEnd]))
         {
-            var caret = Math.Min(_input.Length, _selectionEnd + 1);
+            var caret = Math.Min(updatedInput.Length, _selectionEnd + 1);
             _selectionStart = _selectionEnd = caret;
         }
 


### PR DESCRIPTION
## Summary
- reuse a null-safe buffer when adjusting the caret after inserting a mention to avoid dereferencing a null input string

## Testing
- dotnet build -c Release *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d75e8780d48328b7de1ca227164377