### PR TITLE
Ensure chat bridge sends empty subscription updates

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -54,6 +54,10 @@ public class ChatBridge : IDisposable
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
     private const string ForbiddenMessage = "Forbidden – check API key/roles";
     private bool _permissionWarningShown;
+#if TEST
+    internal bool? ForceWebSocketOpen { get; set; }
+    internal Action<string>? SendRawInterceptor { get; set; }
+#endif
 
     public event Action<string>? MessageReceived;
     public event Action<DiscordUserDto>? TypingReceived;
@@ -751,15 +755,37 @@ public class ChatBridge : IDisposable
         }
     }
 
+    private bool IsWebSocketOpen()
+    {
+#if TEST
+        if (ForceWebSocketOpen.HasValue)
+        {
+            return ForceWebSocketOpen.Value;
+        }
+#endif
+        return _ws != null && _ws.State == WebSocketState.Open;
+    }
+
     private async Task SendRaw(string json)
     {
-        if (_ws == null || _ws.State != WebSocketState.Open)
+        var socketOpen = IsWebSocketOpen();
+#if TEST
+        SendRawInterceptor?.Invoke(json);
+        if (ForceWebSocketOpen == true && _ws == null)
+        {
+            return;
+        }
+#endif
+        if (!socketOpen)
+            return;
+        var socket = _ws;
+        if (socket == null)
             return;
         var bytes = Encoding.UTF8.GetBytes(json);
         try
         {
             var sw = Stopwatch.StartNew();
-            await _ws.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, CancellationToken.None);
+            await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, CancellationToken.None);
             var ms = sw.Elapsed.TotalMilliseconds;
             _sendCount++;
             _sendLatencyTotal += ms;
@@ -801,7 +827,7 @@ public class ChatBridge : IDisposable
 
     private Task SendSubscriptions()
     {
-        if (_ws == null || _ws.State != WebSocketState.Open || _subs.Count == 0)
+        if (!IsWebSocketOpen())
             return Task.CompletedTask;
         var chans = new List<Dictionary<string, object?>>();
         foreach (var kvp in _channelMetadata)
@@ -835,7 +861,6 @@ public class ChatBridge : IDisposable
 
             chans.Add(channel);
         }
-        if (chans.Count == 0) return Task.CompletedTask;
         var json = JsonSerializer.Serialize(new { op = "sub", channels = chans });
         PluginServices.Instance?.Log.Info($"chat.ws subscribe count={chans.Count}");
         return SendRaw(json);

--- a/tests/ChatBridgeNoTokenTests.cs
+++ b/tests/ChatBridgeNoTokenTests.cs
@@ -80,6 +80,34 @@ public class ChatBridgeNoTokenTests
         bridge.Stop();
     }
 
+    [Fact]
+    public void UnsubscribeLastChannel_SendsEmptySubscriptionList()
+    {
+        var handler = new SuccessHandler();
+        var client = new HttpClient(handler);
+        var config = new Config { ApiBaseUrl = "http://localhost", GuildId = "guild" };
+        var tm = new TokenManager();
+        var bridge = new ChatBridge(config, client, tm, () => new Uri("ws://localhost"), new ChannelSelectionService(config));
+
+#if TEST
+        var frames = new List<string>();
+        bridge.ForceWebSocketOpen = true;
+        bridge.SendRawInterceptor = frames.Add;
+#endif
+
+        bridge.Subscribe("channel-1", config.GuildId, ChannelKind.Chat);
+
+#if TEST
+        frames.Clear();
+#endif
+
+        bridge.Unsubscribe("channel-1");
+
+#if TEST
+        Assert.Contains("{\"op\":\"sub\",\"channels\":[]}", frames);
+#endif
+    }
+
     private class CountingHandler : HttpMessageHandler
     {
         public int CallCount { get; private set; }


### PR DESCRIPTION
## Summary
- allow the chat bridge to emit subscription frames even when the channel list is empty so the remote side can observe unsubscribe events
- add test hooks and coverage to verify that unsubscribing the final channel produces a `{"op":"sub","channels":[]}` payload

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: `dotnet` is not available in the container)*
- `python - <<'PY'
import sys, types, pytest
# pre-populate a discord stub before pytest config loads
mod = types.ModuleType("discord")
mod.Embed = type("Embed", (), {})
mod.HTTPException = type("HTTPException", (Exception,), {})
mod.Forbidden = type("Forbidden", (Exception,), {})
mod.NotFound = type("NotFound", (Exception,), {})
mod.ClientException = type("ClientException", (Exception,), {})
class _ThreadStub:
    def __init__(self, *, id=0, parent=None, archived=False):
        self.id = id
        self.parent = parent
        self.archived = archived
mod.Thread = _ThreadStub
mod.Object = type("Object", (), {"__init__": lambda self, id=None, **kw: setattr(self, "id", id if id is not None else kw.get("id"))})
class _Webhook:
    @staticmethod
    def from_url(url, client=None):
        class _Dummy:
            async def send(self, *args, **kwargs):
                return None
        return _Dummy()
mod.Webhook = _Webhook
mod.abc = types.SimpleNamespace(Messageable=object)
commands_module = types.ModuleType("discord.ext.commands")
commands_module.Bot = type("Bot", (), {})
commands_module.AutoShardedBot = type("AutoShardedBot", (), {})
ext_module = types.ModuleType("discord.ext")
ext_module.commands = commands_module
mod.ext = ext_module
sys.modules["discord"] = mod
sys.modules["discord.ext"] = ext_module
sys.modules["discord.ext.commands"] = commands_module
pytest.main(["tests/test_chat_ws.py"])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68d9c52c68848328bbdc2c82a552771d