### PR TITLE
Add migration for syncshell_invites table

### DIFF
--- a/demibot/demibot/db/migrations/versions/0049a_add_syncshell_invites_table.py
+++ b/demibot/demibot/db/migrations/versions/0049a_add_syncshell_invites_table.py
@@ -1,0 +1,74 @@
+"""0049a_add_syncshell_invites_table
+
+Revision ID: 0049a_add_syncshell_invites_table
+Revises: 0049_add_installation_asset_hash
+Create Date: 2024-06-08 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.mysql import BIGINT
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0049a_add_syncshell_invites_table"
+down_revision: Union[str, None] = "0049_add_installation_asset_hash"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "syncshell_invites",
+        sa.Column("id", sa.String(length=64), primary_key=True),
+        sa.Column(
+            "inviter_id",
+            BIGINT(unsigned=True),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "target_user_id",
+            BIGINT(unsigned=True),
+            sa.ForeignKey("users.id"),
+            nullable=True,
+        ),
+        sa.Column("target_display_name", sa.String(length=255), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_syncshell_invites_inviter_id",
+        "syncshell_invites",
+        ["inviter_id"],
+    )
+    op.create_index(
+        "ix_syncshell_invites_target_user_id",
+        "syncshell_invites",
+        ["target_user_id"],
+    )
+    op.create_index(
+        "ix_syncshell_invites_status",
+        "syncshell_invites",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_syncshell_invites_status", table_name="syncshell_invites")
+    op.drop_index(
+        "ix_syncshell_invites_target_user_id",
+        table_name="syncshell_invites",
+    )
+    op.drop_index("ix_syncshell_invites_inviter_id", table_name="syncshell_invites")
+    op.drop_table("syncshell_invites")

--- a/demibot/demibot/db/migrations/versions/0050_add_syncshell_invite_indexes.py
+++ b/demibot/demibot/db/migrations/versions/0050_add_syncshell_invite_indexes.py
@@ -1,7 +1,7 @@
 """0050_add_syncshell_invite_indexes
 
 Revision ID: 0050_add_syncshell_invite_indexes
-Revises: 0049_add_installation_asset_hash
+Revises: 0049a_add_syncshell_invites_table
 Create Date: 2024-06-09 00:00:00.000000
 """
 
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0050_add_syncshell_invite_indexes"
-down_revision: Union[str, None] = "0049_add_installation_asset_hash"
+down_revision: Union[str, None] = "0049a_add_syncshell_invites_table"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- add an Alembic migration that creates the syncshell_invites table with the expected columns and non-composite indexes
- update the syncshell invite index migration to depend on the new table migration so composite indexes apply afterward

## Testing
- PYTHONPATH=demibot python -m alembic -c /tmp/alembic.ini upgrade head *(fails on SQLite due to unsupported constraint alteration)*

------
https://chatgpt.com/codex/tasks/task_e_68d9901362f483288dc5fc4b81871915