### PR TITLE
Add SyncShell websocket handshake endpoint

### DIFF
--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -21,6 +21,7 @@ import structlog
 
 from .ws import websocket_endpoint
 from .ws_chat import websocket_endpoint_chat
+from .ws_syncshell import websocket_endpoint_syncshell
 
 
 logger = structlog.get_logger()
@@ -71,6 +72,7 @@ def create_app() -> FastAPI:
     app.add_api_websocket_route("/ws/channels", websocket_endpoint)
     app.add_api_websocket_route("/ws/requests", websocket_endpoint)
     app.add_api_websocket_route("/ws/chat", websocket_endpoint_chat)
+    app.add_api_websocket_route("/ws/syncshell", websocket_endpoint_syncshell)
 
     @app.get("/health")
     async def health() -> dict[str, str]:

--- a/demibot/demibot/http/ws_syncshell.py
+++ b/demibot/demibot/http/ws_syncshell.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi import HTTPException, WebSocket, WebSocketDisconnect
+
+from ..db.models import SyncshellManifest
+from ..db.session import get_session
+from .deps import RequestContext, api_key_auth
+from .routes import syncshell as syncshell_routes
+
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_LIMITS = {
+    "bytesPerSecond": int(os.getenv("SYNC_SHELL_BYTES_PER_SECOND", str(512 * 1024))),
+    "chunkSizeBytes": int(os.getenv("SYNC_SHELL_CHUNK_SIZE", str(64 * 1024))),
+    "maxOutstandingWants": int(os.getenv("SYNC_SHELL_MAX_OUTSTANDING_WANTS", "64")),
+}
+
+HELLO_MESSAGE = {"type": "hello", "payload": {"version": 1, "limits": DEFAULT_LIMITS}}
+
+
+def _ws_request(ws: WebSocket) -> SimpleNamespace:
+    client_host = getattr(getattr(ws, "client", None), "host", "unknown")
+    return SimpleNamespace(
+        client=SimpleNamespace(host=client_host),
+        method="WS",
+        url=SimpleNamespace(path=ws.scope.get("path", "")),
+    )
+
+
+async def _persist_manifest(ctx: RequestContext, manifest: dict[str, Any]) -> None:
+    manifest_json = json.dumps(manifest)
+    payload_size = len(manifest_json.encode())
+    if payload_size > syncshell_routes.MAX_MANIFEST_BYTES:
+        raise HTTPException(status_code=413, detail="manifest too large")
+
+    async with get_session() as db:
+        await syncshell_routes._require_pairing(ctx, db)
+        await syncshell_routes._check_rate_limit(ctx.user.id, db)
+
+        record = await db.get(SyncshellManifest, ctx.user.id)
+        if record:
+            record.manifest_json = manifest_json
+            record.updated_at = datetime.utcnow()
+        else:
+            record = SyncshellManifest(user_id=ctx.user.id, manifest_json=manifest_json)
+            db.add(record)
+        await db.commit()
+
+
+async def _handle_manifest_message(
+    websocket: WebSocket, ctx: RequestContext, payload: dict[str, Any]
+) -> bool:
+    manifest_payload = payload.get("manifest")
+    if not isinstance(manifest_payload, dict):
+        LOGGER.warning("syncshell manifest payload missing or invalid")
+        return True
+
+    try:
+        await _persist_manifest(ctx, manifest_payload)
+    except HTTPException as exc:
+        LOGGER.warning("syncshell manifest rejected: %s", exc.detail)
+        await websocket.close(code=1008, reason=exc.detail)
+        return False
+    except Exception:  # pragma: no cover - defensive logging
+        LOGGER.exception("syncshell manifest handling failed")
+        await websocket.close(code=1011, reason="internal error")
+        return False
+
+    peer_id = payload.get("peerId")
+    if not peer_id:
+        peer_id = str(ctx.user.discord_user_id or ctx.user.id)
+
+    want_message = {
+        "type": "want",
+        "payload": {
+            "peerId": peer_id,
+            "want": {"blobs": [], "chunks": [], "sizeHints": []},
+        },
+    }
+    await websocket.send_json(want_message)
+    return True
+
+
+def _extract_payload(message: dict[str, Any]) -> dict[str, Any]:
+    payload = message.get("payload")
+    if isinstance(payload, dict):
+        return payload
+    return message
+
+
+async def websocket_endpoint_syncshell(websocket: WebSocket) -> None:
+    path = websocket.scope.get("path", "")
+    token = websocket.headers.get("X-Api-Key")
+    if websocket.query_params.get("token"):
+        LOGGER.warning("WS %s closing with 1008: token in url", path)
+        await websocket.close(code=1008, reason="token in url")
+        return
+    if not token:
+        LOGGER.warning("WS %s closing with 1008: missing token", path)
+        await websocket.close(code=1008, reason="missing token")
+        return
+
+    try:
+        async with get_session() as db:
+            ctx = await api_key_auth(
+                _ws_request(websocket),
+                x_api_key=token,
+                x_discord_id=None,
+                db=db,
+            )
+    except HTTPException as exc:
+        LOGGER.warning("WS %s auth failed (%s): %s", path, exc.status_code, exc.detail)
+        await websocket.close(code=1008, reason="auth failed")
+        return
+    except Exception:  # pragma: no cover - defensive logging
+        LOGGER.exception("WS %s unexpected auth failure", path)
+        await websocket.close(code=1011, reason="internal error")
+        return
+
+    await websocket.accept()
+
+    hello_received = False
+    try:
+        while True:
+            try:
+                message = await websocket.receive_json()
+            except WebSocketDisconnect:
+                break
+            except RuntimeError:
+                break
+            except ValueError:
+                LOGGER.warning("syncshell websocket received invalid JSON payload")
+                await websocket.close(code=1003, reason="invalid payload")
+                break
+
+            if not isinstance(message, dict):
+                continue
+
+            message_type = message.get("type")
+            payload_data = _extract_payload(message)
+
+            if message_type == "hello":
+                hello_received = True
+                await websocket.send_json(HELLO_MESSAGE)
+            elif message_type == "manifest":
+                if not hello_received:
+                    await websocket.close(code=1002, reason="handshake required")
+                    break
+                should_continue = await _handle_manifest_message(
+                    websocket, ctx, payload_data
+                )
+                if not should_continue:
+                    break
+            else:
+                LOGGER.debug("syncshell websocket ignoring message type %s", message_type)
+    finally:
+        # Allow the client context manager to handle closure; best effort to
+        # ensure the coroutine completes cleanly without raising.
+        try:
+            await websocket.close()
+        except Exception:  # pragma: no cover - best effort close
+            pass

--- a/tests/test_syncshell_ws.py
+++ b/tests/test_syncshell_ws.py
@@ -1,0 +1,91 @@
+import asyncio
+import json
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from demibot.http.api import create_app
+from demibot.db.models import (
+    Guild,
+    Membership,
+    SyncshellManifest,
+    SyncshellPairing,
+    User,
+    UserKey,
+)
+from demibot.db.session import get_session, init_db
+import demibot.db.session as db_session
+
+from .syncshell_test_utils import build_manifest_payload
+
+
+async def _prepare_db() -> None:
+    db_session._engine = None
+    db_session._Session = None
+    await init_db("sqlite+aiosqlite://")
+
+    async with get_session() as db:
+        guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
+        user = User(id=1, discord_user_id=1234, global_name="Tester")
+        key = UserKey(
+            id=1,
+            user_id=user.id,
+            guild_id=guild.id,
+            token="syncshell-token",
+            enabled=True,
+        )
+        membership = Membership(id=1, guild_id=guild.id, user_id=user.id)
+        pairing = SyncshellPairing(
+            user_id=user.id,
+            token="pair",
+            created_at=datetime.utcnow(),
+            expires_at=datetime.utcnow() + timedelta(minutes=5),
+        )
+        db.add_all([guild, user, key, membership, pairing])
+        await db.commit()
+
+
+def test_syncshell_websocket_hello_and_manifest(tmp_path):
+    asyncio.run(_prepare_db())
+
+    manifest, _ = build_manifest_payload(tmp_path)
+    app = create_app()
+    client = TestClient(app)
+
+    with client.websocket_connect(
+        "/ws/syncshell", headers={"X-Api-Key": "syncshell-token"}
+    ) as websocket:
+        websocket.send_json(
+            {
+                "type": "hello",
+                "payload": {
+                    "version": 1,
+                    "limits": {
+                        "bytesPerSecond": 512 * 1024,
+                        "chunkSizeBytes": 64 * 1024,
+                        "maxOutstandingWants": 64,
+                    },
+                },
+            }
+        )
+        server_hello = websocket.receive_json()
+        assert server_hello["type"] == "hello"
+        assert server_hello["payload"]["limits"]["chunkSizeBytes"] == 64 * 1024
+
+        websocket.send_json({"type": "manifest", "payload": {"manifest": manifest}})
+        want = websocket.receive_json()
+        assert want["type"] == "want"
+        assert want["payload"]["want"] == {
+            "blobs": [],
+            "chunks": [],
+            "sizeHints": [],
+        }
+
+    async def _fetch_manifest() -> dict:
+        async with get_session() as db:
+            record = await db.get(SyncshellManifest, 1)
+            assert record is not None
+            return json.loads(record.manifest_json)
+
+    stored_manifest = asyncio.run(_fetch_manifest())
+    assert stored_manifest["protocolVersion"] == 1


### PR DESCRIPTION
## Summary
- add a dedicated /ws/syncshell websocket handler that authenticates clients, negotiates limits, and persists manifests
- register the SyncShell websocket route in the FastAPI application factory
- add an integration test that exercises the hello/manifest exchange over the new websocket endpoint

## Testing
- pytest tests/test_syncshell_ws.py

------
https://chatgpt.com/codex/tasks/task_e_68d83c34a22483289a8d88d6d270248d