### PR TITLE
Ensure syncshell budget window timestamps use Z suffix

### DIFF
--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -258,13 +258,11 @@ def _update_transfer_budget(
 
     remaining = max(0, limit - budget.used_bytes)
     window_end = budget.window_start + window
-    if window_end.tzinfo is None:
-        window_end = window_end.replace(tzinfo=timezone.utc)
     return {
         "limitBytes": limit,
         "usedBytes": budget.used_bytes,
         "throttleAfterBytes": remaining,
-        "windowEndsAt": window_end.isoformat(),
+        "windowEndsAt": _to_iso(window_end),
     }
 
 
@@ -335,7 +333,10 @@ def _normalize_display_name(value: str | None) -> str:
 def _to_iso(dt: datetime | None) -> str | None:
     if not dt:
         return None
-    return dt.replace(microsecond=0).isoformat() + "Z"
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc)
+    dt = dt.replace(tzinfo=None, microsecond=0)
+    return dt.isoformat() + "Z"
 
 
 class InviteCreateRequest(BaseModel):

--- a/tests/test_syncshell_limits.py
+++ b/tests/test_syncshell_limits.py
@@ -53,6 +53,7 @@ def test_rate_limit_hits(tmp_path):
             syncshell._transfer_budgets.clear()
             response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert response["diff"]["need"]
+            assert response["limits"]["budget"]["windowEndsAt"].endswith("Z")
             with pytest.raises(syncshell.HTTPException):
                 await syncshell.resync(ctx=ctx, db=db)
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- reuse the existing `_to_iso` helper when serialising transfer budget window expiry values
- normalise `_to_iso` to coerce aware datetimes to UTC before formatting with a `Z` suffix
- extend the syncshell limits test to assert the transfer budget window timestamp ends with `Z`

## Testing
- pytest tests/test_syncshell_limits.py *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68d8be383b9483289a4e222acf16707d