### PR TITLE
Remove bridge message headers and footers

### DIFF
--- a/DemiCatPlugin/BridgeMessageFormatter.cs
+++ b/DemiCatPlugin/BridgeMessageFormatter.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Text;
 using DiscordHelper;
 
 namespace DemiCatPlugin;
@@ -76,21 +73,6 @@ public static class BridgeMessageFormatter
         var displayContent = ChatWindow.ReplaceMentionTokens(content, resolution.Mentions);
         displayContent = displayContent.Replace("@\u200B", "@");
 
-        var header = BuildHeaderLine(options);
-        if (!string.IsNullOrEmpty(header))
-        {
-            if (!string.IsNullOrEmpty(content))
-            {
-                content = string.Concat(header, "\n", content);
-                displayContent = string.Concat(header, "\n", displayContent);
-            }
-            else
-            {
-                content = header;
-                displayContent = header;
-            }
-        }
-
         var warnings = new List<string>();
         var errors = new List<string>();
 
@@ -127,8 +109,6 @@ public static class BridgeMessageFormatter
     {
         var list = new List<EmbedDto>();
         var chunkCount = chunks.Count > 0 ? chunks.Count : 1;
-        var baseFooter = BuildFooterBase(options);
-
         if (chunkCount > DiscordEmbedCountLimit)
         {
             warnings.Add($"Embed count reduced to {DiscordEmbedCountLimit} to satisfy Discord limits.");
@@ -145,42 +125,12 @@ public static class BridgeMessageFormatter
                 Timestamp = options.Timestamp,
                 AuthorName = DetermineAuthor(options),
                 AuthorIconUrl = options.AuthorAvatarUrl,
-                FooterText = BuildFooter(baseFooter, chunkCount, i),
                 Color = DetermineColor(options.ChannelKind)
             };
             list.Add(embed);
         }
 
         return list;
-    }
-
-    private static string BuildFooterBase(BridgeFormatterOptions options)
-    {
-        var channelLabel = options.ChannelKind switch
-        {
-            ChannelKind.OfficerChat => "Officer Chat",
-            ChannelKind.FcChat => "FC Chat",
-            ChannelKind.Chat => "Chat",
-            _ => string.IsNullOrEmpty(options.ChannelKind) ? "Chat" : options.ChannelKind
-        };
-
-        var footer = new StringBuilder(channelLabel);
-        if (!string.IsNullOrWhiteSpace(options.WorldName))
-        {
-            footer.Append(' ');
-            footer.Append('•');
-            footer.Append(' ');
-            footer.Append(options.WorldName);
-        }
-        footer.Append(" • DemiCat");
-        return footer.ToString();
-    }
-
-    private static string BuildFooter(string baseFooter, int totalChunks, int index)
-    {
-        if (totalChunks <= 1)
-            return baseFooter;
-        return $"{baseFooter} • Part {index + 1}/{totalChunks}";
     }
 
     private static string DetermineAuthor(BridgeFormatterOptions options)
@@ -200,36 +150,6 @@ public static class BridgeMessageFormatter
             _ => 0x5865F2 // Discord blurple
         };
     }
-
-    private static string BuildHeaderLine(BridgeFormatterOptions options)
-    {
-        var displayName = string.IsNullOrWhiteSpace(options.AuthorName)
-            ? "You"
-            : options.AuthorName!.Trim();
-
-        var segments = new List<string> { displayName };
-        if (options.UseCharacterName)
-        {
-            if (!string.IsNullOrWhiteSpace(options.CharacterName))
-            {
-                segments.Add(options.CharacterName.Trim());
-                if (!string.IsNullOrWhiteSpace(options.WorldName))
-                {
-                    segments.Add(options.WorldName.Trim());
-                }
-            }
-            else if (!string.IsNullOrWhiteSpace(options.WorldName))
-            {
-                segments.Add(options.WorldName.Trim());
-            }
-        }
-
-        var timestamp = FormatTimestamp(options.Timestamp);
-        return $"Message Sent by: {string.Join(" / ", segments)} @ {timestamp}";
-    }
-
-    private static string FormatTimestamp(DateTimeOffset timestamp)
-        => timestamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
 
     private static IReadOnlyList<string> SplitIntoEmbedChunks(
         string displayContent,

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -456,29 +456,33 @@ public class EventView : IDisposable
 
     private void DrawFooterSection(EmbedDto dto)
     {
-        var footerText = dto.FooterText ?? string.Empty;
+        var parts = new List<string>(capacity: 2);
+
+        if (!string.IsNullOrWhiteSpace(dto.FooterText))
+        {
+            parts.Add(dto.FooterText!.Trim());
+        }
+
         if (dto.Timestamp.HasValue)
         {
-            if (footerText.Length > 0)
-            {
-                footerText += " • ";
-            }
-
-            footerText += dto.Timestamp.Value.LocalDateTime.ToString();
+            parts.Add(dto.Timestamp.Value.LocalDateTime.ToString());
         }
+
+        var hasText = parts.Count > 0;
 
         if (_footerIcon != null)
         {
             var wrap = _footerIcon.GetWrapOrEmpty();
             ImGui.Image(wrap.Handle, new Vector2(16, 16));
-            if (!string.IsNullOrEmpty(footerText))
+            if (hasText)
             {
                 ImGui.SameLine();
             }
         }
 
-        if (!string.IsNullOrEmpty(footerText))
+        if (hasText)
         {
+            var footerText = string.Join(" • ", parts);
             ImGui.TextUnformatted(footerText);
         }
     }

--- a/tests/BridgeMessageFormatterTests.cs
+++ b/tests/BridgeMessageFormatterTests.cs
@@ -20,15 +20,13 @@ public class BridgeMessageFormatterTests
             WorldName = "World"
         };
 
-    private static string ExpectedHeader() => "Message Sent by: You @ 2024-01-02 03:04:05 UTC";
-
     [Fact]
     public void Format_LongContentProducesError()
     {
         var input = new string('x', 2100);
         var result = BridgeMessageFormatter.Format(input, Array.Empty<string>(), CreateOptions());
 
-        Assert.StartsWith(ExpectedHeader(), result.Content);
+        Assert.Equal(input, result.Content);
         Assert.Contains(result.Errors, e => e.Contains("2000"));
     }
 
@@ -41,7 +39,8 @@ public class BridgeMessageFormatterTests
         Assert.True(result.Embeds.Count >= 2);
         Assert.True(result.Embeds[0].Description!.Length <= 4096);
         Assert.Contains(result.Warnings, w => w.Contains("split"));
-        Assert.StartsWith(ExpectedHeader(), result.Embeds[0].Description!);
+        Assert.All(result.Embeds, e => Assert.Null(e.FooterText));
+        Assert.Equal(new string('a', result.Embeds[0].Description!.Length), result.Embeds[0].Description);
     }
 
     [Fact]
@@ -52,8 +51,8 @@ public class BridgeMessageFormatterTests
 
         var result = BridgeMessageFormatter.Format("Hello @Alice", Array.Empty<string>(), options);
 
-        Assert.Equal($"{ExpectedHeader()}\nHello <@1>", result.Content);
-        Assert.StartsWith(ExpectedHeader(), result.DisplayContent);
+        Assert.Equal("Hello <@1>", result.Content);
+        Assert.Equal("Hello @Alice", result.DisplayContent);
         Assert.Contains("@Alice", result.DisplayContent);
         Assert.Single(result.Mentions);
         Assert.Equal("1", result.Mentions[0].Id);


### PR DESCRIPTION
## Summary
- remove the bridge message "Message Sent by" header and stop populating embed footers
- update EventView footer rendering to tolerate missing footer text
- refresh BridgeMessageFormatter tests to assert the simplified output

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db249ec4c48328be3de9a3be9cfaa1