### PR TITLE
Update Penumbra IPC subscription labels

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -1539,7 +1539,7 @@ public class SyncshellWindow : IDisposable
 
         TrySubscribe(() =>
         {
-            var subscriber = pi.GetIpcSubscriber<ModSettingChange, Guid, string, bool, object?>(Penumbra.Api.IpcSubscribers.ModSettings.ModSettingChanged.Label);
+            var subscriber = pi.GetIpcSubscriber<ModSettingChange, Guid, string, bool, object?>(Penumbra.Api.IpcSubscribers.ModSettingChanged.Label);
             void Handler(ModSettingChange _, Guid __, string ___, bool ____) => HandleLocalStateChanged(LocalStateChangeSource.Penumbra);
             subscriber.Subscribe(Handler);
             _ipcUnsubscribers.Add(() =>
@@ -1557,7 +1557,7 @@ public class SyncshellWindow : IDisposable
 
         TrySubscribe(() =>
         {
-            var subscriber = pi.GetIpcSubscriber<bool, object?>(Penumbra.Api.IpcSubscribers.PluginState.EnabledChange.Label);
+            var subscriber = pi.GetIpcSubscriber<bool, object?>(Penumbra.Api.IpcSubscribers.EnabledChange.Label);
             void Handler(bool _) => HandleLocalStateChanged(LocalStateChangeSource.Penumbra);
             subscriber.Subscribe(Handler);
             _ipcUnsubscribers.Add(() =>


### PR DESCRIPTION
## Summary
- update the Penumbra IPC subscription identifiers to use the current ModSettingChanged and EnabledChange labels

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9630d4d5083288fd912c2a2141940