### PR TITLE
Handle numeric notepad section colors

### DIFF
--- a/DemiCatPlugin/NotePadColorHelper.cs
+++ b/DemiCatPlugin/NotePadColorHelper.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DemiCatPlugin;
+
+internal static class NotePadColorHelper
+{
+    public const int DefaultColorValue = 0x4A5568;
+    public const string DefaultHexColor = "#4a5568";
+
+    public static bool TryParseColorString(string? color, out int value)
+    {
+        value = 0;
+        if (string.IsNullOrWhiteSpace(color))
+        {
+            return false;
+        }
+
+        var span = color.AsSpan().Trim();
+        if (span.Length == 0)
+        {
+            return false;
+        }
+
+        if (span[0] == '#')
+        {
+            span = span[1..];
+            return TryParseHex(span, out value);
+        }
+
+        if (span.Length > 2 && span[0] == '0' && (span[1] == 'x' || span[1] == 'X'))
+        {
+            span = span[2..];
+            return TryParseHex(span, out value);
+        }
+
+        if (int.TryParse(span, NumberStyles.Integer, CultureInfo.InvariantCulture, out var dec) && dec >= 0)
+        {
+            value = dec;
+            return true;
+        }
+
+        return TryParseHex(span, out value);
+    }
+
+    public static string ToHex(int value)
+    {
+        var sanitized = value & 0xFFFFFF;
+        return $"#{sanitized:X6}".ToLowerInvariant();
+    }
+
+    public static string Normalize(string? color)
+        => TryParseColorString(color, out var value) ? ToHex(value) : DefaultHexColor;
+
+    private static bool TryParseHex(ReadOnlySpan<char> span, out int value)
+    {
+        if (span.Length == 0)
+        {
+            value = 0;
+            return false;
+        }
+
+        if (int.TryParse(span, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var hex))
+        {
+            value = hex;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+}
+
+internal sealed class NotePadColorJsonConverter : JsonConverter<string>
+{
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            if (reader.TryGetInt64(out var value))
+            {
+                return NotePadColorHelper.ToHex((int)(value & 0xFFFFFF));
+            }
+
+            throw new JsonException("Unable to parse numeric NotePad color");
+        }
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            return NotePadColorHelper.Normalize(reader.GetString());
+        }
+
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return NotePadColorHelper.DefaultHexColor;
+        }
+
+        throw new JsonException($"Unexpected token {reader.TokenType} when parsing NotePad color");
+    }
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        if (NotePadColorHelper.TryParseColorString(value, out var color))
+        {
+            writer.WriteNumberValue(color & 0xFFFFFF);
+            return;
+        }
+
+        writer.WriteNullValue();
+    }
+}

--- a/DemiCatPlugin/NotePadService.cs
+++ b/DemiCatPlugin/NotePadService.cs
@@ -116,11 +116,15 @@ public sealed class NotePadService : IDisposable
 
     public async Task<NotePadSection?> CreateSectionAsync(string name, string colorHex, CancellationToken cancellationToken)
     {
-        var payload = new
+        var payload = new Dictionary<string, object?>
         {
-            name,
-            color = colorHex
+            ["name"] = name
         };
+
+        if (NotePadColorHelper.TryParseColorString(colorHex, out var colorValue))
+        {
+            payload["color"] = colorValue & 0xFFFFFF;
+        }
         var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad/sections";
         var request = new HttpRequestMessage(HttpMethod.Post, url)
         {
@@ -966,9 +970,18 @@ public sealed class NotePadService : IDisposable
 
 public sealed class NotePadSection
 {
+    private string _color = NotePadColorHelper.DefaultHexColor;
+
     public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
-    public string Color { get; set; } = "#4a5568";
+
+    [JsonConverter(typeof(NotePadColorJsonConverter))]
+    public string Color
+    {
+        get => _color;
+        set => _color = NotePadColorHelper.Normalize(value);
+    }
+
     public List<NotePadPage> Pages { get; set; } = new();
 }
 

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -503,7 +503,7 @@ public sealed class NotePadWindow : IDisposable
                 {
                     _ = Task.Run(async () =>
                     {
-                        var section = await _service.CreateSectionAsync(name, "#4a5568", CancellationToken.None);
+                        var section = await _service.CreateSectionAsync(name, NotePadColorHelper.DefaultHexColor, CancellationToken.None);
                         if (section != null)
                         {
                             SelectSection(section.Id);
@@ -849,22 +849,15 @@ public sealed class NotePadWindow : IDisposable
 
     private static Vector4 ParseColor(string? color)
     {
-        if (string.IsNullOrWhiteSpace(color) || color!.Length < 7 || color[0] != '#')
+        if (!NotePadColorHelper.TryParseColorString(color, out var rgb))
         {
-            return new Vector4(0.29f, 0.33f, 0.39f, 1f);
+            rgb = NotePadColorHelper.DefaultColorValue;
         }
 
-        try
-        {
-            var r = Convert.ToInt32(color.Substring(1, 2), 16) / 255f;
-            var g = Convert.ToInt32(color.Substring(3, 2), 16) / 255f;
-            var b = Convert.ToInt32(color.Substring(5, 2), 16) / 255f;
-            return new Vector4(r, g, b, 1f);
-        }
-        catch
-        {
-            return new Vector4(0.29f, 0.33f, 0.39f, 1f);
-        }
+        var r = ((rgb >> 16) & 0xFF) / 255f;
+        var g = ((rgb >> 8) & 0xFF) / 255f;
+        var b = (rgb & 0xFF) / 255f;
+        return new Vector4(r, g, b, 1f);
     }
 
     private void OpenNewSectionPopup()


### PR DESCRIPTION
## Summary
- convert section creation payloads to send numeric colors when possible
- add shared helpers and a JSON converter to normalize API color values into #RRGGBB strings
- update the UI to consume the normalized colors for tab rendering

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db10e85894832889e1149a39337044