### PR TITLE
Ensure invite target defaults to non-null

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -513,7 +513,7 @@ public class SyncshellWindow : IDisposable
         var trimmed = invite?.Trim() ?? string.Empty;
         ImGui.SetNextItemWidth(-150f);
         var submitted = ImGui.InputTextWithHint("##syncshell-invite", "Character name", ref invite, 64, ImGuiInputTextFlags.EnterReturnsTrue);
-        _inviteTarget = invite;
+        _inviteTarget = invite ?? string.Empty;
         if (submitted && !string.IsNullOrWhiteSpace(trimmed))
         {
             TrySendInvite(trimmed);


### PR DESCRIPTION
## Summary
- ensure the invite target string falls back to an empty value after input updates

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d97c071cac832884e5685e59211141