### PR TITLE
Handle SyncShell upload budget exhaustion

### DIFF
--- a/DemiCatPlugin/SyncShell/Client.cs
+++ b/DemiCatPlugin/SyncShell/Client.cs
@@ -471,6 +471,8 @@ public sealed class SyncClient : IDisposable
             ? wantElement.Deserialize<WantBlobs>(JsonOptions) ?? new WantBlobs()
             : new WantBlobs();
 
+        var upload = _uploads.GetOrAdd(peerId, static _ => new PeerUploadState());
+
         if (element.TryGetProperty("limits", out var limitsElement) && limitsElement.ValueKind == JsonValueKind.Object)
         {
             if (limitsElement.TryGetProperty("transfer", out var transferElement) && transferElement.ValueKind == JsonValueKind.Object)
@@ -488,9 +490,20 @@ public sealed class SyncClient : IDisposable
                 if (budgetElement.TryGetProperty("throttleAfterBytes", out var throttleElement) && throttleElement.ValueKind == JsonValueKind.Number)
                 {
                     var remaining = throttleElement.GetInt64();
+                    var budgetUpdate = upload.UpdateBudget(remaining);
                     if (remaining <= 0)
                     {
-                        PluginServices.Instance?.Log.Warning("SyncShell upload budget exhausted; awaiting reset before sending more blobs.");
+                        if (budgetUpdate == PeerUploadState.BudgetUpdateResult.Exhausted)
+                        {
+                            PluginServices.Instance?.Log.Warning($"SyncShell upload budget exhausted for peer {peerId}; awaiting reset before sending more blobs.");
+                        }
+                    }
+                    else
+                    {
+                        if (budgetUpdate == PeerUploadState.BudgetUpdateResult.Resumed)
+                        {
+                            PluginServices.Instance?.Log.Information($"SyncShell upload budget restored for peer {peerId}; resuming uploads.");
+                        }
                     }
                 }
             }
@@ -557,7 +570,11 @@ public sealed class SyncClient : IDisposable
 
         WantsReceived?.Invoke(this, new WantsReceivedEventArgs(peerId, want));
 
-        var upload = _uploads.GetOrAdd(peerId, static _ => new PeerUploadState());
+        if (upload.IsBudgetExhausted)
+        {
+            return;
+        }
+
         upload.AddRequests(want);
         TransferProgress?.Invoke(this, new TransferProgressEventArgs(peerId, upload.Completed, upload.Total, TransferKind.Upload));
 
@@ -969,22 +986,82 @@ public sealed class SyncClient : IDisposable
 
     private sealed class PeerUploadState
     {
+        private readonly object _sync = new();
         private readonly HashSet<string> _pending = new(StringComparer.OrdinalIgnoreCase);
         private int _total;
         private int _completed;
+        private bool _budgetExhausted;
 
-        public int Total => _total;
+        public enum BudgetUpdateResult
+        {
+            Unchanged,
+            Exhausted,
+            StillExhausted,
+            Resumed,
+        }
 
-        public int Completed => _completed;
+        public int Total
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _total;
+                }
+            }
+        }
+
+        public int Completed
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _completed;
+                }
+            }
+        }
 
         public bool IsComplete
         {
             get
             {
-                lock (_pending)
+                lock (_sync)
                 {
                     return _pending.Count == 0;
                 }
+            }
+        }
+
+        public bool IsBudgetExhausted
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _budgetExhausted;
+                }
+            }
+        }
+
+        public BudgetUpdateResult UpdateBudget(long remaining)
+        {
+            lock (_sync)
+            {
+                if (remaining <= 0)
+                {
+                    if (_budgetExhausted)
+                    {
+                        return BudgetUpdateResult.StillExhausted;
+                    }
+
+                    _budgetExhausted = true;
+                    return BudgetUpdateResult.Exhausted;
+                }
+
+                var wasExhausted = _budgetExhausted;
+                _budgetExhausted = false;
+                return wasExhausted ? BudgetUpdateResult.Resumed : BudgetUpdateResult.Unchanged;
             }
         }
 
@@ -995,7 +1072,7 @@ public sealed class SyncClient : IDisposable
                 return;
             }
 
-            lock (_pending)
+            lock (_sync)
             {
                 foreach (var blob in want.Blobs)
                 {
@@ -1018,7 +1095,7 @@ public sealed class SyncClient : IDisposable
 
         public void MarkSent(string hash, BlobChunk? chunk)
         {
-            lock (_pending)
+            lock (_sync)
             {
                 var key = chunk is null ? hash : BuildChunkKey(chunk);
                 if (_pending.Remove(key))

--- a/tests/SyncShellClientTests.cs
+++ b/tests/SyncShellClientTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DemiCatPlugin;
+using DemiCatPlugin.SyncShell;
+using Moq;
+using Xunit;
+
+public class SyncShellClientTests
+{
+    [Fact]
+    public async Task HandleWantAsync_SuppressesUploadsWhenBudgetExhausted()
+    {
+        var previousTokenManager = TokenManager.Instance;
+        var tokenManager = new TokenManager();
+        try
+        {
+            using var client = CreateClient(tokenManager);
+            await InvokeHandleWantAsync(client, BuildWantPayload("peer-one", 0, "blob-one"));
+
+            var uploadState = GetUploadState(client, "peer-one");
+            Assert.True(GetIsBudgetExhausted(uploadState));
+            Assert.Equal(0, GetTotal(uploadState));
+            Assert.False(TryReadOutgoing(client));
+        }
+        finally
+        {
+            typeof(TokenManager).GetProperty("Instance", BindingFlags.Static | BindingFlags.Public)!
+                .SetValue(null, previousTokenManager);
+        }
+    }
+
+    [Fact]
+    public async Task HandleWantAsync_ResumesUploadsWhenBudgetRestored()
+    {
+        var previousTokenManager = TokenManager.Instance;
+        var tokenManager = new TokenManager();
+        try
+        {
+            using var client = CreateClient(tokenManager);
+            await InvokeHandleWantAsync(client, BuildWantPayload("peer-one", 0, "blob-one"));
+            Assert.True(GetIsBudgetExhausted(GetUploadState(client, "peer-one")));
+
+            await InvokeHandleWantAsync(client, BuildWantPayload("peer-one", 2048, "blob-one"));
+
+            var uploadState = GetUploadState(client, "peer-one");
+            Assert.False(GetIsBudgetExhausted(uploadState));
+            Assert.Equal(1, GetTotal(uploadState));
+            Assert.True(TryReadOutgoing(client));
+        }
+        finally
+        {
+            typeof(TokenManager).GetProperty("Instance", BindingFlags.Static | BindingFlags.Public)!
+                .SetValue(null, previousTokenManager);
+        }
+    }
+
+    private static SyncClient CreateClient(TokenManager tokenManager)
+    {
+        var config = new Config { ApiBaseUrl = "http://localhost" };
+        var resolver = Mock.Of<IResolver>();
+        var blobStore = Mock.Of<IBlobStore>();
+        return new SyncClient(config, tokenManager, resolver, blobStore, SyncLimits.Default);
+    }
+
+    private static async Task InvokeHandleWantAsync(SyncClient client, string json)
+    {
+        var method = typeof(SyncClient).GetMethod("HandleWantAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        using var document = JsonDocument.Parse(json);
+        var element = document.RootElement.Clone();
+        var task = (Task)method.Invoke(client, new object[] { element, CancellationToken.None })!;
+        await task.ConfigureAwait(false);
+    }
+
+    private static object GetUploadState(SyncClient client, string peerId)
+    {
+        var uploadsField = typeof(SyncClient).GetField("_uploads", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var uploads = uploadsField.GetValue(client)!;
+        var tryGetValue = uploads.GetType().GetMethod("TryGetValue")!;
+        var arguments = new object?[] { peerId, null };
+        var found = (bool)tryGetValue.Invoke(uploads, arguments)!;
+        Assert.True(found);
+        return arguments[1]!;
+    }
+
+    private static bool GetIsBudgetExhausted(object uploadState)
+    {
+        var property = uploadState.GetType().GetProperty("IsBudgetExhausted", BindingFlags.Instance | BindingFlags.Public)!;
+        return (bool)property.GetValue(uploadState)!;
+    }
+
+    private static int GetTotal(object uploadState)
+    {
+        var property = uploadState.GetType().GetProperty("Total", BindingFlags.Instance | BindingFlags.Public)!;
+        return (int)property.GetValue(uploadState)!;
+    }
+
+    private static bool TryReadOutgoing(SyncClient client)
+    {
+        var channelField = typeof(SyncClient).GetField("_outgoingBlobs", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var channel = channelField.GetValue(client)!;
+        var readerProperty = channel.GetType().GetProperty("Reader", BindingFlags.Instance | BindingFlags.Public)!;
+        var reader = readerProperty.GetValue(channel)!;
+        var tryRead = reader.GetType().GetMethod("TryRead")!;
+        var arguments = new object?[] { null };
+        var result = (bool)tryRead.Invoke(reader, arguments)!;
+        return result;
+    }
+
+    private static string BuildWantPayload(string peerId, long throttleAfterBytes, params string[] blobs)
+    {
+        var payload = new
+        {
+            peerId,
+            want = new
+            {
+                blobs,
+                chunks = Array.Empty<object>(),
+            },
+            limits = new
+            {
+                budget = new
+                {
+                    throttleAfterBytes,
+                },
+            },
+        };
+
+        return JsonSerializer.Serialize(payload);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid queuing new uploads while a peer reports zero remaining throttle budget and log transitions
- persist budget exhaustion state in PeerUploadState so transfers resume automatically when capacity returns
- add SyncShellClient tests covering exhausted budgets and subsequent recovery

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8b1ee5b488328a2638247bfa21b20