### PR TITLE
Set RSVP summary fields inline for Discord layouts

### DIFF
--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -51,7 +51,13 @@ def summarize(att: Dict[str, List[str]], labels: Dict[str, str], order: List[str
     for key in order:
         people = att.get(key, [])
         label = labels.get(key, key.capitalize())
-        fields.append({"name": label, "value": ", ".join(people) if people else "—"})
+        fields.append(
+            {
+                "name": label,
+                "value": ", ".join(people) if people else "—",
+                "inline": True,
+            }
+        )
     return fields
 
 

--- a/demibot/demibot/http/routes/interactions.py
+++ b/demibot/demibot/http/routes/interactions.py
@@ -28,7 +28,13 @@ def summarize(att: Dict[str, List[str]], labels: Dict[str, str], order: List[str
     for key in order:
         people = att.get(key, [])
         label = labels.get(key, key.capitalize())
-        fields.append({"name": label, "value": ", ".join(people) if people else "—"})
+        fields.append(
+            {
+                "name": label,
+                "value": ", ".join(people) if people else "—",
+                "inline": True,
+            }
+        )
     return fields
 
 


### PR DESCRIPTION
## Summary
- set RSVP summary fields generated by the events endpoint to render inline
- keep interaction updates consistent so inline RSVP columns persist in Discord embeds

## Testing
- pytest *(fails: missing optional dependencies such as fastapi, discord, sqlalchemy, httpx, aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_68d76d595ad88328af5a69371954ae46