### PR TITLE
Fix nullable invite target reference

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -509,7 +509,7 @@ public class SyncshellWindow : IDisposable
     {
         ImGui.TextWrapped("Send a SyncShell invite to another member by character name.");
 
-        string? invite = _inviteTarget;
+        var invite = _inviteTarget;
         var trimmed = invite?.Trim() ?? string.Empty;
         ImGui.SetNextItemWidth(-150f);
         var submitted = ImGui.InputTextWithHint("##syncshell-invite", "Character name", ref invite, 64, ImGuiInputTextFlags.EnterReturnsTrue);


### PR DESCRIPTION
## Summary
- update the Syncshell invite input to use a non-nullable string reference
- preserve null-guard assignment back to the invite target field

## Testing
- dotnet build *(fails: dotnet not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97f125c54832899c61929bd1303e1