### PR TITLE
Fix CS1998 by making HandleWantAsync synchronous

### DIFF
--- a/DemiCatPlugin/SyncShell/Client.cs
+++ b/DemiCatPlugin/SyncShell/Client.cs
@@ -462,7 +462,7 @@ public sealed class SyncClient : IDisposable
         return Task.CompletedTask;
     }
 
-    private async Task HandleWantAsync(JsonElement element, CancellationToken token)
+    private Task HandleWantAsync(JsonElement element, CancellationToken token)
     {
         var peerId = element.TryGetProperty("peerId", out var peerProperty)
             ? peerProperty.GetString() ?? "unknown"
@@ -572,7 +572,7 @@ public sealed class SyncClient : IDisposable
 
         if (upload.IsBudgetExhausted)
         {
-            return;
+            return Task.CompletedTask;
         }
 
         upload.AddRequests(want);
@@ -587,6 +587,8 @@ public sealed class SyncClient : IDisposable
         {
             _outgoingBlobs.Writer.TryWrite(new OutgoingBlob(peerId, chunk.Blob, chunk));
         }
+
+        return Task.CompletedTask;
     }
 
     private async Task HandleBlobAsync(JsonElement element, CancellationToken token)


### PR DESCRIPTION
## Summary
- adjust HandleWantAsync to be synchronous and return Task.CompletedTask
- keep callers awaiting the returned Task to avoid CS1998 warnings

## Testing
- Unable to run `dotnet build` (dotnet CLI not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9788edc8883288c7e79687b8f6785