### PR TITLE
Ensure section tabs have minimum width

### DIFF
--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -145,7 +145,12 @@ public sealed class NotePadWindow : IDisposable
                 var label = $"{title}##{section.Id}";
                 var tabFlags = selected ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None;
 
+                var textSize = ImGui.CalcTextSize(title);
+                var padding = ImGui.GetStyle().FramePadding.X + 6f;
+                var minWidth = textSize.X + padding * 2f;
+
                 var color = ParseColor(section.Color);
+                ImGui.PushStyleVar(ImGuiStyleVar.TabMinWidthForCloseButton, minWidth);
                 ImGui.PushStyleColor(ImGuiCol.Tab, AdjustTabColor(color, 0.7f));
                 ImGui.PushStyleColor(ImGuiCol.TabActive, AdjustTabColor(color, 1f));
                 ImGui.PushStyleColor(ImGuiCol.TabHovered, AdjustTabColor(color, 1.2f));
@@ -169,6 +174,7 @@ public sealed class NotePadWindow : IDisposable
                 }
 
                 ImGui.PopStyleColor(3);
+                ImGui.PopStyleVar();
 
                 if (ImGui.BeginDragDropSource())
                 {


### PR DESCRIPTION
## Summary
- measure each section tab title text and calculate a padded minimum width
- push the tab minimum width style var before drawing each tab to ensure consistent sizing
- pop the style var even when the tab is not opened to avoid leaking style changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db3ae53e048328b3bb5a27185a7545