### PR TITLE
Fix membership panel resize direction

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -622,7 +622,7 @@ public class SyncshellWindow : IDisposable
         var minUpper = MinMembershipPanelHeight;
         var minLower = MinMembershipPanelHeight;
         var maxUpper = MathF.Max(minUpper, pairTotal - minLower);
-        var newUpper = Math.Clamp(upper - delta, minUpper, maxUpper);
+        var newUpper = Math.Clamp(upper + delta, minUpper, maxUpper);
         var newLower = pairTotal - newUpper;
         if (newLower < minLower)
         {


### PR DESCRIPTION
## Summary
- update AdjustMembershipPanelHeights to interpret positive drag deltas as expanding the upper panel
- ensure ratio updates continue to run after applying min-height constraints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b1063670832890ba837bd213514b