### PR TITLE
Add Syncshell membership routes and presence tracking

### DIFF
--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -231,6 +231,61 @@ class SyncshellRateLimit(Base):
     window_start: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
+class SyncshellInvite(Base):
+    __tablename__ = "syncshell_invites"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    inviter_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), index=True
+    )
+    target_user_id: Mapped[Optional[int]] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), nullable=True, index=True
+    )
+    target_display_name: Mapped[str] = mapped_column(String(255))
+    status: Mapped[str] = mapped_column(String(32), default="pending", index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+
+class SyncshellMember(Base):
+    __tablename__ = "syncshell_members"
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "member_user_id", name="uq_syncshell_member_pair"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), index=True
+    )
+    member_user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class SyncshellPresence(Base):
+    __tablename__ = "syncshell_presence"
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "member_user_id", name="uq_syncshell_presence_pair"
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), index=True
+    )
+    member_user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), index=True
+    )
+    active: Mapped[bool] = mapped_column(Boolean, default=False)
+    last_seen: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
 class Message(Base):
     __tablename__ = "messages"
     __table_args__ = (

--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -7,10 +7,20 @@ from datetime import datetime, timedelta
 import json
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ...db.models import SyncshellPairing, SyncshellManifest, SyncshellRateLimit
+from ...db.models import (
+    SyncshellPairing,
+    SyncshellManifest,
+    SyncshellRateLimit,
+    SyncshellInvite,
+    SyncshellMember,
+    SyncshellPresence,
+    User,
+)
 from ..vault import presign_upload, presign_download
 
 
@@ -38,10 +48,387 @@ async def _check_rate_limit(user_id: int, db: AsyncSession) -> None:
     await db.commit()
 
 
+def _display_name(user: User | None) -> str:
+    if not user:
+        return "Unknown"
+    return user.global_name or user.character_name or str(user.id)
+
+
+def _to_iso(dt: datetime | None) -> str | None:
+    if not dt:
+        return None
+    return dt.replace(microsecond=0).isoformat() + "Z"
+
+
+class InviteCreateRequest(BaseModel):
+    member: str | None = Field(default=None, description="Display name of target")
+    member_id: int | None = Field(default=None, description="Identifier of target user")
+
+
+class PresenceUpdateRequest(BaseModel):
+    active_member_ids: list[int] = Field(
+        default_factory=list, description="Members currently nearby or active"
+    )
+
+
 async def _require_pairing(ctx: RequestContext, db: AsyncSession) -> None:
     pairing = await db.get(SyncshellPairing, ctx.user.id)
     if not pairing or pairing.expires_at < datetime.utcnow():
         raise HTTPException(status_code=401, detail="pairing token expired")
+
+
+async def _ensure_membership(
+    db: AsyncSession, user_id: int, member_user_id: int
+) -> None:
+    if user_id == member_user_id:
+        return
+    result = await db.execute(
+        select(SyncshellMember).where(
+            SyncshellMember.user_id == user_id,
+            SyncshellMember.member_user_id == member_user_id,
+        )
+    )
+    if result.scalars().first() is None:
+        db.add(
+            SyncshellMember(
+                user_id=user_id,
+                member_user_id=member_user_id,
+                created_at=datetime.utcnow(),
+            )
+        )
+
+
+async def _ensure_presence_record(
+    db: AsyncSession, user_id: int, member_user_id: int
+) -> None:
+    if user_id == member_user_id:
+        return
+    result = await db.execute(
+        select(SyncshellPresence).where(
+            SyncshellPresence.user_id == user_id,
+            SyncshellPresence.member_user_id == member_user_id,
+        )
+    )
+    if result.scalars().first() is None:
+        db.add(
+            SyncshellPresence(
+                user_id=user_id,
+                member_user_id=member_user_id,
+                active=False,
+                last_seen=datetime.utcnow(),
+            )
+        )
+
+
+def _serialize_invite(invite: SyncshellInvite, direction: str) -> dict[str, Any]:
+    return {
+        "id": invite.id,
+        "target": invite.target_display_name,
+        "status": invite.status,
+        "updatedAt": _to_iso(invite.updated_at) or _to_iso(invite.created_at),
+        "direction": direction,
+    }
+
+
+@router.get("/invites")
+async def list_invites(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+    result = await db.execute(
+        select(SyncshellInvite)
+        .where(SyncshellInvite.inviter_id == ctx.user.id)
+        .order_by(SyncshellInvite.updated_at.desc())
+    )
+    invites = [_serialize_invite(invite, "outgoing") for invite in result.scalars().all()]
+    return {"invites": invites}
+
+
+@router.post("/invites")
+async def create_invite(
+    payload: InviteCreateRequest,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+
+    target_user: User | None = None
+    display_name = (payload.member or "").strip()
+    if payload.member_id is not None:
+        target_user = await db.get(User, payload.member_id)
+        if not target_user:
+            raise HTTPException(status_code=404, detail="member not found")
+        display_name = _display_name(target_user)
+
+    if not display_name:
+        raise HTTPException(status_code=422, detail="member is required")
+
+    if target_user and target_user.id == ctx.user.id:
+        raise HTTPException(status_code=400, detail="cannot invite yourself")
+
+    if target_user:
+        existing_member = await db.execute(
+            select(SyncshellMember).where(
+                SyncshellMember.user_id == ctx.user.id,
+                SyncshellMember.member_user_id == target_user.id,
+            )
+        )
+        if existing_member.scalars().first() is not None:
+            raise HTTPException(status_code=409, detail="already a member")
+
+        existing_invite = await db.execute(
+            select(SyncshellInvite).where(
+                SyncshellInvite.inviter_id == ctx.user.id,
+                SyncshellInvite.target_user_id == target_user.id,
+                SyncshellInvite.status == "pending",
+            )
+        )
+        invite = existing_invite.scalars().first()
+        if invite is not None:
+            return _serialize_invite(invite, "outgoing")
+    else:
+        existing_invite = await db.execute(
+            select(SyncshellInvite).where(
+                SyncshellInvite.inviter_id == ctx.user.id,
+                SyncshellInvite.target_display_name == display_name,
+                SyncshellInvite.status == "pending",
+            )
+        )
+        invite = existing_invite.scalars().first()
+        if invite is not None:
+            return _serialize_invite(invite, "outgoing")
+
+    invite = SyncshellInvite(
+        id=uuid4().hex,
+        inviter_id=ctx.user.id,
+        target_user_id=target_user.id if target_user else None,
+        target_display_name=display_name,
+        status="pending",
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+    )
+    db.add(invite)
+    await db.commit()
+    await db.refresh(invite)
+    return _serialize_invite(invite, "outgoing")
+
+
+async def _get_invite_for_target(
+    db: AsyncSession, invite_id: str, target_user_id: int
+) -> SyncshellInvite:
+    invite = await db.get(SyncshellInvite, invite_id)
+    if not invite or invite.target_user_id != target_user_id:
+        raise HTTPException(status_code=404, detail="invite not found")
+    if invite.status != "pending":
+        raise HTTPException(status_code=400, detail="invite already processed")
+    return invite
+
+
+async def _finalize_invite(
+    db: AsyncSession, invite: SyncshellInvite, accepted: bool
+) -> None:
+    invite.status = "accepted" if accepted else "denied"
+    invite.updated_at = datetime.utcnow()
+    if accepted and invite.target_user_id:
+        await _ensure_membership(db, invite.inviter_id, invite.target_user_id)
+        await _ensure_membership(db, invite.target_user_id, invite.inviter_id)
+        await _ensure_presence_record(db, invite.inviter_id, invite.target_user_id)
+        await _ensure_presence_record(db, invite.target_user_id, invite.inviter_id)
+    await db.commit()
+
+
+@router.post("/invites/{invite_id}/accept")
+async def accept_invite(
+    invite_id: str,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+    invite = await _get_invite_for_target(db, invite_id, ctx.user.id)
+    await _finalize_invite(db, invite, accepted=True)
+    return {"status": "accepted"}
+
+
+@router.post("/invites/{invite_id}/deny")
+async def deny_invite(
+    invite_id: str,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+    invite = await _get_invite_for_target(db, invite_id, ctx.user.id)
+    await _finalize_invite(db, invite, accepted=False)
+    return {"status": "denied"}
+
+
+@router.get("/pending")
+async def list_pending(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+    result = await db.execute(
+        select(SyncshellInvite)
+        .where(
+            SyncshellInvite.target_user_id == ctx.user.id,
+            SyncshellInvite.status == "pending",
+        )
+        .order_by(SyncshellInvite.created_at.desc())
+    )
+    invites = result.scalars().all()
+    pending: list[dict[str, Any]] = []
+    for invite in invites:
+        inviter = await db.get(User, invite.inviter_id)
+        pending.append(
+            {
+                "id": invite.id,
+                "requesterId": invite.inviter_id,
+                "displayName": _display_name(inviter),
+                "requestedAt": _to_iso(invite.created_at),
+                "direction": "incoming",
+            }
+        )
+    return {"pending": pending}
+
+
+@router.get("/members")
+async def list_members(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+    result = await db.execute(
+        select(SyncshellMember.member_user_id).where(
+            SyncshellMember.user_id == ctx.user.id
+        )
+    )
+    member_ids = result.scalars().all()
+    if not member_ids:
+        return {"members": []}
+
+    user_result = await db.execute(select(User).where(User.id.in_(member_ids)))
+    users = {user.id: user for user in user_result.scalars().all()}
+
+    presence_result = await db.execute(
+        select(SyncshellPresence).where(
+            SyncshellPresence.user_id == ctx.user.id,
+            SyncshellPresence.member_user_id.in_(member_ids),
+        )
+    )
+    presences = {p.member_user_id: p for p in presence_result.scalars().all()}
+
+    members: list[dict[str, Any]] = []
+    for member_id in member_ids:
+        presence = presences.get(member_id)
+        members.append(
+            {
+                "id": str(member_id),
+                "displayName": _display_name(users.get(member_id)),
+                "active": bool(presence.active) if presence else False,
+                "lastSeen": _to_iso(presence.last_seen) if presence else None,
+            }
+        )
+    members.sort(key=lambda entry: entry["displayName"].lower())
+    return {"members": members}
+
+
+@router.post("/presence")
+async def update_presence(
+    payload: PresenceUpdateRequest,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+    result = await db.execute(
+        select(SyncshellMember.member_user_id).where(
+            SyncshellMember.user_id == ctx.user.id
+        )
+    )
+    valid_members = set(result.scalars().all())
+    active_members = {mid for mid in payload.active_member_ids if mid in valid_members}
+
+    presence_result = await db.execute(
+        select(SyncshellPresence).where(SyncshellPresence.user_id == ctx.user.id)
+    )
+    existing = {record.member_user_id: record for record in presence_result.scalars().all()}
+    now = datetime.utcnow()
+
+    for member_id in valid_members:
+        record = existing.get(member_id)
+        if member_id in active_members:
+            if record:
+                record.active = True
+                record.last_seen = now
+            else:
+                db.add(
+                    SyncshellPresence(
+                        user_id=ctx.user.id,
+                        member_user_id=member_id,
+                        active=True,
+                        last_seen=now,
+                    )
+                )
+        else:
+            if record and record.active:
+                record.active = False
+    await db.commit()
+    return {"status": "ok"}
+
+
+@router.get("/presence")
+async def get_presence(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+    result = await db.execute(
+        select(SyncshellMember.member_user_id).where(
+            SyncshellMember.user_id == ctx.user.id
+        )
+    )
+    member_ids = result.scalars().all()
+    if not member_ids:
+        return {"presence": [], "currentlySynced": []}
+
+    presence_result = await db.execute(
+        select(SyncshellPresence).where(
+            SyncshellPresence.user_id == ctx.user.id,
+            SyncshellPresence.member_user_id.in_(member_ids),
+        )
+    )
+    presence_map = {
+        record.member_user_id: record for record in presence_result.scalars().all()
+    }
+
+    user_result = await db.execute(select(User).where(User.id.in_(member_ids)))
+    users = {user.id: user for user in user_result.scalars().all()}
+
+    presence_entries: list[dict[str, Any]] = []
+    active_entries: list[dict[str, Any]] = []
+    for member_id in member_ids:
+        record = presence_map.get(member_id)
+        entry = {
+            "id": str(member_id),
+            "displayName": _display_name(users.get(member_id)),
+            "active": bool(record.active) if record else False,
+            "lastSeen": _to_iso(record.last_seen) if record else None,
+        }
+        presence_entries.append(entry)
+        if entry["active"]:
+            active_entries.append(entry)
+
+    presence_entries.sort(key=lambda entry: entry["displayName"].lower())
+    active_entries.sort(key=lambda entry: entry["displayName"].lower())
+    return {"presence": presence_entries, "currentlySynced": active_entries}
 
 
 @router.post("/pair")

--- a/tests/test_syncshell_membership.py
+++ b/tests/test_syncshell_membership.py
@@ -1,0 +1,108 @@
+import asyncio
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from demibot.db.session import init_db, get_session
+import demibot.db.session as db_session
+from demibot.db.models import User
+from demibot.http.deps import RequestContext
+from demibot.http.routes import syncshell
+
+
+async def _prepare_db():
+    db_session._engine = None
+    db_session._Session = None
+    await init_db("sqlite+aiosqlite://")
+    return get_session()
+
+
+def _make_ctx(user: User) -> RequestContext:
+    return RequestContext(user=user, guild=None, key=object(), roles=[])
+
+
+def test_syncshell_invite_acceptance_and_members():
+    async def _run():
+        session_factory = await _prepare_db()
+        async with session_factory as db:
+            user_a = User(id=1, discord_user_id=10, global_name="Alpha")
+            user_b = User(id=2, discord_user_id=20, global_name="Beta")
+            db.add_all([user_a, user_b])
+            await db.commit()
+
+            ctx_a = _make_ctx(user_a)
+            ctx_b = _make_ctx(user_b)
+
+            await syncshell.pair(ctx=ctx_a, db=db)
+            await syncshell.pair(ctx=ctx_b, db=db)
+
+            invite = await syncshell.create_invite(
+                payload=syncshell.InviteCreateRequest(member_id=user_b.id),
+                ctx=ctx_a,
+                db=db,
+            )
+            assert invite["status"] == "pending"
+
+            pending = await syncshell.list_pending(ctx=ctx_b, db=db)
+            assert len(pending["pending"]) == 1
+            assert pending["pending"][0]["id"] == invite["id"]
+
+            await syncshell.accept_invite(invite["id"], ctx=ctx_b, db=db)
+
+            invites_after = await syncshell.list_invites(ctx=ctx_a, db=db)
+            assert invites_after["invites"][0]["status"] == "accepted"
+
+            members_a = await syncshell.list_members(ctx=ctx_a, db=db)
+            members_b = await syncshell.list_members(ctx=ctx_b, db=db)
+
+            assert [m["id"] for m in members_a["members"]] == [str(user_b.id)]
+            assert [m["id"] for m in members_b["members"]] == [str(user_a.id)]
+
+            pending_after = await syncshell.list_pending(ctx=ctx_b, db=db)
+            assert pending_after["pending"] == []
+
+    asyncio.run(_run())
+
+
+def test_syncshell_presence_updates():
+    async def _run():
+        session_factory = await _prepare_db()
+        async with session_factory as db:
+            user_a = User(id=11, discord_user_id=110, global_name="Gamma")
+            user_b = User(id=12, discord_user_id=120, global_name="Delta")
+            db.add_all([user_a, user_b])
+            await db.commit()
+
+            ctx_a = _make_ctx(user_a)
+            ctx_b = _make_ctx(user_b)
+
+            await syncshell.pair(ctx=ctx_a, db=db)
+            await syncshell.pair(ctx=ctx_b, db=db)
+
+            invite = await syncshell.create_invite(
+                payload=syncshell.InviteCreateRequest(member_id=user_b.id),
+                ctx=ctx_a,
+                db=db,
+            )
+            await syncshell.accept_invite(invite["id"], ctx=ctx_b, db=db)
+
+            await syncshell.update_presence(
+                payload=syncshell.PresenceUpdateRequest(active_member_ids=[user_b.id]),
+                ctx=ctx_a,
+                db=db,
+            )
+
+            presence = await syncshell.get_presence(ctx=ctx_a, db=db)
+            assert presence["currentlySynced"][0]["id"] == str(user_b.id)
+            assert presence["presence"][0]["active"] is True
+
+            await syncshell.update_presence(
+                payload=syncshell.PresenceUpdateRequest(active_member_ids=[]),
+                ctx=ctx_a,
+                db=db,
+            )
+            presence_after = await syncshell.get_presence(ctx=ctx_a, db=db)
+            assert presence_after["presence"][0]["active"] is False
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add database tables to persist Syncshell invites, memberships, and presence snapshots
- extend the syncshell router with invite management, member listings, and presence polling endpoints
- cover the new functionality with unit tests for invite handling, membership views, and presence updates

## Testing
- pytest tests/test_syncshell_membership.py

------
https://chatgpt.com/codex/tasks/task_e_68d89f345a3c8328816d1a80e8f1030f