### PR TITLE
Add memberships aggregation endpoint for SyncShell

### DIFF
--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -404,6 +404,19 @@ def _serialize_invite(invite: SyncshellInvite, direction: str) -> dict[str, Any]
     }
 
 
+def _presence_payload(
+    presence: SyncshellPresence | None,
+) -> tuple[str, str | None, str | None, str | None]:
+    if not presence:
+        return "offline", None, None, None
+
+    presence_value = "online" if presence.active else "offline"
+    last_seen = _to_iso(presence.last_seen)
+    sync_status = "syncing" if presence.active else None
+    synced_at = last_seen if presence.active else None
+    return presence_value, sync_status, last_seen, synced_at
+
+
 @router.get("/invites")
 async def list_invites(
     ctx: RequestContext = Depends(api_key_auth),
@@ -613,6 +626,115 @@ async def list_members(
         )
     members.sort(key=lambda entry: entry["displayName"].lower())
     return {"members": members}
+
+
+@router.get("/memberships")
+async def list_memberships(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+
+    member_result = await db.execute(
+        select(SyncshellMember.member_user_id).where(
+            SyncshellMember.user_id == ctx.user.id
+        )
+    )
+    member_ids = list(member_result.scalars().all())
+
+    presence_map: dict[int, SyncshellPresence] = {}
+    if member_ids:
+        presence_result = await db.execute(
+            select(SyncshellPresence).where(
+                SyncshellPresence.user_id == ctx.user.id,
+                SyncshellPresence.member_user_id.in_(member_ids),
+            )
+        )
+        presence_map = {
+            record.member_user_id: record for record in presence_result.scalars().all()
+        }
+
+    users: dict[int, User] = {}
+    if member_ids:
+        user_result = await db.execute(select(User).where(User.id.in_(member_ids)))
+        users = {user.id: user for user in user_result.scalars().all()}
+
+    members: list[dict[str, Any]] = []
+    currently_synced: list[dict[str, Any]] = []
+    for member_id in member_ids:
+        user = users.get(member_id)
+        presence = presence_map.get(member_id)
+        presence_value, sync_status, last_seen, synced_at = _presence_payload(presence)
+        entry: dict[str, Any] = {
+            "id": str(member_id),
+            "displayName": _display_name(user),
+            "presence": presence_value,
+            "syncStatus": sync_status,
+            "lastSeen": last_seen,
+        }
+        if synced_at:
+            entry["syncedAt"] = synced_at
+        members.append(entry)
+
+        if presence and presence.active:
+            active_entry = {
+                "id": entry["id"],
+                "displayName": entry["displayName"],
+                "presence": presence_value,
+                "syncStatus": sync_status,
+                "lastSeen": last_seen,
+            }
+            if synced_at:
+                active_entry["syncedAt"] = synced_at
+            currently_synced.append(active_entry)
+
+    members.sort(key=lambda entry: entry["displayName"].lower())
+    currently_synced.sort(key=lambda entry: entry["displayName"].lower())
+
+    invites_result = await db.execute(
+        select(SyncshellInvite)
+        .where(SyncshellInvite.inviter_id == ctx.user.id)
+        .order_by(SyncshellInvite.updated_at.desc())
+    )
+    invites = [
+        _serialize_invite(invite, "outgoing") for invite in invites_result.scalars().all()
+    ]
+
+    pending_result = await db.execute(
+        select(SyncshellInvite)
+        .where(
+            SyncshellInvite.target_user_id == ctx.user.id,
+            SyncshellInvite.status == "pending",
+        )
+        .order_by(SyncshellInvite.created_at.desc())
+    )
+    pending_invites = pending_result.scalars().all()
+    inviter_ids = {invite.inviter_id for invite in pending_invites}
+    inviters: dict[int, User] = {}
+    if inviter_ids:
+        inviter_result = await db.execute(select(User).where(User.id.in_(inviter_ids)))
+        inviters = {user.id: user for user in inviter_result.scalars().all()}
+
+    pending_approvals: list[dict[str, Any]] = []
+    for invite in pending_invites:
+        inviter = inviters.get(invite.inviter_id)
+        pending_approvals.append(
+            {
+                "id": invite.id,
+                "requesterId": invite.inviter_id,
+                "displayName": _display_name(inviter),
+                "requestedAt": _to_iso(invite.created_at),
+                "direction": "incoming",
+            }
+        )
+
+    return {
+        "members": members,
+        "currentlySynced": currently_synced,
+        "pendingApprovals": pending_approvals,
+        "invites": invites,
+    }
 
 
 @router.post("/presence")

--- a/tests/test_syncshell_membership.py
+++ b/tests/test_syncshell_membership.py
@@ -37,12 +37,24 @@ def test_syncshell_invite_acceptance_and_members():
             await syncshell.pair(ctx=ctx_a, db=db)
             await syncshell.pair(ctx=ctx_b, db=db)
 
+            overview_a_initial = await syncshell.list_memberships(ctx=ctx_a, db=db)
+            assert overview_a_initial["members"] == []
+            assert overview_a_initial["pendingApprovals"] == []
+
             invite = await syncshell.create_invite(
                 payload=syncshell.InviteCreateRequest(member_id=user_b.id),
                 ctx=ctx_a,
                 db=db,
             )
             assert invite["status"] == "pending"
+
+            overview_a_after_invite = await syncshell.list_memberships(ctx=ctx_a, db=db)
+            assert overview_a_after_invite["invites"][0]["status"] == "pending"
+            assert overview_a_after_invite["invites"][0]["direction"] == "outgoing"
+
+            overview_b_pending = await syncshell.list_memberships(ctx=ctx_b, db=db)
+            assert overview_b_pending["pendingApprovals"][0]["displayName"] == "Alpha"
+            assert overview_b_pending["pendingApprovals"][0]["requestedAt"].endswith("Z")
 
             pending = await syncshell.list_pending(ctx=ctx_b, db=db)
             assert len(pending["pending"]) == 1
@@ -58,6 +70,19 @@ def test_syncshell_invite_acceptance_and_members():
 
             assert [m["id"] for m in members_a["members"]] == [str(user_b.id)]
             assert [m["id"] for m in members_b["members"]] == [str(user_a.id)]
+
+            overview_a_final = await syncshell.list_memberships(ctx=ctx_a, db=db)
+            assert overview_a_final["currentlySynced"] == []
+            assert overview_a_final["pendingApprovals"] == []
+            assert overview_a_final["members"][0]["id"] == str(user_b.id)
+            assert overview_a_final["members"][0]["presence"] == "offline"
+            assert overview_a_final["members"][0]["syncStatus"] is None
+            assert overview_a_final["invites"][0]["status"] == "accepted"
+
+            overview_b_final = await syncshell.list_memberships(ctx=ctx_b, db=db)
+            assert overview_b_final["members"][0]["id"] == str(user_a.id)
+            assert overview_b_final["members"][0]["presence"] == "offline"
+            assert overview_b_final["pendingApprovals"] == []
 
             pending_after = await syncshell.list_pending(ctx=ctx_b, db=db)
             assert pending_after["pending"] == []
@@ -97,6 +122,13 @@ def test_syncshell_presence_updates():
             assert presence["currentlySynced"][0]["id"] == str(user_b.id)
             assert presence["presence"][0]["active"] is True
 
+            overview_syncing = await syncshell.list_memberships(ctx=ctx_a, db=db)
+            assert overview_syncing["currentlySynced"][0]["id"] == str(user_b.id)
+            assert overview_syncing["currentlySynced"][0]["presence"] == "online"
+            assert overview_syncing["currentlySynced"][0]["syncStatus"] == "syncing"
+            assert overview_syncing["currentlySynced"][0]["syncedAt"].endswith("Z")
+            assert overview_syncing["members"][0]["presence"] == "online"
+
             await syncshell.update_presence(
                 payload=syncshell.PresenceUpdateRequest(active_member_ids=[]),
                 ctx=ctx_a,
@@ -104,5 +136,10 @@ def test_syncshell_presence_updates():
             )
             presence_after = await syncshell.get_presence(ctx=ctx_a, db=db)
             assert presence_after["presence"][0]["active"] is False
+
+            overview_offline = await syncshell.list_memberships(ctx=ctx_a, db=db)
+            assert overview_offline["currentlySynced"] == []
+            assert overview_offline["members"][0]["presence"] == "offline"
+            assert overview_offline["members"][0]["lastSeen"].endswith("Z")
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add a consolidated /memberships endpoint that returns member, presence, invite, and pending approval data
- normalize presence metadata for membership payloads and reuse invite serialization helpers
- extend membership tests to cover the aggregated response shape

## Testing
- pytest tests/test_syncshell_membership.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ac10c77483288de7227136d64149