### PR TITLE
Remove redundant SyncShell compile include

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -42,10 +42,6 @@
     <EmbeddedResource Include="icon.png" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="SyncShell\**\*.cs" />
-  </ItemGroup>
-
   <ItemGroup Condition="Exists('Emoji/NotoColorEmoji.ttf')">
     <None Include="Emoji/NotoColorEmoji.ttf" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- remove the manual SyncShell compile include from the plugin project to rely on default item handling

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: `bash: command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_68d94df5f27c83288791f0819aa7685a