### PR TITLE
Delay syncshell tab closure until tab bar is active

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -27,6 +27,7 @@ public class MainWindow : IDisposable
     private float _timeSinceLastInteraction;
     private float _fadeAlpha = 1f;
     private bool _styleNeedsUpdate = true;
+    private bool _closeSyncshellTab;
 
     public bool IsOpen;
     public bool HasOfficerAccess { get; set; }
@@ -75,7 +76,7 @@ public class MainWindow : IDisposable
         {
             _syncshell?.Dispose();
             _syncshell = null;
-            PluginServices.Instance?.Framework.RunOnTick(() => ImGui.SetTabItemClosed("Syncshell"));
+            _closeSyncshellTab = true;
         }
     }
 
@@ -169,6 +170,12 @@ public class MainWindow : IDisposable
 
             if (ImGui.BeginTabBar("MainTabs"))
             {
+                if (_closeSyncshellTab)
+                {
+                    ImGui.SetTabItemClosed("Syncshell");
+                    _closeSyncshellTab = false;
+                }
+
                 if (!linked)
                 {
                     ImGui.BeginDisabled();


### PR DESCRIPTION
## Summary
- add a flag to defer syncshell tab closure until the next draw
- close the syncshell tab while the main tab bar is active and reset the flag

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9c4830b5483289c43a53f1c928557