### PR TITLE
Ensure note page content defaults are handled in application layer

### DIFF
--- a/demibot/demibot/db/migrations/versions/0053_add_notepad_tables.py
+++ b/demibot/demibot/db/migrations/versions/0053_add_notepad_tables.py
@@ -51,7 +51,7 @@ def upgrade() -> None:
         sa.Column("guild_id", sa.Integer(), nullable=False),
         sa.Column("section_id", sa.Integer(), nullable=False),
         sa.Column("title", sa.String(length=255), nullable=False),
-        sa.Column("content", sa.Text(), nullable=False, server_default=""),
+        sa.Column("content", sa.Text(), nullable=False),
         sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("color", sa.Integer(), nullable=True),
         sa.Column("created_by_id", mysql.BIGINT(unsigned=True), nullable=True),

--- a/demibot/demibot/http/routes/notepad.py
+++ b/demibot/demibot/http/routes/notepad.py
@@ -328,7 +328,7 @@ async def create_page(
         guild_id=ctx.guild.id,
         section_id=section.id,
         title=body.title,
-        content=body.content,
+        content=body.content or "",
         color=body.color,
         sort_order=next_order,
         created_by_id=ctx.user.id,


### PR DESCRIPTION
## Summary
- drop the server-side default from the note_pages.content column in migration 0053
- make note page creation explicitly coerce missing content values to an empty string

## Testing
- pytest tests/test_notepad_routes.py *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68da7a4370c883289045112275971762