### PR TITLE
Add Syncshell progress overlay

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -68,6 +68,8 @@ public class Config : IPluginConfiguration
     public bool IsOfficerToken { get; set; }
     [JsonPropertyName("fcSyncShell")]
     public bool FCSyncShell { get; set; } = false;
+    [JsonPropertyName("showSyncshellProgressOverlay")]
+    public bool ShowSyncshellProgressOverlay { get; set; } = true;
     public bool UseCharacterName { get; set; } = false;
     public List<string> Roles { get; set; } = new();
     [JsonPropertyName("mentionRoleIds")]

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -43,6 +43,7 @@ public class Plugin : IDalamudPlugin
     private readonly RequestWatcher _requestWatcher;
     private readonly ChannelSelectionService _channelSelection;
     private readonly EmojiManager _emojiManager;
+    private readonly ProgressOverlay _progressOverlay;
 
     private Config _config = null!;
     private readonly HttpClient _httpClient;
@@ -91,6 +92,9 @@ public class Plugin : IDalamudPlugin
         _ui = new UiRenderer(_config, _httpClient, _channelSelection, _emojiManager);
         _settings = new SettingsWindow(_config, _tokenManager, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
 
+        _progressOverlay = new ProgressOverlay();
+        _services.ProgressOverlay = _progressOverlay;
+
         _presenceService = _config.SyncedChat && _config.EnableFcChat
             ? new DiscordPresenceService(_config, _httpClient)
             : null;
@@ -131,6 +135,7 @@ public class Plugin : IDalamudPlugin
 
         _services.PluginInterface.UiBuilder.Draw += _mainWindow.Draw;
         _services.PluginInterface.UiBuilder.Draw += _settings.Draw;
+        _services.PluginInterface.UiBuilder.Draw += DrawOverlay;
 
         _openMainUi = () => _mainWindow.IsOpen = true;
         _services.PluginInterface.UiBuilder.OpenMainUi += _openMainUi;
@@ -166,6 +171,7 @@ public class Plugin : IDalamudPlugin
         // Unsubscribe UI draw handlers
         _services.PluginInterface.UiBuilder.Draw -= _mainWindow.Draw;
         _services.PluginInterface.UiBuilder.Draw -= _settings.Draw;
+        _services.PluginInterface.UiBuilder.Draw -= DrawOverlay;
 
         // Unsubscribe UI open handlers
         _services.PluginInterface.UiBuilder.OpenMainUi -= _openMainUi;
@@ -189,6 +195,16 @@ public class Plugin : IDalamudPlugin
         _avatarCache.Dispose();
         _emojiManager.Dispose();
         _httpClient.Dispose();
+        if (PluginServices.Instance != null)
+        {
+            PluginServices.Instance.ProgressOverlay = null;
+        }
+    }
+
+    private void DrawOverlay()
+    {
+        _progressOverlay.IsVisible = _config.FCSyncShell && _config.ShowSyncshellProgressOverlay;
+        _progressOverlay.Draw();
     }
 
     private object? FetchWebTexture(string url, Action<ISharedImmediateTexture?> onReady)

--- a/DemiCatPlugin/PluginServices.cs
+++ b/DemiCatPlugin/PluginServices.cs
@@ -37,6 +37,8 @@ internal class PluginServices
     [PluginService]
     internal IChatGui ChatGui { get; private set; } = null!;
 
+    internal ProgressOverlay? ProgressOverlay { get; set; }
+
     public PluginServices()
     {
         Instance = this;

--- a/DemiCatPlugin/ProgressOverlay.cs
+++ b/DemiCatPlugin/ProgressOverlay.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility;
+
+namespace DemiCatPlugin;
+
+/// <summary>
+/// Renders an overlay showing Syncshell transfer progress.
+/// </summary>
+public sealed class ProgressOverlay
+{
+    private sealed class Entry
+    {
+        public required string PeerId;
+        public int Downloaded;
+        public int Total;
+        public DateTime LastUpdate;
+        public DateTime? CompletedAt;
+        public float FadeAlpha = 1f;
+    }
+
+    private readonly Dictionary<string, Entry> _entries = new(StringComparer.OrdinalIgnoreCase);
+    private readonly List<EntrySnapshot> _drawBuffer = new();
+    private readonly List<string> _removeBuffer = new();
+    private readonly object _lock = new();
+
+    private static readonly TimeSpan CompletionLifetime = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan FadeDuration = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the overlay should be drawn.
+    /// </summary>
+    public bool IsVisible { get; set; } = true;
+
+    /// <summary>
+    /// Updates or inserts a progress entry for the specified peer.
+    /// </summary>
+    public void Update(string peerId, int downloaded, int total)
+    {
+        if (string.IsNullOrWhiteSpace(peerId))
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        lock (_lock)
+        {
+            if (!_entries.TryGetValue(peerId, out var entry))
+            {
+                entry = new Entry
+                {
+                    PeerId = peerId,
+                    LastUpdate = now,
+                };
+                _entries[peerId] = entry;
+            }
+
+            entry.Downloaded = Math.Max(downloaded, 0);
+            entry.Total = Math.Max(total, 0);
+            entry.LastUpdate = now;
+            entry.FadeAlpha = 1f;
+
+            if (entry.Total > 0 && entry.Downloaded >= entry.Total)
+            {
+                entry.CompletedAt ??= now;
+            }
+            else
+            {
+                entry.CompletedAt = null;
+            }
+
+            PurgeExpiredUnsafe(now);
+        }
+    }
+
+    /// <summary>
+    /// Draws the overlay if it is enabled and contains active entries.
+    /// </summary>
+    public void Draw()
+    {
+        if (!IsVisible)
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+
+        lock (_lock)
+        {
+            PurgeExpiredUnsafe(now);
+            _drawBuffer.Clear();
+            foreach (var entry in _entries.Values)
+            {
+                UpdateFade(entry, now);
+                _drawBuffer.Add(new EntrySnapshot(
+                    entry.PeerId,
+                    entry.Downloaded,
+                    entry.Total,
+                    entry.FadeAlpha,
+                    entry.CompletedAt.HasValue,
+                    entry.LastUpdate));
+            }
+        }
+
+        if (_drawBuffer.Count == 0)
+        {
+            return;
+        }
+
+        _drawBuffer.Sort(EntryComparison);
+
+        var viewport = ImGuiHelpers.MainViewport;
+        var scale = ImGuiHelpers.GlobalScale;
+        var margin = new Vector2(16f * scale);
+        var position = new Vector2(
+            viewport.WorkPos.X + viewport.WorkSize.X - margin.X,
+            viewport.WorkPos.Y + margin.Y);
+
+        ImGui.SetNextWindowPos(position, ImGuiCond.Always, new Vector2(1f, 0f));
+        ImGui.SetNextWindowBgAlpha(0.92f);
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(12f, 10f) * scale);
+
+        const string windowId = "##dc_syncshell_progress";
+        var flags = ImGuiWindowFlags.NoDecoration |
+                    ImGuiWindowFlags.AlwaysAutoResize |
+                    ImGuiWindowFlags.NoSavedSettings |
+                    ImGuiWindowFlags.NoFocusOnAppearing |
+                    ImGuiWindowFlags.NoNav |
+                    ImGuiWindowFlags.NoMove |
+                    ImGuiWindowFlags.NoInputs;
+
+        if (ImGui.Begin(windowId, flags))
+        {
+            ImGui.TextUnformatted("Sync Progress");
+            ImGui.Separator();
+
+            var barWidth = 240f * scale;
+
+            for (var i = 0; i < _drawBuffer.Count; i++)
+            {
+                var snapshot = _drawBuffer[i];
+                if (snapshot.Alpha <= 0f)
+                {
+                    continue;
+                }
+
+                ImGui.PushStyleVar(ImGuiStyleVar.Alpha, snapshot.Alpha);
+                ImGui.PushID(snapshot.PeerId);
+
+                var peerLabel = FormatPeerId(snapshot.PeerId);
+                ImGui.TextUnformatted(peerLabel);
+                if (!string.Equals(peerLabel, snapshot.PeerId, StringComparison.Ordinal))
+                {
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.SetTooltip(snapshot.PeerId);
+                    }
+                }
+
+                var progress = snapshot.Total > 0
+                    ? Math.Clamp((float)snapshot.Downloaded / snapshot.Total, 0f, 1f)
+                    : 0f;
+                var progressLabel = snapshot.Total > 0
+                    ? $"{FormatBytes(snapshot.Downloaded)} / {FormatBytes(snapshot.Total)}"
+                    : $"{FormatBytes(snapshot.Downloaded)}";
+
+                ImGui.ProgressBar(progress, new Vector2(barWidth, 0f), progressLabel);
+
+                ImGui.PopID();
+                ImGui.PopStyleVar();
+
+                if (i < _drawBuffer.Count - 1)
+                {
+                    ImGui.Dummy(new Vector2(0f, 4f * scale));
+                }
+            }
+        }
+
+        ImGui.End();
+        ImGui.PopStyleVar();
+    }
+
+    private void PurgeExpiredUnsafe(DateTime now)
+    {
+        _removeBuffer.Clear();
+
+        foreach (var (peerId, entry) in _entries)
+        {
+            if (entry.CompletedAt is { } completed && now - completed >= CompletionLifetime)
+            {
+                _removeBuffer.Add(peerId);
+            }
+        }
+
+        if (_removeBuffer.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var peerId in _removeBuffer)
+        {
+            _entries.Remove(peerId);
+        }
+
+        _removeBuffer.Clear();
+    }
+
+    private static void UpdateFade(Entry entry, DateTime now)
+    {
+        if (entry.CompletedAt is not { } completed)
+        {
+            entry.FadeAlpha = 1f;
+            return;
+        }
+
+        var elapsed = now - completed;
+        if (elapsed <= TimeSpan.Zero)
+        {
+            entry.FadeAlpha = 1f;
+            return;
+        }
+
+        if (elapsed >= CompletionLifetime)
+        {
+            entry.FadeAlpha = 0f;
+            return;
+        }
+
+        var fadeStart = CompletionLifetime - FadeDuration;
+        if (fadeStart < TimeSpan.Zero)
+        {
+            fadeStart = TimeSpan.Zero;
+        }
+
+        if (elapsed <= fadeStart)
+        {
+            entry.FadeAlpha = 1f;
+            return;
+        }
+
+        var duration = FadeDuration <= TimeSpan.Zero
+            ? TimeSpan.FromMilliseconds(1)
+            : FadeDuration;
+        var fadeProgress = (float)((elapsed - fadeStart).TotalSeconds / duration.TotalSeconds);
+        entry.FadeAlpha = Math.Clamp(1f - fadeProgress, 0f, 1f);
+    }
+
+    private static string FormatBytes(long value)
+    {
+        var size = Math.Max(0L, value);
+        string suffix;
+        double readable;
+
+        if (size >= 1_000_000_000)
+        {
+            suffix = "GB";
+            readable = size / 1_000_000_000d;
+        }
+        else if (size >= 1_000_000)
+        {
+            suffix = "MB";
+            readable = size / 1_000_000d;
+        }
+        else if (size >= 1_000)
+        {
+            suffix = "KB";
+            readable = size / 1_000d;
+        }
+        else
+        {
+            suffix = "B";
+            readable = size;
+        }
+
+        return string.Format(CultureInfo.InvariantCulture, "{0:0.#} {1}", readable, suffix);
+    }
+
+    private static string FormatPeerId(string peerId)
+    {
+        if (string.IsNullOrEmpty(peerId))
+        {
+            return "Unknown Peer";
+        }
+
+        const int maxLength = 24;
+        if (peerId.Length <= maxLength)
+        {
+            return peerId;
+        }
+
+        return peerId[..(maxLength - 1)] + "\u2026";
+    }
+
+    private static int EntryComparison(EntrySnapshot left, EntrySnapshot right)
+    {
+        var stateCompare = (left.Completed ? 1 : 0).CompareTo(right.Completed ? 1 : 0);
+        if (stateCompare != 0)
+        {
+            return stateCompare;
+        }
+
+        return right.LastUpdate.CompareTo(left.LastUpdate);
+    }
+
+    private readonly struct EntrySnapshot
+    {
+        public EntrySnapshot(string peerId, int downloaded, int total, float alpha, bool completed, DateTime lastUpdate)
+        {
+            PeerId = peerId;
+            Downloaded = downloaded;
+            Total = total;
+            Alpha = alpha;
+            Completed = completed;
+            LastUpdate = lastUpdate;
+        }
+
+        public string PeerId { get; }
+        public int Downloaded { get; }
+        public int Total { get; }
+        public float Alpha { get; }
+        public bool Completed { get; }
+        public DateTime LastUpdate { get; }
+    }
+}

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -183,6 +183,22 @@ public class SettingsWindow : IDisposable
                 ImGui.SetTooltip("Link DemiCat to enable Syncshell.");
         }
 
+        var overlayVisible = _config.ShowSyncshellProgressOverlay;
+        var overlayDisabled = !_config.FCSyncShell;
+        if (overlayDisabled)
+            ImGui.BeginDisabled();
+        if (ImGui.Checkbox("Show Sync Progress Overlay", ref overlayVisible))
+        {
+            _config.ShowSyncshellProgressOverlay = overlayVisible;
+            SaveConfig();
+        }
+        if (overlayDisabled)
+        {
+            ImGui.EndDisabled();
+            if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                ImGui.SetTooltip("Enable Syncshell to display transfer progress overlay.");
+        }
+
         var paused = !_config.Enabled;
         if (ImGui.Checkbox("Pause", ref paused))
         {

--- a/DemiCatPlugin/SyncShell/Client.cs
+++ b/DemiCatPlugin/SyncShell/Client.cs
@@ -379,6 +379,7 @@ public sealed class SyncClient : IDisposable
 
         var download = new PeerDownloadState(peerId, manifest, missing);
         _downloads[peerId] = download;
+        PluginServices.Instance?.ProgressOverlay?.Update(peerId, download.ReceivedCount, download.TotalCount);
         TransferProgress?.Invoke(this, new TransferProgressEventArgs(peerId, download.ReceivedCount, download.TotalCount, TransferKind.Download));
 
         await SendWantBatchesAsync(socket, peerId, missing, token).ConfigureAwait(false);
@@ -400,6 +401,7 @@ public sealed class SyncClient : IDisposable
 
         var upload = _uploads.GetOrAdd(peerId, static _ => new PeerUploadState());
         upload.AddRequests(want);
+        PluginServices.Instance?.ProgressOverlay?.Update(peerId, upload.Completed, upload.Total);
         TransferProgress?.Invoke(this, new TransferProgressEventArgs(peerId, upload.Completed, upload.Total, TransferKind.Upload));
 
         foreach (var blob in want.Blobs)
@@ -451,6 +453,7 @@ public sealed class SyncClient : IDisposable
         if (_downloads.TryGetValue(peerId, out var download))
         {
             download.MarkReceived(hash!);
+            PluginServices.Instance?.ProgressOverlay?.Update(peerId, download.ReceivedCount, download.TotalCount);
             TransferProgress?.Invoke(this, new TransferProgressEventArgs(peerId, download.ReceivedCount, download.TotalCount, TransferKind.Download));
             if (download.IsComplete)
             {
@@ -467,6 +470,7 @@ public sealed class SyncClient : IDisposable
         var peerId = element.GetProperty("peerId").GetString() ?? "unknown";
         var received = element.TryGetProperty("received", out var recvElement) ? recvElement.GetInt32() : 0;
         var total = element.TryGetProperty("total", out var totalElement) ? totalElement.GetInt32() : 0;
+        PluginServices.Instance?.ProgressOverlay?.Update(peerId, received, total);
         TransferProgress?.Invoke(this, new TransferProgressEventArgs(peerId, received, total, TransferKind.Remote));
     }
 
@@ -616,6 +620,7 @@ public sealed class SyncClient : IDisposable
                 if (_uploads.TryGetValue(request.PeerId, out var uploadState))
                 {
                     uploadState.MarkSent(request.Hash, request.Chunk);
+                    PluginServices.Instance?.ProgressOverlay?.Update(request.PeerId, uploadState.Completed, uploadState.Total);
                     TransferProgress?.Invoke(this, new TransferProgressEventArgs(request.PeerId, uploadState.Completed, uploadState.Total, TransferKind.Upload));
                     if (uploadState.IsComplete)
                     {

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -16,6 +16,7 @@ public class ConfigDefaultsTests
         Assert.True(cfg.Officer);
         Assert.False(cfg.IsOfficerToken);
         Assert.False(cfg.FCSyncShell);
+        Assert.True(cfg.ShowSyncshellProgressOverlay);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add a ProgressOverlay to render stacked Syncshell transfer progress bars with fade out behaviour
- expose a Show Sync Progress Overlay configuration toggle and surface it in the settings UI
- wire SyncClient progress events through PluginServices so overlay data stays up to date and hide the overlay when Syncshell is disabled

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d54ed2b48328a135bd8b4b4be312