### PR TITLE
Refine routes package exports

### DIFF
--- a/demibot/demibot/http/__init__.py
+++ b/demibot/demibot/http/__init__.py
@@ -1,3 +1,16 @@
-from .api import create_app
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 
 __all__ = ["create_app"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "create_app":
+        return import_module(".api", __name__).create_app
+    raise AttributeError(name)
+
+
+if TYPE_CHECKING:  # pragma: no cover - for static type checkers
+    from .api import create_app as create_app

--- a/demibot/demibot/http/routes/__init__.py
+++ b/demibot/demibot/http/routes/__init__.py
@@ -1,31 +1,35 @@
-from . import (
-    channels,
-    messages,
-    officer_messages,
-    users,
-    embeds,
-    events,
-    interactions,
-    validate_roles,
-    guild_roles,
-    requests,
-    user_settings,
-    installations,
-    discord_emojis,
-)
+from __future__ import annotations
 
-__all__ = [
-    "channels",
-    "messages",
-    "officer_messages",
-    "users",
-    "embeds",
-    "events",
-    "interactions",
-    "validate_roles",
-    "guild_roles",
-    "requests",
-    "user_settings",
-    "installations",
-    "discord_emojis",
-]
+import importlib
+import pkgutil
+from types import ModuleType
+from typing import Dict, Iterable, List
+
+
+def _iter_module_names() -> Iterable[str]:
+    for module_info in pkgutil.iter_modules(__path__):  # type: ignore[name-defined]
+        name = module_info.name
+        if not name.startswith("_"):
+            yield name
+
+
+_module_names: List[str] = sorted(_iter_module_names())
+
+__all__ = list(_module_names)
+
+_loaded_modules: Dict[str, ModuleType] = {}
+
+
+def __getattr__(name: str) -> ModuleType:
+    if name in _loaded_modules:
+        return _loaded_modules[name]
+    if name in __all__:
+        module = importlib.import_module(f"{__name__}.{name}")
+        _loaded_modules[name] = module
+        globals()[name] = module
+        return module
+    raise AttributeError(name)
+
+
+def __dir__() -> List[str]:
+    return sorted(list(globals().keys()) + __all__)

--- a/tests/test_routes_imports.py
+++ b/tests/test_routes_imports.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib
+import pkgutil
+import sys
+import types
+
+
+def _install_alembic_stub() -> None:
+    if "alembic" in sys.modules:
+        return
+
+    alembic_pkg = types.ModuleType("alembic")
+    alembic_pkg.__path__ = []  # type: ignore[attr-defined]
+
+    command_module = types.ModuleType("alembic.command")
+
+    def _upgrade(*args: object, **kwargs: object) -> None:  # pragma: no cover - stub
+        return None
+
+    command_module.upgrade = _upgrade  # type: ignore[attr-defined]
+
+    config_module = types.ModuleType("alembic.config")
+
+    class _Config:  # pragma: no cover - stub
+        def __init__(self) -> None:
+            self._options: dict[str, str] = {}
+
+        def set_main_option(self, key: str, value: str) -> None:
+            self._options[key] = value
+
+    config_module.Config = _Config  # type: ignore[attr-defined]
+
+    sys.modules["alembic"] = alembic_pkg
+    sys.modules["alembic.command"] = command_module
+    sys.modules["alembic.config"] = config_module
+    alembic_pkg.command = command_module  # type: ignore[attr-defined]
+    alembic_pkg.config = config_module  # type: ignore[attr-defined]
+
+
+def test_routes_module_exports_all_router_modules() -> None:
+    _install_alembic_stub()
+
+    import demibot.http.routes as routes
+
+    expected_modules = sorted(
+        module_info.name
+        for module_info in pkgutil.iter_modules(routes.__path__)  # type: ignore[attr-defined]
+        if not module_info.name.startswith("_")
+    )
+
+    exported_modules = sorted(routes.__all__)
+    assert exported_modules == expected_modules
+
+    for module_name in expected_modules:
+        module_via_attr = getattr(routes, module_name)
+        module_via_import = importlib.import_module(f"{routes.__name__}.{module_name}")
+        assert module_via_attr is module_via_import


### PR DESCRIPTION
## Summary
- lazily expose http routes by scanning the package and importing modules on demand
- defer importing the FastAPI application factory until requested to avoid dependency churn
- add a unit test ensuring each router module can be imported from the routes package

## Testing
- pytest tests/test_routes_imports.py

------
https://chatgpt.com/codex/tasks/task_e_68d943d2d9ac8328960c6dfaa7cd5f3a