### PR TITLE
Handle name-based syncshell invites and add coverage

### DIFF
--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -9,7 +9,7 @@ import json
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
@@ -328,6 +328,10 @@ def _display_name(user: User | None) -> str:
     return user.global_name or user.character_name or str(user.id)
 
 
+def _normalize_display_name(value: str | None) -> str:
+    return (value or "").strip().casefold()
+
+
 def _to_iso(dt: datetime | None) -> str | None:
     if not dt:
         return None
@@ -445,13 +449,27 @@ async def create_invite(
     await _check_rate_limit(ctx.user.id, db)
 
     target_user: User | None = None
-    display_name = (payload.member or "").strip()
+    normalized_member = _normalize_display_name(payload.member)
+    display_name = normalized_member
     if payload.member_id is not None:
         target_user = await db.get(User, payload.member_id)
         if not target_user:
             raise HTTPException(status_code=404, detail="member not found")
         display_name = _display_name(target_user)
-
+    elif normalized_member:
+        potential_targets = await db.execute(
+            select(User).where(
+                or_(
+                    func.lower(User.global_name) == normalized_member,
+                    func.lower(User.character_name) == normalized_member,
+                )
+            )
+        )
+        matches = potential_targets.scalars().all()
+        if len(matches) == 1:
+            target_user = matches[0]
+            display_name = _display_name(target_user)
+    
     if not display_name:
         raise HTTPException(status_code=422, detail="member is required")
 
@@ -479,10 +497,13 @@ async def create_invite(
         if invite is not None:
             return _serialize_invite(invite, "outgoing")
     else:
+        normalized_display_name = _normalize_display_name(display_name)
         existing_invite = await db.execute(
             select(SyncshellInvite).where(
                 SyncshellInvite.inviter_id == ctx.user.id,
-                SyncshellInvite.target_display_name == display_name,
+                SyncshellInvite.target_user_id.is_(None),
+                func.lower(SyncshellInvite.target_display_name)
+                == normalized_display_name,
                 SyncshellInvite.status == "pending",
             )
         )
@@ -506,13 +527,23 @@ async def create_invite(
 
 
 async def _get_invite_for_target(
-    db: AsyncSession, invite_id: str, target_user_id: int
+    db: AsyncSession, invite_id: str, target_user: User
 ) -> SyncshellInvite:
     invite = await db.get(SyncshellInvite, invite_id)
-    if not invite or invite.target_user_id != target_user_id:
+    if not invite:
         raise HTTPException(status_code=404, detail="invite not found")
     if invite.status != "pending":
         raise HTTPException(status_code=400, detail="invite already processed")
+    if invite.target_user_id is not None:
+        if invite.target_user_id != target_user.id:
+            raise HTTPException(status_code=404, detail="invite not found")
+        return invite
+
+    normalized_target = _normalize_display_name(_display_name(target_user))
+    if not normalized_target:
+        raise HTTPException(status_code=404, detail="invite not found")
+    if _normalize_display_name(invite.target_display_name) != normalized_target:
+        raise HTTPException(status_code=404, detail="invite not found")
     return invite
 
 
@@ -537,7 +568,10 @@ async def accept_invite(
 ) -> dict[str, Any]:
     await _require_pairing(ctx, db)
     await _check_rate_limit(ctx.user.id, db)
-    invite = await _get_invite_for_target(db, invite_id, ctx.user.id)
+    invite = await _get_invite_for_target(db, invite_id, ctx.user)
+    if invite.target_user_id is None:
+        invite.target_user_id = ctx.user.id
+        invite.target_display_name = _display_name(ctx.user)
     await _finalize_invite(db, invite, accepted=True)
     return {"status": "accepted"}
 
@@ -550,7 +584,10 @@ async def deny_invite(
 ) -> dict[str, Any]:
     await _require_pairing(ctx, db)
     await _check_rate_limit(ctx.user.id, db)
-    invite = await _get_invite_for_target(db, invite_id, ctx.user.id)
+    invite = await _get_invite_for_target(db, invite_id, ctx.user)
+    if invite.target_user_id is None:
+        invite.target_user_id = ctx.user.id
+        invite.target_display_name = _display_name(ctx.user)
     await _finalize_invite(db, invite, accepted=False)
     return {"status": "denied"}
 
@@ -582,11 +619,19 @@ async def list_pending(
 ) -> dict[str, Any]:
     await _require_pairing(ctx, db)
     await _check_rate_limit(ctx.user.id, db)
+    normalized_target = _normalize_display_name(_display_name(ctx.user))
     result = await db.execute(
         select(SyncshellInvite)
         .where(
-            SyncshellInvite.target_user_id == ctx.user.id,
             SyncshellInvite.status == "pending",
+            or_(
+                SyncshellInvite.target_user_id == ctx.user.id,
+                and_(
+                    SyncshellInvite.target_user_id.is_(None),
+                    func.lower(SyncshellInvite.target_display_name)
+                    == normalized_target,
+                ),
+            ),
         )
         .order_by(SyncshellInvite.created_at.desc())
     )
@@ -721,11 +766,19 @@ async def list_memberships(
         _serialize_invite(invite, "outgoing") for invite in invites_result.scalars().all()
     ]
 
+    normalized_pending = _normalize_display_name(_display_name(ctx.user))
     pending_result = await db.execute(
         select(SyncshellInvite)
         .where(
-            SyncshellInvite.target_user_id == ctx.user.id,
             SyncshellInvite.status == "pending",
+            or_(
+                SyncshellInvite.target_user_id == ctx.user.id,
+                and_(
+                    SyncshellInvite.target_user_id.is_(None),
+                    func.lower(SyncshellInvite.target_display_name)
+                    == normalized_pending,
+                ),
+            ),
         )
         .order_by(SyncshellInvite.created_at.desc())
     )

--- a/tests/test_syncshell_invites.py
+++ b/tests/test_syncshell_invites.py
@@ -1,0 +1,166 @@
+import asyncio
+from datetime import datetime, timedelta
+
+from demibot.db.models import (
+    SyncshellInvite,
+    SyncshellMember,
+    SyncshellPairing,
+    User,
+)
+from demibot.db.session import get_session, init_db
+import demibot.db.session as db_session
+from demibot.http.deps import RequestContext
+
+from .syncshell_import import syncshell
+
+
+async def _prepare_db():
+    db_session._engine = None
+    db_session._Session = None
+    await init_db("sqlite+aiosqlite://")
+    return get_session()
+
+
+def _pairing(user_id: int, *, token: str) -> SyncshellPairing:
+    return SyncshellPairing(
+        user_id=user_id,
+        token=token,
+        expires_at=datetime.utcnow() + timedelta(hours=1),
+    )
+
+
+def test_create_invite_by_name_unique_match():
+    async def _run():
+        session_factory = await _prepare_db()
+        async with session_factory as db:
+            inviter = User(id=1, discord_user_id=1, global_name="Alpha")
+            target = User(id=2, discord_user_id=2, global_name="Beta")
+            db.add_all(
+                [
+                    inviter,
+                    target,
+                    _pairing(inviter.id, token="token-inviter"),
+                    _pairing(target.id, token="token-target"),
+                ]
+            )
+            await db.commit()
+
+            ctx_inviter = RequestContext(user=inviter, guild=None, key=object(), roles=[])
+            syncshell.RATE_LIMIT = 100
+
+            response = await syncshell.create_invite(
+                syncshell.InviteCreateRequest(member="  beta  "), ctx=ctx_inviter, db=db
+            )
+
+            invite = await db.get(SyncshellInvite, response["id"])
+            assert invite is not None
+            assert invite.target_user_id == target.id
+            assert invite.target_display_name == "Beta"
+
+    asyncio.run(_run())
+
+
+def test_pending_invite_accept_flow_sets_memberships():
+    async def _run():
+        session_factory = await _prepare_db()
+        async with session_factory as db:
+            inviter = User(id=1, discord_user_id=1, global_name="Alpha")
+            target_one = User(id=2, discord_user_id=2, character_name="Echo")
+            target_two = User(id=3, discord_user_id=3, character_name="Echo")
+            db.add_all(
+                [
+                    inviter,
+                    target_one,
+                    target_two,
+                    _pairing(inviter.id, token="token-inviter"),
+                    _pairing(target_one.id, token="token-target-1"),
+                    _pairing(target_two.id, token="token-target-2"),
+                ]
+            )
+            await db.commit()
+
+            ctx_inviter = RequestContext(user=inviter, guild=None, key=object(), roles=[])
+            ctx_target_one = RequestContext(
+                user=target_one, guild=None, key=object(), roles=[]
+            )
+            ctx_target_two = RequestContext(
+                user=target_two, guild=None, key=object(), roles=[]
+            )
+            syncshell.RATE_LIMIT = 100
+
+            response = await syncshell.create_invite(
+                syncshell.InviteCreateRequest(member="Echo"), ctx=ctx_inviter, db=db
+            )
+            invite = await db.get(SyncshellInvite, response["id"])
+            assert invite is not None
+            assert invite.target_user_id is None
+
+            pending_for_one = await syncshell.list_pending(ctx=ctx_target_one, db=db)
+            assert [entry["id"] for entry in pending_for_one["pending"]] == [invite.id]
+
+            pending_for_two = await syncshell.list_pending(ctx=ctx_target_two, db=db)
+            assert [entry["id"] for entry in pending_for_two["pending"]] == [invite.id]
+
+            await syncshell.accept_invite(invite.id, ctx=ctx_target_one, db=db)
+            await db.refresh(invite)
+
+            assert invite.status == "accepted"
+            assert invite.target_user_id == target_one.id
+            assert invite.target_display_name == "Echo"
+
+            members = await db.execute(syncshell.select(SyncshellMember))
+            pairs = {(m.user_id, m.member_user_id) for m in members.scalars()}
+            assert pairs == {(inviter.id, target_one.id), (target_one.id, inviter.id)}
+
+            post_pending_two = await syncshell.list_pending(ctx=ctx_target_two, db=db)
+            assert post_pending_two["pending"] == []
+
+    asyncio.run(_run())
+
+
+def test_pending_invite_deny_sets_target_user():
+    async def _run():
+        session_factory = await _prepare_db()
+        async with session_factory as db:
+            inviter = User(id=1, discord_user_id=1, global_name="Alpha")
+            target_one = User(id=2, discord_user_id=2, character_name="Echo")
+            target_two = User(id=3, discord_user_id=3, character_name="Echo")
+            db.add_all(
+                [
+                    inviter,
+                    target_one,
+                    target_two,
+                    _pairing(inviter.id, token="token-inviter"),
+                    _pairing(target_one.id, token="token-target-1"),
+                    _pairing(target_two.id, token="token-target-2"),
+                ]
+            )
+            await db.commit()
+
+            ctx_inviter = RequestContext(user=inviter, guild=None, key=object(), roles=[])
+            ctx_target_two = RequestContext(
+                user=target_two, guild=None, key=object(), roles=[]
+            )
+            syncshell.RATE_LIMIT = 100
+
+            response = await syncshell.create_invite(
+                syncshell.InviteCreateRequest(member="Echo"), ctx=ctx_inviter, db=db
+            )
+            invite = await db.get(SyncshellInvite, response["id"])
+            assert invite is not None
+
+            pending_for_two = await syncshell.list_pending(ctx=ctx_target_two, db=db)
+            assert [entry["id"] for entry in pending_for_two["pending"]] == [invite.id]
+
+            await syncshell.deny_invite(invite.id, ctx=ctx_target_two, db=db)
+            await db.refresh(invite)
+
+            assert invite.status == "denied"
+            assert invite.target_user_id == target_two.id
+            assert invite.target_display_name == "Echo"
+
+            members = await db.execute(syncshell.select(SyncshellMember))
+            assert list(members.scalars()) == []
+
+    asyncio.run(_run())
+


### PR DESCRIPTION
## Summary
- normalise invite display names and resolve users when a unique match exists
- treat name-only invites as pending for matching users when listing or processing requests
- cover invite creation, pending visibility, accept/deny, and membership updates with new tests

## Testing
- pytest tests/test_syncshell_invites.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ae0ef0a48328b84ed022ca14eaab