### PR TITLE
Add NotePad service and UI integration

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -17,7 +17,7 @@ public class Config : IPluginConfiguration
     public static readonly Vector4 DefaultSecondaryAccentColor = new(0.2f, 0.6f, 1f, 1f);
 
     // Required by Dalamud
-    public int Version { get; set; } = 11;
+    public int Version { get; set; } = 12;
 
     public bool Enabled { get; set; } = true;
     public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
@@ -109,6 +109,21 @@ public class Config : IPluginConfiguration
 
     [JsonPropertyName("categories")]
     public Dictionary<string, CategoryState> Categories { get; set; } = new();
+
+    [JsonPropertyName("notePadEnabled")]
+    public bool NotePadEnabled { get; set; } = true;
+
+    [JsonPropertyName("notePadLastSectionId")]
+    public string? NotePadLastSectionId { get; set; }
+
+    [JsonPropertyName("notePadLastPageId")]
+    public string? NotePadLastPageId { get; set; }
+
+    [JsonPropertyName("notePadPageListWidthRatio")]
+    public float NotePadPageListWidthRatio { get; set; } = 0.3f;
+
+    [JsonPropertyName("notePadEditorZoom")]
+    public float NotePadEditorZoom { get; set; } = 1f;
 
     [JsonExtensionData]
     public Dictionary<string, JsonElement>? ExtensionData { get; set; }
@@ -348,6 +363,34 @@ public class Config : IPluginConfiguration
             SecondaryAccentColor = SanitizeColor(SecondaryAccentColor, DefaultSecondaryAccentColor);
 
             Version = 11;
+            ExtensionData = null;
+        }
+        if (Version < 12)
+        {
+            NotePadEnabled = true;
+            if (string.IsNullOrWhiteSpace(NotePadLastSectionId))
+            {
+                NotePadLastSectionId = null;
+            }
+
+            if (string.IsNullOrWhiteSpace(NotePadLastPageId))
+            {
+                NotePadLastPageId = null;
+            }
+
+            if (!float.IsFinite(NotePadPageListWidthRatio) || NotePadPageListWidthRatio <= 0f)
+            {
+                NotePadPageListWidthRatio = 0.3f;
+            }
+            NotePadPageListWidthRatio = Math.Clamp(NotePadPageListWidthRatio, 0.15f, 0.6f);
+
+            if (!float.IsFinite(NotePadEditorZoom) || NotePadEditorZoom <= 0f)
+            {
+                NotePadEditorZoom = 1f;
+            }
+            NotePadEditorZoom = Math.Clamp(NotePadEditorZoom, 0.5f, 2f);
+
+            Version = 12;
             ExtensionData = null;
         }
     }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -16,9 +16,11 @@ public class MainWindow : IDisposable
     private readonly EventCreateWindow _create;
     private readonly TemplatesWindow _templates;
     private readonly RequestBoardWindow _requestBoard;
+    private readonly NotePadWindow _notePad;
     private SyncshellWindow? _syncshell;
     private bool _syncshellEnabled;
     private bool _templatesTabActive;
+    private bool _notePadTabActive;
     private bool _fcChatTabActive;
     private bool _officerTabActive;
     private readonly HttpClient _httpClient;
@@ -30,10 +32,20 @@ public class MainWindow : IDisposable
     private bool _closeSyncshellTab;
 
     public bool IsOpen;
-    public bool HasOfficerAccess { get; set; }
+    private bool _hasOfficerAccess;
+    public bool HasOfficerAccess
+    {
+        get => _hasOfficerAccess;
+        set
+        {
+            _hasOfficerAccess = value;
+            _notePad.IsReadOnly = !value;
+        }
+    }
     public UiRenderer Ui => _ui;
     public EventCreateWindow EventCreateWindow => _create;
     public TemplatesWindow TemplatesWindow => _templates;
+    public NotePadWindow NotePadWindow => _notePad;
     internal static MainWindow? Instance { get; private set; }
 
     public MainWindow(
@@ -45,7 +57,8 @@ public class MainWindow : IDisposable
         HttpClient httpClient,
         ChannelService channelService,
         ChannelSelectionService channelSelection,
-        EmojiManager emojiManager)
+        EmojiManager emojiManager,
+        NotePadWindow notePad)
     {
         _config = config;
         _ui = ui;
@@ -56,6 +69,7 @@ public class MainWindow : IDisposable
         _create = new EventCreateWindow(config, httpClient, channelService, channelSelection, emojiManager);
         _templates = new TemplatesWindow(config, httpClient, channelService, channelSelection, emojiManager);
         _requestBoard = new RequestBoardWindow(config, httpClient);
+        _notePad = notePad;
         _syncshellEnabled = config.FCSyncShell;
         _syncshell = _syncshellEnabled ? new SyncshellWindow(config, httpClient) : null;
         Instance = this;
@@ -256,6 +270,38 @@ public class MainWindow : IDisposable
                     else
                     {
                         _templatesTabActive = false;
+                    }
+                }
+
+                if (!linked)
+                {
+                    _notePadTabActive = false;
+                    ImGui.BeginDisabled();
+                    ImGui.TabItemButton("NotePad");
+                    ImGui.EndDisabled();
+                    if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                        ImGui.SetTooltip("Link DemiCat to use the NotePad.");
+                }
+                else
+                {
+                    var notePadOpen = ImGui.BeginTabItem("NotePad");
+                    if (notePadOpen)
+                    {
+                        var alphaOverrideState = TryPushWindowOpacityOverride(
+                            previousOpacityOverrideActive,
+                            primaryColor,
+                            childBaseColor,
+                            1f);
+
+                        _notePadTabActive = true;
+                        _notePad.Draw();
+                        ImGui.EndTabItem();
+
+                        PopWindowAlphaOnly(alphaOverrideState);
+                    }
+                    else
+                    {
+                        _notePadTabActive = false;
                     }
                 }
 

--- a/DemiCatPlugin/NotePadService.cs
+++ b/DemiCatPlugin/NotePadService.cs
@@ -1,0 +1,942 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DemiCatPlugin;
+
+public sealed class NotePadService : IDisposable
+{
+    private readonly Config _config;
+    private readonly HttpClient _httpClient;
+    private readonly TokenManager _tokenManager;
+    private readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly List<NotePadSection> _sections = new();
+    private readonly SemaphoreSlim _stateLock = new(1, 1);
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+    private CancellationTokenSource? _cts;
+    private Task? _task;
+    private int _retryAttempt;
+    private DateTime _lastToast;
+    private string? _lastToastSignature;
+
+    private static readonly TimeSpan ToastThrottle = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan AutosyncDelay = TimeSpan.FromSeconds(5);
+
+    public event Action? Changed;
+
+    public NotePadService(Config config, HttpClient httpClient, TokenManager tokenManager)
+    {
+        _config = config;
+        _httpClient = httpClient;
+        _tokenManager = tokenManager;
+    }
+
+    public IReadOnlyList<NotePadSection> Sections
+    {
+        get
+        {
+            lock (_sections)
+            {
+                return _sections.Select(CloneSection).ToList();
+            }
+        }
+    }
+
+    public bool IsRunning => _cts != null;
+
+    public void Start()
+    {
+        Stop();
+        _cts = new CancellationTokenSource();
+        _task = Task.Run(() => RunAsync(_cts.Token));
+    }
+
+    public void Stop()
+    {
+        _cts?.Cancel();
+        try { _task?.GetAwaiter().GetResult(); } catch { }
+        _cts = null;
+        _task = null;
+    }
+
+    public async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        if (!_tokenManager.IsReady() || !ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            await UpdateSectionsAsync(Array.Empty<NotePadSection>());
+            return;
+        }
+
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Warning(ex, "Failed to refresh notepad state");
+            ShowThrottledToast("Unable to load NotePad data.", ex.Message);
+            return;
+        }
+
+        try
+        {
+            await HandleResponseAsync(response, async stream =>
+            {
+                var data = await JsonSerializer.DeserializeAsync<NotePadListResponse>(stream, _serializerOptions, cancellationToken)
+                    .ConfigureAwait(false) ?? new NotePadListResponse();
+
+                var sections = data.Sections?.Select(CloneSection).ToArray() ?? Array.Empty<NotePadSection>();
+                await UpdateSectionsAsync(sections).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+        }
+        catch (NotePadConflictException ex)
+        {
+            ShowThrottledToast("Failed to synchronize NotePad", ex.Message);
+        }
+    }
+
+    public async Task<NotePadSection?> CreateSectionAsync(string name, string colorHex, CancellationToken cancellationToken)
+    {
+        var payload = new
+        {
+            name,
+            color = colorHex
+        };
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections";
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+        };
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "Failed to create notepad section");
+            ShowThrottledToast("Failed to create section", ex.Message);
+            return null;
+        }
+
+        NotePadSection? created = null;
+        try
+        {
+            await HandleResponseAsync(response, async stream =>
+            {
+                created = await JsonSerializer.DeserializeAsync<NotePadSection>(stream, _serializerOptions, cancellationToken)
+                    .ConfigureAwait(false);
+                if (created != null)
+                {
+                    await AddOrUpdateSectionAsync(created).ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
+        }
+        catch (NotePadConflictException ex)
+        {
+            ShowThrottledToast("Section name already exists", ex.Message);
+        }
+
+        return created;
+    }
+
+    public async Task<bool> RenameSectionAsync(string sectionId, string name, CancellationToken cancellationToken)
+    {
+        var payload = new { name };
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}";
+        var request = new HttpRequestMessage(HttpMethod.Patch, url)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+        };
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "Failed to rename notepad section");
+            ShowThrottledToast("Failed to rename section", ex.Message);
+            return false;
+        }
+
+        var success = false;
+        try
+        {
+            await HandleResponseAsync(response, async stream =>
+            {
+                var updated = await JsonSerializer.DeserializeAsync<NotePadSection>(stream, _serializerOptions, cancellationToken)
+                    .ConfigureAwait(false);
+                if (updated != null)
+                {
+                    success = true;
+                    await AddOrUpdateSectionAsync(updated).ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
+        }
+        catch (NotePadConflictException ex)
+        {
+            ShowThrottledToast("Section name already exists", ex.Message);
+        }
+
+        return success;
+    }
+
+    public async Task<bool> DeleteSectionAsync(string sectionId, CancellationToken cancellationToken)
+    {
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}";
+        var request = new HttpRequestMessage(HttpMethod.Delete, url);
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "Failed to delete notepad section");
+            ShowThrottledToast("Failed to delete section", ex.Message);
+            return false;
+        }
+
+        var success = false;
+        try
+        {
+            await HandleResponseAsync(response, _ =>
+            {
+                success = true;
+                return Task.CompletedTask;
+            }).ConfigureAwait(false);
+        }
+        catch (NotePadConflictException ex)
+        {
+            ShowThrottledToast("Unable to delete section", ex.Message);
+        }
+
+        if (success)
+        {
+            await RemoveSectionAsync(sectionId).ConfigureAwait(false);
+        }
+
+        return success;
+    }
+
+    public async Task<bool> ReorderSectionsAsync(IReadOnlyList<string> sectionIds, CancellationToken cancellationToken)
+    {
+        var payload = new { ids = sectionIds };
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/reorder";
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+        };
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "Failed to reorder sections");
+            ShowThrottledToast("Failed to reorder sections", ex.Message);
+            return false;
+        }
+
+        var success = false;
+        try
+        {
+            await HandleResponseAsync(response, _ =>
+            {
+                success = true;
+                return Task.CompletedTask;
+            }).ConfigureAwait(false);
+        }
+        catch (NotePadConflictException ex)
+        {
+            ShowThrottledToast("Unable to reorder sections", ex.Message);
+        }
+
+        if (success)
+        {
+            await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                var ordered = new List<NotePadSection>();
+                foreach (var id in sectionIds)
+                {
+                    var match = _sections.FirstOrDefault(s => string.Equals(s.Id, id, StringComparison.Ordinal));
+                    if (match != null)
+                    {
+                        ordered.Add(match);
+                    }
+                }
+
+                foreach (var section in _sections)
+                {
+                    if (!ordered.Contains(section))
+                    {
+                        ordered.Add(section);
+                    }
+                }
+
+                _sections.Clear();
+                _sections.AddRange(ordered.Select(CloneSection));
+            }
+            finally
+            {
+                _stateLock.Release();
+            }
+
+            RaiseChanged();
+        }
+
+        return success;
+    }
+
+    public async Task<NotePadPage?> CreatePageAsync(string sectionId, string title, CancellationToken cancellationToken)
+    {
+        var payload = new { title };
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}/pages";
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+        };
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "Failed to create notepad page");
+            ShowThrottledToast("Failed to create page", ex.Message);
+            return null;
+        }
+
+        NotePadPage? created = null;
+        try
+        {
+            await HandleResponseAsync(response, async stream =>
+            {
+                created = await JsonSerializer.DeserializeAsync<NotePadPage>(stream, _serializerOptions, cancellationToken)
+                    .ConfigureAwait(false);
+                if (created != null)
+                {
+                    await AddOrUpdatePageAsync(sectionId, created).ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
+        }
+        catch (NotePadConflictException ex)
+        {
+            ShowThrottledToast("Page title already exists", ex.Message);
+        }
+
+        return created;
+    }
+
+    public async Task<bool> RenamePageAsync(string sectionId, string pageId, string title, CancellationToken cancellationToken)
+    {
+        var payload = new { title };
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}/pages/{pageId}";
+        var request = new HttpRequestMessage(HttpMethod.Patch, url)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+        };
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "Failed to rename notepad page");
+            ShowThrottledToast("Failed to rename page", ex.Message);
+            return false;
+        }
+
+        var success = false;
+        try
+        {
+            await HandleResponseAsync(response, async stream =>
+            {
+                var updated = await JsonSerializer.DeserializeAsync<NotePadPage>(stream, _serializerOptions, cancellationToken)
+                    .ConfigureAwait(false);
+                if (updated != null)
+                {
+                    success = true;
+                    await AddOrUpdatePageAsync(sectionId, updated).ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
+        }
+        catch (NotePadConflictException ex)
+        {
+            ShowThrottledToast("Page title already exists", ex.Message);
+        }
+
+        return success;
+    }
+
+    public async Task<bool> DeletePageAsync(string sectionId, string pageId, CancellationToken cancellationToken)
+    {
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}/pages/{pageId}";
+        var request = new HttpRequestMessage(HttpMethod.Delete, url);
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "Failed to delete notepad page");
+            ShowThrottledToast("Failed to delete page", ex.Message);
+            return false;
+        }
+
+        var success = false;
+        try
+        {
+            await HandleResponseAsync(response, _ =>
+            {
+                success = true;
+                return Task.CompletedTask;
+            }).ConfigureAwait(false);
+        }
+        catch (NotePadConflictException ex)
+        {
+            ShowThrottledToast("Unable to delete page", ex.Message);
+        }
+
+        if (success)
+        {
+            await RemovePageAsync(sectionId, pageId).ConfigureAwait(false);
+        }
+
+        return success;
+    }
+
+    public async Task<bool> ReorderPagesAsync(string sectionId, IReadOnlyList<string> pageIds, CancellationToken cancellationToken)
+    {
+        var payload = new { ids = pageIds };
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}/pages/reorder";
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+        };
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "Failed to reorder notepad pages");
+            ShowThrottledToast("Failed to reorder pages", ex.Message);
+            return false;
+        }
+
+        var success = false;
+        try
+        {
+            await HandleResponseAsync(response, _ =>
+            {
+                success = true;
+                return Task.CompletedTask;
+            }).ConfigureAwait(false);
+        }
+        catch (NotePadConflictException ex)
+        {
+            ShowThrottledToast("Unable to reorder pages", ex.Message);
+        }
+
+        if (success)
+        {
+            await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                var section = _sections.FirstOrDefault(s => string.Equals(s.Id, sectionId, StringComparison.Ordinal));
+                if (section != null)
+                {
+                    var ordered = new List<NotePadPage>();
+                    foreach (var id in pageIds)
+                    {
+                        var page = section.Pages.FirstOrDefault(p => string.Equals(p.Id, id, StringComparison.Ordinal));
+                        if (page != null)
+                        {
+                            ordered.Add(page);
+                        }
+                    }
+
+                    foreach (var page in section.Pages)
+                    {
+                        if (!ordered.Contains(page))
+                        {
+                            ordered.Add(page);
+                        }
+                    }
+
+                    section.Pages = ordered.Select(ClonePage).ToList();
+                }
+            }
+            finally
+            {
+                _stateLock.Release();
+            }
+
+            RaiseChanged();
+        }
+
+        return success;
+    }
+
+    public async Task<NotePadPage?> SavePageAsync(string sectionId, string pageId, NotePadPageUpdate update, CancellationToken cancellationToken)
+    {
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}/pages/{pageId}";
+        var request = new HttpRequestMessage(HttpMethod.Put, url)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(update), Encoding.UTF8, "application/json")
+        };
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "Failed to save notepad page");
+            ShowThrottledToast("Failed to save page", ex.Message);
+            return null;
+        }
+
+        NotePadPage? page = null;
+        try
+        {
+            await HandleResponseAsync(response, async stream =>
+            {
+                page = await JsonSerializer.DeserializeAsync<NotePadPage>(stream, _serializerOptions, cancellationToken)
+                    .ConfigureAwait(false);
+                if (page != null)
+                {
+                    await AddOrUpdatePageAsync(sectionId, page).ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
+        }
+        catch (NotePadConflictException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Warning(ex, "Unexpected NotePad save failure");
+        }
+
+        return page;
+    }
+
+    private async Task HandleResponseAsync(HttpResponseMessage response, Func<Stream, Task> onSuccess)
+    {
+        await using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            _tokenManager.Clear("Authentication failed");
+            ShowThrottledToast("Authentication failed", string.Empty);
+            return;
+        }
+
+        if (response.StatusCode == HttpStatusCode.Forbidden)
+        {
+            ShowThrottledToast("Forbidden – check API key/roles", string.Empty);
+            return;
+        }
+
+        if (response.StatusCode == HttpStatusCode.Conflict)
+        {
+            throw new NotePadConflictException(await ReadErrorAsync(stream).ConfigureAwait(false));
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await ReadErrorAsync(stream).ConfigureAwait(false);
+            ShowThrottledToast("NotePad request failed", error);
+            return;
+        }
+
+        await onSuccess(stream).ConfigureAwait(false);
+    }
+
+    private static async Task<string> ReadErrorAsync(Stream stream)
+    {
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms).ConfigureAwait(false);
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    private async Task RunAsync(CancellationToken token)
+    {
+        var baseDelay = TimeSpan.FromSeconds(5);
+        while (!token.IsCancellationRequested)
+        {
+            if (!_config.Enabled || !_config.NotePadEnabled || !_tokenManager.IsReady() || !ApiHelpers.ValidateApiBaseUrl(_config))
+            {
+                await Task.Delay(baseDelay, token).ConfigureAwait(false);
+                _retryAttempt = 0;
+                continue;
+            }
+
+            ClientWebSocket? ws = null;
+            try
+            {
+                await RefreshAsync(token).ConfigureAwait(false);
+
+                ws = new ClientWebSocket();
+                ApiHelpers.AddAuthHeader(ws, _tokenManager);
+
+                var uri = BuildWebSocketUri();
+                if (uri == null)
+                {
+                    ShowThrottledToast("Invalid NotePad websocket URI", string.Empty);
+                    await Task.Delay(baseDelay, token).ConfigureAwait(false);
+                    continue;
+                }
+
+                await ws.ConnectAsync(uri, token).ConfigureAwait(false);
+                _retryAttempt = 0;
+
+                var buffer = ArrayPool<byte>.Shared.Rent(4096);
+                try
+                {
+                    while (ws.State == WebSocketState.Open && !token.IsCancellationRequested)
+                    {
+                        var (message, type) = await ChannelWatcher.ReceiveMessageAsync(ws, buffer, token).ConfigureAwait(false);
+                        if (type == WebSocketMessageType.Close)
+                        {
+                            break;
+                        }
+
+                        if (!string.IsNullOrEmpty(message))
+                        {
+                            _ = TriggerRefreshAsync();
+                        }
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+            }
+            catch (NotePadConflictException conflict)
+            {
+                ShowThrottledToast("NotePad conflict", conflict.Message);
+            }
+            catch (HttpRequestException ex)
+            {
+                PluginServices.Instance?.Log.Warning(ex, "NotePad websocket transport error");
+                ShowThrottledToast("NotePad connection failed", ex.Message);
+            }
+            catch (WebSocketException ex)
+            {
+                PluginServices.Instance?.Log.Warning(ex, "NotePad websocket error");
+                ShowThrottledToast("NotePad connection failed", ex.Message);
+            }
+            catch (Exception ex)
+            {
+                PluginServices.Instance?.Log.Error(ex, "Unexpected NotePad watcher error");
+                ShowThrottledToast("NotePad watcher crashed", ex.Message);
+            }
+            finally
+            {
+                ws?.Dispose();
+            }
+
+            if (token.IsCancellationRequested)
+            {
+                break;
+            }
+
+            _retryAttempt++;
+            var retryDelay = TimeSpan.FromSeconds(Math.Min(60, Math.Pow(2, _retryAttempt)));
+            await Task.Delay(retryDelay, token).ConfigureAwait(false);
+        }
+    }
+
+    private Uri? BuildWebSocketUri()
+    {
+        if (string.IsNullOrWhiteSpace(_config.ApiBaseUrl))
+        {
+            return null;
+        }
+
+        try
+        {
+            var builder = new UriBuilder(_config.ApiBaseUrl)
+            {
+                Path = "/ws/notepad"
+            };
+            if (builder.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
+            {
+                builder.Scheme = "ws";
+            }
+            else if (builder.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+            {
+                builder.Scheme = "wss";
+            }
+
+            return builder.Uri;
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Warning(ex, "Failed to build NotePad websocket URI");
+            return null;
+        }
+    }
+
+    private async Task TriggerRefreshAsync()
+    {
+        if (_refreshLock.CurrentCount == 0)
+        {
+            return;
+        }
+
+        await _refreshLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await RefreshAsync(CancellationToken.None).ConfigureAwait(false);
+            await Task.Delay(AutosyncDelay).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Warning(ex, "Failed to refresh NotePad state after notification");
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    private async Task UpdateSectionsAsync(IReadOnlyList<NotePadSection> sections)
+    {
+        await _stateLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            _sections.Clear();
+            _sections.AddRange(sections.Select(CloneSection));
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+
+        RaiseChanged();
+    }
+
+    private async Task AddOrUpdateSectionAsync(NotePadSection section)
+    {
+        await _stateLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var existing = _sections.FindIndex(s => string.Equals(s.Id, section.Id, StringComparison.Ordinal));
+            if (existing >= 0)
+            {
+                _sections[existing] = CloneSection(section);
+            }
+            else
+            {
+                _sections.Add(CloneSection(section));
+            }
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+
+        RaiseChanged();
+    }
+
+    private async Task RemoveSectionAsync(string sectionId)
+    {
+        await _stateLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            _sections.RemoveAll(s => string.Equals(s.Id, sectionId, StringComparison.Ordinal));
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+
+        RaiseChanged();
+    }
+
+    private async Task AddOrUpdatePageAsync(string sectionId, NotePadPage page)
+    {
+        await _stateLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var section = _sections.FirstOrDefault(s => string.Equals(s.Id, sectionId, StringComparison.Ordinal));
+            if (section == null)
+            {
+                return;
+            }
+
+            var index = section.Pages.FindIndex(p => string.Equals(p.Id, page.Id, StringComparison.Ordinal));
+            if (index >= 0)
+            {
+                section.Pages[index] = ClonePage(page);
+            }
+            else
+            {
+                section.Pages.Add(ClonePage(page));
+            }
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+
+        RaiseChanged();
+    }
+
+    private async Task RemovePageAsync(string sectionId, string pageId)
+    {
+        await _stateLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var section = _sections.FirstOrDefault(s => string.Equals(s.Id, sectionId, StringComparison.Ordinal));
+            section?.Pages.RemoveAll(p => string.Equals(p.Id, pageId, StringComparison.Ordinal));
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+
+        RaiseChanged();
+    }
+
+    private void RaiseChanged()
+    {
+        try
+        {
+            Changed?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log.Warning(ex, "NotePadService change handler failed");
+        }
+    }
+
+    private void ShowThrottledToast(string message, string details)
+    {
+        var signature = $"{message}:{details}";
+        if (_lastToastSignature == signature && DateTime.UtcNow - _lastToast < ToastThrottle)
+        {
+            return;
+        }
+
+        _lastToastSignature = signature;
+        _lastToast = DateTime.UtcNow;
+
+        PluginServices.Instance?.ToastGui.ShowWarning(string.IsNullOrEmpty(details) ? message : $"{message}\n{details}");
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        _stateLock.Dispose();
+        _refreshLock.Dispose();
+    }
+
+    private static NotePadSection CloneSection(NotePadSection source)
+    {
+        return new NotePadSection
+        {
+            Id = source.Id,
+            Name = source.Name,
+            Color = source.Color,
+            Pages = source.Pages.Select(ClonePage).ToList()
+        };
+    }
+
+    private static NotePadPage ClonePage(NotePadPage source)
+    {
+        return new NotePadPage
+        {
+            Id = source.Id,
+            Title = source.Title,
+            Content = source.Content,
+            Version = source.Version,
+            UpdatedAt = source.UpdatedAt
+        };
+    }
+}
+
+public sealed class NotePadSection
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Color { get; set; } = "#4a5568";
+    public List<NotePadPage> Pages { get; set; } = new();
+}
+
+public sealed class NotePadPage
+{
+    public string Id { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public int Version { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+}
+
+public sealed class NotePadListResponse
+{
+    public List<NotePadSection>? Sections { get; set; }
+}
+
+public sealed class NotePadPageUpdate
+{
+    public string Content { get; set; } = string.Empty;
+    public int Version { get; set; }
+}
+
+public sealed class NotePadConflictException : Exception
+{
+    public NotePadConflictException(string message)
+        : base(string.IsNullOrWhiteSpace(message) ? "NotePad content conflict" : message)
+    {
+    }
+}

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -1,0 +1,934 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Bindings.ImGui;
+
+namespace DemiCatPlugin;
+
+public sealed class NotePadWindow : IDisposable
+{
+    private readonly Config _config;
+    private readonly NotePadService _service;
+    private readonly SemaphoreSlim _saveLock = new(1, 1);
+    private readonly List<string> _sectionOrder = new();
+    private readonly Dictionary<string, string> _sectionRenameBuffers = new();
+    private readonly Dictionary<string, string> _pageRenameBuffers = new();
+    private readonly TimeSpan _autosaveDelay = TimeSpan.FromSeconds(2.5);
+
+    private string? _selectedSectionId;
+    private string? _selectedPageId;
+    private string _editorContent = string.Empty;
+    private int _editorVersion;
+    private int _selectionStart;
+    private int _selectionEnd;
+    private bool _dirty;
+    private DateTime _lastEditUtc;
+    private bool _showConflictModal;
+    private string _conflictMessage = string.Empty;
+    private NotePadPage? _conflictServerPage;
+    private string? _conflictSectionId;
+    private string? _conflictPageId;
+    private bool _pendingReload;
+    private bool _sectionOrderDirty;
+    private bool _pageOrderDirty;
+    private bool _focusEditorNextFrame;
+    private string _newSectionName = string.Empty;
+    private string _newPageTitle = string.Empty;
+    private bool _showNewSectionPopup;
+    private bool _showNewPagePopup;
+    private string? _draggingSectionId;
+    private string? _draggingPageId;
+
+    public bool IsReadOnly { get; set; }
+
+    public NotePadWindow(Config config, NotePadService service)
+    {
+        _config = config;
+        _service = service;
+        _service.Changed += HandleServiceChanged;
+        _selectedSectionId = string.IsNullOrEmpty(config.NotePadLastSectionId) ? null : config.NotePadLastSectionId;
+        _selectedPageId = string.IsNullOrEmpty(config.NotePadLastPageId) ? null : config.NotePadLastPageId;
+    }
+
+    public void Dispose()
+    {
+        _service.Changed -= HandleServiceChanged;
+        _saveLock.Dispose();
+    }
+
+    public void Draw()
+    {
+        HandleKeyboardShortcuts();
+        HandleAutosave();
+
+        var sections = _service.Sections;
+        EnsureSectionSelection(sections);
+        var selectedSection = sections.FirstOrDefault(s => string.Equals(s.Id, _selectedSectionId, StringComparison.Ordinal));
+        EnsurePageSelection(selectedSection);
+        var selectedPage = selectedSection?.Pages.FirstOrDefault(p => string.Equals(p.Id, _selectedPageId, StringComparison.Ordinal));
+
+        DrawConflictModal(selectedPage);
+
+        DrawSectionTabs(sections);
+        ImGui.Separator();
+
+        var region = ImGui.GetContentRegionAvail();
+        if (region.X <= 0f || region.Y <= 0f)
+        {
+            return;
+        }
+
+        var splitterWidth = 6f;
+        var ratio = Math.Clamp(_config.NotePadPageListWidthRatio, 0.15f, 0.6f);
+        var pageListWidth = Math.Clamp(region.X * ratio, 160f, Math.Max(160f, region.X - 200f));
+        var editorWidth = Math.Max(200f, region.X - pageListWidth - splitterWidth);
+
+        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), true);
+        DrawPageList(selectedSection, selectedPage);
+        ImGui.EndChild();
+
+        ImGui.SameLine();
+        ImGui.InvisibleButton("NotePadSplitter", new Vector2(splitterWidth, region.Y));
+        if (ImGui.IsItemActive())
+        {
+            var delta = ImGui.GetIO().MouseDelta.X;
+            if (Math.Abs(delta) > float.Epsilon)
+            {
+                var newRatio = Math.Clamp(pageListWidth + delta, 160f, Math.Max(160f, region.X - 200f)) / region.X;
+                newRatio = Math.Clamp(newRatio, 0.15f, 0.6f);
+                if (Math.Abs(newRatio - _config.NotePadPageListWidthRatio) > 0.0001f)
+                {
+                    _config.NotePadPageListWidthRatio = newRatio;
+                    SaveConfig();
+                }
+            }
+        }
+        else if (ImGui.IsItemHovered())
+        {
+            ImGui.SetMouseCursor(ImGuiMouseCursor.ResizeEW);
+        }
+
+        ImGui.SameLine();
+        ImGui.BeginChild("NotePadEditor", new Vector2(editorWidth, region.Y), false);
+        DrawEditor(selectedSection, selectedPage);
+        ImGui.EndChild();
+
+        if (_sectionOrderDirty)
+        {
+            _sectionOrderDirty = false;
+            _ = Task.Run(() => _service.ReorderSectionsAsync(_sectionOrder, CancellationToken.None));
+        }
+
+        if (_pageOrderDirty && selectedSection != null)
+        {
+            _pageOrderDirty = false;
+            var order = selectedSection.Pages.Select(p => p.Id).ToList();
+            _ = Task.Run(() => _service.ReorderPagesAsync(selectedSection.Id, order, CancellationToken.None));
+        }
+    }
+
+    private void DrawSectionTabs(IReadOnlyList<NotePadSection> sections)
+    {
+        if (ImGui.BeginTabBar("NotePadSections", ImGuiTabBarFlags.Reorderable | ImGuiTabBarFlags.TabListPopupButton))
+        {
+            foreach (var section in sections)
+            {
+                ImGui.PushID(section.Id);
+                var selected = string.Equals(section.Id, _selectedSectionId, StringComparison.Ordinal);
+                var title = string.IsNullOrWhiteSpace(section.Name) ? "Untitled" : section.Name;
+                var label = $"{title}##{section.Id}";
+                var tabFlags = selected ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None;
+
+                var color = ParseColor(section.Color);
+                ImGui.PushStyleColor(ImGuiCol.Tab, AdjustTabColor(color, 0.7f));
+                ImGui.PushStyleColor(ImGuiCol.TabActive, AdjustTabColor(color, 1f));
+                ImGui.PushStyleColor(ImGuiCol.TabHovered, AdjustTabColor(color, 1.2f));
+
+                var tabOpen = ImGui.BeginTabItem(label, null, tabFlags);
+                var rectMin = ImGui.GetItemRectMin();
+                var rectMax = ImGui.GetItemRectMax();
+                var drawList = ImGui.GetWindowDrawList();
+                var chipWidth = Math.Min(rectMax.X - rectMin.X, ImGui.GetTextLineHeight());
+                var chipMin = new Vector2(rectMin.X + 4f, rectMin.Y + 4f);
+                var chipMax = new Vector2(chipMin.X + chipWidth * 0.2f, rectMax.Y - 4f);
+                drawList.AddRectFilled(chipMin, chipMax, ImGui.ColorConvertFloat4ToU32(color), 3f);
+
+                if (tabOpen)
+                {
+                    if (!selected)
+                    {
+                        SelectSection(section.Id);
+                    }
+                    ImGui.EndTabItem();
+                }
+
+                ImGui.PopStyleColor(3);
+
+                if (ImGui.BeginDragDropSource())
+                {
+                    _draggingSectionId = section.Id;
+                    ImGui.SetDragDropPayload("NotePadSection", IntPtr.Zero, 0);
+                    ImGui.TextUnformatted(title);
+                    ImGui.EndDragDropSource();
+                }
+
+                if (ImGui.BeginDragDropTarget())
+                {
+                    var payload = ImGui.AcceptDragDropPayload("NotePadSection");
+                    if (payload.NativePtr != null && !string.IsNullOrEmpty(_draggingSectionId) &&
+                        !string.Equals(_draggingSectionId, section.Id, StringComparison.Ordinal))
+                    {
+                        ReorderSections(_draggingSectionId, section.Id);
+                        _draggingSectionId = null;
+                    }
+                    ImGui.EndDragDropTarget();
+                }
+
+                if (ImGui.BeginPopupContextItem($"SectionContext##{section.Id}"))
+                {
+                    DrawSectionContext(section);
+                    ImGui.EndPopup();
+                }
+
+                ImGui.PopID();
+            }
+
+            if (ImGui.TabItemButton("+"))
+            {
+                OpenNewSectionPopup();
+            }
+            ImGui.EndTabBar();
+        }
+
+        if (!ImGui.IsMouseDown(ImGuiMouseButton.Left))
+        {
+            _draggingSectionId = null;
+        }
+
+        DrawNewSectionPopup();
+    }
+
+    private void DrawSectionContext(NotePadSection section)
+    {
+        if (!IsReadOnly && ImGui.MenuItem("Rename"))
+        {
+            _sectionRenameBuffers[section.Id] = section.Name;
+            ImGui.OpenPopup($"RenameSection##{section.Id}");
+        }
+
+        if (!IsReadOnly && ImGui.BeginPopup($"RenameSection##{section.Id}"))
+        {
+            var buffer = _sectionRenameBuffers.GetValueOrDefault(section.Id, section.Name);
+            if (ImGui.InputText("##SectionRename", ref buffer, 128, ImGuiInputTextFlags.EnterReturnsTrue))
+            {
+                _ = Task.Run(() => RenameSectionAsync(section.Id, buffer));
+                ImGui.CloseCurrentPopup();
+            }
+            _sectionRenameBuffers[section.Id] = buffer;
+
+            if (ImGui.Button("Save"))
+            {
+                _ = Task.Run(() => RenameSectionAsync(section.Id, buffer));
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Cancel"))
+            {
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.EndPopup();
+        }
+
+        if (!IsReadOnly && ImGui.MenuItem("Delete"))
+        {
+            _ = Task.Run(() => _service.DeleteSectionAsync(section.Id, CancellationToken.None));
+        }
+
+        if (ImGui.MenuItem("Copy Link"))
+        {
+            ImGui.SetClipboardText(section.Name);
+        }
+    }
+
+    private void DrawPageList(NotePadSection? section, NotePadPage? selectedPage)
+    {
+        if (section == null)
+        {
+            if (ImGui.Button("Create Section"))
+            {
+                OpenNewSectionPopup();
+            }
+            return;
+        }
+
+        DrawNewPagePopup(section);
+
+        if (!IsReadOnly && ImGui.Button("New Page"))
+        {
+            OpenNewPagePopup(section);
+        }
+
+        ImGui.Separator();
+
+        foreach (var page in section.Pages)
+        {
+            ImGui.PushID(page.Id);
+            var label = string.IsNullOrWhiteSpace(page.Title) ? "Untitled Page" : page.Title;
+            var isSelected = string.Equals(page.Id, _selectedPageId, StringComparison.Ordinal);
+            if (ImGui.Selectable(label, isSelected))
+            {
+                SelectPage(section.Id, page.Id);
+            }
+
+            if (ImGui.BeginDragDropSource())
+            {
+                _draggingPageId = page.Id;
+                ImGui.SetDragDropPayload("NotePadPage", IntPtr.Zero, 0);
+                ImGui.TextUnformatted(label);
+                ImGui.EndDragDropSource();
+            }
+
+            if (ImGui.BeginDragDropTarget())
+            {
+                var payload = ImGui.AcceptDragDropPayload("NotePadPage");
+                if (payload.NativePtr != null && !string.IsNullOrEmpty(_draggingPageId) &&
+                    !string.Equals(_draggingPageId, page.Id, StringComparison.Ordinal))
+                {
+                    ReorderPages(section, _draggingPageId, page.Id);
+                    _draggingPageId = null;
+                }
+                ImGui.EndDragDropTarget();
+            }
+
+            if (ImGui.BeginPopupContextItem("PageContext"))
+            {
+                DrawPageContext(section, page);
+                ImGui.EndPopup();
+            }
+
+            ImGui.PopID();
+        }
+
+        if (!ImGui.IsMouseDown(ImGuiMouseButton.Left))
+        {
+            _draggingPageId = null;
+        }
+    }
+
+    private void DrawPageContext(NotePadSection section, NotePadPage page)
+    {
+        if (!IsReadOnly && ImGui.MenuItem("Rename"))
+        {
+            _pageRenameBuffers[page.Id] = page.Title;
+            ImGui.OpenPopup($"RenamePage##{page.Id}");
+        }
+
+        if (!IsReadOnly && ImGui.BeginPopup($"RenamePage##{page.Id}"))
+        {
+            var buffer = _pageRenameBuffers.GetValueOrDefault(page.Id, page.Title);
+            if (ImGui.InputText("##PageRename", ref buffer, 128, ImGuiInputTextFlags.EnterReturnsTrue))
+            {
+                _ = Task.Run(() => RenamePageAsync(section.Id, page.Id, buffer));
+                ImGui.CloseCurrentPopup();
+            }
+            _pageRenameBuffers[page.Id] = buffer;
+
+            if (ImGui.Button("Save"))
+            {
+                _ = Task.Run(() => RenamePageAsync(section.Id, page.Id, buffer));
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Cancel"))
+            {
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.EndPopup();
+        }
+
+        if (!IsReadOnly && ImGui.MenuItem("Delete"))
+        {
+            _ = Task.Run(() => _service.DeletePageAsync(section.Id, page.Id, CancellationToken.None));
+        }
+
+        if (ImGui.MenuItem("Copy Link"))
+        {
+            ImGui.SetClipboardText(page.Title);
+        }
+    }
+
+    private void DrawEditor(NotePadSection? section, NotePadPage? page)
+    {
+        if (section == null || page == null)
+        {
+            ImGui.TextWrapped("Select a section and page to begin editing.");
+            return;
+        }
+
+        if (_pendingReload)
+        {
+            LoadPageContent(page);
+            _pendingReload = false;
+        }
+
+        DrawFormattingToolbar();
+
+        if (IsReadOnly)
+        {
+            var content = page.Content ?? string.Empty;
+            var readOnlyBuffer = ImGuiTextUtil.MakeUtf8Buffer(content, Math.Max(1024, content.Length + 512));
+            ImGui.BeginDisabled();
+            ImGui.InputTextMultiline("##NotePadEditorReadOnly", readOnlyBuffer, new Vector2(-1, -1), ImGuiInputTextFlags.ReadOnly);
+            ImGui.EndDisabled();
+            _editorContent = content;
+            _editorVersion = page.Version;
+            DrawPreview(content);
+            return;
+        }
+
+        var buffer = ImGuiTextUtil.MakeUtf8Buffer(_editorContent, Math.Max(1024, _editorContent.Length + 512));
+        if (_focusEditorNextFrame)
+        {
+            ImGui.SetKeyboardFocusHere();
+            _focusEditorNextFrame = false;
+        }
+
+        ImGui.PushItemWidth(-1);
+        var flags = ImGuiInputTextFlags.AllowTabInput | ImGuiInputTextFlags.CallbackAlways | ImGuiInputTextFlags.CallbackHistory;
+        var edited = ImGui.InputTextMultiline("##NotePadEditor", buffer, new Vector2(-1, -1), flags, new ImGui.ImGuiInputTextCallbackDelegate(OnEditorEdited));
+        ImGui.PopItemWidth();
+
+        var newValue = ImGuiTextUtil.ReadUtf8Buffer(buffer);
+        if (!string.Equals(newValue, _editorContent, StringComparison.Ordinal))
+        {
+            _editorContent = newValue;
+            _dirty = true;
+            _lastEditUtc = DateTime.UtcNow;
+        }
+
+        if (edited && ImGui.IsKeyPressed(ImGuiKey.Enter) && ImGui.GetIO().KeyCtrl)
+        {
+            _ = SavePageAsync(section.Id, page.Id, force: true);
+        }
+
+        DrawPreview(_editorContent);
+    }
+
+    private void DrawFormattingToolbar()
+    {
+        if (IsReadOnly)
+        {
+            return;
+        }
+
+        if (ImGui.SmallButton("B")) ApplyFormatting("**", "**");
+        ImGui.SameLine();
+        if (ImGui.SmallButton("I")) ApplyFormatting("*", "*");
+        ImGui.SameLine();
+        if (ImGui.SmallButton("U")) ApplyFormatting("__", "__");
+        ImGui.SameLine();
+        if (ImGui.SmallButton("Code")) ApplyFormatting("`", "`");
+        ImGui.SameLine();
+        if (ImGui.SmallButton("Quote")) ApplyFormatting("> ", string.Empty);
+        ImGui.SameLine();
+        if (ImGui.SmallButton("Link")) ApplyFormatting("[", "](url)");
+        ImGui.Spacing();
+    }
+
+    private void DrawConflictModal(NotePadPage? selectedPage)
+    {
+        if (_showConflictModal)
+        {
+            ImGui.OpenPopup("NotePadConflict");
+            _showConflictModal = false;
+        }
+
+        if (ImGui.BeginPopupModal("NotePadConflict", ImGuiWindowFlags.AlwaysAutoResize))
+        {
+            ImGui.TextWrapped(_conflictMessage);
+            ImGui.Separator();
+
+            if (ImGui.Button("Reload"))
+            {
+                if (_conflictServerPage != null)
+                {
+                    LoadPageContent(_conflictServerPage);
+                }
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Overwrite"))
+            {
+                if (_conflictSectionId != null && _conflictPageId != null)
+                {
+                    _ = SavePageAsync(_conflictSectionId, _conflictPageId, force: true, overwrite: true);
+                }
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Cancel"))
+            {
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.EndPopup();
+        }
+
+        if (selectedPage != null && !_dirty && !_pendingReload && !string.Equals(selectedPage.Content, _editorContent, StringComparison.Ordinal))
+        {
+            LoadPageContent(selectedPage);
+        }
+    }
+
+    private void DrawNewSectionPopup()
+    {
+        if (_showNewSectionPopup)
+        {
+            ImGui.OpenPopup("CreateSection");
+            _showNewSectionPopup = false;
+        }
+
+        if (ImGui.BeginPopup("CreateSection"))
+        {
+            ImGui.InputText("Name", ref _newSectionName, 128);
+            if (ImGui.Button("Create"))
+            {
+                var name = _newSectionName.Trim();
+                if (!string.IsNullOrEmpty(name))
+                {
+                    _ = Task.Run(async () =>
+                    {
+                        var section = await _service.CreateSectionAsync(name, "#4a5568", CancellationToken.None);
+                        if (section != null)
+                        {
+                            SelectSection(section.Id);
+                        }
+                    });
+                }
+                _newSectionName = string.Empty;
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Cancel"))
+            {
+                _newSectionName = string.Empty;
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.EndPopup();
+        }
+    }
+
+    private void DrawNewPagePopup(NotePadSection section)
+    {
+        if (_showNewPagePopup)
+        {
+            ImGui.OpenPopup("CreatePage");
+            _showNewPagePopup = false;
+        }
+
+        if (ImGui.BeginPopup("CreatePage"))
+        {
+            ImGui.InputText("Title", ref _newPageTitle, 128);
+            if (ImGui.Button("Create"))
+            {
+                var title = _newPageTitle.Trim();
+                if (!string.IsNullOrEmpty(title))
+                {
+                    _ = Task.Run(async () =>
+                    {
+                        var page = await _service.CreatePageAsync(section.Id, title, CancellationToken.None);
+                        if (page != null)
+                        {
+                            SelectPage(section.Id, page.Id);
+                        }
+                    });
+                }
+                _newPageTitle = string.Empty;
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Cancel"))
+            {
+                _newPageTitle = string.Empty;
+                ImGui.CloseCurrentPopup();
+            }
+            ImGui.EndPopup();
+        }
+    }
+
+    private void HandleAutosave()
+    {
+        if (IsReadOnly || !_dirty)
+        {
+            return;
+        }
+
+        if (DateTime.UtcNow - _lastEditUtc < _autosaveDelay)
+        {
+            return;
+        }
+
+        if (_selectedSectionId == null || _selectedPageId == null)
+        {
+            return;
+        }
+
+        _ = SavePageAsync(_selectedSectionId, _selectedPageId, force: false);
+    }
+
+    private void HandleKeyboardShortcuts()
+    {
+        var io = ImGui.GetIO();
+        if (!ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows))
+        {
+            return;
+        }
+
+        if (!IsReadOnly && io.KeyCtrl && ImGui.IsKeyPressed(ImGuiKey.N))
+        {
+            var section = _selectedSectionId;
+            if (section != null)
+            {
+                var actualSection = _service.Sections.FirstOrDefault(s => string.Equals(s.Id, section, StringComparison.Ordinal));
+                if (actualSection != null)
+                {
+                    OpenNewPagePopup(actualSection);
+                }
+            }
+            else
+            {
+                OpenNewSectionPopup();
+            }
+        }
+
+        if (!IsReadOnly && io.KeyCtrl && ImGui.IsKeyPressed(ImGuiKey.S))
+        {
+            if (_selectedSectionId != null && _selectedPageId != null)
+            {
+                _ = SavePageAsync(_selectedSectionId, _selectedPageId, force: true);
+            }
+        }
+    }
+
+    private void EnsureSectionSelection(IReadOnlyList<NotePadSection> sections)
+    {
+        if (_selectedSectionId != null && sections.Any(s => string.Equals(s.Id, _selectedSectionId, StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        _selectedSectionId = sections.FirstOrDefault()?.Id;
+        _config.NotePadLastSectionId = _selectedSectionId;
+        SaveConfig();
+        _pendingReload = true;
+    }
+
+    private void EnsurePageSelection(NotePadSection? section)
+    {
+        if (section == null)
+        {
+            _selectedPageId = null;
+            return;
+        }
+
+        if (_selectedPageId != null && section.Pages.Any(p => string.Equals(p.Id, _selectedPageId, StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        _selectedPageId = section.Pages.FirstOrDefault()?.Id;
+        _config.NotePadLastPageId = _selectedPageId;
+        SaveConfig();
+        _pendingReload = true;
+    }
+
+    private void SelectSection(string sectionId)
+    {
+        if (string.Equals(_selectedSectionId, sectionId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _selectedSectionId = sectionId;
+        _config.NotePadLastSectionId = sectionId;
+        _config.NotePadLastPageId = null;
+        SaveConfig();
+        _selectedPageId = null;
+        _pendingReload = true;
+    }
+
+    private void SelectPage(string sectionId, string pageId)
+    {
+        if (string.Equals(_selectedPageId, pageId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _selectedSectionId = sectionId;
+        _selectedPageId = pageId;
+        _config.NotePadLastSectionId = sectionId;
+        _config.NotePadLastPageId = pageId;
+        SaveConfig();
+        _pendingReload = true;
+    }
+
+    private void LoadPageContent(NotePadPage page)
+    {
+        _editorContent = page.Content ?? string.Empty;
+        _editorVersion = page.Version;
+        _dirty = false;
+        _focusEditorNextFrame = true;
+    }
+
+    private async Task SavePageAsync(string sectionId, string pageId, bool force, bool overwrite = false)
+    {
+        if (IsReadOnly)
+        {
+            return;
+        }
+
+        await _saveLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!_dirty && !force && !overwrite)
+            {
+                return;
+            }
+
+            var content = _editorContent;
+            var version = overwrite ? 0 : _editorVersion;
+            NotePadPage? result = null;
+            try
+            {
+                result = await _service.SavePageAsync(sectionId, pageId, new NotePadPageUpdate
+                {
+                    Content = content,
+                    Version = version
+                }, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (NotePadConflictException ex)
+            {
+                _conflictMessage = string.IsNullOrWhiteSpace(ex.Message)
+                    ? "The page has been updated elsewhere. Reload or overwrite?"
+                    : ex.Message;
+                _conflictSectionId = sectionId;
+                _conflictPageId = pageId;
+                _conflictServerPage = _service.Sections
+                    .SelectMany(s => s.Pages)
+                    .FirstOrDefault(p => string.Equals(p.Id, pageId, StringComparison.Ordinal));
+                _showConflictModal = true;
+                return;
+            }
+
+            if (result != null)
+            {
+                _editorVersion = result.Version;
+                _dirty = false;
+            }
+        }
+        finally
+        {
+            _saveLock.Release();
+        }
+    }
+
+    private async Task RenameSectionAsync(string sectionId, string name)
+    {
+        name = name.Trim();
+        if (string.IsNullOrEmpty(name))
+        {
+            PluginServices.Instance?.ToastGui.ShowWarning("Section name cannot be empty.");
+            return;
+        }
+
+        var success = await _service.RenameSectionAsync(sectionId, name, CancellationToken.None).ConfigureAwait(false);
+        if (success)
+        {
+            _config.NotePadLastSectionId = sectionId;
+            SaveConfig();
+        }
+    }
+
+    private async Task RenamePageAsync(string sectionId, string pageId, string title)
+    {
+        title = title.Trim();
+        if (string.IsNullOrEmpty(title))
+        {
+            PluginServices.Instance?.ToastGui.ShowWarning("Page title cannot be empty.");
+            return;
+        }
+
+        var success = await _service.RenamePageAsync(sectionId, pageId, title, CancellationToken.None).ConfigureAwait(false);
+        if (success)
+        {
+            _config.NotePadLastPageId = pageId;
+            SaveConfig();
+        }
+    }
+
+    private void ApplyFormatting(string prefix, string suffix)
+    {
+        if (IsReadOnly)
+        {
+            return;
+        }
+
+        var text = _editorContent;
+        MarkdownSelectionHelper.WrapSelection(ref text, prefix, suffix, ref _selectionStart, ref _selectionEnd);
+        _editorContent = text ?? string.Empty;
+        _dirty = true;
+        _lastEditUtc = DateTime.UtcNow;
+    }
+
+    private void DrawPreview(string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return;
+        }
+
+        ImGui.Spacing();
+        ImGui.Separator();
+        ImGui.TextColored(new Vector4(0.7f, 0.7f, 0.7f, 1f), "Formatted Preview");
+        ImGui.PushTextWrapPos();
+        ImGui.TextUnformatted(MarkdownFormatter.Format(content));
+        ImGui.PopTextWrapPos();
+    }
+
+    private int OnEditorEdited(ref ImGuiInputTextCallbackData data)
+    {
+        _selectionStart = data.SelectionStart;
+        _selectionEnd = data.SelectionEnd;
+        return 0;
+    }
+
+    private void ReorderSections(string fromId, string toId)
+    {
+        var order = _service.Sections.Select(s => s.Id).ToList();
+        var fromIndex = order.IndexOf(fromId);
+        var toIndex = order.IndexOf(toId);
+        if (fromIndex < 0 || toIndex < 0)
+        {
+            return;
+        }
+
+        var item = order[fromIndex];
+        order.RemoveAt(fromIndex);
+        order.Insert(toIndex, item);
+        _sectionOrder.Clear();
+        _sectionOrder.AddRange(order);
+        _sectionOrderDirty = true;
+    }
+
+    private void ReorderPages(NotePadSection section, string fromId, string toId)
+    {
+        var order = section.Pages.Select(p => p.Id).ToList();
+        var fromIndex = order.IndexOf(fromId);
+        var toIndex = order.IndexOf(toId);
+        if (fromIndex < 0 || toIndex < 0)
+        {
+            return;
+        }
+
+        var item = order[fromIndex];
+        order.RemoveAt(fromIndex);
+        order.Insert(toIndex, item);
+        section.Pages = section.Pages.OrderBy(p => order.IndexOf(p.Id)).ToList();
+        _pageOrderDirty = true;
+    }
+
+    private void SaveConfig()
+    {
+        PluginServices.Instance?.PluginInterface.SavePluginConfig(_config);
+    }
+
+    private static Vector4 ParseColor(string? color)
+    {
+        if (string.IsNullOrWhiteSpace(color) || color!.Length < 7 || color[0] != '#')
+        {
+            return new Vector4(0.29f, 0.33f, 0.39f, 1f);
+        }
+
+        try
+        {
+            var r = Convert.ToInt32(color.Substring(1, 2), 16) / 255f;
+            var g = Convert.ToInt32(color.Substring(3, 2), 16) / 255f;
+            var b = Convert.ToInt32(color.Substring(5, 2), 16) / 255f;
+            return new Vector4(r, g, b, 1f);
+        }
+        catch
+        {
+            return new Vector4(0.29f, 0.33f, 0.39f, 1f);
+        }
+    }
+
+    private void OpenNewSectionPopup()
+    {
+        if (IsReadOnly)
+        {
+            PluginServices.Instance?.ToastGui.ShowWarning("You do not have permission to create sections.");
+            return;
+        }
+
+        _showNewSectionPopup = true;
+        _newSectionName = string.Empty;
+    }
+
+    private void OpenNewPagePopup(NotePadSection section)
+    {
+        if (IsReadOnly)
+        {
+            PluginServices.Instance?.ToastGui.ShowWarning("You do not have permission to create pages.");
+            return;
+        }
+
+        _showNewPagePopup = true;
+        _newPageTitle = string.Empty;
+    }
+
+    private void HandleServiceChanged()
+    {
+        var framework = PluginServices.Instance?.Framework;
+        if (framework != null)
+        {
+            _ = framework.RunOnTick(ApplyServiceChange);
+        }
+        else
+        {
+            ApplyServiceChange();
+        }
+    }
+
+    private void ApplyServiceChange()
+    {
+        var sections = _service.Sections;
+        if (_selectedSectionId != null && !sections.Any(s => string.Equals(s.Id, _selectedSectionId, StringComparison.Ordinal)))
+        {
+            _selectedSectionId = null;
+        }
+
+        if (_selectedPageId != null)
+        {
+            var hasPage = sections.Any(s => s.Pages.Any(p => string.Equals(p.Id, _selectedPageId, StringComparison.Ordinal)));
+            if (!hasPage)
+            {
+                _selectedPageId = null;
+            }
+        }
+
+        _pendingReload = true;
+        _sectionOrder.Clear();
+        _sectionOrder.AddRange(sections.Select(s => s.Id));
+    }
+
+    private static Vector4 AdjustTabColor(Vector4 color, float multiplier)
+    {
+        return new Vector4(
+            Math.Clamp(color.X * multiplier, 0f, 1f),
+            Math.Clamp(color.Y * multiplier, 0f, 1f),
+            Math.Clamp(color.Z * multiplier, 0f, 1f),
+            1f);
+    }
+}

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -44,6 +44,8 @@ public class Plugin : IDalamudPlugin
     private readonly MainWindow _mainWindow;
     private readonly ChannelWatcher _channelWatcher;
     private readonly RequestWatcher _requestWatcher;
+    private readonly NotePadService _notePadService;
+    private readonly NotePadWindow _notePadWindow;
     private readonly ChannelSelectionService _channelSelection;
     private readonly EmojiManager _emojiManager;
 
@@ -106,6 +108,9 @@ public class Plugin : IDalamudPlugin
 
         _presenceService?.Reset();
 
+        _notePadService = new NotePadService(_config, _httpClient, _tokenManager);
+        _notePadWindow = new NotePadWindow(_config, _notePadService);
+
         _mainWindow = new MainWindow(
             _config,
             _ui,
@@ -115,7 +120,8 @@ public class Plugin : IDalamudPlugin
             _httpClient,
             _channelService,
             _channelSelection,
-            _emojiManager
+            _emojiManager,
+            _notePadWindow
         );
 
         _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _mainWindow.TemplatesWindow, _chatWindow, _officerChatWindow, _tokenManager, _httpClient);
@@ -128,6 +134,7 @@ public class Plugin : IDalamudPlugin
         _settings.OfficerChatWindow = _officerChatWindow;
         _settings.ChannelWatcher = _channelWatcher;
         _settings.RequestWatcher = _requestWatcher;
+        _settings.NotePadService = _notePadService;
 
         _mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
 
@@ -194,6 +201,8 @@ public class Plugin : IDalamudPlugin
 
         _channelWatcher.Dispose();
         _requestWatcher.Dispose();
+        _notePadWindow.Dispose();
+        _notePadService.Dispose();
         _presenceService?.Dispose();
         _chatWindow.Dispose();
         _officerChatWindow.Dispose();
@@ -709,6 +718,12 @@ public class Plugin : IDalamudPlugin
             _ = _channelWatcher.Start();
         }
 
+        if (_config.NotePadEnabled)
+        {
+            _services.Log.Info("Starting notepad service");
+            _notePadService.Start();
+        }
+
         if (_config.SyncedChat && _config.EnableFcChat)
         {
             _services.Log.Info("Starting chat window networking");
@@ -823,6 +838,7 @@ public class Plugin : IDalamudPlugin
         _services.Log.Info("Stopping watchers");
         _requestWatcher.Stop();
         _channelWatcher.Stop();
+        _notePadService.Stop();
         _chatWindow.StopNetworking();
         _officerChatWindow.StopNetworking();
         _officerWatcherRunning = false;

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -43,6 +43,7 @@ public class SettingsWindow : IDisposable
     public OfficerChatWindow? OfficerChatWindow { get; set; }
     public ChannelWatcher? ChannelWatcher { get; set; }
     public RequestWatcher? RequestWatcher { get; set; }
+    public NotePadService? NotePadService { get; set; }
 
     public SettingsWindow(Config config, TokenManager tokenManager, HttpClient httpClient, Func<Task<bool>> refreshRoles, Func<Task> startNetworking, IPluginLog log, IDalamudPluginInterface pluginInterface)
     {
@@ -692,6 +693,7 @@ public class SettingsWindow : IDisposable
             }
         }, "Failed to stop ChannelWatcher.");
         SafeInvoke(() => RequestWatcher?.Stop(), "Failed to stop RequestWatcher.");
+        SafeInvoke(() => NotePadService?.Stop(), "Failed to stop NotePad service.");
         SafeInvoke(() =>
         {
             var presence = ChatWindow?.Presence ?? OfficerChatWindow?.Presence;
@@ -770,6 +772,8 @@ public class SettingsWindow : IDisposable
         _config.Categories.Clear();
         _config.AutoApply.Clear();
         _config.PenumbraChoices.Clear();
+        _config.NotePadLastSectionId = null;
+        _config.NotePadLastPageId = null;
 
         _categoryToggles.Clear();
 
@@ -938,6 +942,18 @@ public class SettingsWindow : IDisposable
             catch (Exception ex)
             {
                 _log.Error(ex, "Failed to start RequestWatcher during hard reload.");
+            }
+
+            try
+            {
+                if (_config.NotePadEnabled)
+                {
+                    NotePadService?.Start();
+                }
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Failed to start NotePad service during hard reload.");
             }
 
             try

--- a/tests/PluginChannelValidationTests.cs
+++ b/tests/PluginChannelValidationTests.cs
@@ -67,6 +67,8 @@ public class PluginChannelValidationTests
         var requestWatcher = new RequestWatcher(config, httpClient, tokenManager);
         var chatWindow = new ChatWindow(config, httpClient, null, tokenManager, channelService);
         var officerChatWindow = new OfficerChatWindow(config, httpClient, null, tokenManager, channelService);
+        var notePadService = new NotePadService(config, httpClient, tokenManager);
+        var notePadWindow = new NotePadWindow(config, notePadService);
         var settingsWindow = new SettingsWindow(
             config,
             tokenManager,
@@ -76,6 +78,7 @@ public class PluginChannelValidationTests
             logMock.Object,
             pluginInterfaceMock.Object
         );
+        settingsWindow.NotePadService = notePadService;
         var mainWindow = new MainWindow(
             config,
             ui,
@@ -85,7 +88,8 @@ public class PluginChannelValidationTests
             httpClient,
             channelService,
             channelSelection,
-            emojiManager
+            emojiManager,
+            notePadWindow
         );
         var channelWatcher = new ChannelWatcher(
             config,
@@ -118,6 +122,8 @@ public class PluginChannelValidationTests
         SetPrivateField(plugin, "_mainWindow", mainWindow);
         SetPrivateField(plugin, "_channelWatcher", channelWatcher);
         SetPrivateField(plugin, "_requestWatcher", requestWatcher);
+        SetPrivateField(plugin, "_notePadService", notePadService);
+        SetPrivateField(plugin, "_notePadWindow", notePadWindow);
 
         PingService.Instance = new PingService(httpClient, config, tokenManager);
 

--- a/tests/SyncshellTabToggleTests.cs
+++ b/tests/SyncshellTabToggleTests.cs
@@ -18,7 +18,9 @@ public class SyncshellTabToggleTests
         var ui = new UiRenderer(cfg, http, selection);
         var officer = new OfficerChatWindow(cfg, http, null, token, channelService, selection);
         var settings = (SettingsWindow)FormatterServices.GetUninitializedObject(typeof(SettingsWindow));
-        var main = new MainWindow(cfg, ui, null, officer, settings, http, channelService, selection, () => Task.FromResult(true));
+        var notePadService = new NotePadService(cfg, http, token);
+        var notePadWindow = new NotePadWindow(cfg, notePadService);
+        var main = new MainWindow(cfg, ui, null, officer, settings, http, channelService, selection, () => Task.FromResult(true), notePadWindow);
 
         Assert.Null(SyncshellWindow.Instance);
 


### PR DESCRIPTION
## Summary
- extend the plugin configuration to persist NotePad settings and migrate existing profiles
- add a NotePad service/window pair that handles REST/websocket operations, autosave, and read-only conflict workflows
- integrate the NotePad tab into the main window, plugin lifecycle, and settings reload paths while updating affected tests

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj -c Release *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da69e4c860832884d5a020ae5106e5