### PR TITLE
Adjust mention drawer separator height to avoid removed style property

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1635,9 +1635,27 @@ public class ChatWindow : IDisposable
         var textHeight = ImGui.GetTextLineHeight();
         var avatarSize = textHeight + style.FramePadding.Y;
         var rowHeight = Math.Max(avatarSize + style.FramePadding.Y, ImGui.GetFrameHeight());
-        var separatorHeight = style.SeparatorTextBorderSize > 0f
-            ? style.SeparatorTextBorderSize
-            : 1f * scale;
+        var separatorHeight = style.ItemSpacing.Y * 0.5f;
+        if (separatorHeight <= 0f)
+        {
+            separatorHeight = style.FramePadding.Y;
+        }
+
+        if (separatorHeight <= 0f)
+        {
+            var dpiScale = scale;
+            if (!float.IsFinite(dpiScale) || dpiScale <= 0f)
+            {
+                dpiScale = ImGuiHelpers.GlobalScale;
+            }
+
+            if (!float.IsFinite(dpiScale) || dpiScale <= 0f)
+            {
+                dpiScale = 1f;
+            }
+
+            separatorHeight = 1f * dpiScale;
+        }
 
         var firstElement = true;
 


### PR DESCRIPTION
## Summary
- derive the mention drawer separator height from existing ImGui style spacing and padding
- add DPI-aware fallback so the separator retains a sensible size when spacing values are zero

## Testing
- not run (dotnet CLI unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d9bd60087483289ef5e72be67beea3