### PR TITLE
Simplify bridge embeds and rely on payload nonce

### DIFF
--- a/demibot/demibot/bridge.py
+++ b/demibot/demibot/bridge.py
@@ -32,12 +32,39 @@ class BridgeUpload:
         return discord.File(io.BytesIO(self.data), filename=self.filename)
 
 
-def _tab_label(kind: ChannelKind | None) -> str:
-    if kind == ChannelKind.OFFICER_CHAT:
-        return "Officer Chat"
-    if kind == ChannelKind.FC_CHAT:
-        return "FC Chat"
-    return "Chat"
+def _get_embed_type() -> type:
+    embed_type = getattr(discord, "Embed", None)
+    if embed_type is not None:
+        return embed_type
+
+    class _FallbackEmbed:
+        def __init__(self, *, description: str | None = None, color=None):
+            self._data: dict[str, object] = {}
+            if description is not None:
+                self._data["description"] = description
+            if color is not None:
+                value = getattr(color, "value", color)
+                self._data["color"] = value
+
+        def set_author(
+            self, *, name: str | None = None, icon_url: str | None = None
+        ) -> None:
+            author: dict[str, object] = {}
+            if name is not None:
+                author["name"] = name
+            if icon_url is not None:
+                author["icon_url"] = icon_url
+            if author:
+                self._data.setdefault("author", {}).update(author)
+
+        def set_image(self, *, url: str | None = None) -> None:
+            if url is not None:
+                self._data.setdefault("image", {})["url"] = url
+
+        def to_dict(self) -> dict[str, object]:
+            return dict(self._data)
+
+    return _FallbackEmbed
 
 
 def _is_image(filename: str, content_type: str | None) -> bool:
@@ -184,39 +211,26 @@ def build_bridge_message(
     character_name = user.character_name if use_character_name else None
     world_name = user.world if use_character_name else None
 
-    header_present = _has_existing_header(normalized)
-    if not header_present:
-        header = _format_header_line(
-            display_name=display_name,
-            use_character_name=use_character_name,
-            character_name=character_name,
-            world_name=world_name,
-        )
-        if normalized:
-            normalized = f"{header}\n{normalized}"
-        else:
-            normalized = header
-
-
     chunks, represented = _split_embed_text(normalized)
     if not chunks:
         chunks = [""]
 
     embed_nonce = nonce or uuid.uuid4().hex
-    footer = f"DemiCat • {_tab_label(channel_kind)} • {BRIDGE_MARKER}{embed_nonce}"
     author_name = _determine_author_name(
         user=user, membership=membership, use_character_name=use_character_name
     )
     author_icon = membership.avatar_url if membership else None
 
-    color = discord.Color(0x5865F2)
+    color_value = 0x5865F2
     if channel_kind == ChannelKind.OFFICER_CHAT:
-        color = discord.Color(0xED4245)
+        color_value = 0xED4245
+    color_factory = getattr(discord, "Color", None) or getattr(discord, "Colour", None)
+    color = color_factory(color_value) if callable(color_factory) else color_value
 
+    embed_type = _get_embed_type()
     embeds: list[discord.Embed] = []
     for index, chunk in enumerate(chunks):
-        embed = discord.Embed(description=chunk or None, color=color)
-        embed.set_footer(text=footer)
+        embed = embed_type(description=chunk or None, color=color)
         embed.set_author(name=author_name, icon_url=author_icon)
         if index == 0 and image_filename:
             embed.set_image(url=f"attachment://{image_filename}")
@@ -227,43 +241,6 @@ def build_bridge_message(
         leftover = leftover[1:]
     discord_content = leftover[:DISCORD_CONTENT_LIMIT]
     return discord_content, embeds, uploads, embed_nonce
-
-
-def _format_header_line(
-    *,
-    display_name: str,
-    use_character_name: bool,
-    character_name: str | None,
-    world_name: str | None,
-) -> str:
-    name = display_name.strip() or "You"
-    segments = [name]
-    if use_character_name:
-        char = (character_name or "").strip()
-        world = (world_name or "").strip()
-        if char:
-            segments.append(char)
-            if world:
-                segments.append(world)
-        elif world:
-            segments.append(world)
-    return "Message Sent by: {}\n---".format(" / ".join(segments))
-
-
-
-def _has_existing_header(content: str) -> bool:
-    if not content:
-        return False
-    first_line, sep, remainder = content.partition("\n")
-    if not sep:
-        return False
-    if not first_line.strip().startswith("Message Sent by:"):
-        return False
-    second_line, _, _ = remainder.partition("\n")
-    if second_line.strip() != "---":
-        return False
-    return True
-
 
 
 def extract_bridge_nonce_from_footer(text: str | None) -> str | None:
@@ -318,6 +295,10 @@ def extract_bridge_nonce_from_embed_dict(embed: Mapping[str, object]) -> str | N
 
 
 def extract_bridge_nonce_from_payload(payload: Mapping[str, object]) -> str | None:
+    raw_nonce = payload.get("nonce")
+    if isinstance(raw_nonce, str) and raw_nonce:
+        return raw_nonce
+
     embeds = payload.get("embeds")
     if isinstance(embeds, Iterable):
         for embed in embeds:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -177,7 +177,7 @@ def sample_membership():
     )
 
 
-def test_build_bridge_message_populates_embed_footer(sample_user, sample_membership):
+def test_build_bridge_message_generates_simple_embed(sample_user, sample_membership):
     content = "Hello from DemiCat"
     attachments = [("screenshot.png", b"bytes", "image/png")]
     fixed_time = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
@@ -191,16 +191,14 @@ def test_build_bridge_message_populates_embed_footer(sample_user, sample_members
         timestamp=fixed_time,
     )
 
-    expected_header = "Message Sent by: Nick\n---"
     assert discord_content == ""
     assert nonce
     assert len(embeds) == 1
 
     embed_dict = embeds[0].to_dict()
-    footer_text = embed_dict.get("footer", {}).get("text")
-    assert footer_text and footer_text.endswith(f"{BRIDGE_MARKER}{nonce}")
     description = embed_dict.get("description", "")
-    assert description == f"{expected_header}\n{content}"
+    assert description == content
+    assert "footer" not in embed_dict or not embed_dict["footer"]
     assert embed_dict.get("author", {}).get("name") == sample_membership.nickname
     assert embed_dict.get("author", {}).get("icon_url") == sample_membership.avatar_url
 
@@ -213,7 +211,7 @@ def test_build_bridge_message_populates_embed_footer(sample_user, sample_members
     assert upload.content_type == "image/png"
     assert upload.data == b"bytes"
 
-    payload = {"embeds": [embed_dict]}
+    payload = {"nonce": nonce, "embeds": [embed_dict]}
     assert extract_bridge_nonce_from_payload(payload) == nonce
 
 
@@ -251,22 +249,16 @@ def test_build_bridge_message_splits_long_content(sample_user, sample_membership
         timestamp=fixed_time,
     )
 
-    expected_header = "Message Sent by: Nick\n---"
     assert discord_content
     assert not uploads
     assert nonce
     assert len(embeds) >= 2
 
-    first_description = embeds[0].to_dict().get("description", "")
-    assert first_description.startswith(expected_header)
-
     embed_descriptions = [
         embed.to_dict().get("description", "") for embed in embeds
     ]
     combined = "".join(embed_descriptions)
-    expected_prefix = f"{expected_header}\n"
-    assert combined.startswith(expected_prefix)
-    body_in_embeds = combined[len(expected_prefix):]
+    body_in_embeds = combined
 
     total_length = 0
     for embed in embeds:
@@ -274,7 +266,7 @@ def test_build_bridge_message_splits_long_content(sample_user, sample_membership
         description = data.get("description", "")
         assert len(description) <= 4096
         total_length += len(description)
-        assert data.get("footer", {}).get("text", "").endswith(f"{BRIDGE_MARKER}{nonce}")
+        assert "footer" not in data or not data["footer"]
 
     assert total_length <= 6000
     last_description = embeds[-1].to_dict().get("description", "")
@@ -290,7 +282,7 @@ def test_build_bridge_message_splits_long_content(sample_user, sample_membership
         == expected_leftover[: DISCORD_CONTENT_LIMIT]
     )
 
-    payload = {"embeds": [embed.to_dict() for embed in embeds]}
+    payload = {"nonce": nonce, "embeds": [embed.to_dict() for embed in embeds]}
     assert extract_bridge_nonce_from_payload(payload) == nonce
 
 
@@ -308,12 +300,10 @@ def test_build_bridge_message_includes_character_when_enabled(
         timestamp=fixed_time,
     )
 
-    expected_header = "Message Sent by: Nick / Hero / Eorzea\n---"
     assert discord_content == ""
-    assert (
-        embeds[0].to_dict().get("description", "")
-        == f"{expected_header}\nHi"
-    )
+    embed_dict = embeds[0].to_dict()
+    assert embed_dict.get("description", "") == "Hi"
+    assert embed_dict.get("author", {}).get("name") == sample_user.character_name
     assert not uploads
     assert nonce
 

--- a/tests/test_ws_nonce.py
+++ b/tests/test_ws_nonce.py
@@ -331,7 +331,7 @@ def test_should_drop_due_to_nonce_and_cleanup(monkeypatch):
             "nonce": "abc123",
             "embeds": [
                 {
-                    "footer": {"text": f"DemiCat • Chat • {BRIDGE_MARKER}abc123"},
+                    "description": "hello",
                 }
             ],
         },


### PR DESCRIPTION
## Summary
- stop adding headers and footers to bridge embeds, introduce a fallback embed type, and keep nonce generation without exposing it in the embed
- read bridge nonces from the payload nonce field before falling back to legacy markers
- update backend bridge and websocket nonce tests to assert the leaner embed payloads

## Testing
- pytest tests/test_bridge.py tests/test_ws_nonce.py

------
https://chatgpt.com/codex/tasks/task_e_68db38027da08328a0c0a90cd9c3d114