### PR TITLE
Populate Syncshell WANT size hints

### DIFF
--- a/demibot/demibot/http/ws_syncshell.py
+++ b/demibot/demibot/http/ws_syncshell.py
@@ -54,14 +54,26 @@ async def _handle_manifest_message(
     if not peer_id:
         peer_id = str(ctx.user.discord_user_id or ctx.user.id)
 
+    need_entries = diff.get("need", [])
+    blobs: list[str] = []
+    size_hints: list[dict[str, Any]] = []
+    for entry in need_entries:
+        blob_hash = entry.get("hash")
+        if not blob_hash:
+            continue
+        blobs.append(blob_hash)
+        size = entry.get("size")
+        if isinstance(size, int) and size > 0:
+            size_hints.append({"hash": blob_hash, "size": size})
+
     want_message = {
         "type": "want",
         "payload": {
             "peerId": peer_id,
             "want": {
-                "blobs": [entry["hash"] for entry in diff.get("need", []) if entry.get("hash")],
+                "blobs": blobs,
                 "chunks": [],
-                "sizeHints": [],
+                "sizeHints": size_hints,
             },
             "diff": diff,
             "limits": limits,

--- a/tests/test_syncshell_ws.py
+++ b/tests/test_syncshell_ws.py
@@ -81,6 +81,12 @@ def test_syncshell_websocket_hello_and_manifest(tmp_path):
         payload = want["payload"]
         assert blob_hash in payload["want"]["blobs"]
         assert payload["diff"]["need"]
+        expected_hints = [
+            {"hash": entry["hash"], "size": entry["size"]}
+            for entry in payload["diff"]["need"]
+            if entry.get("hash") and isinstance(entry.get("size"), int) and entry["size"] > 0
+        ]
+        assert payload["want"]["sizeHints"] == expected_hints
         assert payload["limits"]["budget"]["limitBytes"] > 0
 
     async def _fetch_manifest() -> dict:


### PR DESCRIPTION
## Summary
- populate SyncShell WANT payload size hints from the manifest diff to include hash and size metadata
- extend the websocket manifest test to verify the emitted size hint entries

## Testing
- pytest tests/test_syncshell_ws.py *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68d8bed515f08328a7ee68d055e71040