### PR TITLE
Fix Penumbra legacy gate subscription

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -1537,6 +1537,7 @@ public class SyncshellWindow : IDisposable
         }
 
         void HandlePenumbraModSetting(ModSettingChange _, Guid __, string ___, bool ____) => HandleLocalStateChanged(LocalStateChangeSource.Penumbra);
+        void HandlePenumbraLegacyModSetting(Guid __, string ___, bool ____) => HandleLocalStateChanged(LocalStateChangeSource.Penumbra);
         TrySubscribeAny(
             "Penumbra.ModSettingChanged",
             () =>
@@ -1547,9 +1548,9 @@ public class SyncshellWindow : IDisposable
             },
             () =>
             {
-                var subscriber = pi.GetIpcSubscriber<ModSettingChange, Guid, string, bool, object?>("Penumbra.ModSettingChanged");
-                subscriber.Subscribe(HandlePenumbraModSetting);
-                return () => subscriber.Unsubscribe(HandlePenumbraModSetting);
+                var subscriber = pi.GetIpcSubscriber<Guid, string, bool, object?>("Penumbra.ModSettingChanged");
+                subscriber.Subscribe(HandlePenumbraLegacyModSetting);
+                return () => subscriber.Unsubscribe(HandlePenumbraLegacyModSetting);
             });
 
         void HandlePenumbraEnabled(bool _) => HandleLocalStateChanged(LocalStateChangeSource.Penumbra);

--- a/tests/SyncshellStateChangeFallbackTests.cs
+++ b/tests/SyncshellStateChangeFallbackTests.cs
@@ -29,14 +29,21 @@ public class SyncshellStateChangeFallbackTests
             pluginInterface.Setup(pi => pi.GetPluginConfigDirectory()).Returns(tempDir);
             pluginInterface.Setup(pi => pi.SavePluginConfig(It.IsAny<Config>()));
 
-            var modSettingLegacy = new Mock<IIpcSubscriber<ModSettingChange, Guid, string, bool, object?>>();
-            modSettingLegacy.Setup(sub => sub.Subscribe(It.IsAny<Action<ModSettingChange, Guid, string, bool>>()));
-            modSettingLegacy.Setup(sub => sub.Unsubscribe(It.IsAny<Action<ModSettingChange, Guid, string, bool>>()));
+            var modSettingLegacy = new Mock<IIpcSubscriber<Guid, string, bool, object?>>();
+            modSettingLegacy
+                .Setup(sub => sub.Subscribe(It.IsAny<Action<Guid, string, bool>>()))
+                .Verifiable();
+            modSettingLegacy
+                .Setup(sub => sub.Unsubscribe(It.IsAny<Action<Guid, string, bool>>()))
+                .Verifiable();
             pluginInterface
                 .Setup(pi => pi.GetIpcSubscriber<ModSettingChange, Guid, string, bool, object?>(It.Is<string>(c => c == Penumbra.Api.IpcSubscribers.ModSettingChanged.Label)))
                 .Throws(new InvalidOperationException("typed gate unavailable"));
             pluginInterface
                 .Setup(pi => pi.GetIpcSubscriber<ModSettingChange, Guid, string, bool, object?>(It.Is<string>(c => c == "Penumbra.ModSettingChanged")))
+                .Throws(new InvalidOperationException("legacy gate used wrong signature"));
+            pluginInterface
+                .Setup(pi => pi.GetIpcSubscriber<Guid, string, bool, object?>(It.Is<string>(c => c == "Penumbra.ModSettingChanged")))
                 .Returns(modSettingLegacy.Object);
 
             var enabledLegacy = new Mock<IIpcSubscriber<bool, object?>>();
@@ -95,6 +102,8 @@ public class SyncshellStateChangeFallbackTests
             Assert.Equal(1, (int)pendingField.GetValue(window)!);
 
             window.Dispose();
+            modSettingLegacy.Verify(sub => sub.Subscribe(It.IsAny<Action<Guid, string, bool>>()), Times.Once());
+            modSettingLegacy.Verify(sub => sub.Unsubscribe(It.IsAny<Action<Guid, string, bool>>()), Times.Once());
             glamourerLegacyInt.Verify(sub => sub.Unsubscribe(It.IsAny<Action<int>>()), Times.Once());
             window = null;
         }


### PR DESCRIPTION
## Summary
- adjust the Penumbra ModSetting fallback subscriber to use the legacy Guid signature
- update the legacy fallback unit test to expect the Guid-based subscriber and verify subscription/unsubscription

## Testing
- not run (dotnet not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d96d4952bc83289e941e6e79a54527