### PR TITLE
Ensure MainWindow uses the emoji font for icon buttons

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -17,6 +17,7 @@ public class MainWindow : IDisposable
     private readonly TemplatesWindow _templates;
     private readonly RequestBoardWindow _requestBoard;
     private readonly NotePadWindow _notePad;
+    private readonly EmojiManager _emojiManager;
     private SyncshellWindow? _syncshell;
     private bool _syncshellEnabled;
     private bool _templatesTabActive;
@@ -68,6 +69,7 @@ public class MainWindow : IDisposable
         _officer = officer;
         _settings = settings;
         _httpClient = httpClient;
+        _emojiManager = emojiManager;
         _create = new EventCreateWindow(config, httpClient, channelService, channelSelection, emojiManager);
         _templates = new TemplatesWindow(config, httpClient, channelService, channelSelection, emojiManager);
         _requestBoard = new RequestBoardWindow(config, httpClient);
@@ -179,9 +181,12 @@ public class MainWindow : IDisposable
             var buttonSize = ImGui.GetFrameHeight();
             var cursor = ImGui.GetCursorPos();
             ImGui.SetCursorPos(new Vector2(ImGui.GetWindowContentRegionMax().X - buttonSize - padding.X, cursor.Y));
-            if (ImGui.Button("\u2699\uFE0F##dc_settings", new Vector2(buttonSize, buttonSize)))
             {
-                _settings.IsOpen = true;
+                using var emojiFont = _emojiManager.PushEmojiFont();
+                if (ImGui.Button("\u2699\uFE0F##dc_settings", new Vector2(buttonSize, buttonSize)))
+                {
+                    _settings.IsOpen = true;
+                }
             }
             ImGui.SetCursorPos(cursor);
 


### PR DESCRIPTION
## Summary
- store the provided EmojiManager on MainWindow so it can manage fonts while rendering
- wrap the settings button rendering in an emoji font scope so the cog glyph displays correctly

## Testing
- dotnet build *(fails: `dotnet` command not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db44e5cc3c83289e48b74b53ff0cce