### PR TITLE
Track SyncShell installation asset hashes

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -839,6 +839,7 @@ public class SyncshellWindow : IDisposable
         {
             Id = string.IsNullOrWhiteSpace(source.Id) ? Guid.NewGuid().ToString("N") : source.Id,
             Name = string.IsNullOrWhiteSpace(source.Name) ? source.Id ?? "Untitled" : source.Name!,
+            Hash = string.Empty,
             Kind = string.IsNullOrWhiteSpace(source.Kind) ? "UNKNOWN" : source.Kind!,
             Size = source.Size,
             Uploader = string.IsNullOrWhiteSpace(source.Uploader) ? peerId : source.Uploader!,
@@ -863,6 +864,7 @@ public class SyncshellWindow : IDisposable
         {
             Id = asset.Id,
             Name = asset.Name,
+            Hash = asset.Hash,
             Kind = asset.Kind,
             Size = asset.Size,
             Uploader = asset.Uploader,
@@ -1058,7 +1060,7 @@ public class SyncshellWindow : IDisposable
             CommitReservedBytes(reservation);
             committed = true;
 
-            await UpdateInstallationStatus(asset.Id, "DOWNLOADED");
+            await UpdateInstallationStatus(asset.Id, "DOWNLOADED", asset.Hash);
 
             switch (asset.Kind)
             {
@@ -1069,19 +1071,19 @@ public class SyncshellWindow : IDisposable
                     var design = await File.ReadAllTextAsync(tmp);
                     using (JsonDocument.Parse(design)) { }
                     ApplyIpc("Glamourer.Design.Apply", design);
-                    await UpdateInstallationStatus(asset.Id, "APPLIED");
+                    await UpdateInstallationStatus(asset.Id, "APPLIED", asset.Hash);
                     break;
                 case "CUSTOMIZE_PROFILE":
                     var profile = await File.ReadAllTextAsync(tmp);
                     using (JsonDocument.Parse(profile)) { }
                     ApplyIpc("Customize.ApplyProfile", profile);
-                    await UpdateInstallationStatus(asset.Id, "APPLIED");
+                    await UpdateInstallationStatus(asset.Id, "APPLIED", asset.Hash);
                     break;
                 case "SIMPLEHEELS_PROFILE":
                     var heels = await File.ReadAllTextAsync(tmp);
                     using (JsonDocument.Parse(heels)) { }
                     ApplyIpc("SimpleHeels.ApplyProfile", heels);
-                    await UpdateInstallationStatus(asset.Id, "APPLIED");
+                    await UpdateInstallationStatus(asset.Id, "APPLIED", asset.Hash);
                     break;
             }
 
@@ -1111,7 +1113,7 @@ public class SyncshellWindow : IDisposable
             if (!committed)
                 ReleaseReservedBytes(reservation);
             PluginServices.Instance?.Log.Error(ex, $"Failed to install asset {asset.Id}");
-            await UpdateInstallationStatus(asset.Id, "FAILED");
+            await UpdateInstallationStatus(asset.Id, "FAILED", asset.Hash);
             return (false, ex.Message);
         }
         finally
@@ -1491,7 +1493,7 @@ public class SyncshellWindow : IDisposable
                 var proceed = await ResolvePenumbraConflict(asset.Name, dest);
                 if (!proceed)
                 {
-                    await UpdateInstallationStatus(asset.Id, "SKIPPED");
+                    await UpdateInstallationStatus(asset.Id, "SKIPPED", asset.Hash);
                     return;
                 }
             }
@@ -1528,7 +1530,7 @@ public class SyncshellWindow : IDisposable
 
         if (success)
         {
-            await UpdateInstallationStatus(asset.Id, "INSTALLED");
+            await UpdateInstallationStatus(asset.Id, "INSTALLED", asset.Hash);
             if (DateTimeOffset.UtcNow - _lastRedraw > TimeSpan.FromSeconds(5))
             {
                 try
@@ -1541,11 +1543,11 @@ public class SyncshellWindow : IDisposable
                 }
                 _lastRedraw = DateTimeOffset.UtcNow;
             }
-            await UpdateInstallationStatus(asset.Id, "APPLIED");
+            await UpdateInstallationStatus(asset.Id, "APPLIED", asset.Hash);
         }
         else
         {
-            await UpdateInstallationStatus(asset.Id, "FAILED");
+            await UpdateInstallationStatus(asset.Id, "FAILED", asset.Hash);
         }
     }
 
@@ -1587,7 +1589,7 @@ public class SyncshellWindow : IDisposable
         }
     }
 
-    private async Task UpdateInstallationStatus(string assetId, string status)
+    private async Task UpdateInstallationStatus(string assetId, string status, string? assetHash = null)
     {
         try
         {
@@ -1595,7 +1597,13 @@ public class SyncshellWindow : IDisposable
                 return;
 
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users/me/installations";
-            var payload = new { assetId, status };
+            assetHash ??= GetAssetHash(assetId);
+            if (assetHash == null && _installations.TryGetValue(assetId, out var existing) && !string.IsNullOrEmpty(existing.AssetHash))
+            {
+                assetHash = existing.AssetHash;
+            }
+
+            var payload = new { assetId, status, assetHash };
             var request = new HttpRequestMessage(HttpMethod.Post, url)
             {
                 Content = new StringContent(JsonSerializer.Serialize(payload), System.Text.Encoding.UTF8, "application/json")
@@ -1603,7 +1611,13 @@ public class SyncshellWindow : IDisposable
             ApiHelpers.AddAuthHeader(request, _tokenManager);
             await _httpClient.SendAsync(request);
 
-            _installations[assetId] = new Installation { AssetId = assetId, Status = status, UpdatedAt = DateTimeOffset.UtcNow };
+            _installations[assetId] = new Installation
+            {
+                AssetId = assetId,
+                Status = status,
+                UpdatedAt = DateTimeOffset.UtcNow,
+                AssetHash = assetHash,
+            };
             SaveInstalledCache();
             ComputeUpdates();
         }
@@ -1611,6 +1625,49 @@ public class SyncshellWindow : IDisposable
         {
             PluginServices.Instance?.Log.Error(ex, "Failed to update installation status");
         }
+    }
+
+    private string? GetAssetHash(string assetId)
+    {
+        var asset = _assets.FirstOrDefault(a => string.Equals(a.Id, assetId, StringComparison.Ordinal));
+        if (asset != null && !string.IsNullOrEmpty(asset.Hash))
+        {
+            return asset.Hash;
+        }
+
+        return null;
+    }
+
+    private bool EnsureInstallationHashesFromAssets()
+    {
+        var updated = false;
+        var missing = false;
+
+        foreach (var pair in _installations)
+        {
+            if (!string.IsNullOrEmpty(pair.Value.AssetHash))
+            {
+                continue;
+            }
+
+            var hash = GetAssetHash(pair.Key);
+            if (!string.IsNullOrEmpty(hash))
+            {
+                pair.Value.AssetHash = hash;
+                updated = true;
+            }
+            else
+            {
+                missing = true;
+            }
+        }
+
+        if (missing)
+        {
+            Interlocked.Exchange(ref _installationsRefreshRequested, 1);
+        }
+
+        return updated;
     }
 
     private void LoadCaches()
@@ -1645,6 +1702,12 @@ public class SyncshellWindow : IDisposable
                 }
             }
             else
+            {
+                SaveInstalledCache();
+            }
+
+            var hashesBackfilled = EnsureInstallationHashesFromAssets();
+            if (hashesBackfilled)
             {
                 SaveInstalledCache();
             }
@@ -1945,6 +2008,7 @@ public class SyncshellWindow : IDisposable
         {
             Id = asset.Id ?? string.Empty,
             Name = string.IsNullOrWhiteSpace(asset.Name) ? asset.Id ?? string.Empty : asset.Name!,
+            Hash = asset.Hash ?? string.Empty,
             Kind = string.IsNullOrWhiteSpace(asset.Kind) ? "UNKNOWN" : asset.Kind!,
             Size = asset.Size,
             Uploader = string.Empty,
@@ -2334,6 +2398,7 @@ public class SyncshellWindow : IDisposable
                     continue;
                 _installations[inst.AssetId] = inst;
             }
+            EnsureInstallationHashesFromAssets();
             SaveInstalledCache();
         }
         catch
@@ -2347,8 +2412,22 @@ public class SyncshellWindow : IDisposable
         _updatesAvailable.Clear();
         foreach (var asset in _assets)
         {
-            if (_installations.TryGetValue(asset.Id, out var inst) && asset.UpdatedAt > inst.UpdatedAt)
+            if (!_installations.TryGetValue(asset.Id, out var inst))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(asset.Hash))
+            {
+                if (!string.Equals(asset.Hash, inst.AssetHash, StringComparison.Ordinal))
+                {
+                    _updatesAvailable.Add(asset.Id);
+                }
+            }
+            else if (asset.UpdatedAt > inst.UpdatedAt)
+            {
                 _updatesAvailable.Add(asset.Id);
+            }
         }
     }
 
@@ -2589,6 +2668,8 @@ public class SyncshellWindow : IDisposable
         public string Id { get; set; } = string.Empty;
         [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("hash")]
+        public string Hash { get; set; } = string.Empty;
         [JsonPropertyName("kind")]
         public string Kind { get; set; } = string.Empty;
         [JsonPropertyName("size")]
@@ -2655,6 +2736,9 @@ public class SyncshellWindow : IDisposable
         [JsonPropertyName("name")]
         public string? Name { get; set; }
 
+        [JsonPropertyName("hash")]
+        public string? Hash { get; set; }
+
         [JsonPropertyName("kind")]
         public string? Kind { get; set; }
 
@@ -2713,6 +2797,8 @@ public class SyncshellWindow : IDisposable
         public string Status { get; set; } = string.Empty;
         [JsonPropertyName("updatedAt")]
         public DateTimeOffset UpdatedAt { get; set; }
+        [JsonPropertyName("assetHash")]
+        public string? AssetHash { get; set; }
     }
 
     private sealed class InstallationConverter : JsonConverter<Installation>
@@ -2757,6 +2843,12 @@ public class SyncshellWindow : IDisposable
                     continue;
                 }
 
+                if (PropertyMatches(propertyName, "assetHash"))
+                {
+                    installation.AssetHash = ReadStringValue(ref reader);
+                    continue;
+                }
+
                 reader.Skip();
             }
 
@@ -2769,6 +2861,15 @@ public class SyncshellWindow : IDisposable
             writer.WriteString("assetId", value.AssetId ?? string.Empty);
             writer.WriteString("status", value.Status ?? string.Empty);
             writer.WriteString("updatedAt", value.UpdatedAt);
+            writer.WritePropertyName("assetHash");
+            if (!string.IsNullOrEmpty(value.AssetHash))
+            {
+                writer.WriteStringValue(value.AssetHash);
+            }
+            else
+            {
+                writer.WriteNullValue();
+            }
             writer.WriteEndObject();
         }
 

--- a/SQL Schema.sql
+++ b/SQL Schema.sql
@@ -1232,6 +1232,7 @@ CREATE TABLE `user_installation` (
   `user_id` bigint unsigned NOT NULL,
   `asset_id` int NOT NULL,
   `status` enum('DOWNLOADED','INSTALLED','APPLIED','FAILED') NOT NULL,
+  `asset_hash` varchar(64) DEFAULT NULL,
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,
   `version` int NOT NULL DEFAULT '1',

--- a/demibot/demibot/db/migrations/versions/0049_add_installation_asset_hash.py
+++ b/demibot/demibot/db/migrations/versions/0049_add_installation_asset_hash.py
@@ -1,0 +1,57 @@
+"""0049_add_installation_asset_hash
+
+Revision ID: 0049_add_installation_asset_hash
+Revises: 0048_add_membership_banner_and_accent
+Create Date: 2024-05-14 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0049_add_installation_asset_hash"
+down_revision: Union[str, None] = "0048_add_membership_banner_and_accent"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_installation",
+        sa.Column("asset_hash", sa.String(length=64), nullable=True),
+    )
+
+    user_installation = sa.table(
+        "user_installation",
+        sa.column("id", sa.Integer),
+        sa.column("asset_id", sa.Integer),
+        sa.column("asset_hash", sa.String(length=64)),
+    )
+    asset = sa.table(
+        "asset",
+        sa.column("id", sa.Integer),
+        sa.column("hash", sa.String(length=64)),
+    )
+
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.select(user_installation.c.id, asset.c.hash)
+        .select_from(user_installation.join(asset, user_installation.c.asset_id == asset.c.id))
+    ).all()
+
+    for row_id, asset_hash in rows:
+        if asset_hash:
+            conn.execute(
+                sa.update(user_installation)
+                .where(user_installation.c.id == row_id)
+                .values(asset_hash=asset_hash)
+            )
+
+
+def downgrade() -> None:
+    op.drop_column("user_installation", "asset_hash")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -705,6 +705,7 @@ class UserInstallation(Base):
     status: Mapped[InstallStatus] = mapped_column(
         SAEnum(InstallStatus), nullable=False
     )
+    asset_hash: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow

--- a/demibot/demibot/http/routes/installations.py
+++ b/demibot/demibot/http/routes/installations.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ...db.models import InstallStatus, UserInstallation
+from ...db.models import Asset, InstallStatus, UserInstallation
 
 router = APIRouter(prefix="/api")
 
@@ -18,6 +18,7 @@ class InstallationPayload(BaseModel):
 
     asset_id: int = Field(alias="assetId")
     status: InstallStatus
+    asset_hash: str | None = Field(default=None, alias="assetHash")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -37,6 +38,7 @@ async def get_my_installations(
             "assetId": str(row.asset_id),
             "status": row.status.value,
             "updatedAt": row.updated_at.isoformat() if row.updated_at else None,
+            "assetHash": row.asset_hash,
         }
         for row in rows
     ]
@@ -57,17 +59,25 @@ async def post_my_installations(
     )
     result = await db.execute(stmt)
     inst = result.scalar_one_or_none()
+    asset_hash = payload.asset_hash
+    if not asset_hash:
+        asset_res = await db.execute(
+            select(Asset.hash).where(Asset.id == payload.asset_id)
+        )
+        asset_hash = asset_res.scalar_one_or_none()
     now = datetime.utcnow()
     if inst is None:
         inst = UserInstallation(
             user_id=ctx.user.id,
             asset_id=payload.asset_id,
             status=payload.status,
+            asset_hash=asset_hash,
             updated_at=now,
         )
         db.add(inst)
     else:
         inst.status = payload.status
+        inst.asset_hash = asset_hash
         inst.updated_at = now
     await db.commit()
     await db.refresh(inst)
@@ -75,4 +85,5 @@ async def post_my_installations(
         "assetId": str(inst.asset_id),
         "status": inst.status.value,
         "updatedAt": inst.updated_at.isoformat() if inst.updated_at else None,
+        "assetHash": inst.asset_hash,
     }

--- a/tests/test_installations.py
+++ b/tests/test_installations.py
@@ -41,18 +41,21 @@ def test_installations_flow():
             await post_my_installations(payload, ctx=ctx, db=db)
             items = await get_my_installations(ctx=ctx, db=db)
             assert items[0]["status"] == "DOWNLOADED"
+            assert items[0]["assetHash"] == "h"
 
             # install
             payload = InstallationPayload(assetId=1, status=InstallStatus.INSTALLED)
             await post_my_installations(payload, ctx=ctx, db=db)
             items = await get_my_installations(ctx=ctx, db=db)
             assert items[0]["status"] == "INSTALLED"
+            assert items[0]["assetHash"] == "h"
 
             # apply
             payload = InstallationPayload(assetId=1, status=InstallStatus.APPLIED)
             await post_my_installations(payload, ctx=ctx, db=db)
             items = await get_my_installations(ctx=ctx, db=db)
             assert items[0]["status"] == "APPLIED"
+            assert items[0]["assetHash"] == "h"
 
             # only one row exists
             rows = (await db.execute(select(UserInstallation))).scalars().all()


### PR DESCRIPTION
## Summary
- persist the asset hash on SyncShell installation records and use hashes to detect updates client-side
- include asset hashes in the installations API and database schema, with a migration and cache backfill logic
- update tests to validate the new asset hash field in installation responses

## Testing
- `pytest tests/test_installations.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d88e16e0348328a30d642ef8778811