### PR TITLE
Add composite indexes for syncshell invites

### DIFF
--- a/demibot/demibot/db/migrations/versions/0050_add_syncshell_invite_indexes.py
+++ b/demibot/demibot/db/migrations/versions/0050_add_syncshell_invite_indexes.py
@@ -1,0 +1,43 @@
+"""0050_add_syncshell_invite_indexes
+
+Revision ID: 0050_add_syncshell_invite_indexes
+Revises: 0049_add_installation_asset_hash
+Create Date: 2024-06-09 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0050_add_syncshell_invite_indexes"
+down_revision: Union[str, None] = "0049_add_installation_asset_hash"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_syncshell_invites_inviter_target_user_status",
+        "syncshell_invites",
+        ["inviter_id", "target_user_id", "status"],
+    )
+    op.create_index(
+        "ix_syncshell_invites_inviter_target_display_name_status",
+        "syncshell_invites",
+        ["inviter_id", "target_display_name", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_syncshell_invites_inviter_target_display_name_status",
+        table_name="syncshell_invites",
+    )
+    op.drop_index(
+        "ix_syncshell_invites_inviter_target_user_status",
+        table_name="syncshell_invites",
+    )

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -233,6 +233,20 @@ class SyncshellRateLimit(Base):
 
 class SyncshellInvite(Base):
     __tablename__ = "syncshell_invites"
+    __table_args__ = (
+        Index(
+            "ix_syncshell_invites_inviter_target_user_status",
+            "inviter_id",
+            "target_user_id",
+            "status",
+        ),
+        Index(
+            "ix_syncshell_invites_inviter_target_display_name_status",
+            "inviter_id",
+            "target_display_name",
+            "status",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     inviter_id: Mapped[int] = mapped_column(


### PR DESCRIPTION
## Summary
- add Alembic migration 0050_add_syncshell_invite_indexes to create composite indexes on syncshell_invites
- update SyncshellInvite.__table_args__ to document the new composite indexes in the ORM model

## Testing
- pytest tests/test_migration_event_signup_index.py

------
https://chatgpt.com/codex/tasks/task_e_68d8b08bdbe88328a48817834c31c1a1