### PR TITLE
Expose mention allowlist in guild role responses

### DIFF
--- a/DemiCatPlugin/GuildRolesResponseDto.cs
+++ b/DemiCatPlugin/GuildRolesResponseDto.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace DemiCatPlugin;
+
+internal sealed class GuildRolesResponseDto
+{
+    [JsonPropertyName("roles")]
+    public List<RoleDto> Roles { get; set; } = new();
+
+    [JsonPropertyName("mention_role_ids")]
+    public List<string> MentionRoleIds { get; set; } = new();
+}
+

--- a/DemiCatPlugin/RoleCache.cs
+++ b/DemiCatPlugin/RoleCache.cs
@@ -64,13 +64,18 @@ internal static class RoleCache
                 return;
             }
             var stream = await response.Content.ReadAsStreamAsync();
-            var roles = await JsonSerializer.DeserializeAsync<List<RoleDto>>(stream) ?? new List<RoleDto>();
+            var payload = await JsonSerializer.DeserializeAsync<GuildRolesResponseDto>(stream)
+                ?? new GuildRolesResponseDto();
+            var roles = payload.Roles ?? new List<RoleDto>();
+            var mentionRoleIds = payload.MentionRoleIds ?? new List<string>();
+
             _roles = roles;
             _lastErrorMessage = null;
             _loaded = true;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 config.GuildRoles = roles;
+                config.MentionRoleIds = mentionRoleIds;
                 PluginServices.Instance!.PluginInterface.SavePluginConfig(config);
             });
         }

--- a/demibot/demibot/http/routes/guild_roles.py
+++ b/demibot/demibot/http/routes/guild_roles.py
@@ -18,18 +18,29 @@ async def get_guild_roles(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ):
+    cfg = await db.scalar(
+        select(GuildConfig).where(GuildConfig.guild_id == ctx.guild.id)
+    )
+    mention_role_ids = [
+        rid
+        for rid in (cfg.mention_role_ids.split(",") if cfg and cfg.mention_role_ids else [])
+        if rid
+    ]
+
     mention_ids: set[int] | None = None
     roles = _role_set(ctx)
     if "officer" not in roles:
-        cfg = await db.scalar(
-            select(GuildConfig).where(GuildConfig.guild_id == ctx.guild.id)
-        )
-        if cfg and cfg.mention_role_ids:
+        if mention_role_ids:
             mention_ids = {
-                int(r) for r in cfg.mention_role_ids.split(",") if r
+                int(r)
+                for r in mention_role_ids
+                if r.isdigit()
             }
         else:
-            return []
+            return {
+                "roles": [],
+                "mention_role_ids": mention_role_ids,
+            }
 
     stmt = select(Role).where(Role.guild_id == ctx.guild.id)
     if mention_ids is not None:
@@ -37,7 +48,8 @@ async def get_guild_roles(
     result = await db.execute(stmt)
     rows = result.scalars().all()
     if rows:
-        return [
+        return {
+            "roles": [
             {
                 "id": str(role.discord_role_id),
                 "name": role.name,
@@ -48,7 +60,9 @@ async def get_guild_roles(
                 },
             }
             for role in rows
-        ]
+        ],
+            "mention_role_ids": mention_role_ids,
+        }
 
     if discord_client:
         guild = discord_client.get_guild(ctx.guild.discord_guild_id)
@@ -83,6 +97,12 @@ async def get_guild_roles(
                     )
                 )
             await db.commit()
-            return roles_out
-    return []
+            return {
+                "roles": roles_out,
+                "mention_role_ids": mention_role_ids,
+            }
+    return {
+        "roles": [],
+        "mention_role_ids": mention_role_ids,
+    }
 

--- a/tests/ChatWindowMentionTests.cs
+++ b/tests/ChatWindowMentionTests.cs
@@ -5,10 +5,14 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using DemiCatPlugin;
+using Dalamud.Configuration;
+using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
+using DemiCatPlugin;
+using Moq;
 using Xunit;
 
 public class ChatWindowMentionTests
@@ -129,6 +133,39 @@ public class ChatWindowMentionTests
     }
 
     [Fact]
+    public async Task MentionDrawer_PopulatesAfterAllowlistSync()
+    {
+        SetupServices();
+        RoleCache.Reset();
+        try
+        {
+            var config = new Config { ApiBaseUrl = "http://localhost" };
+            using var httpClient = new HttpClient(new JsonHandler(
+                "{\"roles\":[{\"id\":\"2\",\"name\":\"Raiders\",\"position\":0,\"hoist\":false,\"tags\":{\"premium_subscriber\":false}}],\"mention_role_ids\":[\"2\"]}"
+            ));
+            var tokenManager = new TokenManager();
+            var channelService = new ChannelService(config, httpClient, tokenManager);
+            var window = new ChatWindow(config, httpClient, null, tokenManager, channelService);
+
+            await RoleCache.Refresh(httpClient, config);
+
+            Assert.Equal(new[] { "2" }, config.MentionRoleIds);
+            Assert.Single(RoleCache.Roles);
+            Assert.Equal("2", RoleCache.Roles[0].Id);
+
+            var candidates = InvokeBuildMentionCandidates(window, string.Empty).Cast<object>().ToList();
+            Assert.Single(candidates);
+            var candidateType = candidates[0].GetType();
+            Assert.Equal("2", candidateType.GetProperty("Id")!.GetValue(candidates[0]));
+            Assert.Equal("Raiders", candidateType.GetProperty("Name")!.GetValue(candidates[0]));
+        }
+        finally
+        {
+            RoleCache.Reset();
+        }
+    }
+
+    [Fact]
     public void UpdateMentionState_DismissesWhenQueryHasNoMatches()
     {
         SetupServices();
@@ -226,6 +263,10 @@ public class ChatWindowMentionTests
         var log = new TestLog();
         typeof(PluginServices).GetProperty("Framework", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, framework);
         typeof(PluginServices).GetProperty("Log", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, log);
+        var pluginInterfaceMock = new Mock<IDalamudPluginInterface>();
+        pluginInterfaceMock.Setup(p => p.SavePluginConfig(It.IsAny<IPluginConfiguration>()));
+        typeof(PluginServices).GetProperty("PluginInterface", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, pluginInterfaceMock.Object);
     }
 
     private class DummyHandler : HttpMessageHandler
@@ -233,6 +274,25 @@ public class ChatWindowMentionTests
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    private class JsonHandler : HttpMessageHandler
+    {
+        private readonly string _json;
+
+        public JsonHandler(string json)
+        {
+            _json = json;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_json, Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
         }
     }
 

--- a/tests/test_guild_roles.py
+++ b/tests/test_guild_roles.py
@@ -32,9 +32,9 @@ async def _run_test() -> None:
         db.add(Role(guild_id=guild.id, discord_role_id=10, name="Alpha"))
         db.add(Role(guild_id=guild.id, discord_role_id=20, name="Beta"))
         await db.commit()
-        ctx = SimpleNamespace(guild=guild)
+        ctx = SimpleNamespace(guild=guild, roles=["officer"])
         res = await get_guild_roles(ctx=ctx, db=db)
-        pairs = {(r["id"], r["name"]) for r in res}
+        pairs = {(r["id"], r["name"]) for r in res["roles"]}
         assert pairs == {("10", "Alpha"), ("20", "Beta")}
 
 

--- a/tests/test_guild_roles_filter.py
+++ b/tests/test_guild_roles_filter.py
@@ -56,10 +56,12 @@ def test_guild_roles_filter():
             await db.commit()
         ctx = StubContext(1, [])
         async with get_session() as db:
-            roles = await guild_roles.get_guild_roles(ctx=ctx, db=db)
-            assert {r["id"] for r in roles} == {"1", "2"}
+            payload = await guild_roles.get_guild_roles(ctx=ctx, db=db)
+            assert {r["id"] for r in payload["roles"]} == {"1", "2"}
+            assert payload["mention_role_ids"] == ["1", "2"]
         ctx_off = StubContext(1, ["officer"])
         async with get_session() as db:
-            roles = await guild_roles.get_guild_roles(ctx=ctx_off, db=db)
-            assert {r["id"] for r in roles} == {"1", "2", "3"}
+            payload = await guild_roles.get_guild_roles(ctx=ctx_off, db=db)
+            assert {r["id"] for r in payload["roles"]} == {"1", "2", "3"}
+            assert payload["mention_role_ids"] == ["1", "2"]
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- include the configured mention allowlist in the `/api/guild-roles` response and propagate it through the plugin role cache
- deserialize the new payload in the plugin so mentionable role IDs persist in configuration
- add and update tests to cover the new response shape and verify the chat mention drawer populates after syncing the allowlist

## Testing
- pytest tests/test_guild_roles.py tests/test_guild_roles_filter.py

------
https://chatgpt.com/codex/tasks/task_e_68d9eecaa8f0832892f172ce583f13d1