### PR TITLE
Adjust texture cache clearing on channel switch

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -451,6 +451,7 @@ public class ChatWindow : IDisposable
 
             if (!string.IsNullOrEmpty(oldId))
             {
+                ClearTextureCache();
                 _bridge.Unsubscribe(oldId);
             }
 
@@ -516,7 +517,6 @@ public class ChatWindow : IDisposable
 
             if (selectedChannelId != null)
             {
-                ClearTextureCache();
                 _channelSelection.SetChannel(_channelKind, _config.GuildId, selectedChannelId);
             }
         }


### PR DESCRIPTION
## Summary
- defer texture cache clearing until the channel change tick handler runs
- avoid clearing textures immediately when selecting a channel in the combo box

## Testing
- not run (UI behavior change)


------
https://chatgpt.com/codex/tasks/task_e_68d9e5cdb488832882847fc93d72ca85