### PR TITLE
Add NotePad documentation and sync tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ DemiCat/
 - **Events** – Browse and RSVP to Apollo events from within FFXIV.
 - **Create** – Draft new events without leaving the game.
 - **Templates** – Save and reuse preset event layouts.
+- **NotePad** – Organize guild knowledge in OneNote-style sections and pages. Officers can create and reorder sections while members browse the latest autosaved content.
 - **Request Board** – Track signup requests and interest.
 - **SyncShell** – Work-in-progress replacement for the Mare Synchronos mod-sharing plugin. Syncs Penumbra mod lists to replicate player appearances and is disabled by default while under development (see `DemiCatPlugin/SyncshellWindow.cs`).
 - **FC Chat** – Mirror Discord conversations directly in game.
@@ -29,6 +30,14 @@ DemiCat/
 - Delta tokens for incremental sync (`demibot/demibot/http/routes/delta_token.py`).
 - User settings endpoints (`demibot/demibot/http/routes/user_settings.py`).
 - Privacy and data controls (`demibot/demibot/http/routes/users.py`).
+
+### NotePad tab
+
+The NotePad tab mirrors the familiar OneNote hierarchy: sections contain ordered pages, each with its own color, metadata, and version number. Officers (users with the `officer` role on their API key) can create, rename, delete, or reorder sections and pages, while everyone else sees a read-only view that stays in sync with DemiBot. The plugin autosaves edits after a short debounce or when pressing **Ctrl+S**, and it records your last section/page so the same note reopens on launch.
+
+Each save sends the current `version` to the backend. If another editor has already changed the page, DemiBot returns HTTP 409 and the plugin surfaces a conflict dialog so you can reload or overwrite the remote copy. All mutations broadcast through the `/ws/notepad` websocket so connected clients update immediately, even across multiple characters or officers editing simultaneously.
+
+To enable editing, ensure the plugin configuration keeps `notePadEnabled` true (the default) and that the linked API key belongs to an officer.
 
 ## Prerequisites
 

--- a/demibot/README.md
+++ b/demibot/README.md
@@ -48,3 +48,10 @@ python -m demibot.main
 The Discord bot requires the `GUILD_MESSAGES` and `GUILD_MEMBERS` intents.
 After obtaining an API key, the plugin wizard can configure channels via
 the `/api/channels` endpoint.
+
+## Notepad API
+
+DemiBot exposes `/api/notepad` for listing sections and pages plus mutation endpoints for creating, renaming, deleting, and reordering content. All write operations require an API key tied to an officer role, while any linked user may read the current state.
+
+Real-time updates stream over `/ws/notepad`; the payloads mirror the REST responses so the Dalamud plugin and any other clients stay synchronized. Each page update carries a `version` field—send it back when saving to perform optimistic concurrency checks. If the stored version is newer, the API returns HTTP 409 so the client can surface a conflict dialog or refresh before overwriting remote changes.
+

--- a/tests/NotePadWindowTests.cs
+++ b/tests/NotePadWindowTests.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DemiCatPlugin;
+using Xunit;
+
+public class NotePadWindowTests
+{
+    [Fact]
+    public void ReorderSections_RebuildsOrderAndMarksDirty()
+    {
+        using var fixture = new NotePadWindowFixture();
+        var method = typeof(NotePadWindow).GetMethod(
+            "ReorderSections",
+            BindingFlags.Instance | BindingFlags.NonPublic) ?? throw new InvalidOperationException();
+
+        method.Invoke(fixture.Window, new object[] { "s3", "s1" });
+
+        var order = (List<string>)typeof(NotePadWindow)
+            .GetField("_sectionOrder", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(fixture.Window)!;
+        var dirty = (bool)typeof(NotePadWindow)
+            .GetField("_sectionOrderDirty", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(fixture.Window)!;
+
+        Assert.Equal(new[] { "s3", "s1", "s2" }, order);
+        Assert.True(dirty);
+    }
+
+    [Fact]
+    public void ReorderPages_ReordersInPlaceAndFlagsDirty()
+    {
+        using var fixture = new NotePadWindowFixture();
+        var section = fixture.Service.Sections.First(s => s.Id == "s1");
+
+        var method = typeof(NotePadWindow).GetMethod(
+            "ReorderPages",
+            BindingFlags.Instance | BindingFlags.NonPublic) ?? throw new InvalidOperationException();
+
+        method.Invoke(fixture.Window, new object[] { section, "p3", "p1" });
+
+        Assert.Equal(new[] { "p3", "p1", "p2" }, section.Pages.Select(p => p.Id));
+        var dirty = (bool)typeof(NotePadWindow)
+            .GetField("_pageOrderDirty", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(fixture.Window)!;
+        Assert.True(dirty);
+    }
+
+    [Fact]
+    public async Task HandleAutosave_SendsSaveRequestAfterDelay()
+    {
+        using var fixture = new NotePadWindowFixture();
+        fixture.Handler.Responder = request =>
+        {
+            var payload = JsonSerializer.Serialize(new NotePadPage
+            {
+                Id = "p1",
+                Title = "Notes",
+                Content = "Updated",
+                Version = 2,
+                UpdatedAt = DateTimeOffset.UtcNow,
+            });
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json")
+            };
+        };
+
+        fixture.SetSelection("s1", "p1");
+        fixture.SetEditorState(content: "Updated", version: 1, dirty: true, lastEditUtc: DateTime.UtcNow.AddSeconds(-10));
+
+        var method = typeof(NotePadWindow).GetMethod(
+            "HandleAutosave",
+            BindingFlags.Instance | BindingFlags.NonPublic) ?? throw new InvalidOperationException();
+
+        method.Invoke(fixture.Window, Array.Empty<object>());
+
+        var request = await fixture.Handler.WaitForRequestAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(HttpMethod.Put, request.Method);
+        Assert.Contains("/api/notepad/sections/s1/pages/p1", request.RequestUri!.ToString());
+
+        await fixture.WaitForDirtyFlagAsync(expectedDirty: false);
+        var currentVersion = (int)typeof(NotePadWindow)
+            .GetField("_editorVersion", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(fixture.Window)!;
+        Assert.Equal(2, currentVersion);
+    }
+
+    [Fact]
+    public async Task HandleAutosave_ReadOnlySkipsSaves()
+    {
+        using var fixture = new NotePadWindowFixture();
+        fixture.Window.IsReadOnly = true;
+        fixture.SetSelection("s1", "p1");
+        fixture.SetEditorState(content: "Updated", version: 1, dirty: true, lastEditUtc: DateTime.UtcNow.AddSeconds(-10));
+
+        var method = typeof(NotePadWindow).GetMethod(
+            "HandleAutosave",
+            BindingFlags.Instance | BindingFlags.NonPublic) ?? throw new InvalidOperationException();
+
+        method.Invoke(fixture.Window, Array.Empty<object>());
+
+        await Task.Delay(50);
+        Assert.Empty(fixture.Handler.Requests);
+        var dirty = (bool)typeof(NotePadWindow)
+            .GetField("_dirty", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(fixture.Window)!;
+        Assert.True(dirty);
+    }
+
+    [Fact]
+    public async Task HandleAutosave_WithRecentEditDoesNotSave()
+    {
+        using var fixture = new NotePadWindowFixture();
+        fixture.SetSelection("s1", "p1");
+        fixture.SetEditorState(content: "Updated", version: 1, dirty: true, lastEditUtc: DateTime.UtcNow);
+
+        var method = typeof(NotePadWindow).GetMethod(
+            "HandleAutosave",
+            BindingFlags.Instance | BindingFlags.NonPublic) ?? throw new InvalidOperationException();
+
+        method.Invoke(fixture.Window, Array.Empty<object>());
+
+        await Task.Delay(50);
+        Assert.Empty(fixture.Handler.Requests);
+    }
+
+    private sealed class NotePadWindowFixture : IDisposable
+    {
+        public Config Config { get; }
+        public NotePadService Service { get; }
+        public NotePadWindow Window { get; }
+        public TestHttpMessageHandler Handler { get; }
+
+        public NotePadWindowFixture()
+        {
+            Config = new Config();
+            Handler = new TestHttpMessageHandler();
+            Service = new NotePadService(Config, new HttpClient(Handler), new TokenManager());
+
+            var sections = new List<NotePadSection>
+            {
+                new()
+                {
+                    Id = "s1",
+                    Name = "Alpha",
+                    Pages = new List<NotePadPage>
+                    {
+                        new()
+                        {
+                            Id = "p1",
+                            Title = "Notes",
+                            Content = "Initial",
+                            Version = 1,
+                            UpdatedAt = DateTimeOffset.UtcNow
+                        },
+                        new()
+                        {
+                            Id = "p2",
+                            Title = "Todo",
+                            Content = "Items",
+                            Version = 1,
+                            UpdatedAt = DateTimeOffset.UtcNow
+                        },
+                        new()
+                        {
+                            Id = "p3",
+                            Title = "Archive",
+                            Content = "Old",
+                            Version = 1,
+                            UpdatedAt = DateTimeOffset.UtcNow
+                        }
+                    }
+                },
+                new()
+                {
+                    Id = "s2",
+                    Name = "Beta",
+                    Pages = new List<NotePadPage>
+                    {
+                        new()
+                        {
+                            Id = "p4",
+                            Title = "Log",
+                            Content = "",
+                            Version = 0,
+                            UpdatedAt = DateTimeOffset.UtcNow
+                        }
+                    }
+                },
+                new()
+                {
+                    Id = "s3",
+                    Name = "Gamma",
+                    Pages = new List<NotePadPage>()
+                }
+            };
+
+            var sectionsField = typeof(NotePadService).GetField("_sections", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("_sections field not found");
+            sectionsField.SetValue(Service, sections);
+
+            Window = new NotePadWindow(Config, Service);
+        }
+
+        public void Dispose()
+        {
+            Window.Dispose();
+        }
+
+        public void SetSelection(string sectionId, string pageId)
+        {
+            typeof(NotePadWindow).GetField("_selectedSectionId", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(Window, sectionId);
+            typeof(NotePadWindow).GetField("_selectedPageId", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(Window, pageId);
+        }
+
+        public void SetEditorState(string content, int version, bool dirty, DateTime lastEditUtc)
+        {
+            typeof(NotePadWindow).GetField("_editorContent", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(Window, content);
+            typeof(NotePadWindow).GetField("_editorVersion", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(Window, version);
+            typeof(NotePadWindow).GetField("_dirty", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(Window, dirty);
+            typeof(NotePadWindow).GetField("_lastEditUtc", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(Window, lastEditUtc);
+        }
+
+        public async Task WaitForDirtyFlagAsync(bool expectedDirty)
+        {
+            var dirtyField = typeof(NotePadWindow).GetField("_dirty", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var timeout = DateTime.UtcNow.AddMilliseconds(200);
+            while (DateTime.UtcNow < timeout)
+            {
+                if ((bool)dirtyField.GetValue(Window)! == expectedDirty)
+                {
+                    return;
+                }
+
+                await Task.Delay(10);
+            }
+
+            Assert.Equal(expectedDirty, (bool)dirtyField.GetValue(Window)!);
+        }
+    }
+
+    public sealed class TestHttpMessageHandler : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = new();
+        public Func<HttpRequestMessage, HttpResponseMessage>? Responder { get; set; }
+        private TaskCompletionSource<HttpRequestMessage>? _tcs;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            _tcs?.TrySetResult(request);
+
+            if (Responder != null)
+            {
+                return Task.FromResult(Responder(request));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+
+        public Task<HttpRequestMessage> WaitForRequestAsync(TimeSpan timeout)
+        {
+            _tcs = new TaskCompletionSource<HttpRequestMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (Requests.Count > 0)
+            {
+                _tcs.TrySetResult(Requests.Last());
+            }
+
+            return Task.WhenAny(_tcs.Task, Task.Delay(timeout))
+                .ContinueWith(task =>
+                {
+                    if (_tcs.Task.IsCompletedSuccessfully)
+                    {
+                        return _tcs.Task.Result;
+                    }
+
+                    throw new TimeoutException("Timed out waiting for HTTP request");
+                }, TaskScheduler.Default);
+        }
+    }
+}

--- a/tests/test_notepad_sync.py
+++ b/tests/test_notepad_sync.py
@@ -1,0 +1,157 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+# Setup module paths identical to other websocket sync tests
+root = Path(__file__).resolve().parents[1] / "demibot"
+sys.path.append(str(root))
+
+# Package stubs for namespace packages when running without installation
+demibot_pkg = types.ModuleType("demibot")
+demibot_pkg.__path__ = [str(root / "demibot")]
+sys.modules.setdefault("demibot", demibot_pkg)
+http_pkg = types.ModuleType("demibot.http")
+http_pkg.__path__ = [str(root / "demibot/http")]
+sys.modules.setdefault("demibot.http", http_pkg)
+
+deps_pkg = types.ModuleType("demibot.http.deps")
+
+
+class RequestContext:
+    def __init__(self, guild, user, roles):
+        self.guild = guild
+        self.user = user
+        self.roles = roles
+
+
+def api_key_auth(*args, **kwargs):  # pragma: no cover - unused but kept for parity
+    pass
+
+async def get_db(*args, **kwargs):
+    if False:
+        yield None
+
+
+deps_pkg.RequestContext = RequestContext
+deps_pkg.api_key_auth = api_key_auth
+deps_pkg.get_db = get_db
+sys.modules.setdefault("demibot.http.deps", deps_pkg)
+
+# Minimal discord stub for modules that expect discord.py
+sys.modules.setdefault("discord", types.ModuleType("discord"))
+
+import pytest
+
+from demibot.http.ws import ConnectionManager
+from demibot.http.routes import notepad
+from demibot.db.models import Guild, User
+from demibot.db.session import get_session, init_db
+from demibot.http.schemas import (
+    NotePageContentBody,
+    NotePageCreateBody,
+    NoteSectionCreateBody,
+)
+
+
+class StubWebSocket:
+    def __init__(self, path: str):
+        self.scope = {"path": path}
+        self.sent: list[str] = []
+
+    async def accept(self) -> None:
+        pass
+
+    async def send_text(self, message: str) -> None:
+        self.sent.append(message)
+
+    async def ping(self) -> None:  # pragma: no cover - compatibility shim
+        return None
+
+
+class StubContext:
+    def __init__(self, guild_id: int, user_id: int, roles: list[str]):
+        self.guild = types.SimpleNamespace(id=guild_id)
+        self.user = types.SimpleNamespace(id=user_id)
+        self.roles = roles
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_notepad_sync_and_conflict_flow(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "notepad_sync.db"
+    await init_db(f"sqlite+aiosqlite:///{db_path}")
+
+    async with get_session() as db:
+        guild = Guild(id=1, discord_guild_id=1, name="Guild")
+        user = User(id=1, discord_user_id=42, global_name="Officer")
+        db.add_all([guild, user])
+        await db.commit()
+
+    manager = ConnectionManager()
+    monkeypatch.setattr(notepad, "manager", manager)
+
+    ws_member = StubWebSocket("/ws/notepad")
+    ws_officer = StubWebSocket("/ws/notepad")
+    await manager.connect(ws_member, StubContext(1, 2, roles=[]))
+    await manager.connect(ws_officer, StubContext(1, 1, roles=["officer"]))
+
+    ctx_member = StubContext(1, 2, roles=[])
+    ctx_officer = StubContext(1, 1, roles=["officer"])
+
+    async with get_session() as db:
+        section = await notepad.create_section(
+            body=NoteSectionCreateBody(name="Raid", color=0x123456),
+            ctx=ctx_officer,
+            db=db,
+        )
+
+    assert len(ws_member.sent) == 1
+    assert json.loads(ws_member.sent[-1])["topic"] == "notepad.section.created"
+    assert ws_member.sent[-1] == ws_officer.sent[-1]
+
+    async with get_session() as db:
+        page = await notepad.create_page(
+            body=NotePageCreateBody(sectionId=section.id, title="Notes", content="Initial"),
+            ctx=ctx_officer,
+            db=db,
+        )
+
+    assert len(ws_member.sent) == 2
+    assert json.loads(ws_member.sent[-1])["topic"] == "notepad.page.created"
+
+    async with get_session() as db:
+        updated = await notepad.update_page_content(
+            page_id=page.id,
+            body=NotePageContentBody(content="Revised", version=page.version),
+            ctx=ctx_officer,
+            db=db,
+        )
+
+    assert len(ws_officer.sent) == 3
+    assert json.loads(ws_officer.sent[-1])["topic"] == "notepad.page.updated"
+
+    stale_version = page.version
+    async with get_session() as db:
+        with pytest.raises(Exception) as excinfo:
+            await notepad.update_page_content(
+                page_id=page.id,
+                body=NotePageContentBody(content="Stale", version=stale_version),
+                ctx=ctx_officer,
+                db=db,
+            )
+    assert getattr(excinfo.value, "status_code", None) == 409
+
+    # Conflict should not broadcast a new websocket payload
+    assert len(ws_member.sent) == 3
+    assert ws_member.sent == ws_officer.sent
+
+    # Members can still read updated state
+    async with get_session() as db:
+        state = await notepad.list_notepad(ctx=ctx_member, db=db)
+    assert state.sections[0].pages[0].content == "Revised"
+    assert state.sections[0].pages[0].version == updated.version

--- a/tests/test_templates_sync.py
+++ b/tests/test_templates_sync.py
@@ -24,16 +24,16 @@ class RequestContext:
         self.roles = roles
 async def api_key_auth(*args, **kwargs):
     pass
+
+async def get_db(*args, **kwargs):
+    yield None
 deps_pkg.RequestContext = RequestContext
 deps_pkg.api_key_auth = api_key_auth
+deps_pkg.get_db = get_db
 sys.modules.setdefault("demibot.http.deps", deps_pkg)
 
-# Minimal discord/fastapi stubs
+# Minimal discord stub
 sys.modules.setdefault("discord", types.ModuleType("discord"))
-fastapi_stub = types.ModuleType("fastapi")
-fastapi_stub.WebSocket = type("WebSocket", (), {})
-fastapi_stub.WebSocketDisconnect = type("WebSocketDisconnect", (Exception,), {})
-sys.modules.setdefault("fastapi", fastapi_stub)
 
 from demibot.http.ws import ConnectionManager
 from demibot.http.routes import templates


### PR DESCRIPTION
## Summary
- document the NotePad tab workflow, permissions, and sync behavior in the top-level README and the demibot backend README
- extend the notepad test coverage with a websocket sync and conflict test while keeping the existing template sync harness working without FastAPI
- add C# unit tests around NotePadWindow section/page ordering and autosave logic, including read-only safeguards

## Testing
- pytest tests/test_templates_sync.py tests/test_notepad_sync.py tests/test_notepad_routes.py tests/test_notepad_ws.py
- dotnet test tests/DemiCatPlugin.Tests.csproj --filter NotePadWindowTests *(fails: Dalamud.NET.Sdk expects a Dalamud installation path in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68da710088548328836df106993b574b