### PR TITLE
Handle nullable invite input

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -509,11 +509,12 @@ public class SyncshellWindow : IDisposable
     {
         ImGui.TextWrapped("Send a SyncShell invite to another member by character name.");
 
-        var invite = _inviteTarget;
-        var trimmed = invite?.Trim() ?? string.Empty;
+        string? invite = _inviteTarget;
         ImGui.SetNextItemWidth(-150f);
         var submitted = ImGui.InputTextWithHint("##syncshell-invite", "Character name", ref invite, 64, ImGuiInputTextFlags.EnterReturnsTrue);
-        _inviteTarget = invite ?? string.Empty;
+        invite ??= string.Empty;
+        _inviteTarget = invite;
+        var trimmed = invite.Trim();
         if (submitted && !string.IsNullOrWhiteSpace(trimmed))
         {
             TrySendInvite(trimmed);


### PR DESCRIPTION
## Summary
- treat the invite input string as nullable before coalescing it to an empty value
- update the stored invite target after ensuring the value is non-null

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d985a767d88328bf865623574a9422