### PR TITLE
Fix chat clipper row measurement

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -828,6 +828,8 @@ public class ChatWindow : IDisposable
                 }
                 drawList.ChannelsMerge();
 
+                clipper.IncludeItemByIndex(i);
+
                 if (i < _messages.Count - 1)
                 {
                     var spacingY = styleForRow.ItemSpacing.Y * 0.5f;


### PR DESCRIPTION
## Summary
- call `IncludeItemByIndex` for every rendered chat message so the clipper records the true row height

## Testing
- not run (requires manual UI interaction)


------
https://chatgpt.com/codex/tasks/task_e_68d9ca7fbf788328980319a6de27f952