### PR TITLE
Adjust fade interaction logic

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -490,7 +490,8 @@ public class MainWindow : IDisposable
     private static bool HasWindowInteraction()
     {
         var hovered = ImGui.IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows | ImGuiHoveredFlags.AllowWhenBlockedByActiveItem | ImGuiHoveredFlags.AllowWhenBlockedByPopup);
-        var focused = ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows);
+        var hasActiveItem = ImGui.IsAnyItemActive() || ImGui.IsAnyItemFocused();
+        var focused = hasActiveItem && ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows);
         return hovered || focused;
     }
 


### PR DESCRIPTION
## Summary
- restrict focus-based interaction to active or focused widgets so idle focus no longer blocks fade-out
- preserve hover and active widget interaction to keep fade timer reset during typing

## Testing
- Failed `dotnet build` (not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9e7895c748328bd18aa884974f0b2