### PR TITLE
Add SyncShell manifest diffing and transfer budget guidance

### DIFF
--- a/DemiCatPlugin/SyncShell/Client.cs
+++ b/DemiCatPlugin/SyncShell/Client.cs
@@ -467,13 +467,94 @@ public sealed class SyncClient : IDisposable
         var peerId = element.TryGetProperty("peerId", out var peerProperty)
             ? peerProperty.GetString() ?? "unknown"
             : "unknown";
-        if (!element.TryGetProperty("want", out var wantElement))
+        var want = element.TryGetProperty("want", out var wantElement)
+            ? wantElement.Deserialize<WantBlobs>(JsonOptions) ?? new WantBlobs()
+            : new WantBlobs();
+
+        if (element.TryGetProperty("limits", out var limitsElement) && limitsElement.ValueKind == JsonValueKind.Object)
         {
-            PluginServices.Instance?.Log.Warning("Received want message without payload");
-            return;
+            if (limitsElement.TryGetProperty("transfer", out var transferElement) && transferElement.ValueKind == JsonValueKind.Object)
+            {
+                var remoteLimits = transferElement.Deserialize<SyncLimits>(JsonOptions);
+                if (remoteLimits != null)
+                {
+                    _negotiatedLimits = SyncLimits.Negotiate(_localLimits, remoteLimits);
+                    _sendBucket = new TokenBucket(_negotiatedLimits.BytesPerSecond, _negotiatedLimits.BytesPerSecond);
+                }
+            }
+
+            if (limitsElement.TryGetProperty("budget", out var budgetElement) && budgetElement.ValueKind == JsonValueKind.Object)
+            {
+                if (budgetElement.TryGetProperty("throttleAfterBytes", out var throttleElement) && throttleElement.ValueKind == JsonValueKind.Number)
+                {
+                    var remaining = throttleElement.GetInt64();
+                    if (remaining <= 0)
+                    {
+                        PluginServices.Instance?.Log.Warning("SyncShell upload budget exhausted; awaiting reset before sending more blobs.");
+                    }
+                }
+            }
         }
 
-        var want = wantElement.Deserialize<WantBlobs>(JsonOptions) ?? new WantBlobs();
+        var diffHashes = new List<string>();
+        var diffChunks = new List<BlobChunk>();
+        if (element.TryGetProperty("diff", out var diffElement) && diffElement.ValueKind == JsonValueKind.Object)
+        {
+            if (diffElement.TryGetProperty("need", out var needElement) && needElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in needElement.EnumerateArray())
+                {
+                    if (item.ValueKind != JsonValueKind.Object)
+                    {
+                        continue;
+                    }
+
+                    if (item.TryGetProperty("chunk", out var chunkElement) && chunkElement.ValueKind == JsonValueKind.Object)
+                    {
+                        var chunk = chunkElement.Deserialize<BlobChunk>(JsonOptions);
+                        if (chunk != null)
+                        {
+                            diffChunks.Add(chunk);
+                            continue;
+                        }
+                    }
+
+                    if (item.TryGetProperty("hash", out var hashElement) && hashElement.ValueKind == JsonValueKind.String)
+                    {
+                        var hash = hashElement.GetString();
+                        if (!string.IsNullOrEmpty(hash))
+                        {
+                            diffHashes.Add(hash!);
+                        }
+                    }
+                }
+            }
+
+            if (diffElement.TryGetProperty("conflicts", out var conflictsElement) && conflictsElement.ValueKind == JsonValueKind.Array && conflictsElement.GetArrayLength() > 0)
+            {
+                PluginServices.Instance?.Log.Information($"SyncShell diff reported {conflictsElement.GetArrayLength()} conflicts for peer {peerId}");
+            }
+        }
+
+        foreach (var hash in diffHashes)
+        {
+            if (!want.Blobs.Contains(hash))
+            {
+                want.Blobs.Add(hash);
+            }
+        }
+
+        foreach (var chunk in diffChunks)
+        {
+            if (!want.Chunks.Any(existing =>
+                    existing.Blob.Equals(chunk.Blob, StringComparison.OrdinalIgnoreCase) &&
+                    existing.Offset == chunk.Offset &&
+                    existing.Length == chunk.Length))
+            {
+                want.Chunks.Add(chunk);
+            }
+        }
+
         WantsReceived?.Invoke(this, new WantsReceivedEventArgs(peerId, want));
 
         var upload = _uploads.GetOrAdd(peerId, static _ => new PeerUploadState());

--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import os
 from uuid import uuid4
-from typing import Any
-from datetime import datetime, timedelta
+from typing import Any, Optional
+from datetime import datetime, timedelta, timezone
+from dataclasses import dataclass
 import json
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -29,6 +30,276 @@ router = APIRouter(prefix="/api/syncshell", tags=["syncshell"])
 RATE_LIMIT = int(os.getenv("SYNC_SHELL_MAX_REQUESTS_PER_MINUTE", "30"))
 TOKEN_TTL = int(os.getenv("SYNC_SHELL_TOKEN_TTL", "300"))  # seconds
 MAX_MANIFEST_BYTES = 1024 * 1024  # 1 MiB manifest payload cap
+
+DEFAULT_TRANSFER_LIMITS: dict[str, int] = {
+    "bytesPerSecond": int(os.getenv("SYNC_SHELL_BYTES_PER_SECOND", str(512 * 1024))),
+    "chunkSizeBytes": int(os.getenv("SYNC_SHELL_CHUNK_SIZE", str(64 * 1024))),
+    "maxOutstandingWants": int(os.getenv("SYNC_SHELL_MAX_OUTSTANDING_WANTS", "64")),
+}
+
+TRANSFER_BUDGET_BYTES = int(
+    os.getenv("SYNC_SHELL_TRANSFER_BUDGET_BYTES", str(512 * 1024 * 1024))
+)
+TRANSFER_BUDGET_WINDOW_SECONDS = int(
+    os.getenv("SYNC_SHELL_TRANSFER_BUDGET_WINDOW", str(60 * 60))
+)
+
+
+@dataclass
+class _TransferBudget:
+    window_start: datetime
+    used_bytes: int = 0
+
+
+_transfer_budgets: dict[int, _TransferBudget] = {}
+
+
+def _now_utc() -> datetime:
+    return datetime.utcnow()
+
+
+def _normalise_size(value: Any) -> int:
+    try:
+        if value is None:
+            return 0
+        if isinstance(value, (int, float)):
+            return int(value)
+        if isinstance(value, str) and value.strip():
+            return int(float(value))
+    except (ValueError, TypeError):
+        return 0
+    return 0
+
+
+def _extract_manifest_assets(manifest: Any) -> dict[tuple[Any, ...], dict[str, Any]]:
+    assets: dict[tuple[Any, ...], dict[str, Any]] = {}
+    if not isinstance(manifest, dict):
+        return assets
+
+    collections = manifest.get("collections") or []
+    for collection in collections:
+        if not isinstance(collection, dict):
+            continue
+        collection_id = collection.get("collectionId") or "default"
+
+        mods = collection.get("mods") or []
+        for mod in mods:
+            if not isinstance(mod, dict):
+                continue
+            mod_id = mod.get("modId") or ""
+            mod_key = ("mod", collection_id, mod_id)
+            assets[mod_key] = {
+                "kind": "mod",
+                "collectionId": collection_id,
+                "modId": mod_id,
+                "hash": mod.get("hash"),
+                "size": _normalise_size(mod.get("size")),
+                "transferable": False,
+            }
+
+            files = mod.get("files") or []
+            for file_entry in files:
+                if not isinstance(file_entry, dict):
+                    continue
+                path = file_entry.get("path") or ""
+                file_key = ("file", collection_id, mod_id, path)
+                assets[file_key] = {
+                    "kind": "file",
+                    "collectionId": collection_id,
+                    "modId": mod_id,
+                    "path": path,
+                    "hash": file_entry.get("hash"),
+                    "size": _normalise_size(file_entry.get("size")),
+                    "transferable": True,
+                }
+
+            patches = mod.get("patches") or []
+            for patch in patches:
+                if not isinstance(patch, dict):
+                    continue
+                path = patch.get("path") or ""
+                patch_key = ("mod_patch", collection_id, mod_id, path)
+                assets[patch_key] = {
+                    "kind": "mod_patch",
+                    "collectionId": collection_id,
+                    "modId": mod_id,
+                    "path": path,
+                    "hash": patch.get("hash"),
+                    "size": _normalise_size(patch.get("size")),
+                    "transferable": True,
+                }
+
+        collection_patches = collection.get("patches") or []
+        for patch in collection_patches:
+            if not isinstance(patch, dict):\n+                continue
+            path = patch.get("path") or ""
+            patch_key = ("patch", collection_id, path)
+            assets[patch_key] = {
+                "kind": "patch",
+                "collectionId": collection_id,
+                "path": path,
+                "hash": patch.get("hash"),
+                "size": _normalise_size(patch.get("size")),
+                "transferable": True,
+            }
+
+    return assets
+
+
+def _serialise_asset(asset: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {"kind": asset.get("kind"), "hash": asset.get("hash")}
+    if asset.get("collectionId"):
+        payload["collectionId"] = asset.get("collectionId")
+    if asset.get("modId"):
+        payload["modId"] = asset.get("modId")
+    if asset.get("path"):
+        payload["path"] = asset.get("path")
+    size = asset.get("size")
+    if isinstance(size, int) and size > 0:
+        payload["size"] = size
+    return payload
+
+
+def _serialise_conflict(
+    current: dict[str, Any], previous: dict[str, Any]
+) -> dict[str, Any]:
+    payload = {
+        "kind": current.get("kind") or previous.get("kind"),
+        "hash": current.get("hash"),
+        "expected": previous.get("hash"),
+    }
+    if current.get("collectionId") or previous.get("collectionId"):
+        payload["collectionId"] = current.get("collectionId") or previous.get("collectionId")
+    if current.get("modId") or previous.get("modId"):
+        payload["modId"] = current.get("modId") or previous.get("modId")
+    if current.get("path") or previous.get("path"):
+        payload["path"] = current.get("path") or previous.get("path")
+
+    current_size = current.get("size")
+    if isinstance(current_size, int) and current_size >= 0:
+        payload["size"] = current_size
+    previous_size = previous.get("size")
+    if isinstance(previous_size, int) and previous_size >= 0:
+        payload["previousSize"] = previous_size
+    return payload
+
+
+def _compute_manifest_diff(
+    previous: Optional[dict[str, Any]], current: dict[str, Any]
+) -> dict[str, list[dict[str, Any]]]:
+    previous_assets = _extract_manifest_assets(previous or {})
+    current_assets = _extract_manifest_assets(current)
+
+    need: dict[tuple[Any, ...], dict[str, Any]] = {}
+    remove: dict[tuple[Any, ...], dict[str, Any]] = {}
+    conflicts: list[dict[str, Any]] = []
+
+    previous_keys = set(previous_assets)
+    current_keys = set(current_assets)
+
+    for key in current_keys - previous_keys:
+        asset = current_assets[key]
+        if asset.get("transferable") and asset.get("hash"):
+            need[key] = _serialise_asset(asset)
+
+    for key in previous_keys - current_keys:
+        asset = previous_assets[key]
+        if asset.get("transferable") and asset.get("hash"):
+            remove[key] = _serialise_asset(asset)
+
+    for key in current_keys & previous_keys:
+        current_asset = current_assets[key]
+        previous_asset = previous_assets[key]
+        if (current_asset.get("hash") or "") != (previous_asset.get("hash") or ""):
+            conflicts.append(_serialise_conflict(current_asset, previous_asset))
+            if current_asset.get("transferable") and current_asset.get("hash"):
+                need[key] = _serialise_asset(current_asset)
+            if previous_asset.get("transferable") and previous_asset.get("hash"):
+                remove[key] = _serialise_asset(previous_asset)
+
+    need_list = sorted(need.values(), key=lambda item: item.get("hash", ""))
+    remove_list = sorted(remove.values(), key=lambda item: item.get("hash", ""))
+    conflicts.sort(
+        key=lambda item: (
+            item.get("collectionId", ""),
+            item.get("modId", ""),
+            item.get("path", ""),
+            item.get("kind", ""),
+        )
+    )
+
+    return {"need": need_list, "remove": remove_list, "conflicts": conflicts}
+
+
+def _update_transfer_budget(
+    user_id: int, diff: dict[str, list[dict[str, Any]]]
+) -> dict[str, Any]:
+    limit = max(0, TRANSFER_BUDGET_BYTES)
+    window = timedelta(seconds=max(1, TRANSFER_BUDGET_WINDOW_SECONDS))
+    now = _now_utc()
+
+    budget = _transfer_budgets.get(user_id)
+    if not budget or now - budget.window_start >= window:
+        budget = _TransferBudget(window_start=now, used_bytes=0)
+        _transfer_budgets[user_id] = budget
+
+    incremental = 0
+    for entry in diff.get("need", []):
+        size = entry.get("size")
+        if isinstance(size, int) and size > 0:
+            incremental += size
+
+    budget.used_bytes += incremental
+    if budget.used_bytes < 0:
+        budget.used_bytes = 0
+
+    remaining = max(0, limit - budget.used_bytes)
+    window_end = budget.window_start + window
+    if window_end.tzinfo is None:
+        window_end = window_end.replace(tzinfo=timezone.utc)
+    return {
+        "limitBytes": limit,
+        "usedBytes": budget.used_bytes,
+        "throttleAfterBytes": remaining,
+        "windowEndsAt": window_end.isoformat(),
+    }
+
+
+async def handle_manifest_upload(
+    manifest: dict[str, Any], ctx: RequestContext, db: AsyncSession
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, Any]]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+
+    manifest_json = json.dumps(manifest)
+    payload_size = len(manifest_json.encode())
+    if payload_size > MAX_MANIFEST_BYTES:
+        raise HTTPException(status_code=413, detail="manifest too large")
+
+    record = await db.get(SyncshellManifest, ctx.user.id)
+    previous_manifest: Optional[dict[str, Any]] = None
+    if record:
+        try:
+            previous_manifest = json.loads(record.manifest_json)
+        except json.JSONDecodeError:
+            previous_manifest = None
+
+    diff = _compute_manifest_diff(previous_manifest, manifest)
+
+    if record:
+        record.manifest_json = manifest_json
+        record.updated_at = datetime.utcnow()
+    else:
+        record = SyncshellManifest(user_id=ctx.user.id, manifest_json=manifest_json)
+        db.add(record)
+
+    await db.commit()
+
+    limits_payload = {
+        "budget": _update_transfer_budget(ctx.user.id, diff),
+        "transfer": dict(DEFAULT_TRANSFER_LIMITS),
+    }
+    return diff, limits_payload
 
 
 async def _check_rate_limit(user_id: int, db: AsyncSession) -> None:
@@ -458,7 +729,7 @@ async def pair(
 
 @router.post("/manifest")
 async def upload_manifest(
-    manifest: list[dict[str, Any]],
+    manifest: dict[str, Any],
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
@@ -467,21 +738,8 @@ async def upload_manifest(
     The manifest is capped in size to prevent excessive memory usage and
     naive clients from overwhelming the API.
     """
-    await _require_pairing(ctx, db)
-    await _check_rate_limit(ctx.user.id, db)
-    payload_size = len(str(manifest).encode())
-    if payload_size > MAX_MANIFEST_BYTES:
-        raise HTTPException(status_code=413, detail="manifest too large")
-    manifest_json = json.dumps(manifest)
-    record = await db.get(SyncshellManifest, ctx.user.id)
-    if record:
-        record.manifest_json = manifest_json
-        record.updated_at = datetime.utcnow()
-    else:
-        record = SyncshellManifest(user_id=ctx.user.id, manifest_json=manifest_json)
-        db.add(record)
-    await db.commit()
-    return {"status": "ok"}
+    diff, limits = await handle_manifest_upload(manifest, ctx, db)
+    return {"status": "ok", "diff": diff, "limits": limits}
 
 
 @router.post("/asset/upload")

--- a/demibot/demibot/http/ws_syncshell.py
+++ b/demibot/demibot/http/ws_syncshell.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
-from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 
 from fastapi import HTTPException, WebSocket, WebSocketDisconnect
 
-from ..db.models import SyncshellManifest
 from ..db.session import get_session
 from .deps import RequestContext, api_key_auth
 from .routes import syncshell as syncshell_routes
@@ -17,11 +14,7 @@ from .routes import syncshell as syncshell_routes
 
 LOGGER = logging.getLogger(__name__)
 
-DEFAULT_LIMITS = {
-    "bytesPerSecond": int(os.getenv("SYNC_SHELL_BYTES_PER_SECOND", str(512 * 1024))),
-    "chunkSizeBytes": int(os.getenv("SYNC_SHELL_CHUNK_SIZE", str(64 * 1024))),
-    "maxOutstandingWants": int(os.getenv("SYNC_SHELL_MAX_OUTSTANDING_WANTS", "64")),
-}
+DEFAULT_LIMITS = syncshell_routes.DEFAULT_TRANSFER_LIMITS
 
 HELLO_MESSAGE = {"type": "hello", "payload": {"version": 1, "limits": DEFAULT_LIMITS}}
 
@@ -35,26 +28,6 @@ def _ws_request(ws: WebSocket) -> SimpleNamespace:
     )
 
 
-async def _persist_manifest(ctx: RequestContext, manifest: dict[str, Any]) -> None:
-    manifest_json = json.dumps(manifest)
-    payload_size = len(manifest_json.encode())
-    if payload_size > syncshell_routes.MAX_MANIFEST_BYTES:
-        raise HTTPException(status_code=413, detail="manifest too large")
-
-    async with get_session() as db:
-        await syncshell_routes._require_pairing(ctx, db)
-        await syncshell_routes._check_rate_limit(ctx.user.id, db)
-
-        record = await db.get(SyncshellManifest, ctx.user.id)
-        if record:
-            record.manifest_json = manifest_json
-            record.updated_at = datetime.utcnow()
-        else:
-            record = SyncshellManifest(user_id=ctx.user.id, manifest_json=manifest_json)
-            db.add(record)
-        await db.commit()
-
-
 async def _handle_manifest_message(
     websocket: WebSocket, ctx: RequestContext, payload: dict[str, Any]
 ) -> bool:
@@ -64,7 +37,10 @@ async def _handle_manifest_message(
         return True
 
     try:
-        await _persist_manifest(ctx, manifest_payload)
+        async with get_session() as db:
+            diff, limits = await syncshell_routes.handle_manifest_upload(
+                manifest_payload, ctx, db
+            )
     except HTTPException as exc:
         LOGGER.warning("syncshell manifest rejected: %s", exc.detail)
         await websocket.close(code=1008, reason=exc.detail)
@@ -82,7 +58,13 @@ async def _handle_manifest_message(
         "type": "want",
         "payload": {
             "peerId": peer_id,
-            "want": {"blobs": [], "chunks": [], "sizeHints": []},
+            "want": {
+                "blobs": [entry["hash"] for entry in diff.get("need", []) if entry.get("hash")],
+                "chunks": [],
+                "sizeHints": [],
+            },
+            "diff": diff,
+            "limits": limits,
         },
     }
     await websocket.send_json(want_message)

--- a/tests/test_syncshell.py
+++ b/tests/test_syncshell.py
@@ -35,7 +35,12 @@ def test_pair_token_persistence_and_expiry(tmp_path):
             assert pairing and pairing.token == token
 
             manifest, _ = build_manifest_payload(tmp_path)
-            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            syncshell._transfer_budgets.clear()
+            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            assert response["status"] == "ok"
+            assert response["diff"]["need"]
+            assert response["diff"]["remove"] == []
+            assert response["limits"]["budget"]["limitBytes"] > 0
 
             await asyncio.sleep(1.1)
             with pytest.raises(syncshell.HTTPException) as exc:
@@ -57,7 +62,9 @@ def test_manifest_rate_limit(tmp_path):
             syncshell.RATE_LIMIT = 2
             await syncshell.pair(ctx=ctx, db=db)
             manifest, _ = build_manifest_payload(tmp_path)
-            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            syncshell._transfer_budgets.clear()
+            first = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            assert first["diff"]["need"]
             with pytest.raises(syncshell.HTTPException) as exc:
                 await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert exc.value.status_code == 429
@@ -106,7 +113,9 @@ def test_asset_upload_download_and_rate_limit(tmp_path):
 
             await syncshell.pair(ctx=ctx, db=db)
             manifest, _ = build_manifest_payload(tmp_path)
-            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            syncshell._transfer_budgets.clear()
+            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            assert response["diff"]["need"]
             up = await syncshell.request_asset_upload(ctx=ctx, db=db)
             assert up["url"] == "upload-url"
             down = await syncshell.request_asset_download("x", ctx=ctx, db=db)

--- a/tests/test_syncshell_blob_store.py
+++ b/tests/test_syncshell_blob_store.py
@@ -26,7 +26,10 @@ def test_manifest_blob_hashes_persist(tmp_path):
             await syncshell.pair(ctx=ctx, db=db)
 
             manifest, blob_hash = build_manifest_payload(tmp_path)
-            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            syncshell._transfer_budgets.clear()
+            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            need_hashes = {entry["hash"] for entry in response["diff"]["need"]}
+            assert blob_hash in need_hashes
             record = await db.get(SyncshellManifest, user.id)
             assert record is not None
             stored = json.loads(record.manifest_json)
@@ -36,7 +39,13 @@ def test_manifest_blob_hashes_persist(tmp_path):
 
             # Updating the manifest replaces the stored payload.
             newer_manifest, newer_hash = build_manifest_payload(tmp_path / "second")
-            await syncshell.upload_manifest(newer_manifest, ctx=ctx, db=db)
+            response = await syncshell.upload_manifest(newer_manifest, ctx=ctx, db=db)
+            diff = response["diff"]
+            need_hashes = {entry["hash"] for entry in diff["need"]}
+            remove_hashes = {entry["hash"] for entry in diff["remove"]}
+            assert newer_hash in need_hashes
+            assert blob_hash in remove_hashes
+            assert diff["conflicts"]
             updated = await db.get(SyncshellManifest, user.id)
             assert updated is not None
             updated_payload = json.loads(updated.manifest_json)

--- a/tests/test_syncshell_limits.py
+++ b/tests/test_syncshell_limits.py
@@ -26,7 +26,9 @@ def test_token_expiry(tmp_path):
             syncshell.TOKEN_TTL = 1
             await syncshell.pair(ctx=ctx, db=db)
             manifest, _ = build_manifest_payload(tmp_path)
-            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            syncshell._transfer_budgets.clear()
+            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            assert response["diff"]["need"]
             await asyncio.sleep(1.1)
             with pytest.raises(syncshell.HTTPException):
                 await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
@@ -48,7 +50,9 @@ def test_rate_limit_hits(tmp_path):
             syncshell.RATE_LIMIT = 2
             await syncshell.pair(ctx=ctx, db=db)
             manifest, _ = build_manifest_payload(tmp_path)
-            await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            syncshell._transfer_budgets.clear()
+            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            assert response["diff"]["need"]
             with pytest.raises(syncshell.HTTPException):
                 await syncshell.resync(ctx=ctx, db=db)
     asyncio.run(_run())

--- a/tests/test_syncshell_ws.py
+++ b/tests/test_syncshell_ws.py
@@ -16,6 +16,7 @@ from demibot.db.models import (
 from demibot.db.session import get_session, init_db
 import demibot.db.session as db_session
 
+from .syncshell_import import syncshell
 from .syncshell_test_utils import build_manifest_payload
 
 
@@ -48,9 +49,11 @@ async def _prepare_db() -> None:
 def test_syncshell_websocket_hello_and_manifest(tmp_path):
     asyncio.run(_prepare_db())
 
-    manifest, _ = build_manifest_payload(tmp_path)
+    manifest, blob_hash = build_manifest_payload(tmp_path)
     app = create_app()
     client = TestClient(app)
+
+    syncshell._transfer_budgets.clear()
 
     with client.websocket_connect(
         "/ws/syncshell", headers={"X-Api-Key": "syncshell-token"}
@@ -75,11 +78,10 @@ def test_syncshell_websocket_hello_and_manifest(tmp_path):
         websocket.send_json({"type": "manifest", "payload": {"manifest": manifest}})
         want = websocket.receive_json()
         assert want["type"] == "want"
-        assert want["payload"]["want"] == {
-            "blobs": [],
-            "chunks": [],
-            "sizeHints": [],
-        }
+        payload = want["payload"]
+        assert blob_hash in payload["want"]["blobs"]
+        assert payload["diff"]["need"]
+        assert payload["limits"]["budget"]["limitBytes"] > 0
 
     async def _fetch_manifest() -> dict:
         async with get_session() as db:


### PR DESCRIPTION
## Summary
- compute manifest diffs and per-user transfer budget metadata when uploads occur and return them in the manifest API response
- propagate the new diff/limit payloads through the SyncShell websocket want flow so clients know what to send
- update the plugin client to honour the diff payload and budget hints while requesting blobs/chunks, and extend syncshell tests accordingly

## Testing
- pytest tests/test_syncshell.py tests/test_syncshell_limits.py tests/test_syncshell_blob_store.py tests/test_syncshell_ws.py *(fails: missing sqlalchemy/fastapi test dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a139b5a48328a57d04e79631a732