### PR TITLE
Use synchronous disposal for linked CTS in SyncClient

### DIFF
--- a/DemiCatPlugin/SyncShell/Client.cs
+++ b/DemiCatPlugin/SyncShell/Client.cs
@@ -220,7 +220,7 @@ public sealed class SyncClient : IDisposable
 
     private async Task ConnectAndPumpAsync(CancellationToken token)
     {
-        await using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token);
         var socket = new ClientWebSocket();
         ApiHelpers.AddAuthHeader(socket, _tokenManager);
         socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(30);


### PR DESCRIPTION
## Summary
- switch the linked cancellation token source in SyncClient to a synchronous using statement to avoid requiring IAsyncDisposable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d96292f2248328b68fabf24a4cf1ca