### PR TITLE
Add configurable emoji picker sizing

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -291,7 +291,7 @@ public class ChatWindow : IDisposable
         _avatarCache = avatarCache;
         _channelKind = channelKind;
         _emojiManager = emojiManager;
-        _emojiPicker = new EmojiPicker(_emojiManager);
+        _emojiPicker = new EmojiPicker(_emojiManager, _config, SaveConfig);
         _ = _emojiManager.EnsureUnicodeAsync();
         _ = _emojiManager.EnsureCustomAsync();
         _useCharacterName = config.UseCharacterName;

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -17,7 +17,12 @@ public class Config : IPluginConfiguration
     public static readonly Vector4 DefaultSecondaryAccentColor = new(0.2f, 0.6f, 1f, 1f);
 
     // Required by Dalamud
-    public int Version { get; set; } = 12;
+    public const float MinEmojiTileSize = 16f;
+    public const float MaxEmojiTileSize = 64f;
+    public const float MinEmojiGridHeight = 120f;
+    public const float MaxEmojiGridHeight = 800f;
+
+    public int Version { get; set; } = 13;
 
     public bool Enabled { get; set; } = true;
     public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
@@ -44,6 +49,12 @@ public class Config : IPluginConfiguration
     public float ChatFontScale { get; set; } = 1f;
     public bool ChatImageAutoStretch { get; set; } = true;
     public float ChatImageManualScale { get; set; } = 1f;
+
+    [JsonPropertyName("emojiTileSize")]
+    public float EmojiTileSize { get; set; } = 28f;
+
+    [JsonPropertyName("emojiGridHeight")]
+    public float EmojiGridHeight { get; set; } = 220f;
 
     [JsonPropertyName("primaryWindowColor")]
     public Vector4 PrimaryWindowColor { get; set; } = DefaultPrimaryWindowColor;
@@ -393,6 +404,14 @@ public class Config : IPluginConfiguration
             Version = 12;
             ExtensionData = null;
         }
+        if (Version < 13)
+        {
+            EmojiTileSize = SanitizeEmojiTileSize(EmojiTileSize);
+            EmojiGridHeight = SanitizeEmojiGridHeight(EmojiGridHeight);
+
+            Version = 13;
+            ExtensionData = null;
+        }
     }
 
     internal static Vector4 SanitizeColor(Vector4 color, Vector4 fallback)
@@ -407,5 +426,30 @@ public class Config : IPluginConfiguration
             Math.Clamp(color.Y, 0f, 1f),
             Math.Clamp(color.Z, 0f, 1f),
             Math.Clamp(color.W, 0f, 1f));
+    }
+
+    internal static float SanitizeEmojiTileSize(float value)
+    {
+        if (!float.IsFinite(value) || value <= 0f)
+        {
+            return 28f;
+        }
+
+        return Math.Clamp(value, MinEmojiTileSize, MaxEmojiTileSize);
+    }
+
+    internal static float SanitizeEmojiGridHeight(float value)
+    {
+        if (!float.IsFinite(value))
+        {
+            return 220f;
+        }
+
+        if (value <= 0f)
+        {
+            return 0f;
+        }
+
+        return Math.Clamp(value, MinEmojiGridHeight, MaxEmojiGridHeight);
     }
 }

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -9,6 +9,10 @@ namespace DemiCatPlugin.Emoji;
 public sealed class EmojiPicker
 {
     private readonly EmojiManager _manager;
+    private readonly Config _config;
+    private readonly Action? _persistSettings;
+    private float _tileSize;
+    private float _gridHeight;
     private EmojiTab _tab;
     private string _search = string.Empty;
     private readonly ConcurrentDictionary<string, bool> _customTextureRequests = new();
@@ -19,25 +23,58 @@ public sealed class EmojiPicker
         Custom
     }
 
-    public EmojiPicker(EmojiManager manager) => _manager = manager;
+    public EmojiPicker(EmojiManager manager, Config config, Action? persistSettings = null)
+    {
+        _manager = manager;
+        _config = config;
+        _persistSettings = persistSettings;
+        _tileSize = Config.SanitizeEmojiTileSize(config.EmojiTileSize);
+        _gridHeight = Config.SanitizeEmojiGridHeight(config.EmojiGridHeight);
+    }
 
-    public string? Draw(float buttonSize = 28f)
+    public string? Draw()
     {
         var previous = _tab;
         string? selected = null;
+
+        var size = _tileSize;
+        if (ImGui.SliderFloat(
+                "Emoji Size",
+                ref size,
+                Config.MinEmojiTileSize,
+                Config.MaxEmojiTileSize,
+                "%.0f px"))
+        {
+            SetTileSize(size);
+        }
+
+        var height = _gridHeight;
+        if (ImGui.DragFloat(
+                "Grid Height",
+                ref height,
+                1f,
+                0f,
+                Config.MaxEmojiGridHeight,
+                height <= 0f ? "Fill" : "%.0f px"))
+        {
+            SetGridHeight(height);
+        }
+
+        ImGui.Separator();
+
         if (ImGui.BeginTabBar("##dc_emoji_tabs"))
         {
             if (ImGui.BeginTabItem("Standard"))
             {
                 _tab = EmojiTab.Standard;
-                selected = DrawStandard(buttonSize);
+                selected = DrawStandard();
                 ImGui.EndTabItem();
             }
 
             if (ImGui.BeginTabItem("Custom"))
             {
                 _tab = EmojiTab.Custom;
-                selected ??= DrawCustom(buttonSize);
+                selected ??= DrawCustom();
                 ImGui.EndTabItem();
             }
 
@@ -52,7 +89,7 @@ public sealed class EmojiPicker
         return string.IsNullOrEmpty(selected) ? null : selected;
     }
 
-    private string? DrawStandard(float size)
+    private string? DrawStandard()
     {
         ImGui.InputTextWithHint("##emoji_std_search", "Search…", ref _search, 64);
         ImGui.Separator();
@@ -100,9 +137,10 @@ public sealed class EmojiPicker
             return null;
         }
 
-        ImGui.BeginChild("##emoji_std_grid", new Vector2(0, 220f), false);
+        var childSize = _gridHeight > 0f ? new Vector2(0, _gridHeight) : Vector2.Zero;
+        ImGui.BeginChild("##emoji_std_grid", childSize, false);
         var avail = ImGui.GetContentRegionAvail().X;
-        var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (size + 4f)));
+        var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (_tileSize + 4f)));
         var column = 0;
         string? selected = null;
 
@@ -117,7 +155,7 @@ public sealed class EmojiPicker
             var emoji = filtered[i];
             ImGui.PushID(i);
             using var _ = _manager.PushEmojiFont();
-            if (ImGui.Button(emoji.Emoji, new Vector2(size, size)))
+            if (ImGui.Button(emoji.Emoji, new Vector2(_tileSize, _tileSize)))
             {
                 selected = EmojiFormatter.CreateUnicodeToken(emoji);
             }
@@ -143,7 +181,7 @@ public sealed class EmojiPicker
         return string.IsNullOrEmpty(selected) ? null : selected;
     }
 
-    private string? DrawCustom(float size)
+    private string? DrawCustom()
     {
         ImGui.InputTextWithHint("##emoji_custom_search", "Search :name:", ref _search, 64);
         ImGui.SameLine();
@@ -198,9 +236,10 @@ public sealed class EmojiPicker
             return null;
         }
 
-        ImGui.BeginChild("##emoji_custom_grid", new Vector2(0, 220f), false);
+        var childSize = _gridHeight > 0f ? new Vector2(0, _gridHeight) : Vector2.Zero;
+        ImGui.BeginChild("##emoji_custom_grid", childSize, false);
         var avail = ImGui.GetContentRegionAvail().X;
-        var columns = Math.Max(1, (int)Math.Floor((avail + 6f) / (size + 6f)));
+        var columns = Math.Max(1, (int)Math.Floor((avail + 6f) / (_tileSize + 6f)));
         var column = 0;
         string? selected = null;
 
@@ -242,14 +281,14 @@ public sealed class EmojiPicker
                 texture != null)
             {
                 var wrap = texture.GetWrapOrEmpty();
-                if (ImGui.ImageButton(wrap.Handle, new Vector2(size, size)))
+                if (ImGui.ImageButton(wrap.Handle, new Vector2(_tileSize, _tileSize)))
                 {
                     clicked = true;
                 }
             }
             else
             {
-                if (ImGui.Button(tooltip, new Vector2(size * 3f, size)))
+                if (ImGui.Button(tooltip, new Vector2(_tileSize * 3f, _tileSize)))
                 {
                     clicked = true;
                 }
@@ -287,5 +326,42 @@ public sealed class EmojiPicker
         ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(1f, 0.4f, 0.4f, 1f));
         ImGui.TextWrapped(message);
         ImGui.PopStyleColor();
+    }
+
+    private void SetTileSize(float value)
+    {
+        var sanitized = Config.SanitizeEmojiTileSize(value);
+        if (Math.Abs(sanitized - _tileSize) < 0.01f)
+        {
+            return;
+        }
+
+        _tileSize = sanitized;
+        if (Math.Abs(_config.EmojiTileSize - sanitized) >= 0.01f)
+        {
+            _config.EmojiTileSize = sanitized;
+            PersistSettings();
+        }
+    }
+
+    private void SetGridHeight(float value)
+    {
+        var sanitized = Config.SanitizeEmojiGridHeight(value);
+        if (Math.Abs(sanitized - _gridHeight) < 0.01f)
+        {
+            return;
+        }
+
+        _gridHeight = sanitized;
+        if (Math.Abs(_config.EmojiGridHeight - sanitized) >= 0.01f)
+        {
+            _config.EmojiGridHeight = sanitized;
+            PersistSettings();
+        }
+    }
+
+    private void PersistSettings()
+    {
+        _persistSettings?.Invoke();
     }
 }

--- a/DemiCatPlugin/Emoji/EmojiPopup.cs
+++ b/DemiCatPlugin/Emoji/EmojiPopup.cs
@@ -9,9 +9,9 @@ public sealed class EmojiPopup
     private readonly string _popupId;
     private Action<string>? _onSelected;
 
-    public EmojiPopup(EmojiManager manager, string popupId = "PickEmoji")
+    public EmojiPopup(Config config, EmojiManager manager, string popupId = "PickEmoji", Action? persistSettings = null)
     {
-        _picker = new EmojiPicker(manager);
+        _picker = new EmojiPicker(manager, config, persistSettings);
         _popupId = popupId;
     }
 

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -80,7 +80,7 @@ public class EventCreateWindow
         _emojiManager = emojiManager;
         _channelSelection = channelSelection;
         _optionEditor = new SignupOptionEditor(config, httpClient, emojiManager);
-        _descriptionEmojiPopup = new EmojiPopup(emojiManager, "EventDescriptionEmoji");
+        _descriptionEmojiPopup = new EmojiPopup(config, emojiManager, "EventDescriptionEmoji", SaveConfig);
         var defaultTime = DateTimePicker.GetDefaultTime();
         _timePicker = new DateTimePicker(defaultTime);
         _time = defaultTime.ToUniversalTime().ToString("O");

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -14,6 +14,7 @@ public class SignupOptionEditor
     private bool _open;
     private Template.TemplateButton _working = new();
     private Action<Template.TemplateButton>? _onSave;
+    private readonly Config _config;
     private readonly EmojiPopup _emojiPopup;
     private readonly EmojiManager _emojiManager;
     private int _emojiSelectionStart;
@@ -22,8 +23,9 @@ public class SignupOptionEditor
 
     public SignupOptionEditor(Config config, HttpClient httpClient, EmojiManager emojiManager)
     {
+        _config = config;
         _emojiManager = emojiManager;
-        _emojiPopup = new EmojiPopup(emojiManager);
+        _emojiPopup = new EmojiPopup(config, emojiManager, persistSettings: SaveConfig);
     }
 
     public void Open(Template.TemplateButton button, Action<Template.TemplateButton> onSave)
@@ -182,5 +184,10 @@ public class SignupOptionEditor
         _emojiSelectionStart = data.SelectionStart;
         _emojiSelectionEnd = data.SelectionEnd;
         return 0;
+    }
+
+    private void SaveConfig()
+    {
+        PluginServices.Instance?.PluginInterface.SavePluginConfig(_config);
     }
 }


### PR DESCRIPTION
## Summary
- add configuration settings for emoji tile size and grid height with migration defaults
- expose runtime controls in the emoji picker UI so users can adjust size and persist preferences
- update picker call sites to pass configuration persistence hooks so settings are remembered across windows

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db458d1cd0832889a8a19d0c6a0659