### PR TITLE
Handle deleted notepad pages when reordering

### DIFF
--- a/demibot/demibot/http/routes/notepad.py
+++ b/demibot/demibot/http/routes/notepad.py
@@ -446,8 +446,24 @@ async def reorder_pages(
             continue
         final_orders.setdefault(page.section_id, []).append(page.id)
 
+    affected_section_ids = {sid for sid in final_orders if sid in section_map}
+    deleted_pages: list[NotePage] = []
+    if affected_section_ids:
+        result = await db.execute(
+            select(NotePage).where(
+                NotePage.guild_id == ctx.guild.id,
+                NotePage.section_id.in_(affected_section_ids),
+                NotePage.is_deleted.is_(True),
+            )
+        )
+        deleted_pages = result.scalars().all()
+
+    max_sort_order = await db.scalar(
+        select(func.max(NotePage.sort_order)).where(NotePage.guild_id == ctx.guild.id)
+    )
+    next_temp_order = (max_sort_order if max_sort_order is not None else -1) + 1
+
     temp_page_updates: list[tuple[NotePage, int]] = []
-    total_pages = len(pages)
     for section_id, ids in final_orders.items():
         if section_id not in section_map:
             continue
@@ -461,8 +477,21 @@ async def reorder_pages(
             if page.sort_order != index:
                 changed = True
             if changed:
-                page.sort_order = total_pages + len(temp_page_updates)
+                page.sort_order = next_temp_order
+                next_temp_order += 1
                 temp_page_updates.append((page, index))
+
+    deleted_offsets: dict[int, int] = {}
+    for page in sorted(deleted_pages, key=lambda p: (p.section_id, p.sort_order, p.id)):
+        active_count = len(final_orders.get(page.section_id, []))
+        offset = deleted_offsets.get(page.section_id, 0)
+        deleted_offsets[page.section_id] = offset + 1
+        target_index = active_count + offset
+        if page.sort_order != target_index:
+            page.sort_order = next_temp_order
+            next_temp_order += 1
+            temp_page_updates.append((page, target_index))
+
     if temp_page_updates:
         await db.flush()
         for page, index in temp_page_updates:

--- a/tests/test_notepad_routes.py
+++ b/tests/test_notepad_routes.py
@@ -180,6 +180,22 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
     async with get_session() as db:
         await notepad.delete_page(page_id=page2.id, ctx=ctx_officer, db=db)
 
+    reorder_after_delete = NotePageReorderBody(
+        sections=[
+            NotePageReorderEntry(sectionId=section2.id, pageIds=[]),
+            NotePageReorderEntry(sectionId=section.id, pageIds=[page.id]),
+        ]
+    )
+    async with get_session() as db:
+        post_delete_state = await notepad.reorder_pages(
+            body=reorder_after_delete,
+            ctx=ctx_officer,
+            db=db,
+        )
+    sections_after_delete = {s.id: s for s in post_delete_state.sections}
+    assert sections_after_delete[section.id].pages[0].id == page.id
+    assert sections_after_delete[section2.id].pages == []
+
     async with get_session() as db:
         await notepad.delete_section(section_id=section.id, ctx=ctx_officer, db=db)
 


### PR DESCRIPTION
## Summary
- move soft-deleted notepad pages beyond the active ordering before compacting survivors
- update version metadata when page order changes
- extend the notepad route test flow to cover reordering after a deletion

## Testing
- pytest tests/test_notepad_routes.py *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68da6f1769188328ba650b16e58c1e95