### PR TITLE
Remove unused NotePad tab flag to silence warning

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -20,7 +20,6 @@ public class MainWindow : IDisposable
     private SyncshellWindow? _syncshell;
     private bool _syncshellEnabled;
     private bool _templatesTabActive;
-    private bool _notePadTabActive;
     private bool _fcChatTabActive;
     private bool _officerTabActive;
     private readonly HttpClient _httpClient;
@@ -275,7 +274,6 @@ public class MainWindow : IDisposable
 
                 if (!linked)
                 {
-                    _notePadTabActive = false;
                     ImGui.BeginDisabled();
                     ImGui.TabItemButton("NotePad");
                     ImGui.EndDisabled();
@@ -293,15 +291,10 @@ public class MainWindow : IDisposable
                             childBaseColor,
                             1f);
 
-                        _notePadTabActive = true;
                         _notePad.Draw();
                         ImGui.EndTabItem();
 
                         PopWindowAlphaOnly(alphaOverrideState);
-                    }
-                    else
-                    {
-                        _notePadTabActive = false;
                     }
                 }
 


### PR DESCRIPTION
## Summary
- remove the unused NotePad tab tracking field and its assignments to resolve the CS0414 build warning

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68da77d50ed48328a204370deb4d8b19