### PR TITLE
Extend NotePad autosave interval

### DIFF
--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -19,7 +19,7 @@ public sealed class NotePadWindow : IDisposable
     private readonly List<string> _sectionOrder = new();
     private readonly Dictionary<string, string> _sectionRenameBuffers = new();
     private readonly Dictionary<string, string> _pageRenameBuffers = new();
-    private readonly TimeSpan _autosaveDelay = TimeSpan.FromSeconds(2.5);
+    private readonly TimeSpan _autosaveDelay = TimeSpan.FromMinutes(1);
 
     private string? _selectedSectionId;
     private string? _selectedPageId;

--- a/tests/NotePadWindowTests.cs
+++ b/tests/NotePadWindowTests.cs
@@ -83,7 +83,7 @@ public class NotePadWindowTests
 
         Assert.False(fixture.Window.IsReadOnly);
         fixture.SetSelection("s1", "p1");
-        fixture.SetEditorState(content: "Updated", version: 1, dirty: true, lastEditUtc: DateTime.UtcNow.AddSeconds(-10));
+        fixture.SetEditorState(content: "Updated", version: 1, dirty: true, lastEditUtc: DateTime.UtcNow.AddMinutes(-2));
 
         var method = typeof(NotePadWindow).GetMethod(
             "HandleAutosave",
@@ -157,7 +157,7 @@ public class NotePadWindowTests
         using var fixture = new NotePadWindowFixture();
         fixture.Window.IsReadOnly = true;
         fixture.SetSelection("s1", "p1");
-        fixture.SetEditorState(content: "Updated", version: 1, dirty: true, lastEditUtc: DateTime.UtcNow.AddSeconds(-10));
+        fixture.SetEditorState(content: "Updated", version: 1, dirty: true, lastEditUtc: DateTime.UtcNow.AddMinutes(-2));
 
         var method = typeof(NotePadWindow).GetMethod(
             "HandleAutosave",


### PR DESCRIPTION
## Summary
- increase the NotePad autosave delay to one minute and keep HandleAutosave behavior unchanged
- update autosave-related unit tests to account for the longer delay threshold

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db29e57f808328a421e381a418a72c