### PR TITLE
Add legacy IPC fallback for Syncshell state change subscriptions

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -1536,71 +1536,107 @@ public class SyncshellWindow : IDisposable
             return;
         }
 
-        TrySubscribe(() =>
-        {
-            var subscriber = pi.GetIpcSubscriber<ModSettingChange, Guid, string, bool, object?>(Penumbra.Api.IpcSubscribers.ModSettingChanged.Label);
-            void Handler(ModSettingChange _, Guid __, string ___, bool ____) => HandleLocalStateChanged(LocalStateChangeSource.Penumbra);
-            subscriber.Subscribe(Handler);
-            _ipcUnsubscribers.Add(() =>
+        void HandlePenumbraModSetting(ModSettingChange _, Guid __, string ___, bool ____) => HandleLocalStateChanged(LocalStateChangeSource.Penumbra);
+        TrySubscribeAny(
+            "Penumbra.ModSettingChanged",
+            () =>
             {
-                try
-                {
-                    subscriber.Unsubscribe(Handler);
-                }
-                catch (Exception ex)
-                {
-                    PluginServices.Instance?.Log.Debug(ex, "Failed to unsubscribe from Penumbra.ModSettingChanged");
-                }
+                var subscriber = pi.GetIpcSubscriber<ModSettingChange, Guid, string, bool, object?>(Penumbra.Api.IpcSubscribers.ModSettingChanged.Label);
+                subscriber.Subscribe(HandlePenumbraModSetting);
+                return () => subscriber.Unsubscribe(HandlePenumbraModSetting);
+            },
+            () =>
+            {
+                var subscriber = pi.GetIpcSubscriber<ModSettingChange, Guid, string, bool, object?>("Penumbra.ModSettingChanged");
+                subscriber.Subscribe(HandlePenumbraModSetting);
+                return () => subscriber.Unsubscribe(HandlePenumbraModSetting);
             });
-        }, "Penumbra.ModSettingChanged");
 
-        TrySubscribe(() =>
-        {
-            var subscriber = pi.GetIpcSubscriber<bool, object?>(Penumbra.Api.IpcSubscribers.EnabledChange.Label);
-            void Handler(bool _) => HandleLocalStateChanged(LocalStateChangeSource.Penumbra);
-            subscriber.Subscribe(Handler);
-            _ipcUnsubscribers.Add(() =>
+        void HandlePenumbraEnabled(bool _) => HandleLocalStateChanged(LocalStateChangeSource.Penumbra);
+        TrySubscribeAny(
+            "Penumbra.EnabledChange",
+            () =>
             {
-                try
-                {
-                    subscriber.Unsubscribe(Handler);
-                }
-                catch (Exception ex)
-                {
-                    PluginServices.Instance?.Log.Debug(ex, "Failed to unsubscribe from Penumbra.EnabledChange");
-                }
+                var subscriber = pi.GetIpcSubscriber<bool, object?>(Penumbra.Api.IpcSubscribers.EnabledChange.Label);
+                subscriber.Subscribe(HandlePenumbraEnabled);
+                return () => subscriber.Unsubscribe(HandlePenumbraEnabled);
+            },
+            () =>
+            {
+                var subscriber = pi.GetIpcSubscriber<bool, object?>("Penumbra.EnabledChange");
+                subscriber.Subscribe(HandlePenumbraEnabled);
+                return () => subscriber.Unsubscribe(HandlePenumbraEnabled);
             });
-        }, "Penumbra.EnabledChange");
 
-        TrySubscribe(() =>
-        {
-            var subscriber = pi.GetIpcSubscriber<nint, object?>(Glamourer.Api.IpcSubscribers.StateChanged.Label);
-            void Handler(nint _) => HandleLocalStateChanged(LocalStateChangeSource.Glamourer);
-            subscriber.Subscribe(Handler);
-            _ipcUnsubscribers.Add(() =>
+        void HandleGlamourerState(nint _) => HandleLocalStateChanged(LocalStateChangeSource.Glamourer);
+        void HandleGlamourerStateInt(int _) => HandleLocalStateChanged(LocalStateChangeSource.Glamourer);
+        TrySubscribeAny(
+            "Glamourer.StateChanged",
+            () =>
             {
-                try
-                {
-                    subscriber.Unsubscribe(Handler);
-                }
-                catch (Exception ex)
-                {
-                    PluginServices.Instance?.Log.Debug(ex, "Failed to unsubscribe from Glamourer.StateChanged");
-                }
+                var subscriber = pi.GetIpcSubscriber<nint, object?>(Glamourer.Api.IpcSubscribers.StateChanged.Label);
+                subscriber.Subscribe(HandleGlamourerState);
+                return () => subscriber.Unsubscribe(HandleGlamourerState);
+            },
+            () =>
+            {
+                var subscriber = pi.GetIpcSubscriber<int, object?>(Glamourer.Api.IpcSubscribers.StateChanged.Label);
+                subscriber.Subscribe(HandleGlamourerStateInt);
+                return () => subscriber.Unsubscribe(HandleGlamourerStateInt);
+            },
+            () =>
+            {
+                var subscriber = pi.GetIpcSubscriber<nint, object?>("Glamourer.StateChanged");
+                subscriber.Subscribe(HandleGlamourerState);
+                return () => subscriber.Unsubscribe(HandleGlamourerState);
+            },
+            () =>
+            {
+                var subscriber = pi.GetIpcSubscriber<int, object?>("Glamourer.StateChanged");
+                subscriber.Subscribe(HandleGlamourerStateInt);
+                return () => subscriber.Unsubscribe(HandleGlamourerStateInt);
             });
-        }, "Glamourer.StateChanged");
     }
 
-    private void TrySubscribe(Action subscribe, string description)
+    private void TrySubscribeAny(string description, params Func<Action>[] attempts)
+    {
+        foreach (var attempt in attempts)
+        {
+            if (TrySubscribe(attempt, description))
+            {
+                return;
+            }
+        }
+    }
+
+    private bool TrySubscribe(Func<Action> subscribe, string description)
     {
         try
         {
-            subscribe();
+            var unsubscribe = subscribe();
+            RegisterUnsubscriber(unsubscribe, description);
+            return true;
         }
         catch (Exception ex)
         {
             PluginServices.Instance?.Log.Debug(ex, $"Failed to subscribe to {description} IPC event.");
+            return false;
         }
+    }
+
+    private void RegisterUnsubscriber(Action unsubscribe, string description)
+    {
+        _ipcUnsubscribers.Add(() =>
+        {
+            try
+            {
+                unsubscribe();
+            }
+            catch (Exception ex)
+            {
+                PluginServices.Instance?.Log.Debug(ex, $"Failed to unsubscribe from {description} IPC event.");
+            }
+        });
     }
 
     internal void PumpClientEvents()

--- a/tests/SyncshellStateChangeFallbackTests.cs
+++ b/tests/SyncshellStateChangeFallbackTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using DemiCatPlugin;
+using Moq;
+using Penumbra.Api.Enums;
+using Xunit;
+
+public class SyncshellStateChangeFallbackTests
+{
+    [Fact]
+    public void LegacyGateFallbackStillRaisesStateChange()
+    {
+        var previousServices = PluginServices.Instance;
+        var previousTokenManager = TokenManager.Instance;
+        SyncshellWindow? window = null;
+        var tempDir = Path.Combine(Path.GetTempPath(), "DemiCat", "SyncshellFallbackTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        using var httpClient = new HttpClient();
+
+        try
+        {
+            var services = new PluginServices();
+            var pluginInterface = new Mock<IDalamudPluginInterface>();
+            pluginInterface.Setup(pi => pi.GetPluginConfigDirectory()).Returns(tempDir);
+            pluginInterface.Setup(pi => pi.SavePluginConfig(It.IsAny<Config>()));
+
+            var modSettingLegacy = new Mock<IIpcSubscriber<ModSettingChange, Guid, string, bool, object?>>();
+            modSettingLegacy.Setup(sub => sub.Subscribe(It.IsAny<Action<ModSettingChange, Guid, string, bool>>()));
+            modSettingLegacy.Setup(sub => sub.Unsubscribe(It.IsAny<Action<ModSettingChange, Guid, string, bool>>()));
+            pluginInterface
+                .Setup(pi => pi.GetIpcSubscriber<ModSettingChange, Guid, string, bool, object?>(It.Is<string>(c => c == Penumbra.Api.IpcSubscribers.ModSettingChanged.Label)))
+                .Throws(new InvalidOperationException("typed gate unavailable"));
+            pluginInterface
+                .Setup(pi => pi.GetIpcSubscriber<ModSettingChange, Guid, string, bool, object?>(It.Is<string>(c => c == "Penumbra.ModSettingChanged")))
+                .Returns(modSettingLegacy.Object);
+
+            var enabledLegacy = new Mock<IIpcSubscriber<bool, object?>>();
+            enabledLegacy.Setup(sub => sub.Subscribe(It.IsAny<Action<bool>>()));
+            enabledLegacy.Setup(sub => sub.Unsubscribe(It.IsAny<Action<bool>>()));
+            pluginInterface
+                .Setup(pi => pi.GetIpcSubscriber<bool, object?>(It.Is<string>(c => c == Penumbra.Api.IpcSubscribers.EnabledChange.Label)))
+                .Throws(new InvalidOperationException("typed gate unavailable"));
+            pluginInterface
+                .Setup(pi => pi.GetIpcSubscriber<bool, object?>(It.Is<string>(c => c == "Penumbra.EnabledChange")))
+                .Returns(enabledLegacy.Object);
+
+            pluginInterface
+                .Setup(pi => pi.GetIpcSubscriber<nint, object?>(It.Is<string>(c => c == Glamourer.Api.IpcSubscribers.StateChanged.Label)))
+                .Throws(new InvalidOperationException("typed gate unavailable"));
+            pluginInterface
+                .Setup(pi => pi.GetIpcSubscriber<int, object?>(It.Is<string>(c => c == Glamourer.Api.IpcSubscribers.StateChanged.Label)))
+                .Throws(new InvalidOperationException("typed gate unavailable"));
+            pluginInterface
+                .Setup(pi => pi.GetIpcSubscriber<nint, object?>(It.Is<string>(c => c == "Glamourer.StateChanged")))
+                .Throws(new InvalidOperationException("legacy gate unavailable"));
+
+            var glamourerLegacyInt = new Mock<IIpcSubscriber<int, object?>>();
+            Action<int>? glamourerHandler = null;
+            glamourerLegacyInt
+                .Setup(sub => sub.Subscribe(It.IsAny<Action<int>>()))
+                .Callback<Action<int>>(handler => glamourerHandler = handler);
+            glamourerLegacyInt
+                .Setup(sub => sub.Unsubscribe(It.IsAny<Action<int>>()))
+                .Verifiable();
+            pluginInterface
+                .Setup(pi => pi.GetIpcSubscriber<int, object?>(It.Is<string>(c => c == "Glamourer.StateChanged")))
+                .Returns(glamourerLegacyInt.Object);
+
+            SetPluginService(services, "PluginInterface", pluginInterface.Object);
+
+            _ = new TokenManager();
+
+            var config = new Config
+            {
+                FCSyncShell = true,
+                SyncshellAutoSyncAllUsers = false,
+                SyncshellManualSyncAllUsers = true,
+            };
+
+            window = new SyncshellWindow(config, httpClient);
+
+            Assert.NotNull(glamourerHandler);
+
+            var pendingField = typeof(SyncshellWindow)
+                .GetField("_manualSyncPendingFlag", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            Assert.Equal(0, (int)pendingField.GetValue(window)!);
+
+            glamourerHandler!(123);
+
+            Assert.Equal(1, (int)pendingField.GetValue(window)!);
+
+            window.Dispose();
+            glamourerLegacyInt.Verify(sub => sub.Unsubscribe(It.IsAny<Action<int>>()), Times.Once());
+            window = null;
+        }
+        finally
+        {
+            window?.Dispose();
+            SetPluginServicesInstance(previousServices);
+            SetTokenManagerInstance(previousTokenManager);
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    private static void SetPluginService(PluginServices services, string propertyName, object value)
+    {
+        typeof(PluginServices)
+            .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, value);
+    }
+
+    private static void SetPluginServicesInstance(PluginServices? value)
+    {
+        typeof(PluginServices)
+            .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!
+            .SetValue(null, value);
+    }
+
+    private static void SetTokenManagerInstance(TokenManager? value)
+    {
+        typeof(TokenManager)
+            .GetProperty("Instance", BindingFlags.Static | BindingFlags.Public)!
+            .SetValue(null, value);
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch
+        {
+            // best effort cleanup
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update SyncshellWindow to probe typed IPC subscribers first and fall back to legacy string gates while sharing unsubscribe helpers
- handle both nint and int Glamourer payloads when probing IPC channels
- add a unit test covering the legacy gate fallback path when typed probes fail

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj --filter SyncshellStateChangeFallbackTests --no-build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9675976048328af306445bb0aaa35