### PR TITLE
Switch NotePad page operations to shared endpoints

### DIFF
--- a/DemiCatPlugin/NotePadService.cs
+++ b/DemiCatPlugin/NotePadService.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -319,8 +320,11 @@ public sealed class NotePadService : IDisposable
 
     public async Task<NotePadPage?> CreatePageAsync(string sectionId, string title, CancellationToken cancellationToken)
     {
-        var payload = new { title };
-        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}/pages";
+        var color = await GetSectionColorAsync(sectionId, cancellationToken).ConfigureAwait(false);
+        object payload = color != null
+            ? new { sectionId, title, content = string.Empty, color }
+            : new { sectionId, title, content = string.Empty };
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/pages";
         var request = new HttpRequestMessage(HttpMethod.Post, url)
         {
             Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
@@ -362,8 +366,24 @@ public sealed class NotePadService : IDisposable
 
     public async Task<bool> RenamePageAsync(string sectionId, string pageId, string title, CancellationToken cancellationToken)
     {
-        var payload = new { title };
-        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}/pages/{pageId}";
+        var existing = await GetPageSnapshotAsync(sectionId, pageId, cancellationToken).ConfigureAwait(false);
+        if (existing == null)
+        {
+            PluginServices.Instance?.Log.Warning("Unable to rename page {PageId}: not found in section {SectionId}", pageId, sectionId);
+            return false;
+        }
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["version"] = existing.Version,
+            ["title"] = title
+        };
+        if (!string.IsNullOrEmpty(existing.Color))
+        {
+            payload["color"] = existing.Color;
+        }
+
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/pages/{pageId}";
         var request = new HttpRequestMessage(HttpMethod.Patch, url)
         {
             Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
@@ -406,7 +426,7 @@ public sealed class NotePadService : IDisposable
 
     public async Task<bool> DeletePageAsync(string sectionId, string pageId, CancellationToken cancellationToken)
     {
-        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}/pages/{pageId}";
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/pages/{pageId}";
         var request = new HttpRequestMessage(HttpMethod.Delete, url);
         ApiHelpers.AddAuthHeader(request, _tokenManager);
 
@@ -446,8 +466,18 @@ public sealed class NotePadService : IDisposable
 
     public async Task<bool> ReorderPagesAsync(string sectionId, IReadOnlyList<string> pageIds, CancellationToken cancellationToken)
     {
-        var payload = new { ids = pageIds };
-        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}/pages/reorder";
+        var payload = new
+        {
+            sections = new[]
+            {
+                new
+                {
+                    sectionId,
+                    pageIds = pageIds.ToArray()
+                }
+            }
+        };
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/pages/reorder";
         var request = new HttpRequestMessage(HttpMethod.Post, url)
         {
             Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
@@ -522,8 +552,8 @@ public sealed class NotePadService : IDisposable
 
     public async Task<NotePadPage?> SavePageAsync(string sectionId, string pageId, NotePadPageUpdate update, CancellationToken cancellationToken)
     {
-        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections/{sectionId}/pages/{pageId}";
-        var request = new HttpRequestMessage(HttpMethod.Put, url)
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/pages/{pageId}/content";
+        var request = new HttpRequestMessage(HttpMethod.Patch, url)
         {
             Content = new StringContent(JsonSerializer.Serialize(update), Encoding.UTF8, "application/json")
         };
@@ -564,6 +594,34 @@ public sealed class NotePadService : IDisposable
         }
 
         return page;
+    }
+
+    private async Task<NotePadPage?> GetPageSnapshotAsync(string sectionId, string pageId, CancellationToken cancellationToken)
+    {
+        await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var section = _sections.FirstOrDefault(s => string.Equals(s.Id, sectionId, StringComparison.Ordinal));
+            var page = section?.Pages.FirstOrDefault(p => string.Equals(p.Id, pageId, StringComparison.Ordinal));
+            return page != null ? ClonePage(page) : null;
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
+    }
+
+    private async Task<string?> GetSectionColorAsync(string sectionId, CancellationToken cancellationToken)
+    {
+        await _stateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return _sections.FirstOrDefault(s => string.Equals(s.Id, sectionId, StringComparison.Ordinal))?.Color;
+        }
+        finally
+        {
+            _stateLock.Release();
+        }
     }
 
     private async Task HandleResponseAsync(HttpResponseMessage response, Func<Stream, Task> onSuccess)
@@ -900,7 +958,8 @@ public sealed class NotePadService : IDisposable
             Title = source.Title,
             Content = source.Content,
             Version = source.Version,
-            UpdatedAt = source.UpdatedAt
+            UpdatedAt = source.UpdatedAt,
+            Color = source.Color
         };
     }
 }
@@ -920,6 +979,7 @@ public sealed class NotePadPage
     public string Content { get; set; } = string.Empty;
     public int Version { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }
+    public string? Color { get; set; }
 }
 
 public sealed class NotePadListResponse
@@ -929,7 +989,10 @@ public sealed class NotePadListResponse
 
 public sealed class NotePadPageUpdate
 {
+    [JsonPropertyName("content")]
     public string Content { get; set; } = string.Empty;
+
+    [JsonPropertyName("version")]
     public int Version { get; set; }
 }
 

--- a/tests/NotePadWindowTests.cs
+++ b/tests/NotePadWindowTests.cs
@@ -59,6 +59,14 @@ public class NotePadWindowTests
         using var fixture = new NotePadWindowFixture();
         fixture.Handler.Responder = request =>
         {
+            Assert.Equal(HttpMethod.Patch, request.Method);
+            Assert.Equal("/api/notepad/pages/p1/content", request.RequestUri!.AbsolutePath);
+            var body = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            using var document = JsonDocument.Parse(body);
+            var root = document.RootElement;
+            Assert.Equal("Updated", root.GetProperty("content").GetString());
+            Assert.Equal(1, root.GetProperty("version").GetInt32());
+
             var payload = JsonSerializer.Serialize(new NotePadPage
             {
                 Id = "p1",
@@ -84,8 +92,15 @@ public class NotePadWindowTests
         method.Invoke(fixture.Window, Array.Empty<object>());
 
         var request = await fixture.Handler.WaitForRequestAsync(TimeSpan.FromSeconds(1));
-        Assert.Equal(HttpMethod.Put, request.Method);
-        Assert.Contains("/api/notepad/sections/s1/pages/p1", request.RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Patch, request.Method);
+        Assert.Equal("/api/notepad/pages/p1/content", request.RequestUri!.AbsolutePath);
+        var body = await request.Content!.ReadAsStringAsync();
+        using (var document = JsonDocument.Parse(body))
+        {
+            var root = document.RootElement;
+            Assert.Equal("Updated", root.GetProperty("content").GetString());
+            Assert.Equal(1, root.GetProperty("version").GetInt32());
+        }
 
         await fixture.WaitForDirtyFlagAsync(expectedDirty: false);
         var currentVersion = (int)typeof(NotePadWindow)
@@ -93,6 +108,47 @@ public class NotePadWindowTests
             .GetValue(fixture.Window)!;
         Assert.Equal(2, currentVersion);
         Assert.False(fixture.Window.IsReadOnly);
+    }
+
+    [Fact]
+    public async Task CreatePageAsync_UsesGlobalPagesEndpointAndPayload()
+    {
+        using var fixture = new NotePadWindowFixture();
+        fixture.Handler.Responder = request =>
+        {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("/api/notepad/pages", request.RequestUri!.AbsolutePath);
+            var body = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            using var document = JsonDocument.Parse(body);
+            var root = document.RootElement;
+            Assert.Equal("s1", root.GetProperty("sectionId").GetString());
+            Assert.Equal("New Page", root.GetProperty("title").GetString());
+            Assert.Equal(string.Empty, root.GetProperty("content").GetString());
+            Assert.Equal("#123456", root.GetProperty("color").GetString());
+
+            var responsePayload = JsonSerializer.Serialize(new NotePadPage
+            {
+                Id = "p-new",
+                Title = "New Page",
+                Content = string.Empty,
+                Version = 0,
+                UpdatedAt = DateTimeOffset.UtcNow,
+                Color = "#123456"
+            });
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responsePayload, Encoding.UTF8, "application/json")
+            };
+        };
+
+        var page = await fixture.Service.CreatePageAsync("s1", "New Page", CancellationToken.None);
+
+        Assert.NotNull(page);
+        Assert.Equal("p-new", page!.Id);
+        var request = fixture.Handler.Requests.Last();
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal("/api/notepad/pages", request.RequestUri!.AbsolutePath);
     }
 
     [Fact]
@@ -153,6 +209,7 @@ public class NotePadWindowTests
                 {
                     Id = "s1",
                     Name = "Alpha",
+                    Color = "#123456",
                     Pages = new List<NotePadPage>
                     {
                         new()
@@ -185,6 +242,7 @@ public class NotePadWindowTests
                 {
                     Id = "s2",
                     Name = "Beta",
+                    Color = "#654321",
                     Pages = new List<NotePadPage>
                     {
                         new()
@@ -201,6 +259,7 @@ public class NotePadWindowTests
                 {
                     Id = "s3",
                     Name = "Gamma",
+                    Color = "#abcdef",
                     Pages = new List<NotePadPage>()
                 }
             };


### PR DESCRIPTION
## Summary
- update NotePadService to use the new /api/notepad/pages endpoints for creating, updating, deleting, and reordering pages
- include section color and version metadata when sending page payloads and add helpers to read the cached state
- extend the NotePadWindow tests to cover the revised endpoints and payload schemas

## Testing
- dotnet test *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68db031c1cf88328a90ce3a5b66afd1b