### PR TITLE
Handle ChatBridge connect timeouts

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -30,6 +30,9 @@ public class ChatBridge : IDisposable
     private readonly Dictionary<string, (string GuildId, string Kind)> _channelMetadata = new();
     private readonly HashSet<string> _subs = new();
     private readonly ChannelSelectionService _channelSelection;
+    private readonly Func<ClientWebSocket> _webSocketFactory;
+    private readonly Func<ClientWebSocket, Uri, CancellationToken, Task> _connectAsync;
+    private readonly TimeSpan _connectTimeout;
     private int _connectCount;
     private int _reconnectCount;
     private int _resyncCount;
@@ -52,6 +55,7 @@ public class ChatBridge : IDisposable
     private static readonly TimeSpan BatchDropThrottle = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan WebSocketCloseTimeout = TimeSpan.FromSeconds(1);
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
+    private static readonly TimeSpan DefaultConnectTimeout = TimeSpan.FromSeconds(10);
     private const string ForbiddenMessage = "Forbidden – check API key/roles";
     private bool _permissionWarningShown;
 #if TEST
@@ -67,13 +71,16 @@ public class ChatBridge : IDisposable
     public event Action<string, long>? ResyncRequested;
     public event Action? TemplatesUpdated;
 
-    public ChatBridge(Config config, HttpClient httpClient, TokenManager tokenManager, Func<Uri> uriBuilder, ChannelSelectionService channelSelection)
+    public ChatBridge(Config config, HttpClient httpClient, TokenManager tokenManager, Func<Uri> uriBuilder, ChannelSelectionService channelSelection, Func<ClientWebSocket>? webSocketFactory = null, TimeSpan? connectTimeout = null, Func<ClientWebSocket, Uri, CancellationToken, Task>? connectAsync = null)
     {
         _config = config;
         _httpClient = httpClient;
         _tokenManager = tokenManager;
         _uriBuilder = uriBuilder;
         _channelSelection = channelSelection;
+        _webSocketFactory = webSocketFactory ?? (() => new ClientWebSocket());
+        _connectTimeout = connectTimeout ?? DefaultConnectTimeout;
+        _connectAsync = connectAsync ?? ((socket, uri, ct) => socket.ConnectAsync(uri, ct));
     }
 
     public void Start()
@@ -459,6 +466,8 @@ public class ChatBridge : IDisposable
             var failureStage = "connect";
             var connected = false;
             var attemptedConnect = false;
+            var connectTimedOut = false;
+            CancellationTokenSource? connectCts = null;
             try
             {
                 StatusChanged?.Invoke("Connecting...");
@@ -484,12 +493,14 @@ public class ChatBridge : IDisposable
                 }
 
                 _ws?.Dispose();
-                _ws = new ClientWebSocket();
+                _ws = _webSocketFactory();
                 _ws.Options.DangerousDeflateOptions = new WebSocketDeflateOptions();
                 _ws.Options.SetRequestHeader("Sec-WebSocket-Extensions", "permessage-deflate");
                 ApiHelpers.AddAuthHeader(_ws, _tokenManager);
                 attemptedConnect = true;
-                await _ws.ConnectAsync(uri!, token);
+                connectCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+                connectCts.CancelAfter(_connectTimeout);
+                await _connectAsync(_ws, uri!, connectCts.Token);
                 _connectedSince = DateTime.UtcNow;
                 _reconnectAttempt = 0;
                 _tokenValid = true;
@@ -508,6 +519,11 @@ public class ChatBridge : IDisposable
             }
             catch (OperationCanceledException ex) when (!ShouldRethrow(ex, token))
             {
+                if (!token.IsCancellationRequested && connectCts?.IsCancellationRequested == true)
+                {
+                    connectTimedOut = true;
+                    PluginServices.Instance?.Log.Warning($"chat.ws connect timed out after {_connectTimeout.TotalSeconds:0.#}s");
+                }
             }
             catch (OperationCanceledException)
             {
@@ -542,6 +558,7 @@ public class ChatBridge : IDisposable
             }
             finally
             {
+                connectCts?.Dispose();
                 var status = _ws?.CloseStatus;
                 var description = _ws?.CloseStatusDescription;
                 try
@@ -588,7 +605,9 @@ public class ChatBridge : IDisposable
             var backoff = GetReconnectDelay(_reconnectAttempt);
             StatusChanged?.Invoke(forbidden
                 ? ForbiddenMessage
-                : $"Reconnecting in {backoff.TotalSeconds:0.#}s...");
+                : connectTimedOut
+                    ? "Connection timed out; retrying..."
+                    : $"Reconnecting in {backoff.TotalSeconds:0.#}s...");
             await DelayWithBackoff(backoff, token);
         }
     }

--- a/tests/ChatWindowWebSocketTests.cs
+++ b/tests/ChatWindowWebSocketTests.cs
@@ -83,6 +83,51 @@ public class ChatWindowWebSocketTests
     }
 
     [Fact]
+    public async Task WebSocket_ConnectionTimeoutSurfacesStatus()
+    {
+        _ = SetupServices();
+        var config = new Config { EnableFcChat = true, ApiBaseUrl = "http://localhost", ChatChannelId = "1" };
+        var selection = new ChannelSelectionService(config);
+        using var client = new HttpClient(new PingOkHandler());
+        var attempts = 0;
+        var bridge = new ChatBridge(
+            config,
+            client,
+            new TokenManager(),
+            () => new Uri("ws://localhost/ws/chat"),
+            selection,
+            connectTimeout: TimeSpan.FromMilliseconds(50),
+            connectAsync: (_, _, ct) =>
+            {
+                Interlocked.Increment(ref attempts);
+                return Task.Delay(Timeout.Infinite, ct);
+            });
+
+        using var timeoutSeen = new ManualResetEventSlim();
+        bridge.StatusChanged += status =>
+        {
+            if (status == "Connection timed out; retrying...")
+            {
+                timeoutSeen.Set();
+            }
+        };
+
+        bridge.Start();
+
+        try
+        {
+            await WaitUntil(() => timeoutSeen.IsSet, TimeSpan.FromSeconds(5));
+            await WaitUntil(() => Volatile.Read(ref attempts) >= 2, TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            bridge.Stop();
+        }
+
+        Assert.True(timeoutSeen.IsSet);
+    }
+
+    [Fact]
     public async Task OfficerChatWebSocket_UsesOfficerMetadata()
     {
         using var server = new MockWsServer(async (ws, _, srv) =>
@@ -869,6 +914,14 @@ public class ChatWindowWebSocketTests
             }
 
             return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    private sealed class PingOkHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         }
     }
 


### PR DESCRIPTION
## Summary
- add a configurable WebSocket connect timeout for ChatBridge and surface a timeout status
- inject the WebSocket connect operation for tests and log timed-out connections
- add a unit test that simulates a stalled WebSocket handshake and verifies the timeout retry message

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9ccb66078832898aec99d0c64dae0