### PR TITLE
Add missing globalization namespace

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;


### PR DESCRIPTION
## Summary
- add the System.Globalization namespace to EventCreateWindow so DateTimeStyles compiles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9622ebd1c83289d151cdd8b5913ef