### PR TITLE
Add target status index for syncshell invites

### DIFF
--- a/demibot/demibot/db/migrations/versions/0051_add_syncshell_invites_target_status_index.py
+++ b/demibot/demibot/db/migrations/versions/0051_add_syncshell_invites_target_status_index.py
@@ -1,0 +1,34 @@
+"""0051_add_syncshell_invites_target_status_index
+
+Revision ID: 0051_add_syncshell_invites_target_status_index
+Revises: 0050_add_syncshell_invite_indexes
+Create Date: 2024-06-09 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0051_add_syncshell_invites_target_status_index"
+down_revision: Union[str, None] = "0050_add_syncshell_invite_indexes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_syncshell_invites_target_status",
+        "syncshell_invites",
+        ["target_user_id", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_syncshell_invites_target_status",
+        table_name="syncshell_invites",
+    )

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -246,6 +246,11 @@ class SyncshellInvite(Base):
             "target_display_name",
             "status",
         ),
+        Index(
+            "ix_syncshell_invites_target_status",
+            "target_user_id",
+            "status",
+        ),
     )
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)


### PR DESCRIPTION
## Summary
- add migration 0051_add_syncshell_invites_target_status_index to create the `(target_user_id, status)` index on `syncshell_invites`
- update `SyncshellInvite.__table_args__` so the ORM metadata includes the new index definition

## Testing
- `PYTHONPATH=/workspace/DemiCat/demibot alembic -c /tmp/demibot_alembic.ini stamp 0050_add_syncshell_invite_indexes`
- `PYTHONPATH=/workspace/DemiCat/demibot alembic -c /tmp/demibot_alembic.ini upgrade head`
- `python - <<'PY' ...` (verify index exists in sqlite test database)


------
https://chatgpt.com/codex/tasks/task_e_68d94987ea64832896976215954f1635