### PR TITLE
Fix officer roles deserialization

### DIFF
--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
@@ -487,6 +488,7 @@ public class OfficerChatWindow : ChatWindow
 
     private class RolesDto
     {
+        [JsonPropertyName("roles")]
         public List<string> Roles { get; set; } = new();
     }
 


### PR DESCRIPTION
## Summary
- annotate the officer roles DTO with JsonPropertyName to bind the camel-case roles field

## Testing
- ⚠️ `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: dotnet CLI is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d580a6f483288a7c91b1ea6db7ae