### PR TITLE
Remove timestamps from bridge headers

### DIFF
--- a/demibot/demibot/bridge.py
+++ b/demibot/demibot/bridge.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Iterable, Mapping, Sequence
 
 import discord
@@ -180,7 +180,6 @@ def build_bridge_message(
             if image_filename is None and _is_image(filename, content_type):
                 image_filename = filename
 
-    timestamp = timestamp or datetime.now(timezone.utc)
     display_name = _determine_display_name(user=user, membership=membership)
     character_name = user.character_name if use_character_name else None
     world_name = user.world if use_character_name else None
@@ -192,7 +191,6 @@ def build_bridge_message(
             use_character_name=use_character_name,
             character_name=character_name,
             world_name=world_name,
-            timestamp=timestamp,
         )
         if normalized:
             normalized = f"{header}\n{normalized}"
@@ -217,7 +215,7 @@ def build_bridge_message(
 
     embeds: list[discord.Embed] = []
     for index, chunk in enumerate(chunks):
-        embed = discord.Embed(description=chunk or None, timestamp=timestamp, color=color)
+        embed = discord.Embed(description=chunk or None, color=color)
         embed.set_footer(text=footer)
         embed.set_author(name=author_name, icon_url=author_icon)
         if index == 0 and image_filename:
@@ -237,7 +235,6 @@ def _format_header_line(
     use_character_name: bool,
     character_name: str | None,
     world_name: str | None,
-    timestamp: datetime,
 ) -> str:
     name = display_name.strip() or "You"
     segments = [name]
@@ -250,29 +247,20 @@ def _format_header_line(
                 segments.append(world)
         elif world:
             segments.append(world)
-    formatted_timestamp = timestamp.astimezone(timezone.utc).strftime(
-        "%Y-%m-%d %H:%M:%S UTC"
-    )
-    return f"Message Sent by: {' / '.join(segments)} @ {formatted_timestamp}"
+    return "Message Sent by: {}\n---".format(" / ".join(segments))
 
 
 
 def _has_existing_header(content: str) -> bool:
     if not content:
         return False
-    first_line, _, _ = content.partition("\n")
-    line = first_line.strip()
-    if not line.startswith("Message Sent by:"):
+    first_line, sep, remainder = content.partition("\n")
+    if not sep:
         return False
-    parts = line.rsplit("@", 1)
-    if len(parts) != 2:
+    if not first_line.strip().startswith("Message Sent by:"):
         return False
-    timestamp_text = parts[1].strip()
-    if not timestamp_text:
-        return False
-    try:
-        datetime.strptime(timestamp_text, "%Y-%m-%d %H:%M:%S UTC")
-    except ValueError:
+    second_line, _, _ = remainder.partition("\n")
+    if second_line.strip() != "---":
         return False
     return True
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -191,7 +191,7 @@ def test_build_bridge_message_populates_embed_footer(sample_user, sample_members
         timestamp=fixed_time,
     )
 
-    expected_header = "Message Sent by: Nick @ 2024-01-02 03:04:05 UTC"
+    expected_header = "Message Sent by: Nick\n---"
     assert discord_content == ""
     assert nonce
     assert len(embeds) == 1
@@ -200,8 +200,7 @@ def test_build_bridge_message_populates_embed_footer(sample_user, sample_members
     footer_text = embed_dict.get("footer", {}).get("text")
     assert footer_text and footer_text.endswith(f"{BRIDGE_MARKER}{nonce}")
     description = embed_dict.get("description", "")
-    assert description.startswith(expected_header)
-    assert description.split("\n", 1)[1] == content
+    assert description == f"{expected_header}\n{content}"
     assert embed_dict.get("author", {}).get("name") == sample_membership.nickname
     assert embed_dict.get("author", {}).get("icon_url") == sample_membership.avatar_url
 
@@ -252,7 +251,7 @@ def test_build_bridge_message_splits_long_content(sample_user, sample_membership
         timestamp=fixed_time,
     )
 
-    expected_header = "Message Sent by: Nick @ 2024-05-06 07:08:09 UTC"
+    expected_header = "Message Sent by: Nick\n---"
     assert discord_content
     assert not uploads
     assert nonce
@@ -265,10 +264,9 @@ def test_build_bridge_message_splits_long_content(sample_user, sample_membership
         embed.to_dict().get("description", "") for embed in embeds
     ]
     combined = "".join(embed_descriptions)
-    assert combined.startswith(expected_header)
-    body_in_embeds = combined[len(expected_header):]
-    if body_in_embeds.startswith("\n"):
-        body_in_embeds = body_in_embeds[1:]
+    expected_prefix = f"{expected_header}\n"
+    assert combined.startswith(expected_prefix)
+    body_in_embeds = combined[len(expected_prefix):]
 
     total_length = 0
     for embed in embeds:
@@ -310,17 +308,18 @@ def test_build_bridge_message_includes_character_when_enabled(
         timestamp=fixed_time,
     )
 
-    expected_header = (
-        "Message Sent by: Nick / Hero / Eorzea @ 2024-07-08 09:10:11 UTC"
-    )
+    expected_header = "Message Sent by: Nick / Hero / Eorzea\n---"
     assert discord_content == ""
-    assert embeds[0].to_dict().get("description", "").startswith(expected_header)
+    assert (
+        embeds[0].to_dict().get("description", "")
+        == f"{expected_header}\nHi"
+    )
     assert not uploads
     assert nonce
 
 
 def test_build_bridge_message_preserves_existing_header(sample_user, sample_membership):
-    existing_header = "Message Sent by: Nick @ 2024-01-02 03:04:05 UTC"
+    existing_header = "Message Sent by: Nick\n---"
     body = "Preformatted content"
     preformatted = f"{existing_header}\n{body}"
     server_timestamp = datetime(2024, 12, 11, 10, 9, 8, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- update bridge header formatting to drop timestamps and include a separator line
- ensure bridge message bodies follow the new header layout and embed timestamps are omitted
- refresh bridge unit tests for the revised header format

## Testing
- pytest tests/test_bridge.py *(fails: AttributeError: module 'discord' has no attribute 'Color')*

------
https://chatgpt.com/codex/tasks/task_e_68d9d74d104c83288e8f9f6838814604