### PR TITLE
Add modal time picker to event creation window

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -32,7 +32,7 @@ public class EventCreateWindow
     private int _descriptionSelectionStart;
     private int _descriptionSelectionEnd;
     private bool _focusDescriptionNextFrame;
-    private string _time = DateTime.UtcNow.ToString("O");
+    private string _time = string.Empty;
     private string _imageUrl = string.Empty;
     private string _url = string.Empty;
     private string _thumbnailUrl = string.Empty;
@@ -64,6 +64,7 @@ public class EventCreateWindow
     private readonly FileDialogManager _thumbnailFileDialog = new();
     private readonly ImageUploadState _bannerUpload = new();
     private readonly ImageUploadState _thumbnailUpload = new();
+    private readonly DateTimePicker _timePicker;
 
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
@@ -80,6 +81,9 @@ public class EventCreateWindow
         _channelSelection = channelSelection;
         _optionEditor = new SignupOptionEditor(config, httpClient, emojiManager);
         _descriptionEmojiPopup = new EmojiPopup(emojiManager, "EventDescriptionEmoji");
+        var defaultTime = GetDefaultTime();
+        _timePicker = new DateTimePicker(defaultTime);
+        _time = defaultTime.ToUniversalTime().ToString("O");
         ResetDefaultButtons();
         _channelSelection.ChannelChanged += HandleChannelChanged;
     }
@@ -184,7 +188,15 @@ public class EventCreateWindow
             }
 
             DrawFormRow("Title", () => ImGui.InputText("##Title", ref _title, 256));
-            DrawFormRow("Time", () => ImGui.InputText("##Time", ref _time, 64));
+            DrawFormRow(
+                "Time",
+                () =>
+                {
+                    if (_timePicker.Draw("EventTime", out var selected))
+                    {
+                        ApplyTime(selected);
+                    }
+                });
             DrawFormRow(
                 "Description",
                 () =>
@@ -244,9 +256,9 @@ public class EventCreateWindow
                 }
             });
 
-            if (_repeat != RepeatOption.None &&
-                DateTime.TryParse(_time, null, DateTimeStyles.AdjustToUniversal, out var baseTime))
+            if (_repeat != RepeatOption.None)
             {
+                var baseTime = _timePicker.Value;
                 var next = _repeat == RepeatOption.Daily ? baseTime.AddDays(1) : baseTime.AddDays(7);
                 var nextStr = next.ToUniversalTime().ToString("O");
                 DrawFormRow(string.Empty, () => ImGui.TextUnformatted($"Next: {nextStr}"), alignLabel: false, setFullWidth: false);
@@ -649,9 +661,7 @@ public class EventCreateWindow
         _title = template.Title;
         _description = template.Description ?? string.Empty;
         _descriptionSelectionStart = _descriptionSelectionEnd = _description.Length;
-        _time = string.IsNullOrEmpty(template.Time)
-            ? DateTime.UtcNow.ToString("O")
-            : template.Time;
+        SetTimeFromString(template.Time);
         _url = template.Url;
         _imageUrl = template.ImageUrl;
         _thumbnailUrl = template.ThumbnailUrl;
@@ -712,11 +722,12 @@ public class EventCreateWindow
             var preview = BuildPreview();
             var dto = preview.Embed;
             var buttons = preview.Buttons.ToList();
+            var isoTime = GetIsoTime();
             var payload = new
             {
                 channelId = ChannelId,
                 title = dto.Title,
-                time = _time,
+                time = isoTime,
                 description = dto.Description,
                 url = dto.Url,
                 imageUrl = dto.ImageUrl,
@@ -787,11 +798,12 @@ public class EventCreateWindow
             var preview = BuildPreview();
             var dto = preview.Embed;
             var buttons = preview.Buttons.ToList();
+            var isoTime = GetIsoTime();
             var body = new
             {
                 channelId,
                 title = dto.Title,
-                time = dto.Timestamp?.ToString("O") ?? _time,
+                time = isoTime,
                 description = dto.Description,
                 url = dto.Url,
                 imageUrl = dto.ImageUrl,
@@ -922,6 +934,63 @@ public class EventCreateWindow
         return 0;
     }
 
+    private void ApplyTime(DateTimeOffset value)
+    {
+        _timePicker.SetValue(value);
+        _time = value.ToUniversalTime().ToString("O");
+    }
+
+    private void SetTimeFromString(string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value) &&
+            DateTimeOffset.TryParse(value, null, DateTimeStyles.AdjustToUniversal, out var parsed))
+        {
+            ApplyTime(parsed);
+        }
+        else
+        {
+            ApplyTime(GetDefaultTime());
+        }
+    }
+
+    private string GetIsoTime()
+    {
+        var iso = _timePicker.Value.ToUniversalTime().ToString("O");
+        _time = iso;
+        return iso;
+    }
+
+    private static DateTimeOffset GetDefaultTime()
+    {
+        var today = DateTime.Today;
+        var localNoon = new DateTime(today.Year, today.Month, today.Day, 12, 0, 0, DateTimeKind.Unspecified);
+        return NormalizeLocalTime(localNoon);
+    }
+
+    private static DateTimeOffset NormalizeLocalTime(DateTime localDateTime)
+    {
+        var timeZone = TimeZoneInfo.Local;
+        var working = localDateTime;
+
+        if (timeZone.IsInvalidTime(working))
+        {
+            working = working.AddHours(1);
+        }
+
+        TimeSpan offset;
+        if (timeZone.IsAmbiguousTime(working))
+        {
+            var offsets = timeZone.GetAmbiguousTimeOffsets(working);
+            offset = offsets.Length > 0 ? offsets[0] : timeZone.GetUtcOffset(working);
+        }
+        else
+        {
+            offset = timeZone.GetUtcOffset(working);
+        }
+
+        return new DateTimeOffset(working, offset);
+    }
+
     private void SaveConfig()
     {
         PluginServices.Instance!.PluginInterface.SavePluginConfig(_config);
@@ -958,11 +1027,7 @@ public class EventCreateWindow
             }
         }
 
-        DateTimeOffset? timestamp = null;
-        if (DateTimeOffset.TryParse(_time, null, DateTimeStyles.AdjustToUniversal, out var parsedTs))
-        {
-            timestamp = parsedTs;
-        }
+        DateTimeOffset? timestamp = _timePicker.Value.ToUniversalTime();
 
         var creatorLabel = MembershipCache.GetCreatorLabel();
 
@@ -1474,6 +1539,217 @@ public class EventCreateWindow
             Label = "No",
             Style = ButtonStyle.Danger
         });
+    }
+
+    private sealed class DateTimePicker
+    {
+        private DateTimeOffset _value;
+        private DateTime _displayMonth;
+        private DateTime _tempDate;
+        private int _tempHour;
+        private int _tempMinute;
+        private bool _tempIsPm;
+
+        public DateTimePicker(DateTimeOffset initial)
+        {
+            SetValue(initial);
+        }
+
+        public DateTimeOffset Value => _value;
+
+        public void SetValue(DateTimeOffset value)
+        {
+            _value = value;
+            var local = value.ToLocalTime();
+            _displayMonth = new DateTime(local.Year, local.Month, 1);
+            _tempDate = local.Date;
+            _tempMinute = local.Minute;
+            var hour = local.Hour;
+            _tempIsPm = hour >= 12;
+            var hour12 = hour % 12;
+            if (hour12 == 0)
+            {
+                hour12 = 12;
+            }
+            _tempHour = hour12;
+        }
+
+        public bool Draw(string idSuffix, out DateTimeOffset newValue)
+        {
+            var local = _value.ToLocalTime();
+            var preview = local.ToString("MMM d, yyyy h:mm tt", CultureInfo.CurrentCulture);
+            var popupId = $"TimePickerPopup##{idSuffix}";
+            newValue = _value;
+            var changed = false;
+
+            var avail = ImGui.GetContentRegionAvail();
+            var buttonWidth = Math.Max(avail.X, 1f);
+            if (ImGui.Button($"{preview}##{idSuffix}", new Vector2(buttonWidth, 0f)))
+            {
+                SyncTemporaryState();
+                ImGui.OpenPopup(popupId);
+            }
+
+            if (ImGui.BeginPopupModal(popupId, ImGuiWindowFlags.AlwaysAutoResize))
+            {
+                DrawMonthHeader(idSuffix);
+                DrawCalendar(idSuffix);
+                ImGui.Spacing();
+                DrawTimeInputs(idSuffix);
+                ImGui.Spacing();
+
+                if (ImGui.Button($"Confirm##{idSuffix}"))
+                {
+                    ClampTemporaryValues();
+                    var hour24 = _tempHour % 12;
+                    if (_tempIsPm)
+                    {
+                        hour24 += 12;
+                    }
+                    else if (_tempHour == 12)
+                    {
+                        hour24 = 0;
+                    }
+
+                    var localDateTime = new DateTime(
+                        _tempDate.Year,
+                        _tempDate.Month,
+                        _tempDate.Day,
+                        hour24,
+                        _tempMinute,
+                        0,
+                        DateTimeKind.Unspecified);
+                    var selected = NormalizeLocalTime(localDateTime);
+                    SetValue(selected);
+                    newValue = _value;
+                    changed = true;
+                    ImGui.CloseCurrentPopup();
+                }
+
+                ImGui.SameLine();
+
+                if (ImGui.Button($"Cancel##{idSuffix}"))
+                {
+                    ImGui.CloseCurrentPopup();
+                }
+
+                ImGui.EndPopup();
+            }
+
+            return changed;
+        }
+
+        private void SyncTemporaryState()
+        {
+            SetValue(_value);
+        }
+
+        private void DrawMonthHeader(string idSuffix)
+        {
+            if (ImGui.Button($"<##Prev{idSuffix}"))
+            {
+                _displayMonth = _displayMonth.AddMonths(-1);
+            }
+
+            ImGui.SameLine();
+            ImGui.TextUnformatted(_displayMonth.ToString("MMMM yyyy", CultureInfo.CurrentCulture));
+            ImGui.SameLine();
+            if (ImGui.Button($">##Next{idSuffix}"))
+            {
+                _displayMonth = _displayMonth.AddMonths(1);
+            }
+        }
+
+        private void DrawCalendar(string idSuffix)
+        {
+            var culture = CultureInfo.CurrentCulture;
+            var firstDayOfWeek = culture.DateTimeFormat.FirstDayOfWeek;
+            var dayNames = culture.DateTimeFormat.AbbreviatedDayNames;
+            var headers = new string[7];
+            for (var i = 0; i < 7; i++)
+            {
+                headers[i] = dayNames[((int)firstDayOfWeek + i) % 7];
+            }
+
+            if (ImGui.BeginTable($"##Calendar{idSuffix}", 7, ImGuiTableFlags.SizingStretchSame))
+            {
+                ImGui.TableNextRow();
+                for (var i = 0; i < 7; i++)
+                {
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted(headers[i]);
+                }
+
+                var firstOfMonth = new DateTime(_displayMonth.Year, _displayMonth.Month, 1);
+                var daysInMonth = DateTime.DaysInMonth(_displayMonth.Year, _displayMonth.Month);
+                var offset = ((int)firstOfMonth.DayOfWeek - (int)firstDayOfWeek + 7) % 7;
+                var totalCells = offset + daysInMonth;
+                var rows = (int)Math.Ceiling(totalCells / 7f);
+                var day = 1;
+
+                for (var row = 0; row < rows; row++)
+                {
+                    ImGui.TableNextRow();
+                    for (var col = 0; col < 7; col++)
+                    {
+                        ImGui.TableNextColumn();
+                        var index = row * 7 + col;
+                        if (index < offset || day > daysInMonth)
+                        {
+                            ImGui.TextUnformatted(" ");
+                            continue;
+                        }
+
+                        var cellDate = new DateTime(_displayMonth.Year, _displayMonth.Month, day);
+                        var isSelected = cellDate == _tempDate;
+                        ImGui.PushID(day);
+                        if (ImGui.Selectable(cellDate.Day.ToString(CultureInfo.InvariantCulture), isSelected, ImGuiSelectableFlags.DontClosePopups))
+                        {
+                            _tempDate = cellDate;
+                        }
+                        ImGui.PopID();
+                        day++;
+                    }
+                }
+
+                ImGui.EndTable();
+            }
+        }
+
+        private void DrawTimeInputs(string idSuffix)
+        {
+            ClampTemporaryValues();
+
+            if (ImGui.RadioButton($"AM##{idSuffix}", !_tempIsPm))
+            {
+                _tempIsPm = false;
+            }
+
+            ImGui.SameLine();
+
+            if (ImGui.RadioButton($"PM##{idSuffix}", _tempIsPm))
+            {
+                _tempIsPm = true;
+            }
+
+            ImGui.PushItemWidth(80f);
+            ImGui.InputInt($"Hour##{idSuffix}", ref _tempHour);
+            ImGui.PopItemWidth();
+
+            ImGui.SameLine();
+
+            ImGui.PushItemWidth(80f);
+            ImGui.InputInt($"Minute##{idSuffix}", ref _tempMinute);
+            ImGui.PopItemWidth();
+
+            ClampTemporaryValues();
+        }
+
+        private void ClampTemporaryValues()
+        {
+            _tempHour = Math.Clamp(_tempHour, 1, 12);
+            _tempMinute = Math.Clamp(_tempMinute, 0, 59);
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- replace the free-form time textbox with a modal date/time picker that includes calendar navigation and AM/PM controls
- default the picker to local noon and synchronize the stored ISO-8601 timestamp when the user confirms
- update repeat previews and outbound template/event payloads to use the structured picker value

## Testing
- not run (dotnet is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d7692e37d88328a5bae27a07f5d2a4