### PR TITLE
Allow nullable invite input in SyncshellWindow

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -509,7 +509,7 @@ public class SyncshellWindow : IDisposable
     {
         ImGui.TextWrapped("Send a SyncShell invite to another member by character name.");
 
-        var invite = _inviteTarget;
+        string? invite = _inviteTarget;
         var trimmed = invite?.Trim() ?? string.Empty;
         ImGui.SetNextItemWidth(-150f);
         var submitted = ImGui.InputTextWithHint("##syncshell-invite", "Character name", ref invite, 64, ImGuiInputTextFlags.EnterReturnsTrue);


### PR DESCRIPTION
## Summary
- update the invite input local to use a nullable string prior to passing by reference
- retain the non-null invariant when persisting the invite target

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97da022908328ac1ef8fb83643aed