### PR TITLE
Update IPC subscriber mocks to call gate subscribers

### DIFF
--- a/tests/SyncShellResolverTests.cs
+++ b/tests/SyncShellResolverTests.cs
@@ -198,13 +198,13 @@ public class SyncShellResolverTests
         manifest.Appearance.CustomState["glamourer"] = "glam-state";
         manifest.Appearance.CustomState["customize+"] = "custom-state";
 
-        var reloadMock = new Mock<IIpcSubscriber<object>>();
+        var reloadMock = new Mock<ICallGateSubscriber<object>>();
         reloadMock.Setup(sub => sub.InvokeAction());
-        var redrawMock = new Mock<IIpcSubscriber<object>>();
+        var redrawMock = new Mock<ICallGateSubscriber<object>>();
         redrawMock.Setup(sub => sub.InvokeAction());
-        var glamApplyMock = new Mock<IIpcSubscriber<string, object?>>();
+        var glamApplyMock = new Mock<ICallGateSubscriber<string, object?>>();
         glamApplyMock.Setup(sub => sub.InvokeAction(It.IsAny<string>()));
-        var customizeApplyMock = new Mock<IIpcSubscriber<string, object?>>();
+        var customizeApplyMock = new Mock<ICallGateSubscriber<string, object?>>();
         customizeApplyMock.Setup(sub => sub.InvokeAction(It.IsAny<string>()));
 
         var pluginInterface = CreatePluginInterfaceMock(
@@ -273,9 +273,9 @@ public class SyncShellResolverTests
         return pluginInterface;
     }
 
-    private static IIpcSubscriber<T> CreateFuncSubscriber<T>(T value)
+    private static ICallGateSubscriber<T> CreateFuncSubscriber<T>(T value)
     {
-        var subscriber = new Mock<IIpcSubscriber<T>>();
+        var subscriber = new Mock<ICallGateSubscriber<T>>();
         subscriber.Setup(sub => sub.InvokeFunc()).Returns(value);
         return subscriber.Object;
     }

--- a/tests/SyncshellStateChangeFallbackTests.cs
+++ b/tests/SyncshellStateChangeFallbackTests.cs
@@ -29,7 +29,7 @@ public class SyncshellStateChangeFallbackTests
             pluginInterface.Setup(pi => pi.GetPluginConfigDirectory()).Returns(tempDir);
             pluginInterface.Setup(pi => pi.SavePluginConfig(It.IsAny<Config>()));
 
-            var modSettingLegacy = new Mock<IIpcSubscriber<Guid, string, bool, object?>>();
+            var modSettingLegacy = new Mock<ICallGateSubscriber<Guid, string, bool, object?>>();
             modSettingLegacy
                 .Setup(sub => sub.Subscribe(It.IsAny<Action<Guid, string, bool>>()))
                 .Verifiable();
@@ -46,7 +46,7 @@ public class SyncshellStateChangeFallbackTests
                 .Setup(pi => pi.GetIpcSubscriber<Guid, string, bool, object?>(It.Is<string>(c => c == "Penumbra.ModSettingChanged")))
                 .Returns(modSettingLegacy.Object);
 
-            var enabledLegacy = new Mock<IIpcSubscriber<bool, object?>>();
+            var enabledLegacy = new Mock<ICallGateSubscriber<bool, object?>>();
             enabledLegacy.Setup(sub => sub.Subscribe(It.IsAny<Action<bool>>()));
             enabledLegacy.Setup(sub => sub.Unsubscribe(It.IsAny<Action<bool>>()));
             pluginInterface
@@ -66,7 +66,7 @@ public class SyncshellStateChangeFallbackTests
                 .Setup(pi => pi.GetIpcSubscriber<nint, object?>(It.Is<string>(c => c == "Glamourer.StateChanged")))
                 .Throws(new InvalidOperationException("legacy gate unavailable"));
 
-            var glamourerLegacyInt = new Mock<IIpcSubscriber<int, object?>>();
+            var glamourerLegacyInt = new Mock<ICallGateSubscriber<int, object?>>();
             Action<int>? glamourerHandler = null;
             glamourerLegacyInt
                 .Setup(sub => sub.Subscribe(It.IsAny<Action<int>>()))


### PR DESCRIPTION
## Summary
- replace IIpcSubscriber mocks with ICallGateSubscriber mocks in SyncshellStateChangeFallbackTests
- update SyncShellResolverTests to use ICallGateSubscriber mocks and helper factory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9708129c48328ba9cdc4d50c6b0fa