### PR TITLE
Add configurable theme colors for DemiCat windows

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -1,6 +1,7 @@
 using Dalamud.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -12,9 +13,11 @@ public class Config : IPluginConfiguration
     public const float MaxChatFontScale = 1.5f;
     public const float MinChatImageScale = 0.5f;
     public const float MaxChatImageScale = 3f;
+    public static readonly Vector4 DefaultPrimaryWindowColor = new(0.11f, 0.11f, 0.12f, 1f);
+    public static readonly Vector4 DefaultSecondaryAccentColor = new(0.2f, 0.6f, 1f, 1f);
 
     // Required by Dalamud
-    public int Version { get; set; } = 10;
+    public int Version { get; set; } = 11;
 
     public bool Enabled { get; set; } = true;
     public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
@@ -41,6 +44,12 @@ public class Config : IPluginConfiguration
     public float ChatFontScale { get; set; } = 1f;
     public bool ChatImageAutoStretch { get; set; } = true;
     public float ChatImageManualScale { get; set; } = 1f;
+
+    [JsonPropertyName("primaryWindowColor")]
+    public Vector4 PrimaryWindowColor { get; set; } = DefaultPrimaryWindowColor;
+
+    [JsonPropertyName("secondaryAccentColor")]
+    public Vector4 SecondaryAccentColor { get; set; } = DefaultSecondaryAccentColor;
 
     [JsonPropertyName("chatInputSplitRatio")]
     public float ChatInputSplitRatio { get; set; } = 0.35f;
@@ -286,5 +295,27 @@ public class Config : IPluginConfiguration
             Version = 10;
             ExtensionData = null;
         }
+        if (Version < 11)
+        {
+            PrimaryWindowColor = SanitizeColor(PrimaryWindowColor, DefaultPrimaryWindowColor);
+            SecondaryAccentColor = SanitizeColor(SecondaryAccentColor, DefaultSecondaryAccentColor);
+
+            Version = 11;
+            ExtensionData = null;
+        }
+    }
+
+    internal static Vector4 SanitizeColor(Vector4 color, Vector4 fallback)
+    {
+        if (!float.IsFinite(color.X) || !float.IsFinite(color.Y) || !float.IsFinite(color.Z) || !float.IsFinite(color.W))
+        {
+            return fallback;
+        }
+
+        return new Vector4(
+            Math.Clamp(color.X, 0f, 1f),
+            Math.Clamp(color.Y, 0f, 1f),
+            Math.Clamp(color.Z, 0f, 1f),
+            Math.Clamp(color.W, 0f, 1f));
     }
 }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -24,6 +24,7 @@ public class MainWindow : IDisposable
     private const float MinimumFadeDuration = 0.001f;
     private float _timeSinceLastInteraction;
     private float _fadeAlpha = 1f;
+    private bool _styleNeedsUpdate = true;
 
     public bool IsOpen;
     public bool HasOfficerAccess { get; set; }
@@ -91,13 +92,26 @@ public class MainWindow : IDisposable
         var fadeAlpha = GetCurrentFadeAlpha();
         var fadeActive = _config.ChatFadeOutEnabled && fadeAlpha < 1f - FadeAlphaTolerance;
 
+        if (_styleNeedsUpdate)
+        {
+            ApplyAccentColors();
+            _styleNeedsUpdate = false;
+        }
+
+        var primaryColor = Config.SanitizeColor(_config.PrimaryWindowColor, Config.DefaultPrimaryWindowColor);
+        var windowColor = WithAlpha(primaryColor, fadeAlpha);
+        var childColor = WithAlpha(AdjustBrightness(primaryColor, 0.9f), fadeAlpha);
+        var tabColor = WithAlpha(AdjustBrightness(primaryColor, 1.05f), fadeAlpha);
+        var tabActiveColor = WithAlpha(AdjustBrightness(primaryColor, 1.15f), fadeAlpha);
+        var tabHoveredColor = WithAlpha(AdjustBrightness(primaryColor, 1.25f), fadeAlpha);
+
         ImGui.SetNextWindowSize(new Vector2(800, 600), ImGuiCond.FirstUseEver);
         ImGui.SetNextWindowSizeConstraints(new Vector2(600, 400), new Vector2(float.MaxValue, float.MaxValue));
-        ImGui.PushStyleColor(ImGuiCol.WindowBg, new Vector4(0.11f, 0.11f, 0.12f, fadeAlpha));
-        ImGui.PushStyleColor(ImGuiCol.ChildBg, new Vector4(0.09f, 0.09f, 0.1f, fadeAlpha));
-        ImGui.PushStyleColor(ImGuiCol.Tab, new Vector4(0.15f, 0.15f, 0.16f, fadeAlpha));
-        ImGui.PushStyleColor(ImGuiCol.TabActive, new Vector4(0.2f, 0.2f, 0.21f, fadeAlpha));
-        ImGui.PushStyleColor(ImGuiCol.TabHovered, new Vector4(0.25f, 0.25f, 0.26f, fadeAlpha));
+        ImGui.PushStyleColor(ImGuiCol.WindowBg, windowColor);
+        ImGui.PushStyleColor(ImGuiCol.ChildBg, childColor);
+        ImGui.PushStyleColor(ImGuiCol.Tab, tabColor);
+        ImGui.PushStyleColor(ImGuiCol.TabActive, tabActiveColor);
+        ImGui.PushStyleColor(ImGuiCol.TabHovered, tabHoveredColor);
 
         var styleAlphaPushed = false;
         if (fadeActive)
@@ -309,6 +323,11 @@ public class MainWindow : IDisposable
         UpdateFadeState(interacted, deltaTime);
     }
 
+    public void OnAppearanceSettingsChanged()
+    {
+        _styleNeedsUpdate = true;
+    }
+
     public void ResetEventCreateRoles()
     {
         _create.ResetRoles();
@@ -388,5 +407,34 @@ public class MainWindow : IDisposable
         {
             Instance = null;
         }
+    }
+
+    private void ApplyAccentColors()
+    {
+        var style = ImGui.GetStyle();
+        var accent = Config.SanitizeColor(_config.SecondaryAccentColor, Config.DefaultSecondaryAccentColor);
+        var accentHovered = AdjustBrightness(accent, 1.1f);
+        var accentActive = AdjustBrightness(accent, 1.2f);
+
+        style.Colors[(int)ImGuiCol.ScrollbarGrab] = accent;
+        style.Colors[(int)ImGuiCol.ScrollbarGrabHovered] = accentHovered;
+        style.Colors[(int)ImGuiCol.ScrollbarGrabActive] = accentActive;
+        style.Colors[(int)ImGuiCol.Separator] = accent;
+        style.Colors[(int)ImGuiCol.SeparatorHovered] = accentHovered;
+        style.Colors[(int)ImGuiCol.SeparatorActive] = accentActive;
+    }
+
+    private static Vector4 AdjustBrightness(Vector4 color, float factor)
+    {
+        return new Vector4(
+            Math.Clamp(color.X * factor, 0f, 1f),
+            Math.Clamp(color.Y * factor, 0f, 1f),
+            Math.Clamp(color.Z * factor, 0f, 1f),
+            color.W);
+    }
+
+    private static Vector4 WithAlpha(Vector4 color, float alphaMultiplier)
+    {
+        return new Vector4(color.X, color.Y, color.Z, Math.Clamp(color.W * alphaMultiplier, 0f, 1f));
     }
 }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -312,6 +312,37 @@ public class SettingsWindow : IDisposable
 
         ImGui.Spacing();
 
+        ImGui.TextUnformatted("Theme");
+        ImGui.Spacing();
+
+        var primaryColor = _config.PrimaryWindowColor;
+        if (ImGui.ColorEdit4("Primary window color", ref primaryColor))
+        {
+            var sanitized = Config.SanitizeColor(primaryColor, Config.DefaultPrimaryWindowColor);
+            if (!ColorsAlmostEqual(sanitized, _config.PrimaryWindowColor))
+            {
+                _config.PrimaryWindowColor = sanitized;
+                SaveConfig();
+                RefreshChatWindows();
+                MainWindow?.OnAppearanceSettingsChanged();
+            }
+        }
+
+        var secondaryColor = _config.SecondaryAccentColor;
+        if (ImGui.ColorEdit4("Secondary accent color", ref secondaryColor))
+        {
+            var sanitized = Config.SanitizeColor(secondaryColor, Config.DefaultSecondaryAccentColor);
+            if (!ColorsAlmostEqual(sanitized, _config.SecondaryAccentColor))
+            {
+                _config.SecondaryAccentColor = sanitized;
+                SaveConfig();
+                RefreshChatWindows();
+                MainWindow?.OnAppearanceSettingsChanged();
+            }
+        }
+
+        ImGui.Spacing();
+
         ImGui.BeginDisabled(fadeOutEnabled);
         var fcOpacity = _config.FcChatOpacity * 100f;
         if (ImGui.SliderFloat("FC Chat Opacity", ref fcOpacity, 0f, 100f, "%.0f%%"))
@@ -391,6 +422,11 @@ public class SettingsWindow : IDisposable
     {
         ChatWindow?.OnAppearanceSettingsChanged();
         OfficerChatWindow?.OnAppearanceSettingsChanged();
+    }
+
+    private static bool ColorsAlmostEqual(Vector4 a, Vector4 b)
+    {
+        return Vector4.DistanceSquared(a, b) <= 0.0001f;
     }
 
     private static void DrawFadePreview(string id, float alpha)


### PR DESCRIPTION
## Summary
- add configurable primary and accent colors to the plugin config with migration support
- expose new color pickers in the appearance settings and refresh open windows when updated
- use the configured colors in the main window styles and apply the accent to separators and scrollbars

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7d088088c8328b946efce413e0450