### PR TITLE
Filter SyncShell invite suggestions to token-linked members

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -135,6 +135,7 @@ public class SyncshellWindow : IDisposable
     private Vector2 _inviteSuggestionAnchorMin;
     private Vector2 _inviteSuggestionAnchorMax;
     private Vector2 _inviteSuggestionWindowSize;
+    private bool _inviteSuggestionFiltered;
     private bool _focusInviteInputNextFrame;
     private readonly ImGui.ImGuiInputTextCallbackDelegate _inviteInputCallback;
     private int _inviteInFlight;
@@ -843,6 +844,12 @@ public class SyncshellWindow : IDisposable
                 ImGui.SameLine();
                 ImGui.TextDisabled($"[{member.SyncStatus}]");
             }
+
+            if (!member.TokenLinked)
+            {
+                ImGui.SameLine();
+                ImGui.TextDisabled("[Token not linked]");
+            }
         }
     }
 
@@ -904,6 +911,11 @@ public class SyncshellWindow : IDisposable
             ImGui.EndDisabled();
         }
 
+        if (_inviteSuggestionFiltered && !_inviteSuggestionsOpen)
+        {
+            ImGui.TextDisabled("Matching members must link their SyncShell token before they can receive invites.");
+        }
+
         ImGui.Separator();
 
         var invites = _syncshellState.Invites
@@ -944,6 +956,7 @@ public class SyncshellWindow : IDisposable
         if (!inputActive)
         {
             CloseInviteSuggestions();
+            _inviteSuggestionFiltered = false;
             _inviteSuggestionsDirty = false;
             return;
         }
@@ -957,6 +970,7 @@ public class SyncshellWindow : IDisposable
         }
 
         _inviteSuggestionsDirty = false;
+        _inviteSuggestionFiltered = false;
         var query = GetInviteSuggestionQuery(_inviteTarget);
         if (string.IsNullOrEmpty(query))
         {
@@ -965,6 +979,7 @@ public class SyncshellWindow : IDisposable
         }
 
         _inviteSuggestions.Clear();
+        var filteredDueToToken = false;
         foreach (var member in _memberPresence)
         {
             if (string.IsNullOrWhiteSpace(member.DisplayName))
@@ -977,6 +992,12 @@ public class SyncshellWindow : IDisposable
                 continue;
             }
 
+            if (!member.TokenLinked)
+            {
+                filteredDueToToken = true;
+                continue;
+            }
+
             _inviteSuggestions.Add(member);
             if (_inviteSuggestions.Count >= InviteSuggestionLimit)
             {
@@ -984,9 +1005,11 @@ public class SyncshellWindow : IDisposable
             }
         }
 
+        _inviteSuggestionFiltered = filteredDueToToken;
+
         if (_inviteSuggestions.Count == 0)
         {
-            CloseInviteSuggestions();
+            CloseInviteSuggestions(filteredDueToToken);
             return;
         }
 
@@ -1078,6 +1101,15 @@ public class SyncshellWindow : IDisposable
                 {
                     _inviteSuggestionIndex = i;
                 }
+            }
+
+            if (_inviteSuggestionFiltered)
+            {
+                ImGui.Separator();
+                var wrap = ImGui.GetCursorPosX() + 280f;
+                ImGui.PushTextWrapPos(wrap);
+                ImGui.TextDisabled("Some members must link their SyncShell token before they can receive invites.");
+                ImGui.PopTextWrapPos();
             }
         }
         ImGui.End();
@@ -1198,12 +1230,16 @@ public class SyncshellWindow : IDisposable
     private static bool IsInviteSuggestionMatch(string name, string query)
         => name?.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
 
-    private void CloseInviteSuggestions()
+    private void CloseInviteSuggestions(bool preserveFilterNotice = false)
     {
         _inviteSuggestionsOpen = false;
         _inviteSuggestionIndex = -1;
         _inviteSuggestions.Clear();
         _inviteSuggestionsDirty = false;
+        if (!preserveFilterNotice)
+        {
+            _inviteSuggestionFiltered = false;
+        }
     }
 
     private int OnInviteInputEdited(ref ImGuiInputTextCallbackData data)
@@ -1750,6 +1786,7 @@ public class SyncshellWindow : IDisposable
             SyncStatus = GetString(element, "syncStatus", "state"),
             LastSeen = GetDateTime(element, "lastSeen", "last_seen"),
             SyncedAt = GetDateTime(element, "syncedAt", "since", "synced_at"),
+            TokenLinked = GetBoolean(element, "tokenLinked", "token_linked"),
         };
     }
 
@@ -1900,6 +1937,66 @@ public class SyncshellWindow : IDisposable
         }
 
         return string.Empty;
+    }
+
+    private static bool GetBoolean(JsonElement element, params string[] propertyNames)
+    {
+        foreach (var name in propertyNames)
+        {
+            if (!TryGetProperty(element, name, out var value))
+            {
+                continue;
+            }
+
+            switch (value.ValueKind)
+            {
+                case JsonValueKind.True:
+                    return true;
+                case JsonValueKind.False:
+                    return false;
+                case JsonValueKind.String:
+                {
+                    var text = value.GetString();
+                    if (string.IsNullOrWhiteSpace(text))
+                    {
+                        return false;
+                    }
+
+                    if (bool.TryParse(text, out var boolResult))
+                    {
+                        return boolResult;
+                    }
+
+                    if (long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
+                    {
+                        return longValue != 0;
+                    }
+
+                    if (double.TryParse(text, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleValue))
+                    {
+                        return Math.Abs(doubleValue) > double.Epsilon;
+                    }
+
+                    break;
+                }
+                case JsonValueKind.Number:
+                {
+                    if (value.TryGetInt64(out var longValue))
+                    {
+                        return longValue != 0;
+                    }
+
+                    if (value.TryGetDouble(out var doubleValue))
+                    {
+                        return Math.Abs(doubleValue) > double.Epsilon;
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static DateTimeOffset? GetDateTime(JsonElement element, params string[] propertyNames)
@@ -4316,6 +4413,9 @@ public class SyncshellWindow : IDisposable
 
         public DateTimeOffset? SyncedAt { get; set; }
             = null;
+
+        public bool TokenLinked { get; set; }
+            = false;
     }
 
     private sealed class PendingApprovalEntry

--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -704,6 +704,7 @@ async def list_members(
                 "displayName": _display_name(users.get(member_id)),
                 "active": bool(presence.active) if presence else False,
                 "lastSeen": _to_iso(presence.last_seen) if presence else None,
+                "tokenLinked": presence is not None,
             }
         )
     members.sort(key=lambda entry: entry["displayName"].lower())
@@ -754,6 +755,7 @@ async def list_memberships(
             "presence": presence_value,
             "syncStatus": sync_status,
             "lastSeen": last_seen,
+            "tokenLinked": presence is not None,
         }
         if synced_at:
             entry["syncedAt"] = synced_at
@@ -766,6 +768,7 @@ async def list_memberships(
                 "presence": presence_value,
                 "syncStatus": sync_status,
                 "lastSeen": last_seen,
+                "tokenLinked": True,
             }
             if synced_at:
                 active_entry["syncedAt"] = synced_at

--- a/tests/test_syncshell_membership.py
+++ b/tests/test_syncshell_membership.py
@@ -78,11 +78,13 @@ def test_syncshell_invite_acceptance_and_members():
             assert overview_a_final["members"][0]["id"] == str(user_b.id)
             assert overview_a_final["members"][0]["presence"] == "offline"
             assert overview_a_final["members"][0]["syncStatus"] is None
+            assert overview_a_final["members"][0]["tokenLinked"] is False
             assert overview_a_final["invites"][0]["status"] == "accepted"
 
             overview_b_final = await syncshell.list_memberships(ctx=ctx_b, db=db)
             assert overview_b_final["members"][0]["id"] == str(user_a.id)
             assert overview_b_final["members"][0]["presence"] == "offline"
+            assert overview_b_final["members"][0]["tokenLinked"] is False
             assert overview_b_final["pendingApprovals"] == []
 
             pending_after = await syncshell.list_pending(ctx=ctx_b, db=db)
@@ -167,7 +169,9 @@ def test_syncshell_presence_updates():
             assert overview_syncing["currentlySynced"][0]["presence"] == "online"
             assert overview_syncing["currentlySynced"][0]["syncStatus"] == "syncing"
             assert overview_syncing["currentlySynced"][0]["syncedAt"].endswith("Z")
+            assert overview_syncing["currentlySynced"][0]["tokenLinked"] is True
             assert overview_syncing["members"][0]["presence"] == "online"
+            assert overview_syncing["members"][0]["tokenLinked"] is True
 
             await syncshell.update_presence(
                 payload=syncshell.PresenceUpdateRequest(active_member_ids=[]),
@@ -181,5 +185,6 @@ def test_syncshell_presence_updates():
             assert overview_offline["currentlySynced"] == []
             assert overview_offline["members"][0]["presence"] == "offline"
             assert overview_offline["members"][0]["lastSeen"].endswith("Z")
+            assert overview_offline["members"][0]["tokenLinked"] is True
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- extend the SyncShell membership API responses with a tokenLinked flag
- filter invite suggestions in the plugin to token-linked members and surface messaging for filtered names
- show token link status in the member presence list and add coverage for the new field

## Testing
- pytest tests/test_syncshell_membership.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b20822fc832884d7f59006571a19