### PR TITLE
Adjust texture cache cleanup lifecycle

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -3232,10 +3232,6 @@ public class ChatWindow : IDisposable
         }
         _textureCache.Clear();
         _textureLru.Clear();
-        foreach (var m in _messages)
-        {
-            DisposeMessageTextures(m);
-        }
         foreach (var e in _emojiCatalog.Values)
         {
             e.Texture = null;
@@ -3256,6 +3252,10 @@ public class ChatWindow : IDisposable
         StopNetworking();
         _channelSelection.ChannelChanged -= HandleChannelSelectionChanged;
         _bridge.Dispose();
+        foreach (var message in _messages)
+        {
+            DisposeMessageTextures(message);
+        }
         ClearTextureCache();
     }
 


### PR DESCRIPTION
## Summary
- limit `ClearTextureCache` to clearing shared caches so message textures persist during channel switches
- dispose lingering message textures explicitly when the chat window shuts down

## Testing
- not run (environment does not support FFXIV plugin runtime)


------
https://chatgpt.com/codex/tasks/task_e_68d9e0ba09e083289feeeee919622812