### PR TITLE
Handle corrupt syncshell manifests

### DIFF
--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
 import json
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -23,6 +24,9 @@ from ...db.models import (
     User,
 )
 from ..vault import presign_upload, presign_download
+
+
+logger = logging.getLogger(__name__)
 
 
 router = APIRouter(prefix="/api/syncshell", tags=["syncshell"])
@@ -282,7 +286,12 @@ async def handle_manifest_upload(
     if record:
         try:
             previous_manifest = json.loads(record.manifest_json)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "syncshell.manifest.previous.decode_failed user_id=%s",
+                ctx.user.id,
+                exc_info=exc,
+            )
             previous_manifest = None
 
     diff = _compute_manifest_diff(previous_manifest, manifest)

--- a/tests/test_syncshell.py
+++ b/tests/test_syncshell.py
@@ -1,10 +1,11 @@
 import asyncio
+import logging
 
 import pytest
 
 from demibot.db.session import init_db, get_session
 import demibot.db.session as db_session
-from demibot.db.models import User, SyncshellPairing
+from demibot.db.models import User, SyncshellPairing, SyncshellManifest
 from demibot.http.deps import RequestContext
 
 from .syncshell_import import syncshell
@@ -124,3 +125,35 @@ def test_asset_upload_download_and_rate_limit(tmp_path):
                 await syncshell.request_asset_upload(ctx=ctx, db=db)
             assert exc.value.status_code == 429
     asyncio.run(_run())
+
+
+def test_manifest_corrupt_previous_logs_warning(tmp_path, caplog):
+    async def _run():
+        session_factory = await _prepare_db()
+        async with session_factory as db:
+            user = User(id=1, discord_user_id=1, global_name="Test")
+            db.add(user)
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            syncshell.RATE_LIMIT = 5
+
+            await syncshell.pair(ctx=ctx, db=db)
+
+            corrupted = SyncshellManifest(user_id=user.id, manifest_json="{invalid}")
+            db.add(corrupted)
+            await db.commit()
+
+            manifest, _ = build_manifest_payload(tmp_path)
+            syncshell._transfer_budgets.clear()
+
+            caplog.set_level(logging.WARNING, logger="demibot.http.routes.syncshell")
+            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            assert response["status"] == "ok"
+
+    asyncio.run(_run())
+    assert any(
+        "syncshell.manifest.previous.decode_failed" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log a warning when a stored syncshell manifest cannot be decoded before falling back to an empty manifest
- add a unit test that seeds a corrupt manifest and asserts the warning is emitted during upload

## Testing
- pytest tests/test_syncshell.py::test_manifest_corrupt_previous_logs_warning


------
https://chatgpt.com/codex/tasks/task_e_68d8c05ec30483288bbd18170770f4ec