### PR TITLE
Allow linked members to edit Notepad

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -38,8 +38,11 @@ public class MainWindow : IDisposable
         set
         {
             _hasOfficerAccess = value;
-            _notePad.IsReadOnly = !value;
         }
+    }
+    public void SetNotePadReadOnly(bool isReadOnly)
+    {
+        _notePad.IsReadOnly = isReadOnly;
     }
     public UiRenderer Ui => _ui;
     public EventCreateWindow EventCreateWindow => _create;

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -137,6 +137,7 @@ public class Plugin : IDalamudPlugin
         _settings.NotePadService = _notePadService;
 
         _mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
+        _mainWindow.SetNotePadReadOnly(!_tokenManager.IsReady());
 
         _ = RoleCache.EnsureLoaded(_httpClient, _config);
 
@@ -627,6 +628,7 @@ public class Plugin : IDalamudPlugin
     {
         _invalidTokenToastShown = false;
         try { _services.ChatGui.RemoveChatLinkHandler(InvalidTokenLinkCommandId); } catch { }
+        _mainWindow.SetNotePadReadOnly(false);
         StartWatchers();
     }
 
@@ -635,6 +637,7 @@ public class Plugin : IDalamudPlugin
         void Execute()
         {
             StopWatchers();
+            _mainWindow.SetNotePadReadOnly(true);
 
             var hadOfficerAccess = _config.IsOfficerToken;
             _config.IsOfficerToken = false;

--- a/demibot/demibot/http/routes/notepad.py
+++ b/demibot/demibot/http/routes/notepad.py
@@ -31,13 +31,6 @@ router = APIRouter(prefix="/api")
 logger = logging.getLogger(__name__)
 
 
-def _require_officer(ctx: RequestContext) -> None:
-    if "officer" not in ctx.roles:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="officer role required"
-        )
-
-
 def _parse_int(value: str, label: str) -> int:
     try:
         return int(value)
@@ -165,7 +158,6 @@ async def create_section(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> NoteSectionDto:
-    _require_officer(ctx)
     max_order = await db.scalar(
         select(func.max(NoteSection.sort_order)).where(
             NoteSection.guild_id == ctx.guild.id,
@@ -200,7 +192,6 @@ async def update_section(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> NoteSectionDto:
-    _require_officer(ctx)
     sid = _parse_int(section_id, "sectionId")
     section = await _get_section(db, ctx.guild.id, sid)
     if section.version != body.version:
@@ -228,7 +219,6 @@ async def reorder_sections(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> NotepadStateDto:
-    _require_officer(ctx)
     requested_ids = [_parse_int(section_id, "sectionId") for section_id in body.section_ids]
     if len(requested_ids) != len(set(requested_ids)):
         raise HTTPException(status_code=400, detail="duplicate section ids")
@@ -283,7 +273,6 @@ async def delete_section(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    _require_officer(ctx)
     sid = _parse_int(section_id, "sectionId")
     section = await _get_section(db, ctx.guild.id, sid)
     now = datetime.utcnow()
@@ -314,7 +303,6 @@ async def create_page(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> NotePageDto:
-    _require_officer(ctx)
     section_id = _parse_int(body.section_id, "sectionId")
     section = await _get_section(db, ctx.guild.id, section_id)
     max_order = await db.scalar(
@@ -353,7 +341,6 @@ async def update_page(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> NotePageDto:
-    _require_officer(ctx)
     pid = _parse_int(page_id, "pageId")
     page = await _get_page(db, ctx.guild.id, pid)
     if page.version != body.version:
@@ -382,7 +369,6 @@ async def update_page_content(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> NotePageDto:
-    _require_officer(ctx)
     pid = _parse_int(page_id, "pageId")
     page = await _get_page(db, ctx.guild.id, pid)
     if page.version != body.version:
@@ -407,7 +393,6 @@ async def reorder_pages(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> NotepadStateDto:
-    _require_officer(ctx)
     provided_section_ids: list[int] = []
     provided_page_ids: list[int] = []
     for entry in body.sections:
@@ -515,7 +500,6 @@ async def delete_page(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    _require_officer(ctx)
     pid = _parse_int(page_id, "pageId")
     page = await _get_page(db, ctx.guild.id, pid)
     now = datetime.utcnow()

--- a/tests/NotePadWindowTests.cs
+++ b/tests/NotePadWindowTests.cs
@@ -73,6 +73,7 @@ public class NotePadWindowTests
             };
         };
 
+        Assert.False(fixture.Window.IsReadOnly);
         fixture.SetSelection("s1", "p1");
         fixture.SetEditorState(content: "Updated", version: 1, dirty: true, lastEditUtc: DateTime.UtcNow.AddSeconds(-10));
 
@@ -91,6 +92,7 @@ public class NotePadWindowTests
             .GetField("_editorVersion", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(fixture.Window)!;
         Assert.Equal(2, currentVersion);
+        Assert.False(fixture.Window.IsReadOnly);
     }
 
     [Fact]

--- a/tests/test_notepad_routes.py
+++ b/tests/test_notepad_routes.py
@@ -37,8 +37,9 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
 
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Guild")
-        user = User(id=1, discord_user_id=10, global_name="Officer")
-        db.add_all([guild, user])
+        officer = User(id=1, discord_user_id=10, global_name="Officer")
+        member = User(id=2, discord_user_id=11, global_name="Member")
+        db.add_all([guild, officer, member])
         await db.commit()
 
     ctx_officer = StubContext(
@@ -48,7 +49,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
     )
     ctx_member = StubContext(
         guild=SimpleNamespace(id=1),
-        user=SimpleNamespace(id=1),
+        user=SimpleNamespace(id=2),
         roles=[],
     )
 
@@ -64,16 +65,9 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
         assert state.sections == []
 
     async with get_session() as db:
-        with pytest.raises(HTTPException) as excinfo:
-            await notepad.create_section(
-                body=NoteSectionCreateBody(name="Member"), ctx=ctx_member, db=db
-            )
-        assert excinfo.value.status_code == 403
-
-    async with get_session() as db:
         section = await notepad.create_section(
             body=NoteSectionCreateBody(name="Raid", color=123456),
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
     assert section.name == "Raid"
@@ -83,7 +77,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
         renamed = await notepad.update_section(
             section_id=section.id,
             body=NoteSectionUpdateBody(name="Raid Alpha", version=section.version),
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
     assert renamed.name == "Raid Alpha"
@@ -94,7 +88,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
             await notepad.update_section(
                 section_id=section.id,
                 body=NoteSectionUpdateBody(name="oops", version=section.version),
-                ctx=ctx_officer,
+                ctx=ctx_member,
                 db=db,
             )
         assert excinfo.value.status_code == 409
@@ -107,7 +101,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
     async with get_session() as db:
         page = await notepad.create_page(
             body=NotePageCreateBody(sectionId=section_id, title="Notes", content="A"),
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
     assert page.content == "A"
@@ -116,7 +110,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
         updated_page = await notepad.update_page_content(
             page_id=page.id,
             body=NotePageContentBody(content="Updated", version=page.version),
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
     assert updated_page.version == page.version + 1
@@ -143,13 +137,13 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
 
     async with get_session() as db:
         section2 = await notepad.create_section(
-            body=NoteSectionCreateBody(name="Logs"), ctx=ctx_officer, db=db
+            body=NoteSectionCreateBody(name="Logs"), ctx=ctx_member, db=db
         )
 
     async with get_session() as db:
         state = await notepad.reorder_sections(
             body=NoteSectionReorderBody(sectionIds=[section2.id, section.id]),
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
     assert [s.id for s in state.sections][:2] == [section2.id, section.id]
@@ -157,7 +151,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
     async with get_session() as db:
         page2 = await notepad.create_page(
             body=NotePageCreateBody(sectionId=section.id, title="Other", content="B"),
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
 
@@ -178,7 +172,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
     assert sections_by_id[section.id].pages[0].id == page.id
 
     async with get_session() as db:
-        await notepad.delete_page(page_id=page2.id, ctx=ctx_officer, db=db)
+        await notepad.delete_page(page_id=page2.id, ctx=ctx_member, db=db)
 
     reorder_after_delete = NotePageReorderBody(
         sections=[
@@ -189,7 +183,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
     async with get_session() as db:
         post_delete_state = await notepad.reorder_pages(
             body=reorder_after_delete,
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
     sections_after_delete = {s.id: s for s in post_delete_state.sections}
@@ -197,12 +191,16 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
     assert sections_after_delete[section2.id].pages == []
 
     async with get_session() as db:
-        await notepad.delete_section(section_id=section.id, ctx=ctx_officer, db=db)
+        await notepad.delete_section(section_id=section.id, ctx=ctx_member, db=db)
 
     async with get_session() as db:
         state = await notepad.list_notepad(ctx=ctx_member, db=db)
     returned_ids = {s.id for s in state.sections}
     assert section.id not in returned_ids
+
+    async with get_session() as db:
+        officer_view = await notepad.list_notepad(ctx=ctx_officer, db=db)
+    assert officer_view.sections == state.sections
 
     topics = {event[0]["topic"] for event in events}
     assert {
@@ -224,14 +222,15 @@ async def test_reorder_sections_with_soft_deleted(tmp_path, monkeypatch):
 
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Guild")
-        user = User(id=1, discord_user_id=10, global_name="Officer")
-        db.add_all([guild, user])
+        officer = User(id=1, discord_user_id=10, global_name="Officer")
+        member = User(id=2, discord_user_id=20, global_name="Member")
+        db.add_all([guild, officer, member])
         await db.commit()
 
-    ctx_officer = StubContext(
+    ctx_member = StubContext(
         guild=SimpleNamespace(id=1),
-        user=SimpleNamespace(id=1),
-        roles=["officer"],
+        user=SimpleNamespace(id=2),
+        roles=[],
     )
 
     events: list[tuple[dict, int, str]] = []
@@ -243,18 +242,18 @@ async def test_reorder_sections_with_soft_deleted(tmp_path, monkeypatch):
 
     async with get_session() as db:
         section_one = await notepad.create_section(
-            body=NoteSectionCreateBody(name="Alpha"), ctx=ctx_officer, db=db
+            body=NoteSectionCreateBody(name="Alpha"), ctx=ctx_member, db=db
         )
         section_two = await notepad.create_section(
-            body=NoteSectionCreateBody(name="Beta"), ctx=ctx_officer, db=db
+            body=NoteSectionCreateBody(name="Beta"), ctx=ctx_member, db=db
         )
         section_three = await notepad.create_section(
-            body=NoteSectionCreateBody(name="Gamma"), ctx=ctx_officer, db=db
+            body=NoteSectionCreateBody(name="Gamma"), ctx=ctx_member, db=db
         )
 
     async with get_session() as db:
         await notepad.delete_section(
-            section_id=section_two.id, ctx=ctx_officer, db=db
+            section_id=section_two.id, ctx=ctx_member, db=db
         )
 
     reorder_body = NoteSectionReorderBody(
@@ -263,7 +262,7 @@ async def test_reorder_sections_with_soft_deleted(tmp_path, monkeypatch):
     async with get_session() as db:
         state = await notepad.reorder_sections(
             body=reorder_body,
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
 

--- a/tests/test_notepad_sync.py
+++ b/tests/test_notepad_sync.py
@@ -88,8 +88,9 @@ async def test_notepad_sync_and_conflict_flow(tmp_path, monkeypatch):
 
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Guild")
-        user = User(id=1, discord_user_id=42, global_name="Officer")
-        db.add_all([guild, user])
+        officer = User(id=1, discord_user_id=42, global_name="Officer")
+        member = User(id=2, discord_user_id=99, global_name="Member")
+        db.add_all([guild, officer, member])
         await db.commit()
 
     manager = ConnectionManager()
@@ -106,7 +107,7 @@ async def test_notepad_sync_and_conflict_flow(tmp_path, monkeypatch):
     async with get_session() as db:
         section = await notepad.create_section(
             body=NoteSectionCreateBody(name="Raid", color=0x123456),
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
 
@@ -117,7 +118,7 @@ async def test_notepad_sync_and_conflict_flow(tmp_path, monkeypatch):
     async with get_session() as db:
         page = await notepad.create_page(
             body=NotePageCreateBody(sectionId=section.id, title="Notes", content="Initial"),
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
 
@@ -128,7 +129,7 @@ async def test_notepad_sync_and_conflict_flow(tmp_path, monkeypatch):
         updated = await notepad.update_page_content(
             page_id=page.id,
             body=NotePageContentBody(content="Revised", version=page.version),
-            ctx=ctx_officer,
+            ctx=ctx_member,
             db=db,
         )
 
@@ -141,7 +142,7 @@ async def test_notepad_sync_and_conflict_flow(tmp_path, monkeypatch):
             await notepad.update_page_content(
                 page_id=page.id,
                 body=NotePageContentBody(content="Stale", version=stale_version),
-                ctx=ctx_officer,
+                ctx=ctx_member,
                 db=db,
             )
     assert getattr(excinfo.value, "status_code", None) == 409


### PR DESCRIPTION
## Summary
- stop toggling the notepad UI between read-only and editable states based on officer roles and instead drive it off of link status
- permit note pad section and page mutations from any authenticated API key by removing officer role gating
- update plugin, HTTP, and client tests to exercise non-officer editing flows and keep the notepad window editable for regular members

## Testing
- pytest tests/test_notepad_routes.py tests/test_notepad_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68da7b08cda88328be66a18459203047