### PR TITLE
Add missing information overloads to NullPluginLog

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -3689,6 +3689,14 @@ public class SyncshellWindow : IDisposable
         {
         }
 
+        public void Information(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Information(Exception? exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
         public void Warning(string messageTemplate, params object[] propertyValues)
         {
         }
@@ -3710,6 +3718,10 @@ public class SyncshellWindow : IDisposable
         }
 
         public void Fatal(Exception? exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Write(LogEventLevel level, Exception? exception, string messageTemplate, params object[] propertyValues)
         {
         }
     }

--- a/tests/UiRendererShutdownTests.cs
+++ b/tests/UiRendererShutdownTests.cs
@@ -301,6 +301,14 @@ public class UiRendererShutdownTests
         {
         }
 
+        public void Information(string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Information(Exception? exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
         public void Warning(string messageTemplate, params object[] propertyValues)
         {
         }
@@ -322,6 +330,10 @@ public class UiRendererShutdownTests
         }
 
         public void Fatal(Exception? exception, string messageTemplate, params object[] propertyValues)
+        {
+        }
+
+        public void Write(LogEventLevel level, Exception? exception, string messageTemplate, params object[] propertyValues)
         {
         }
     }


### PR DESCRIPTION
## Summary
- add the missing Information and Write overloads to the plugin NullPluginLog stub
- mirror the same interface additions in the test helper implementation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9594b6de483288385513e43029aa5