### PR TITLE
Add SyncShell resolver and manifest tests

### DIFF
--- a/tests/SyncShellResolverTests.cs
+++ b/tests/SyncShellResolverTests.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Services;
+using DemiCatPlugin.SyncShell;
+using Moq;
+using Xunit;
+
+public class SyncShellResolverTests
+{
+    [Fact]
+    public async Task BuildManifestAsync_ComputesHashesAndStoresMissingBlobs()
+    {
+        using var temp = new TempDirectory();
+        var modsDirectory = Path.Combine(temp.Path, "mods");
+        var configDirectory = Path.Combine(temp.Path, "config");
+        Directory.CreateDirectory(modsDirectory);
+        Directory.CreateDirectory(configDirectory);
+
+        var defaultModPath = Path.Combine(configDirectory, "default_mod.json");
+        var modDirectory = Path.Combine(modsDirectory, "SampleMod");
+        Directory.CreateDirectory(modDirectory);
+
+        var filePath = Path.Combine(modDirectory, "character.mtrl");
+        var fileBytes = Encoding.UTF8.GetBytes("resolver-test");
+        await File.WriteAllBytesAsync(filePath, fileBytes).ConfigureAwait(false);
+
+        var patchDirectory = Path.Combine(modsDirectory, "_patches");
+        Directory.CreateDirectory(patchDirectory);
+        var patchPath = Path.Combine(patchDirectory, "appearance.bin");
+        var patchBytes = Encoding.UTF8.GetBytes("patch");
+        await File.WriteAllBytesAsync(patchPath, patchBytes).ConfigureAwait(false);
+
+        var defaultMod = new
+        {
+            Mods = new Dictionary<string, object>
+            {
+                ["sample-mod"] = new
+                {
+                    Name = "Sample Mod",
+                    Enabled = true,
+                    Directory = "SampleMod",
+                    Settings = new Dictionary<string, string> { ["Option"] = "Value" },
+                    Options = new Dictionary<string, string> { ["Choice"] = "One" },
+                }
+            }
+        };
+        await File.WriteAllTextAsync(defaultModPath, JsonSerializer.Serialize(defaultMod)).ConfigureAwait(false);
+
+        var metaPath = Path.Combine(modDirectory, "meta.json");
+        var meta = new
+        {
+            Tags = new[] { "tag1", "tag2" },
+            Meta = new { Author = "Tester" }
+        };
+        await File.WriteAllTextAsync(metaPath, JsonSerializer.Serialize(meta)).ConfigureAwait(false);
+
+        var blobStore = new Mock<IBlobStore>();
+        var storedHashes = new List<string>();
+        blobStore.Setup(bs => bs.Has(It.IsAny<string>())).Returns(false);
+        blobStore
+            .Setup(bs => bs.StoreAsync(It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Stream, CancellationToken>((hash, stream, _) =>
+            {
+                storedHashes.Add(hash);
+                using var sink = new MemoryStream();
+                stream.CopyTo(sink);
+            })
+            .Returns(Task.CompletedTask);
+
+        var glamState = "{\"design\":true}";
+        var customizeState = "{\"profile\":true}";
+        var pluginInterface = CreatePluginInterfaceMock(
+            modsDirectory,
+            configDirectory,
+            glamState,
+            customizeState);
+
+        var resolver = new Resolver(blobStore.Object, Mock.Of<IPluginLog>(), pluginInterface.Object);
+
+        var manifest = await resolver.BuildManifestAsync().ConfigureAwait(false);
+
+        var collection = Assert.Single(manifest.Collections);
+        Assert.Equal("default", collection.CollectionId);
+        var modEntry = Assert.Single(collection.Mods);
+        Assert.Equal("sample-mod", modEntry.ModId);
+        Assert.Equal("Sample Mod", modEntry.Name);
+        Assert.True(modEntry.Enabled);
+        Assert.Equal(fileBytes.Length, modEntry.Size);
+
+        var fileEntry = Assert.Single(modEntry.Files);
+        Assert.Equal("character.mtrl", fileEntry.Path);
+        var expectedFileHash = ComputeSha256Hex(fileBytes);
+        Assert.Equal(expectedFileHash, fileEntry.Hash);
+        Assert.Contains(expectedFileHash, storedHashes);
+
+        var patchEntry = Assert.Single(collection.Patches);
+        Assert.Equal("appearance.bin", patchEntry.Path.Replace('\\', '/'));
+        var expectedPatchHash = ComputeSha256Hex(patchBytes);
+        Assert.Equal(expectedPatchHash, patchEntry.Hash);
+        Assert.Contains(expectedPatchHash, storedHashes);
+
+        var aggregate = SHA256.HashData(Convert.FromHexString(expectedFileHash));
+        Assert.Equal(Convert.ToHexString(aggregate).ToLowerInvariant(), modEntry.Hash);
+
+        Assert.Equal(glamState, manifest.Appearance.CustomState["glamourer"]);
+        Assert.Equal(customizeState, manifest.Appearance.CustomState["customize+"]);
+        Assert.Contains("sample-mod", manifest.Appearance.ActiveMods);
+
+        var glamSizeHint = manifest.SizeHints.Single(h => h.Path == "glamourer");
+        Assert.Equal(Encoding.UTF8.GetByteCount(glamState), glamSizeHint.Size);
+    }
+
+    [Fact]
+    public void GetMissingBlobs_ReturnsOnlyHashesNotPresent()
+    {
+        var blobStore = new Mock<IBlobStore>();
+        blobStore.Setup(bs => bs.Has("present")).Returns(true);
+        blobStore.Setup(bs => bs.Has("missing")).Returns(false);
+
+        var manifest = new SyncManifest
+        {
+            Collections =
+            {
+                new CollectionDelta
+                {
+                    Mods =
+                    {
+                        new ModEntry
+                        {
+                            Files =
+                            {
+                                new FileHash { Path = "a", Hash = "present", Size = 1 },
+                                new FileHash { Path = "b", Hash = "missing", Size = 1 },
+                                new FileHash { Path = "c", Hash = "missing", Size = 1 },
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var resolver = new Resolver(blobStore.Object, Mock.Of<IPluginLog>(), null);
+        var missing = resolver.GetMissingBlobs(manifest).ToList();
+
+        Assert.Single(missing);
+        Assert.Equal("missing", missing[0]);
+    }
+
+    [Fact]
+    public async Task ApplyManifestAsync_WritesFilesAndInvokesIpc()
+    {
+        using var temp = new TempDirectory();
+        var modsDirectory = Path.Combine(temp.Path, "mods");
+        var configDirectory = Path.Combine(temp.Path, "config");
+        Directory.CreateDirectory(modsDirectory);
+        Directory.CreateDirectory(configDirectory);
+        await File.WriteAllTextAsync(Path.Combine(configDirectory, "default_mod.json"), "{}").ConfigureAwait(false);
+
+        var cacheDirectory = Path.Combine(temp.Path, "cache");
+        Directory.CreateDirectory(cacheDirectory);
+        var blobStore = new FileBlobStore(cacheDirectory);
+
+        var modBytes = Encoding.UTF8.GetBytes("apply-data");
+        var modHash = ComputeSha256Hex(modBytes);
+        await blobStore.StoreAsync(modHash, new MemoryStream(modBytes)).ConfigureAwait(false);
+
+        var patchBytes = Encoding.UTF8.GetBytes("patch-data");
+        var patchHash = ComputeSha256Hex(patchBytes);
+        await blobStore.StoreAsync(patchHash, new MemoryStream(patchBytes)).ConfigureAwait(false);
+
+        var manifest = new SyncManifest();
+        manifest.Collections.Add(new CollectionDelta
+        {
+            Mods =
+            {
+                new ModEntry
+                {
+                    ModId = "mod-one",
+                    Enabled = true,
+                    Hash = Convert.ToHexString(SHA256.HashData(Convert.FromHexString(modHash))).ToLowerInvariant(),
+                    Files = { new FileHash { Path = "assets/file.bin", Hash = modHash, Size = modBytes.Length } },
+                }
+            },
+            Patches =
+            {
+                new PatchEntry { Path = "patches/patch.bin", Hash = patchHash, Size = patchBytes.Length }
+            }
+        });
+        manifest.Appearance.CustomState["glamourer"] = "glam-state";
+        manifest.Appearance.CustomState["customize+"] = "custom-state";
+
+        var reloadMock = new Mock<IIpcSubscriber<object>>();
+        reloadMock.Setup(sub => sub.InvokeAction());
+        var redrawMock = new Mock<IIpcSubscriber<object>>();
+        redrawMock.Setup(sub => sub.InvokeAction());
+        var glamApplyMock = new Mock<IIpcSubscriber<string, object?>>();
+        glamApplyMock.Setup(sub => sub.InvokeAction(It.IsAny<string>()));
+        var customizeApplyMock = new Mock<IIpcSubscriber<string, object?>>();
+        customizeApplyMock.Setup(sub => sub.InvokeAction(It.IsAny<string>()));
+
+        var pluginInterface = CreatePluginInterfaceMock(
+            modsDirectory,
+            configDirectory,
+            glamState: null,
+            customizeState: null);
+        pluginInterface
+            .Setup(pi => pi.GetIpcSubscriber<object>(It.Is<string>(c => c == "Penumbra.Reload")))
+            .Returns(reloadMock.Object);
+        pluginInterface
+            .Setup(pi => pi.GetIpcSubscriber<object>(It.Is<string>(c => c == "Penumbra.RedrawAll")))
+            .Returns(redrawMock.Object);
+        pluginInterface
+            .Setup(pi => pi.GetIpcSubscriber<string, object?>(It.Is<string>(c => c == "Glamourer.Design.Apply")))
+            .Returns(glamApplyMock.Object);
+        pluginInterface
+            .Setup(pi => pi.GetIpcSubscriber<string, object?>(It.Is<string>(c => c == "Customize.ApplyProfile")))
+            .Returns(customizeApplyMock.Object);
+
+        var resolver = new Resolver(blobStore, Mock.Of<IPluginLog>(), pluginInterface.Object);
+        await resolver.ApplyManifestAsync("peer-one", manifest).ConfigureAwait(false);
+
+        var appliedFile = Path.Combine(modsDirectory, "SyncShell", "peer-one", "mod-one", "assets", "file.bin");
+        Assert.True(File.Exists(appliedFile));
+        Assert.Equal(modBytes, await File.ReadAllBytesAsync(appliedFile).ConfigureAwait(false));
+
+        var patchFile = Path.Combine(modsDirectory, "SyncShell", "peer-one", "patches", "patches", "patch.bin");
+        Assert.True(File.Exists(patchFile));
+        Assert.Equal(patchBytes, await File.ReadAllBytesAsync(patchFile).ConfigureAwait(false));
+
+        var defaultModPath = Path.Combine(configDirectory, "default_mod.json");
+        var defaultConfig = JsonSerializer.Deserialize<JsonElement>(await File.ReadAllTextAsync(defaultModPath).ConfigureAwait(false));
+        var modConfig = defaultConfig.GetProperty("Mods").GetProperty("mod-one");
+        Assert.True(modConfig.GetProperty("Enabled").GetBoolean());
+        Assert.Equal(Path.Combine("SyncShell", "peer-one", "mod-one"), modConfig.GetProperty("Directory").GetString());
+
+        reloadMock.Verify(sub => sub.InvokeAction(), Times.Once());
+        redrawMock.Verify(sub => sub.InvokeAction(), Times.Once());
+        glamApplyMock.Verify(sub => sub.InvokeAction("glam-state"), Times.Once());
+        customizeApplyMock.Verify(sub => sub.InvokeAction("custom-state"), Times.Once());
+    }
+
+    private static string ComputeSha256Hex(ReadOnlySpan<byte> data)
+        => Convert.ToHexString(SHA256.HashData(data)).ToLowerInvariant();
+
+    private static Mock<IDalamudPluginInterface> CreatePluginInterfaceMock(
+        string modsDirectory,
+        string configDirectory,
+        string? glamState,
+        string? customizeState)
+    {
+        var pluginInterface = new Mock<IDalamudPluginInterface>();
+        pluginInterface
+            .Setup(pi => pi.GetIpcSubscriber<string>(It.IsAny<string>()))
+            .Returns<string>(channel => channel switch
+            {
+                "Penumbra.GetModsDirectory" => CreateFuncSubscriber(modsDirectory),
+                "Penumbra.GetConfigurationDirectory" => CreateFuncSubscriber(configDirectory),
+                "Penumbra.GetConfigDirectory" => CreateFuncSubscriber(configDirectory),
+                "Glamourer.GetCharacterState" => CreateFuncSubscriber(glamState),
+                "Customize.GetCharacterProfile" => CreateFuncSubscriber(customizeState),
+                "Customize.GetActiveProfile" => CreateFuncSubscriber<string?>(null),
+                _ => CreateFuncSubscriber<string?>(null),
+            });
+        return pluginInterface;
+    }
+
+    private static IIpcSubscriber<T> CreateFuncSubscriber<T>(T value)
+    {
+        var subscriber = new Mock<IIpcSubscriber<T>>();
+        subscriber.Setup(sub => sub.InvokeFunc()).Returns(value);
+        return subscriber.Object;
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+        public TempDirectory()
+        {
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                {
+                    Directory.Delete(Path, recursive: true);
+                }
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+import types
+
+project_root = Path(__file__).resolve().parents[1]
+demibot_root = project_root / "demibot"
+if str(demibot_root) not in sys.path:
+    sys.path.insert(0, str(demibot_root))
+
+structlog_stub = types.SimpleNamespace(
+    processors=types.SimpleNamespace(
+        TimeStamper=lambda fmt=None: None,
+        add_log_level=lambda *a, **k: None,
+        EventRenamer=lambda *a, **k: None,
+        JSONRenderer=lambda *a, **k: None,
+    ),
+    make_filtering_bound_logger=lambda *a, **k: None,
+    stdlib=types.SimpleNamespace(LoggerFactory=lambda: None),
+    configure=lambda *a, **k: None,
+    get_logger=lambda *a, **k: None,
+)
+sys.modules.setdefault("structlog", structlog_stub)
+
+if "discord" not in sys.modules:
+    discord_module = types.ModuleType("discord")
+    commands_module = types.ModuleType("discord.ext.commands")
+
+    class _DummyBot:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    commands_module.Bot = _DummyBot
+    commands_module.AutoShardedBot = _DummyBot
+
+    discord_ext = types.ModuleType("discord.ext")
+    discord_ext.commands = commands_module
+    discord_module.ext = discord_ext
+    discord_module.ClientException = type("ClientException", (Exception,), {})
+
+    sys.modules["discord"] = discord_module
+    sys.modules["discord.ext"] = discord_ext
+    sys.modules["discord.ext.commands"] = commands_module

--- a/tests/syncshell_import.py
+++ b/tests/syncshell_import.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+import types
+
+# Ensure the demibot package is available on sys.path for route imports.
+project_root = Path(__file__).resolve().parents[1]
+demibot_root = project_root / "demibot"
+if str(demibot_root) not in sys.path:
+    sys.path.insert(0, str(demibot_root))
+
+# Stub out structlog to avoid optional dependency requirements when importing the route module.
+structlog_stub = types.SimpleNamespace(
+    processors=types.SimpleNamespace(
+        TimeStamper=lambda fmt=None: None,
+        add_log_level=lambda *a, **k: None,
+        EventRenamer=lambda *a, **k: None,
+        JSONRenderer=lambda *a, **k: None,
+    ),
+    make_filtering_bound_logger=lambda *a, **k: None,
+    stdlib=types.SimpleNamespace(LoggerFactory=lambda: None),
+    configure=lambda *a, **k: None,
+    get_logger=lambda *a, **k: None,
+)
+sys.modules.setdefault("structlog", structlog_stub)
+
+syncshell_path = (
+    project_root
+    / "demibot"
+    / "demibot"
+    / "http"
+    / "routes"
+    / "syncshell.py"
+)
+
+
+def _load_syncshell_module():
+    spec = importlib.util.spec_from_file_location(
+        "demibot.http.routes.syncshell", syncshell_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["demibot.http.routes.syncshell"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+syncshell = _load_syncshell_module()

--- a/tests/syncshell_test_utils.py
+++ b/tests/syncshell_test_utils.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Tuple
+
+
+def _write_sample_mod(root: Path, *, content: bytes) -> tuple[Path, str, int]:
+    mod_root = root / "mods" / "SampleMod"
+    mod_root.mkdir(parents=True, exist_ok=True)
+    file_path = mod_root / "character.mtrl"
+    file_path.write_bytes(content)
+    file_hash = hashlib.sha256(content).hexdigest()
+    return file_path, file_hash, len(content)
+
+
+def build_manifest_payload(base: Path) -> Tuple[dict, str]:
+    """Construct a SyncShell manifest payload mirroring the plugin schema.
+
+    Parameters
+    ----------
+    base:
+        Temporary directory used to materialise sample files whose hashes are
+        referenced by the manifest.
+
+    Returns
+    -------
+    tuple
+        The manifest payload dictionary alongside the computed blob hash.
+    """
+
+    file_path, file_hash, size = _write_sample_mod(base, content=b"syncshell-test-payload")
+
+    aggregate = hashlib.sha256(bytes.fromhex(file_hash)).hexdigest()
+    last_updated = datetime.now(timezone.utc).isoformat()
+
+    manifest = {
+        "protocolVersion": 1,
+        "clientId": "test-client",
+        "appearance": {
+            "collectionId": "default",
+            "activeMods": ["sample-mod"],
+            "customState": {},
+            "lastUpdated": last_updated,
+        },
+        "collections": [
+            {
+                "collectionId": "default",
+                "mods": [
+                    {
+                        "modId": "sample-mod",
+                        "name": "Sample Mod",
+                        "hash": aggregate,
+                        "size": size,
+                        "files": [
+                            {
+                                "path": file_path.name,
+                                "hash": file_hash,
+                                "size": size,
+                            }
+                        ],
+                        "options": {},
+                        "tags": ["tests"],
+                        "enabled": True,
+                        "patches": [],
+                        "meta": [],
+                    }
+                ],
+                "removedMods": [],
+                "patches": [],
+                "removedPatches": [],
+                "meta": [],
+            }
+        ],
+        "sizeHints": [
+            {
+                "path": "default",
+                "size": size,
+            }
+        ],
+        "meta": [],
+        "wantBlobs": {
+            "blobs": [file_hash],
+            "chunks": [],
+            "sizeHints": [],
+        },
+        "presence": {
+            "status": "online",
+        },
+    }
+
+    # Normalise through JSON to avoid non-serialisable objects leaking into tests.
+    normalised = json.loads(json.dumps(manifest))
+    return normalised, file_hash

--- a/tests/test_syncshell.py
+++ b/tests/test_syncshell.py
@@ -1,41 +1,14 @@
 import asyncio
+
 import pytest
-
-import importlib.util
-import sys
-from pathlib import Path
-import types
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "demibot"))
-
-structlog_stub = types.SimpleNamespace(
-    processors=types.SimpleNamespace(
-        TimeStamper=lambda fmt=None: None,
-        add_log_level=lambda *a, **k: None,
-        EventRenamer=lambda *a, **k: None,
-        JSONRenderer=lambda *a, **k: None,
-    ),
-    make_filtering_bound_logger=lambda *a, **k: None,
-    stdlib=types.SimpleNamespace(LoggerFactory=lambda: None),
-    configure=lambda *a, **k: None,
-    get_logger=lambda *a, **k: None,
-)
-sys.modules.setdefault("structlog", structlog_stub)
 
 from demibot.db.session import init_db, get_session
 import demibot.db.session as db_session
 from demibot.db.models import User, SyncshellPairing
 from demibot.http.deps import RequestContext
 
-syncshell_path = (
-    Path(__file__).resolve().parents[1] / "demibot" / "demibot" / "http" / "routes" / "syncshell.py"
-)
-spec = importlib.util.spec_from_file_location(
-    "demibot.http.routes.syncshell", syncshell_path
-)
-syncshell = importlib.util.module_from_spec(spec)
-sys.modules["demibot.http.routes.syncshell"] = syncshell
-spec.loader.exec_module(syncshell)
+from .syncshell_import import syncshell
+from .syncshell_test_utils import build_manifest_payload
 
 
 async def _prepare_db():
@@ -45,7 +18,7 @@ async def _prepare_db():
     return get_session()
 
 
-def test_pair_token_persistence_and_expiry():
+def test_pair_token_persistence_and_expiry(tmp_path):
     async def _run():
         session_factory = await _prepare_db()
         async with session_factory as db:
@@ -54,20 +27,24 @@ def test_pair_token_persistence_and_expiry():
             await db.commit()
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
             syncshell.TOKEN_TTL = 1
             resp = await syncshell.pair(ctx=ctx, db=db)
             token = resp["token"]
             pairing = await db.get(SyncshellPairing, user.id)
             assert pairing and pairing.token == token
 
+            manifest, _ = build_manifest_payload(tmp_path)
+            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+
             await asyncio.sleep(1.1)
             with pytest.raises(syncshell.HTTPException) as exc:
-                await syncshell.upload_manifest([], ctx=ctx, db=db)
+                await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert exc.value.status_code == 401
     asyncio.run(_run())
 
 
-def test_manifest_rate_limit():
+def test_manifest_rate_limit(tmp_path):
     async def _run():
         session_factory = await _prepare_db()
         async with session_factory as db:
@@ -76,16 +53,18 @@ def test_manifest_rate_limit():
             await db.commit()
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
             syncshell.RATE_LIMIT = 2
             await syncshell.pair(ctx=ctx, db=db)
-            await syncshell.upload_manifest([], ctx=ctx, db=db)
+            manifest, _ = build_manifest_payload(tmp_path)
+            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             with pytest.raises(syncshell.HTTPException) as exc:
-                await syncshell.upload_manifest([], ctx=ctx, db=db)
+                await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert exc.value.status_code == 429
     asyncio.run(_run())
 
 
-def test_manifest_too_large():
+def test_manifest_too_large(tmp_path):
     async def _run():
         session_factory = await _prepare_db()
         async with session_factory as db:
@@ -96,14 +75,15 @@ def test_manifest_too_large():
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
             syncshell.MAX_MANIFEST_BYTES = 10
             await syncshell.pair(ctx=ctx, db=db)
-            big_manifest = [{"id": "a" * 20}]
+            big_manifest, _ = build_manifest_payload(tmp_path)
+            big_manifest.setdefault("meta", []).append({"key": "x", "value": "y" * 50})
             with pytest.raises(syncshell.HTTPException) as exc:
                 await syncshell.upload_manifest(big_manifest, ctx=ctx, db=db)
             assert exc.value.status_code == 413
     asyncio.run(_run())
 
 
-def test_asset_upload_download_and_rate_limit():
+def test_asset_upload_download_and_rate_limit(tmp_path):
     async def _run():
         session_factory = await _prepare_db()
         async with session_factory as db:
@@ -112,7 +92,8 @@ def test_asset_upload_download_and_rate_limit():
             await db.commit()
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
-            syncshell.RATE_LIMIT = 3
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            syncshell.RATE_LIMIT = 4
 
             async def fake_upload():
                 return "upload-url"
@@ -124,6 +105,8 @@ def test_asset_upload_download_and_rate_limit():
             syncshell.presign_download = fake_download
 
             await syncshell.pair(ctx=ctx, db=db)
+            manifest, _ = build_manifest_payload(tmp_path)
+            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             up = await syncshell.request_asset_upload(ctx=ctx, db=db)
             assert up["url"] == "upload-url"
             down = await syncshell.request_asset_download("x", ctx=ctx, db=db)

--- a/tests/test_syncshell_blob_store.py
+++ b/tests/test_syncshell_blob_store.py
@@ -1,0 +1,45 @@
+import asyncio
+import json
+
+from demibot.db.session import init_db, get_session
+import demibot.db.session as db_session
+from demibot.db.models import User, SyncshellManifest
+from demibot.http.deps import RequestContext
+
+from .syncshell_import import syncshell
+from .syncshell_test_utils import build_manifest_payload
+
+
+def test_manifest_blob_hashes_persist(tmp_path):
+    async def _run():
+        db_session._engine = None
+        db_session._Session = None
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            user = User(id=10, discord_user_id=10, global_name="BlobTester")
+            db.add(user)
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            syncshell.RATE_LIMIT = 5
+            await syncshell.pair(ctx=ctx, db=db)
+
+            manifest, blob_hash = build_manifest_payload(tmp_path)
+            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            record = await db.get(SyncshellManifest, user.id)
+            assert record is not None
+            stored = json.loads(record.manifest_json)
+            stored_file = stored["collections"][0]["mods"][0]["files"][0]
+            assert stored_file["hash"] == blob_hash
+            assert stored["wantBlobs"]["blobs"] == [blob_hash]
+
+            # Updating the manifest replaces the stored payload.
+            newer_manifest, newer_hash = build_manifest_payload(tmp_path / "second")
+            await syncshell.upload_manifest(newer_manifest, ctx=ctx, db=db)
+            updated = await db.get(SyncshellManifest, user.id)
+            assert updated is not None
+            updated_payload = json.loads(updated.manifest_json)
+            assert updated_payload["collections"][0]["mods"][0]["files"][0]["hash"] == newer_hash
+            assert updated_payload["wantBlobs"]["blobs"] == [newer_hash]
+    asyncio.run(_run())

--- a/tests/test_syncshell_limits.py
+++ b/tests/test_syncshell_limits.py
@@ -1,8 +1,4 @@
 import asyncio
-import asyncio
-import importlib.util
-import sys
-from pathlib import Path
 
 import pytest
 
@@ -11,18 +7,11 @@ import demibot.db.session as db_session
 from demibot.db.models import User
 from demibot.http.deps import RequestContext
 
-syncshell_path = (
-    Path(__file__).resolve().parents[1] / "demibot" / "demibot" / "http" / "routes" / "syncshell.py"
-)
-spec = importlib.util.spec_from_file_location(
-    "demibot.http.routes.syncshell", syncshell_path
-)
-syncshell = importlib.util.module_from_spec(spec)
-sys.modules["demibot.http.routes.syncshell"] = syncshell
-spec.loader.exec_module(syncshell)
+from .syncshell_import import syncshell
+from .syncshell_test_utils import build_manifest_payload
 
 
-def test_token_expiry():
+def test_token_expiry(tmp_path):
     async def _run():
         db_session._engine = None
         db_session._Session = None
@@ -33,15 +22,18 @@ def test_token_expiry():
             await db.commit()
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
             syncshell.TOKEN_TTL = 1
             await syncshell.pair(ctx=ctx, db=db)
+            manifest, _ = build_manifest_payload(tmp_path)
+            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             await asyncio.sleep(1.1)
             with pytest.raises(syncshell.HTTPException):
-                await syncshell.upload_manifest([], ctx=ctx, db=db)
+                await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
     asyncio.run(_run())
 
 
-def test_rate_limit_hits():
+def test_rate_limit_hits(tmp_path):
     async def _run():
         db_session._engine = None
         db_session._Session = None
@@ -52,9 +44,11 @@ def test_rate_limit_hits():
             await db.commit()
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
             syncshell.RATE_LIMIT = 2
             await syncshell.pair(ctx=ctx, db=db)
-            await syncshell.upload_manifest([], ctx=ctx, db=db)
+            manifest, _ = build_manifest_payload(tmp_path)
+            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             with pytest.raises(syncshell.HTTPException):
                 await syncshell.resync(ctx=ctx, db=db)
     asyncio.run(_run())

--- a/tests/test_syncshell_resync_cache.py
+++ b/tests/test_syncshell_resync_cache.py
@@ -4,22 +4,12 @@ from demibot.db.session import init_db, get_session
 import demibot.db.session as db_session
 from demibot.db.models import User, SyncshellManifest
 from demibot.http.deps import RequestContext
-import importlib.util
-import sys
-from pathlib import Path
 
-syncshell_path = (
-    Path(__file__).resolve().parents[1] / "demibot" / "demibot" / "http" / "routes" / "syncshell.py"
-)
-spec = importlib.util.spec_from_file_location(
-    "demibot.http.routes.syncshell", syncshell_path
-)
-syncshell = importlib.util.module_from_spec(spec)
-sys.modules["demibot.http.routes.syncshell"] = syncshell
-spec.loader.exec_module(syncshell)
+from .syncshell_import import syncshell
+from .syncshell_test_utils import build_manifest_payload
 
 
-def test_resync_and_cache_clear():
+def test_resync_and_cache_clear(tmp_path):
     async def _run():
         db_session._engine = None
         db_session._Session = None
@@ -30,7 +20,9 @@ def test_resync_and_cache_clear():
             await db.commit()
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
-            manifest = [{"id": "a"}]
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            syncshell.RATE_LIMIT = 5
+            manifest, _ = build_manifest_payload(tmp_path)
             await syncshell.pair(ctx=ctx, db=db)
             await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert await db.get(SyncshellManifest, 1) is not None
@@ -38,7 +30,8 @@ def test_resync_and_cache_clear():
             await syncshell.clear_cache(ctx=ctx, db=db)
             assert await db.get(SyncshellManifest, 1) is None
 
-            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            manifest2, _ = build_manifest_payload(tmp_path / "second")
+            await syncshell.upload_manifest(manifest2, ctx=ctx, db=db)
             assert await db.get(SyncshellManifest, 1) is not None
 
             await syncshell.resync(ctx=ctx, db=db)


### PR DESCRIPTION
## Summary
- add shared SyncShell test helpers and stubs so the HTTP route can be imported in isolation
- update the existing SyncShell Python tests to use the structured manifest payload and cover the adjusted rate limiting behaviour
- add new tests for manifest persistence and C# resolver scenarios that exercise hashing, blob storage, and apply logic

## Testing
- pytest tests/test_syncshell.py tests/test_syncshell_limits.py tests/test_syncshell_resync_cache.py tests/test_syncshell_blob_store.py

------
https://chatgpt.com/codex/tasks/task_e_68d7de1360548328b74215acf2162e17