### PR TITLE
Add notepad database models and API endpoints

### DIFF
--- a/demibot/demibot/db/migrations/versions/0053_add_notepad_tables.py
+++ b/demibot/demibot/db/migrations/versions/0053_add_notepad_tables.py
@@ -1,0 +1,82 @@
+"""0053_add_notepad_tables
+
+Revision ID: 0053_add_notepad_tables
+Revises: 0052_add_syncshell_members_presence_tables
+Create Date: 2024-07-02 00:00:01.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0053_add_notepad_tables"
+down_revision: Union[str, None] = "0052_add_syncshell_members_presence_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "note_sections",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("guild_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("color", sa.Integer(), nullable=True),
+        sa.Column("created_by_id", mysql.BIGINT(unsigned=True), nullable=True),
+        sa.Column("updated_by_id", mysql.BIGINT(unsigned=True), nullable=True),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("is_deleted", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["guild_id"], ["guilds.id"]),
+        sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["updated_by_id"], ["users.id"]),
+        sa.UniqueConstraint(
+            "guild_id", "sort_order", name="uq_note_sections_guild_order"
+        ),
+    )
+    op.create_index("ix_note_sections_guild_id", "note_sections", ["guild_id"])
+
+    op.create_table(
+        "note_pages",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("guild_id", sa.Integer(), nullable=False),
+        sa.Column("section_id", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False, server_default=""),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("color", sa.Integer(), nullable=True),
+        sa.Column("created_by_id", mysql.BIGINT(unsigned=True), nullable=True),
+        sa.Column("updated_by_id", mysql.BIGINT(unsigned=True), nullable=True),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("is_deleted", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["guild_id"], ["guilds.id"]),
+        sa.ForeignKeyConstraint(["section_id"], ["note_sections.id"]),
+        sa.ForeignKeyConstraint(["created_by_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["updated_by_id"], ["users.id"]),
+        sa.UniqueConstraint(
+            "section_id", "sort_order", name="uq_note_pages_section_order"
+        ),
+    )
+    op.create_index("ix_note_pages_guild_id", "note_pages", ["guild_id"])
+    op.create_index("ix_note_pages_section_id", "note_pages", ["section_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_note_pages_section_id", table_name="note_pages")
+    op.drop_index("ix_note_pages_guild_id", table_name="note_pages")
+    op.drop_table("note_pages")
+
+    op.drop_index("ix_note_sections_guild_id", table_name="note_sections")
+    op.drop_table("note_sections")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -82,6 +82,7 @@ class Guild(Base):
     )
 
     config: Mapped["GuildConfig"] = relationship(back_populates="guild", uselist=False)
+    note_sections: Mapped[list["NoteSection"]] = relationship(back_populates="guild")
 
 
 class GuildConfig(Base):
@@ -140,6 +141,18 @@ class User(Base):
     installations: Mapped[list["UserInstallation"]] = relationship(
         back_populates="user", cascade="all, delete-orphan"
     )
+    note_sections_created: Mapped[list["NoteSection"]] = relationship(
+        back_populates="created_by", foreign_keys="NoteSection.created_by_id"
+    )
+    note_sections_updated: Mapped[list["NoteSection"]] = relationship(
+        back_populates="updated_by", foreign_keys="NoteSection.updated_by_id"
+    )
+    note_pages_created: Mapped[list["NotePage"]] = relationship(
+        back_populates="created_by", foreign_keys="NotePage.created_by_id"
+    )
+    note_pages_updated: Mapped[list["NotePage"]] = relationship(
+        back_populates="updated_by", foreign_keys="NotePage.updated_by_id"
+    )
 
 
 class UserKey(Base):
@@ -195,6 +208,83 @@ class MembershipRole(Base):
         ForeignKey("memberships.id"), primary_key=True
     )
     role_id: Mapped[int] = mapped_column(ForeignKey("roles.id"), primary_key=True)
+
+
+class NoteSection(Base):
+    __tablename__ = "note_sections"
+    __table_args__ = (
+        UniqueConstraint("guild_id", "sort_order", name="uq_note_sections_guild_order"),
+        Index("ix_note_sections_guild_id", "guild_id"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
+    name: Mapped[str] = mapped_column(String(255))
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    color: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    created_by_id: Mapped[Optional[int]] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), nullable=True
+    )
+    updated_by_id: Mapped[Optional[int]] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), nullable=True
+    )
+    version: Mapped[int] = mapped_column(Integer, default=1)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    guild: Mapped[Guild] = relationship(back_populates="note_sections")
+    created_by: Mapped[Optional[User]] = relationship(
+        foreign_keys=[created_by_id], back_populates="note_sections_created"
+    )
+    updated_by: Mapped[Optional[User]] = relationship(
+        foreign_keys=[updated_by_id], back_populates="note_sections_updated"
+    )
+    pages: Mapped[list["NotePage"]] = relationship(
+        back_populates="section", order_by="NotePage.sort_order"
+    )
+
+
+class NotePage(Base):
+    __tablename__ = "note_pages"
+    __table_args__ = (
+        UniqueConstraint("section_id", "sort_order", name="uq_note_pages_section_order"),
+        Index("ix_note_pages_guild_id", "guild_id"),
+        Index("ix_note_pages_section_id", "section_id"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
+    section_id: Mapped[int] = mapped_column(ForeignKey("note_sections.id"))
+    title: Mapped[str] = mapped_column(String(255))
+    content: Mapped[str] = mapped_column(Text, default="")
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    color: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    created_by_id: Mapped[Optional[int]] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), nullable=True
+    )
+    updated_by_id: Mapped[Optional[int]] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), nullable=True
+    )
+    version: Mapped[int] = mapped_column(Integer, default=1)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+
+    guild: Mapped[Guild] = relationship()
+    section: Mapped[NoteSection] = relationship(back_populates="pages")
+    created_by: Mapped[Optional[User]] = relationship(
+        foreign_keys=[created_by_id], back_populates="note_pages_created"
+    )
+    updated_by: Mapped[Optional[User]] = relationship(
+        foreign_keys=[updated_by_id], back_populates="note_pages_updated"
+    )
 
 
 class SyncshellPairing(Base):

--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -71,6 +71,7 @@ def create_app() -> FastAPI:
     app.add_api_websocket_route("/ws/presences", websocket_endpoint)
     app.add_api_websocket_route("/ws/channels", websocket_endpoint)
     app.add_api_websocket_route("/ws/requests", websocket_endpoint)
+    app.add_api_websocket_route("/ws/notepad", websocket_endpoint)
     app.add_api_websocket_route("/ws/chat", websocket_endpoint_chat)
     app.add_api_websocket_route("/ws/syncshell", websocket_endpoint_syncshell)
 

--- a/demibot/demibot/http/routes/notepad.py
+++ b/demibot/demibot/http/routes/notepad.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Iterable, Sequence
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ..schemas import (
+    NotepadStateDto,
+    NotePageContentBody,
+    NotePageCreateBody,
+    NotePageDto,
+    NotePageReorderBody,
+    NotePageUpdateBody,
+    NoteSectionCreateBody,
+    NoteSectionDto,
+    NoteSectionReorderBody,
+    NoteSectionUpdateBody,
+)
+from ..ws import manager
+from ...db.models import NotePage, NoteSection
+
+
+router = APIRouter(prefix="/api")
+logger = logging.getLogger(__name__)
+
+
+def _require_officer(ctx: RequestContext) -> None:
+    if "officer" not in ctx.roles:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="officer role required"
+        )
+
+
+def _parse_int(value: str, label: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=f"invalid {label}") from exc
+
+
+async def _load_sections(
+    db: AsyncSession, guild_id: int
+) -> Sequence[NoteSection]:
+    result = await db.execute(
+        select(NoteSection)
+        .options(selectinload(NoteSection.pages))
+        .where(NoteSection.guild_id == guild_id)
+        .order_by(NoteSection.sort_order, NoteSection.id)
+    )
+    return result.scalars().unique().all()
+
+
+def _serialize_note_page(page: NotePage) -> NotePageDto:
+    return NotePageDto(
+        id=str(page.id),
+        section_id=str(page.section_id),
+        title=page.title,
+        content=page.content or "",
+        order=page.sort_order,
+        color=page.color,
+        created_by_id=str(page.created_by_id) if page.created_by_id is not None else None,
+        updated_by_id=str(page.updated_by_id) if page.updated_by_id is not None else None,
+        created_at=page.created_at,
+        updated_at=page.updated_at,
+        version=page.version,
+    )
+
+
+def _serialize_note_section(section: NoteSection) -> NoteSectionDto:
+    raw_pages = section.__dict__.get("pages")
+    if raw_pages is None:
+        raw_pages = []
+    pages = [
+        _serialize_note_page(page)
+        for page in sorted(
+            (p for p in raw_pages if not p.is_deleted),
+            key=lambda p: (p.sort_order, p.id),
+        )
+    ]
+    return NoteSectionDto(
+        id=str(section.id),
+        name=section.name,
+        order=section.sort_order,
+        color=section.color,
+        created_by_id=
+        str(section.created_by_id) if section.created_by_id is not None else None,
+        updated_by_id=
+        str(section.updated_by_id) if section.updated_by_id is not None else None,
+        created_at=section.created_at,
+        updated_at=section.updated_at,
+        version=section.version,
+        pages=pages,
+    )
+
+
+def _serialize_notepad_state(sections: Iterable[NoteSection]) -> NotepadStateDto:
+    active_sections = [
+        _serialize_note_section(section)
+        for section in sections
+        if not section.is_deleted
+    ]
+    return NotepadStateDto(sections=active_sections)
+
+
+async def _broadcast_notepad_event(
+    ctx: RequestContext, topic: str, payload: dict
+) -> None:
+    message = json.dumps(
+        {"topic": topic, "payload": payload},
+        ensure_ascii=False,
+    )
+    await manager.broadcast_text(message, ctx.guild.id, path="/ws/notepad")
+
+
+async def _get_section(
+    db: AsyncSession, guild_id: int, section_id: int, include_deleted: bool = False
+) -> NoteSection:
+    result = await db.execute(
+        select(NoteSection)
+        .options(selectinload(NoteSection.pages))
+        .where(NoteSection.id == section_id)
+    )
+    section = result.scalar_one_or_none()
+    if (
+        section is None
+        or section.guild_id != guild_id
+        or (section.is_deleted and not include_deleted)
+    ):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="section not found")
+    return section
+
+
+async def _get_page(
+    db: AsyncSession, guild_id: int, page_id: int, include_deleted: bool = False
+) -> NotePage:
+    page = await db.get(NotePage, page_id)
+    if (
+        page is None
+        or page.guild_id != guild_id
+        or (page.is_deleted and not include_deleted)
+    ):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="page not found")
+    return page
+
+
+@router.get("/notepad")
+async def list_notepad(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> NotepadStateDto:
+    sections = await _load_sections(db, ctx.guild.id)
+    return _serialize_notepad_state(sections)
+
+
+@router.post("/notepad/sections")
+async def create_section(
+    body: NoteSectionCreateBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> NoteSectionDto:
+    _require_officer(ctx)
+    max_order = await db.scalar(
+        select(func.max(NoteSection.sort_order)).where(
+            NoteSection.guild_id == ctx.guild.id,
+            NoteSection.is_deleted.is_(False),
+        )
+    )
+    next_order = (max_order if max_order is not None else -1) + 1
+    section = NoteSection(
+        guild_id=ctx.guild.id,
+        name=body.name,
+        color=body.color,
+        sort_order=next_order,
+        created_by_id=ctx.user.id,
+        updated_by_id=ctx.user.id,
+    )
+    db.add(section)
+    await db.commit()
+    await db.refresh(section)
+    dto = _serialize_note_section(section)
+    await _broadcast_notepad_event(
+        ctx,
+        "notepad.section.created",
+        {"section": dto.model_dump(mode="json", by_alias=True)},
+    )
+    return dto
+
+
+@router.patch("/notepad/sections/{section_id}")
+async def update_section(
+    section_id: str,
+    body: NoteSectionUpdateBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> NoteSectionDto:
+    _require_officer(ctx)
+    sid = _parse_int(section_id, "sectionId")
+    section = await _get_section(db, ctx.guild.id, sid)
+    if section.version != body.version:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="version conflict")
+    if body.name is not None:
+        section.name = body.name
+    if body.color is not None:
+        section.color = body.color
+    section.version += 1
+    section.updated_by_id = ctx.user.id
+    await db.commit()
+    await db.refresh(section)
+    dto = _serialize_note_section(section)
+    await _broadcast_notepad_event(
+        ctx,
+        "notepad.section.updated",
+        {"section": dto.model_dump(mode="json", by_alias=True)},
+    )
+    return dto
+
+
+@router.post("/notepad/sections/reorder")
+async def reorder_sections(
+    body: NoteSectionReorderBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> NotepadStateDto:
+    _require_officer(ctx)
+    requested_ids = [_parse_int(section_id, "sectionId") for section_id in body.section_ids]
+    if len(requested_ids) != len(set(requested_ids)):
+        raise HTTPException(status_code=400, detail="duplicate section ids")
+    sections = await _load_sections(db, ctx.guild.id)
+    section_map = {section.id: section for section in sections if not section.is_deleted}
+    missing = [sid for sid in requested_ids if sid not in section_map]
+    if missing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="section not found")
+    remaining = [
+        section
+        for section in sections
+        if section.id not in requested_ids and not section.is_deleted
+    ]
+    ordered_sections = [section_map[sid] for sid in requested_ids]
+    ordered_sections.extend(sorted(remaining, key=lambda s: (s.sort_order, s.id)))
+    temp_updates: list[tuple[NoteSection, int]] = []
+    total = len(ordered_sections)
+    for index, section in enumerate(ordered_sections):
+        if section.sort_order != index:
+            section.sort_order = total + index
+            temp_updates.append((section, index))
+    if temp_updates:
+        await db.flush()
+        for section, index in temp_updates:
+            section.sort_order = index
+            section.version += 1
+            section.updated_by_id = ctx.user.id
+    await db.commit()
+    sections = await _load_sections(db, ctx.guild.id)
+    state = _serialize_notepad_state(sections)
+    await _broadcast_notepad_event(
+        ctx,
+        "notepad.section.reordered",
+        {"sections": state.model_dump(mode="json", by_alias=True)["sections"]},
+    )
+    return state
+
+
+@router.delete("/notepad/sections/{section_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_section(
+    section_id: str,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    _require_officer(ctx)
+    sid = _parse_int(section_id, "sectionId")
+    section = await _get_section(db, ctx.guild.id, sid)
+    now = datetime.utcnow()
+    raw_pages = section.__dict__.get("pages") or []
+    if not section.is_deleted:
+        section.is_deleted = True
+        section.deleted_at = now
+        section.version += 1
+        section.updated_by_id = ctx.user.id
+    for page in raw_pages:
+        if not page.is_deleted:
+            page.is_deleted = True
+            page.deleted_at = now
+            page.version += 1
+            page.updated_by_id = ctx.user.id
+    await db.commit()
+    await _broadcast_notepad_event(
+        ctx,
+        "notepad.section.deleted",
+        {"sectionId": str(section.id)},
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/notepad/pages")
+async def create_page(
+    body: NotePageCreateBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> NotePageDto:
+    _require_officer(ctx)
+    section_id = _parse_int(body.section_id, "sectionId")
+    section = await _get_section(db, ctx.guild.id, section_id)
+    max_order = await db.scalar(
+        select(func.max(NotePage.sort_order)).where(
+            NotePage.section_id == section.id,
+            NotePage.is_deleted.is_(False),
+        )
+    )
+    next_order = (max_order if max_order is not None else -1) + 1
+    page = NotePage(
+        guild_id=ctx.guild.id,
+        section_id=section.id,
+        title=body.title,
+        content=body.content,
+        color=body.color,
+        sort_order=next_order,
+        created_by_id=ctx.user.id,
+        updated_by_id=ctx.user.id,
+    )
+    db.add(page)
+    await db.commit()
+    await db.refresh(page)
+    dto = _serialize_note_page(page)
+    await _broadcast_notepad_event(
+        ctx,
+        "notepad.page.created",
+        {"page": dto.model_dump(mode="json", by_alias=True)},
+    )
+    return dto
+
+
+@router.patch("/notepad/pages/{page_id}")
+async def update_page(
+    page_id: str,
+    body: NotePageUpdateBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> NotePageDto:
+    _require_officer(ctx)
+    pid = _parse_int(page_id, "pageId")
+    page = await _get_page(db, ctx.guild.id, pid)
+    if page.version != body.version:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="version conflict")
+    if body.title is not None:
+        page.title = body.title
+    if body.color is not None:
+        page.color = body.color
+    page.version += 1
+    page.updated_by_id = ctx.user.id
+    await db.commit()
+    await db.refresh(page)
+    dto = _serialize_note_page(page)
+    await _broadcast_notepad_event(
+        ctx,
+        "notepad.page.updated",
+        {"page": dto.model_dump(mode="json", by_alias=True)},
+    )
+    return dto
+
+
+@router.patch("/notepad/pages/{page_id}/content")
+async def update_page_content(
+    page_id: str,
+    body: NotePageContentBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> NotePageDto:
+    _require_officer(ctx)
+    pid = _parse_int(page_id, "pageId")
+    page = await _get_page(db, ctx.guild.id, pid)
+    if page.version != body.version:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="version conflict")
+    page.content = body.content
+    page.version += 1
+    page.updated_by_id = ctx.user.id
+    await db.commit()
+    await db.refresh(page)
+    dto = _serialize_note_page(page)
+    await _broadcast_notepad_event(
+        ctx,
+        "notepad.page.updated",
+        {"page": dto.model_dump(mode="json", by_alias=True)},
+    )
+    return dto
+
+
+@router.post("/notepad/pages/reorder")
+async def reorder_pages(
+    body: NotePageReorderBody,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> NotepadStateDto:
+    _require_officer(ctx)
+    provided_section_ids: list[int] = []
+    provided_page_ids: list[int] = []
+    for entry in body.sections:
+        sid = _parse_int(entry.section_id, "sectionId")
+        provided_section_ids.append(sid)
+        for pid_str in entry.page_ids:
+            provided_page_ids.append(_parse_int(pid_str, "pageId"))
+    if len(provided_page_ids) != len(set(provided_page_ids)):
+        raise HTTPException(status_code=400, detail="duplicate page ids")
+
+    sections = await _load_sections(db, ctx.guild.id)
+    section_map = {section.id: section for section in sections if not section.is_deleted}
+    missing_sections = [sid for sid in provided_section_ids if sid not in section_map]
+    if missing_sections:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="section not found")
+
+    result = await db.execute(
+        select(NotePage).where(
+            NotePage.guild_id == ctx.guild.id,
+            NotePage.is_deleted.is_(False),
+        )
+    )
+    pages = result.scalars().all()
+    page_map = {page.id: page for page in pages}
+    missing_pages = [pid for pid in provided_page_ids if pid not in page_map]
+    if missing_pages:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="page not found")
+
+    final_orders: dict[int, list[int]] = {}
+    for entry in body.sections:
+        sid = _parse_int(entry.section_id, "sectionId")
+        final_orders[sid] = [_parse_int(pid, "pageId") for pid in entry.page_ids]
+
+    for page in sorted(pages, key=lambda p: (p.section_id, p.sort_order, p.id)):
+        if page.id in provided_page_ids:
+            continue
+        final_orders.setdefault(page.section_id, []).append(page.id)
+
+    temp_page_updates: list[tuple[NotePage, int]] = []
+    total_pages = len(pages)
+    for section_id, ids in final_orders.items():
+        if section_id not in section_map:
+            continue
+        for index, page_id in enumerate(ids):
+            page = page_map[page_id]
+            changed = False
+            if page.section_id != section_id:
+                page.section_id = section_id
+                page.section = section_map[section_id]
+                changed = True
+            if page.sort_order != index:
+                changed = True
+            if changed:
+                page.sort_order = total_pages + len(temp_page_updates)
+                temp_page_updates.append((page, index))
+    if temp_page_updates:
+        await db.flush()
+        for page, index in temp_page_updates:
+            page.sort_order = index
+            page.version += 1
+            page.updated_by_id = ctx.user.id
+    await db.commit()
+    sections = await _load_sections(db, ctx.guild.id)
+    state = _serialize_notepad_state(sections)
+    await _broadcast_notepad_event(
+        ctx,
+        "notepad.page.reordered",
+        {"sections": state.model_dump(mode="json", by_alias=True)["sections"]},
+    )
+    return state
+
+
+@router.delete("/notepad/pages/{page_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_page(
+    page_id: str,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    _require_officer(ctx)
+    pid = _parse_int(page_id, "pageId")
+    page = await _get_page(db, ctx.guild.id, pid)
+    now = datetime.utcnow()
+    if not page.is_deleted:
+        page.is_deleted = True
+        page.deleted_at = now
+        page.version += 1
+        page.updated_by_id = ctx.user.id
+    await db.commit()
+    await _broadcast_notepad_event(
+        ctx,
+        "notepad.page.deleted",
+        {"pageId": str(page.id), "sectionId": str(page.section_id)},
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -183,3 +183,79 @@ class TemplateDto(CamelModel):
     description: str | None = None
     payload: TemplatePayload
     updated_at: datetime = Field(alias="updatedAt")
+
+
+# ---- Notepad ----
+
+
+class NotePageDto(CamelModel):
+    id: str
+    section_id: str = Field(alias="sectionId")
+    title: str
+    content: str
+    order: int
+    color: int | None = None
+    created_by_id: str | None = Field(default=None, alias="createdById")
+    updated_by_id: str | None = Field(default=None, alias="updatedById")
+    created_at: datetime = Field(alias="createdAt")
+    updated_at: datetime = Field(alias="updatedAt")
+    version: int
+
+
+class NoteSectionDto(CamelModel):
+    id: str
+    name: str
+    order: int
+    color: int | None = None
+    created_by_id: str | None = Field(default=None, alias="createdById")
+    updated_by_id: str | None = Field(default=None, alias="updatedById")
+    created_at: datetime = Field(alias="createdAt")
+    updated_at: datetime = Field(alias="updatedAt")
+    version: int
+    pages: List[NotePageDto] = Field(default_factory=list)
+
+
+class NotepadStateDto(CamelModel):
+    sections: List[NoteSectionDto] = Field(default_factory=list)
+
+
+class NoteSectionCreateBody(CamelModel):
+    name: str
+    color: int | None = None
+
+
+class NoteSectionUpdateBody(CamelModel):
+    name: str | None = None
+    color: int | None = None
+    version: int
+
+
+class NoteSectionReorderBody(CamelModel):
+    section_ids: List[str] = Field(alias="sectionIds")
+
+
+class NotePageCreateBody(CamelModel):
+    section_id: str = Field(alias="sectionId")
+    title: str
+    content: str = ""
+    color: int | None = None
+
+
+class NotePageUpdateBody(CamelModel):
+    title: str | None = None
+    color: int | None = None
+    version: int
+
+
+class NotePageReorderEntry(CamelModel):
+    section_id: str = Field(alias="sectionId")
+    page_ids: List[str] = Field(default_factory=list, alias="pageIds")
+
+
+class NotePageReorderBody(CamelModel):
+    sections: List[NotePageReorderEntry] = Field(default_factory=list)
+
+
+class NotePageContentBody(CamelModel):
+    content: str
+    version: int

--- a/tests/test_notepad_routes.py
+++ b/tests/test_notepad_routes.py
@@ -1,0 +1,200 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from demibot.db.models import Guild, User
+from demibot.db.session import get_session, init_db
+from demibot.http.routes import notepad
+from demibot.http.schemas import (
+    NotePageContentBody,
+    NotePageCreateBody,
+    NotePageReorderBody,
+    NotePageReorderEntry,
+    NotePageUpdateBody,
+    NoteSectionCreateBody,
+    NoteSectionReorderBody,
+    NoteSectionUpdateBody,
+)
+
+
+class StubContext(SimpleNamespace):
+    pass
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_notepad_crud_flow(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "notepad.db"
+    await init_db(f"sqlite+aiosqlite:///{db_path}")
+
+    async with get_session() as db:
+        guild = Guild(id=1, discord_guild_id=1, name="Guild")
+        user = User(id=1, discord_user_id=10, global_name="Officer")
+        db.add_all([guild, user])
+        await db.commit()
+
+    ctx_officer = StubContext(
+        guild=SimpleNamespace(id=1),
+        user=SimpleNamespace(id=1),
+        roles=["officer"],
+    )
+    ctx_member = StubContext(
+        guild=SimpleNamespace(id=1),
+        user=SimpleNamespace(id=1),
+        roles=[],
+    )
+
+    events: list[tuple[dict, int, str]] = []
+
+    async def fake_broadcast(message: str, guild_id: int, path: str):
+        events.append((json.loads(message), guild_id, path))
+
+    monkeypatch.setattr(notepad.manager, "broadcast_text", fake_broadcast)
+
+    async with get_session() as db:
+        state = await notepad.list_notepad(ctx=ctx_member, db=db)
+        assert state.sections == []
+
+    async with get_session() as db:
+        with pytest.raises(HTTPException) as excinfo:
+            await notepad.create_section(
+                body=NoteSectionCreateBody(name="Member"), ctx=ctx_member, db=db
+            )
+        assert excinfo.value.status_code == 403
+
+    async with get_session() as db:
+        section = await notepad.create_section(
+            body=NoteSectionCreateBody(name="Raid", color=123456),
+            ctx=ctx_officer,
+            db=db,
+        )
+    assert section.name == "Raid"
+    assert section.color == 123456
+
+    async with get_session() as db:
+        renamed = await notepad.update_section(
+            section_id=section.id,
+            body=NoteSectionUpdateBody(name="Raid Alpha", version=section.version),
+            ctx=ctx_officer,
+            db=db,
+        )
+    assert renamed.name == "Raid Alpha"
+    assert renamed.version == section.version + 1
+
+    async with get_session() as db:
+        with pytest.raises(HTTPException) as excinfo:
+            await notepad.update_section(
+                section_id=section.id,
+                body=NoteSectionUpdateBody(name="oops", version=section.version),
+                ctx=ctx_officer,
+                db=db,
+            )
+        assert excinfo.value.status_code == 409
+
+    async with get_session() as db:
+        state = await notepad.list_notepad(ctx=ctx_member, db=db)
+    assert len(state.sections) == 1
+    section_id = state.sections[0].id
+
+    async with get_session() as db:
+        page = await notepad.create_page(
+            body=NotePageCreateBody(sectionId=section_id, title="Notes", content="A"),
+            ctx=ctx_officer,
+            db=db,
+        )
+    assert page.content == "A"
+
+    async with get_session() as db:
+        updated_page = await notepad.update_page_content(
+            page_id=page.id,
+            body=NotePageContentBody(content="Updated", version=page.version),
+            ctx=ctx_officer,
+            db=db,
+        )
+    assert updated_page.version == page.version + 1
+
+    async with get_session() as db:
+        with pytest.raises(HTTPException) as excinfo:
+            await notepad.update_page_content(
+                page_id=page.id,
+                body=NotePageContentBody(content="stale", version=page.version),
+                ctx=ctx_officer,
+                db=db,
+            )
+        assert excinfo.value.status_code == 409
+
+    async with get_session() as db:
+        updated_meta = await notepad.update_page(
+            page_id=page.id,
+            body=NotePageUpdateBody(title="New Title", version=updated_page.version),
+            ctx=ctx_officer,
+            db=db,
+        )
+    assert updated_meta.title == "New Title"
+    assert updated_meta.version == updated_page.version + 1
+
+    async with get_session() as db:
+        section2 = await notepad.create_section(
+            body=NoteSectionCreateBody(name="Logs"), ctx=ctx_officer, db=db
+        )
+
+    async with get_session() as db:
+        state = await notepad.reorder_sections(
+            body=NoteSectionReorderBody(sectionIds=[section2.id, section.id]),
+            ctx=ctx_officer,
+            db=db,
+        )
+    assert [s.id for s in state.sections][:2] == [section2.id, section.id]
+
+    async with get_session() as db:
+        page2 = await notepad.create_page(
+            body=NotePageCreateBody(sectionId=section.id, title="Other", content="B"),
+            ctx=ctx_officer,
+            db=db,
+        )
+
+    reorder_body = NotePageReorderBody(
+        sections=[
+            NotePageReorderEntry(sectionId=section2.id, pageIds=[page2.id]),
+            NotePageReorderEntry(sectionId=section.id, pageIds=[page.id]),
+        ]
+    )
+    async with get_session() as db:
+        state = await notepad.reorder_pages(
+            body=reorder_body,
+            ctx=ctx_officer,
+            db=db,
+        )
+    sections_by_id = {s.id: s for s in state.sections}
+    assert sections_by_id[section2.id].pages[0].id == page2.id
+    assert sections_by_id[section.id].pages[0].id == page.id
+
+    async with get_session() as db:
+        await notepad.delete_page(page_id=page2.id, ctx=ctx_officer, db=db)
+
+    async with get_session() as db:
+        await notepad.delete_section(section_id=section.id, ctx=ctx_officer, db=db)
+
+    async with get_session() as db:
+        state = await notepad.list_notepad(ctx=ctx_member, db=db)
+    returned_ids = {s.id for s in state.sections}
+    assert section.id not in returned_ids
+
+    topics = {event[0]["topic"] for event in events}
+    assert {
+        "notepad.section.created",
+        "notepad.page.created",
+        "notepad.page.updated",
+        "notepad.section.reordered",
+        "notepad.page.reordered",
+        "notepad.page.deleted",
+        "notepad.section.deleted",
+    }.issubset(topics)
+    assert all(event[2] == "/ws/notepad" for event in events)

--- a/tests/test_notepad_ws.py
+++ b/tests/test_notepad_ws.py
@@ -1,0 +1,49 @@
+import json
+import types
+
+import pytest
+
+from demibot.http.ws import ConnectionManager
+
+
+class StubWebSocket:
+    def __init__(self, path: str):
+        self.scope = {"path": path}
+        self.sent: list[str] = []
+
+    async def accept(self) -> None:
+        pass
+
+    async def send_text(self, message: str) -> None:
+        self.sent.append(message)
+
+
+class StubContext:
+    def __init__(self, guild_id: int, roles: list[str]):
+        self.guild = types.SimpleNamespace(id=guild_id)
+        self.roles = roles
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_notepad_broadcasts_to_all_roles():
+    manager = ConnectionManager()
+    ws_officer = StubWebSocket("/ws/notepad")
+    ws_member = StubWebSocket("/ws/notepad")
+
+    await manager.connect(ws_officer, StubContext(1, ["officer"]))
+    await manager.connect(ws_member, StubContext(1, []))
+
+    payload = {"topic": "notepad.section.created", "payload": {}}
+    message = json.dumps(payload)
+    await manager.broadcast_text(message, 1, path="/ws/notepad")
+
+    assert ws_officer.sent == [message]
+    assert ws_member.sent == [message]
+
+    manager.disconnect(ws_officer)
+    manager.disconnect(ws_member)


### PR DESCRIPTION
## Summary
- add NoteSection and NotePage ORM models plus Alembic migration
- implement notepad HTTP schemas, routes, and websocket broadcasts
- add tests covering notepad CRUD, ordering, and websocket fan-out

## Testing
- pytest tests/test_notepad_routes.py tests/test_notepad_ws.py

------
https://chatgpt.com/codex/tasks/task_e_68da0bddc15c83289e9f35a7c982f2f9