### PR TITLE
Ensure refresh flags use Volatile helpers

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -57,7 +57,7 @@ public class SyncshellWindow : IDisposable
     private string? _etag;
     private string? _bundleEtag;
     private bool _loading;
-    private volatile bool _needsRefresh = true;
+    private bool _needsRefresh = true;
     private PenumbraConflict? _penumbraConflict;
     private static DateTimeOffset _lastRedraw;
     private DateTimeOffset? _pairingExpiresAt;
@@ -103,7 +103,7 @@ public class SyncshellWindow : IDisposable
     private string _inviteTarget = string.Empty;
     private int _inviteInFlight;
     private DateTimeOffset _lastMembershipFetch;
-    private volatile bool _membershipNeedsRefresh = true;
+    private bool _membershipNeedsRefresh = true;
     private int _membershipRefreshInProgress;
     private int _membershipRefreshRequested;
     private string? _membershipError;
@@ -213,7 +213,7 @@ public class SyncshellWindow : IDisposable
             return;
         }
 
-        if (!_loading && (_needsRefresh || DateTimeOffset.UtcNow - _lastRefresh > TimeSpan.FromMinutes(5)))
+        if (!_loading && (Volatile.Read(ref _needsRefresh) || DateTimeOffset.UtcNow - _lastRefresh > TimeSpan.FromMinutes(5)))
             _ = Refresh();
 
         if (Volatile.Read(ref _membershipRefreshInProgress) == 0)
@@ -1737,7 +1737,7 @@ public class SyncshellWindow : IDisposable
         finally
         {
             _loading = false;
-            _needsRefresh = false;
+            Volatile.Write(ref _needsRefresh, false);
         }
     }
 
@@ -3122,7 +3122,7 @@ public class SyncshellWindow : IDisposable
             _peerInventories.Clear();
         _etag = null;
         _bundleEtag = null;
-        _needsRefresh = true;
+        Volatile.Write(ref _needsRefresh, true);
     }
 
     private async Task<bool> EnsurePairingAsync(bool force = false, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- remove unnecessary volatile modifiers from the refresh flags
- route all refresh flag reads and writes through System.Threading.Volatile helpers to retain ordering semantics and eliminate CS0420 warnings

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d973de7d788328aac7136f97660c1d