### PR TITLE
Preserve Syncshell invite display name casing

### DIFF
--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -9,7 +9,7 @@ import json
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
@@ -449,8 +449,9 @@ async def create_invite(
     await _check_rate_limit(ctx.user.id, db)
 
     target_user: User | None = None
-    normalized_member = _normalize_display_name(payload.member)
-    display_name = normalized_member
+    original_member = (payload.member or "").strip()
+    normalized_member = _normalize_display_name(original_member)
+    display_name = original_member
     if payload.member_id is not None:
         target_user = await db.get(User, payload.member_id)
         if not target_user:
@@ -497,7 +498,7 @@ async def create_invite(
         if invite is not None:
             return _serialize_invite(invite, "outgoing")
     else:
-        normalized_display_name = _normalize_display_name(display_name)
+        normalized_display_name = normalized_member
         existing_invite = await db.execute(
             select(SyncshellInvite).where(
                 SyncshellInvite.inviter_id == ctx.user.id,
@@ -542,7 +543,8 @@ async def _get_invite_for_target(
     normalized_target = _normalize_display_name(_display_name(target_user))
     if not normalized_target:
         raise HTTPException(status_code=404, detail="invite not found")
-    if _normalize_display_name(invite.target_display_name) != normalized_target:
+    normalized_invite_target = _normalize_display_name(invite.target_display_name)
+    if normalized_invite_target != normalized_target:
         raise HTTPException(status_code=404, detail="invite not found")
     return invite
 
@@ -626,16 +628,21 @@ async def list_pending(
             SyncshellInvite.status == "pending",
             or_(
                 SyncshellInvite.target_user_id == ctx.user.id,
-                and_(
-                    SyncshellInvite.target_user_id.is_(None),
-                    func.lower(SyncshellInvite.target_display_name)
-                    == normalized_target,
-                ),
+                SyncshellInvite.target_user_id.is_(None),
             ),
         )
         .order_by(SyncshellInvite.created_at.desc())
     )
-    invites = result.scalars().all()
+    invites = [
+        invite
+        for invite in result.scalars().all()
+        if invite.target_user_id == ctx.user.id
+        or (
+            normalized_target
+            and _normalize_display_name(invite.target_display_name)
+            == normalized_target
+        )
+    ]
     pending: list[dict[str, Any]] = []
     for invite in invites:
         inviter = await db.get(User, invite.inviter_id)
@@ -773,16 +780,21 @@ async def list_memberships(
             SyncshellInvite.status == "pending",
             or_(
                 SyncshellInvite.target_user_id == ctx.user.id,
-                and_(
-                    SyncshellInvite.target_user_id.is_(None),
-                    func.lower(SyncshellInvite.target_display_name)
-                    == normalized_pending,
-                ),
+                SyncshellInvite.target_user_id.is_(None),
             ),
         )
         .order_by(SyncshellInvite.created_at.desc())
     )
-    pending_invites = pending_result.scalars().all()
+    pending_invites = [
+        invite
+        for invite in pending_result.scalars().all()
+        if invite.target_user_id == ctx.user.id
+        or (
+            normalized_pending
+            and _normalize_display_name(invite.target_display_name)
+            == normalized_pending
+        )
+    ]
     inviter_ids = {invite.inviter_id for invite in pending_invites}
     inviters: dict[int, User] = {}
     if inviter_ids:

--- a/tests/test_syncshell_invites.py
+++ b/tests/test_syncshell_invites.py
@@ -118,6 +118,40 @@ def test_pending_invite_accept_flow_sets_memberships():
     asyncio.run(_run())
 
 
+def test_create_invite_preserves_display_name_casing_for_ambiguous_match():
+    async def _run():
+        session_factory = await _prepare_db()
+        async with session_factory as db:
+            inviter = User(id=1, discord_user_id=1, global_name="Alpha")
+            target_one = User(id=2, discord_user_id=2, character_name="Echo")
+            target_two = User(id=3, discord_user_id=3, character_name="Echo")
+            db.add_all(
+                [
+                    inviter,
+                    target_one,
+                    target_two,
+                    _pairing(inviter.id, token="token-inviter"),
+                    _pairing(target_one.id, token="token-target-1"),
+                    _pairing(target_two.id, token="token-target-2"),
+                ]
+            )
+            await db.commit()
+
+            ctx_inviter = RequestContext(user=inviter, guild=None, key=object(), roles=[])
+            syncshell.RATE_LIMIT = 100
+
+            response = await syncshell.create_invite(
+                syncshell.InviteCreateRequest(member="  eChO  "), ctx=ctx_inviter, db=db
+            )
+
+            invite = await db.get(SyncshellInvite, response["id"])
+            assert invite is not None
+            assert invite.target_user_id is None
+            assert invite.target_display_name == "eChO"
+
+    asyncio.run(_run())
+
+
 def test_pending_invite_deny_sets_target_user():
     async def _run():
         session_factory = await _prepare_db()


### PR DESCRIPTION
## Summary
- retain the original casing of user-provided invite targets while still resolving exact matches when possible
- normalize display names only when comparing pending invites and memberships to avoid mutating stored values
- add a regression test ensuring ambiguous invite display names preserve the caller-provided casing

## Testing
- pytest tests/test_syncshell_invites.py *(fails: missing sqlalchemy dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bd1f02e88328a1b1b486f05cf81a