### PR TITLE
Adjust NullPluginLog stubs to new IPluginLog interface

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -20,6 +20,8 @@ using Dalamud.Plugin.Services;
 using DemiCatPlugin.SyncShell;
 using Glamourer.Api.IpcSubscribers;
 using Penumbra.Api.Enums;
+using Serilog;
+using Serilog.Events;
 
 namespace DemiCatPlugin;
 
@@ -3659,18 +3661,57 @@ public class SyncshellWindow : IDisposable
 
     private sealed class NullPluginLog : IPluginLog
     {
-        public void Verbose(string message) { }
-        public void Verbose(string message, Exception exception) { }
-        public void Debug(string message) { }
-        public void Debug(string message, Exception exception) { }
-        public void Info(string message) { }
-        public void Info(string message, Exception exception) { }
-        public void Warning(string message) { }
-        public void Warning(string message, Exception exception) { }
-        public void Error(string message) { }
-        public void Error(Exception exception, string message) { }
-        public void Fatal(string message) { }
-        public void Fatal(string message, Exception exception) { }
+        public ILogger Logger { get; } = new LoggerConfiguration().CreateLogger();
+
+        public LogEventLevel MinimumLogLevel { get; set; }
+
+        public void Verbose(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Verbose(Exception? exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Debug(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Debug(Exception? exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Info(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Info(Exception? exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Warning(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Warning(Exception? exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Error(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Error(Exception? exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Fatal(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Fatal(Exception? exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
     }
 
     private sealed class DownloadDeferredException : Exception

--- a/tests/UiRendererShutdownTests.cs
+++ b/tests/UiRendererShutdownTests.cs
@@ -10,6 +10,8 @@ using Dalamud.Plugin.Services;
 using DemiCatPlugin;
 using DemiCatPlugin.Emoji;
 using Moq;
+using Serilog;
+using Serilog.Events;
 using Xunit;
 
 [CollectionDefinition("UiRenderer Shutdown Tests", DisableParallelization = true)]
@@ -271,51 +273,55 @@ public class UiRendererShutdownTests
 
     private sealed class NullPluginLog : IPluginLog
     {
-        public void Debug(string message)
+        public ILogger Logger { get; } = new LoggerConfiguration().CreateLogger();
+
+        public LogEventLevel MinimumLogLevel { get; set; }
+
+        public void Verbose(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Debug(string message, Exception exception)
+        public void Verbose(Exception? exception, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Error(string message)
+        public void Debug(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Error(Exception exception, string message)
+        public void Debug(Exception? exception, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Fatal(string message)
+        public void Info(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Fatal(Exception exception, string message)
+        public void Info(Exception? exception, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Info(string message)
+        public void Warning(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Info(string message, Exception exception)
+        public void Warning(Exception? exception, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Verbose(string message)
+        public void Error(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Verbose(string message, Exception exception)
+        public void Error(Exception? exception, string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Warning(string message)
+        public void Fatal(string messageTemplate, params object[] propertyValues)
         {
         }
 
-        public void Warning(string message, Exception exception)
+        public void Fatal(Exception? exception, string messageTemplate, params object[] propertyValues)
         {
         }
     }


### PR DESCRIPTION
## Summary
- update the plugin NullPluginLog stub to expose Logger and MinimumLogLevel and use the new method signatures
- sync the test NullPluginLog helper with the updated interface and add the required Serilog imports

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d94ffc0ce48328adb419ce23f36e85