### PR TITLE
Add configurable embed colors for FC and officer chat

### DIFF
--- a/DemiCatPlugin/BridgeMessageFormatter.cs
+++ b/DemiCatPlugin/BridgeMessageFormatter.cs
@@ -30,6 +30,7 @@ public static class BridgeMessageFormatter
         public string? CharacterName { get; init; }
         public string? WorldName { get; init; }
         public string? AuthorAvatarUrl { get; init; }
+        public uint? EmbedColor { get; init; }
         public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
     }
 
@@ -125,7 +126,7 @@ public static class BridgeMessageFormatter
                 Timestamp = options.Timestamp,
                 AuthorName = DetermineAuthor(options),
                 AuthorIconUrl = options.AuthorAvatarUrl,
-                Color = DetermineColor(options.ChannelKind)
+                Color = DetermineColor(options)
             };
             list.Add(embed);
         }
@@ -142,13 +143,14 @@ public static class BridgeMessageFormatter
         return "You";
     }
 
-    private static uint DetermineColor(string? channelKind)
+    private static uint DetermineColor(BridgeFormatterOptions options)
     {
-        return channelKind switch
+        if (options.EmbedColor is uint color)
         {
-            ChannelKind.OfficerChat => 0xED4245, // red-ish for emphasis
-            _ => 0x5865F2 // Discord blurple
-        };
+            return color;
+        }
+
+        return Config.GetDefaultEmbedColor(options.ChannelKind);
     }
 
     private static IReadOnlyList<string> SplitIntoEmbedChunks(

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -123,6 +123,95 @@ public class ChatWindow : IDisposable
         return Math.Clamp(manualScale, Config.MinChatImageScale, Config.MaxChatImageScale);
     }
 
+    private bool SupportsEmbedColorSelection()
+        => _channelKind == ChannelKind.FcChat || _channelKind == ChannelKind.OfficerChat;
+
+    private uint? GetEmbedColorOverride()
+        => _channelKind switch
+        {
+            ChannelKind.FcChat => _config.FcEmbedColor,
+            ChannelKind.OfficerChat => _config.OfficerEmbedColor,
+            _ => null
+        };
+
+    private uint GetEffectiveEmbedColor()
+    {
+        var overrideColor = GetEmbedColorOverride();
+        return overrideColor ?? Config.GetDefaultEmbedColor(_channelKind);
+    }
+
+    private void SetEmbedColorOverride(uint? color)
+    {
+        var changed = false;
+        if (_channelKind == ChannelKind.FcChat)
+        {
+            if (_config.FcEmbedColor != color)
+            {
+                _config.FcEmbedColor = color;
+                changed = true;
+            }
+        }
+        else if (_channelKind == ChannelKind.OfficerChat)
+        {
+            if (_config.OfficerEmbedColor != color)
+            {
+                _config.OfficerEmbedColor = color;
+                changed = true;
+            }
+        }
+
+        if (changed)
+        {
+            SaveConfig();
+            InvalidatePreview();
+        }
+    }
+
+    private void DrawEmbedColorPicker()
+    {
+        if (!SupportsEmbedColorSelection())
+        {
+            return;
+        }
+
+        ImGui.AlignTextToFramePadding();
+        ImGui.TextUnformatted("Embed Color:");
+        ImGui.SameLine();
+
+        var effectiveColor = GetEffectiveEmbedColor();
+        var colorVec = ColorUtils.RgbToVector4(effectiveColor);
+        var buttonSize = new Vector2(ImGui.GetFrameHeight() * 2.2f, ImGui.GetFrameHeight());
+        var popupId = $"embedColorPicker##{_channelKind}";
+        if (ImGui.ColorButton($"##embedColorButton_{_channelKind}", colorVec, ImGuiColorEditFlags.NoAlpha, buttonSize))
+        {
+            ImGui.OpenPopup(popupId);
+        }
+
+        if (ImGui.BeginPopup(popupId))
+        {
+            var pickerColor = new Vector3(colorVec.X, colorVec.Y, colorVec.Z);
+            var pickerFlags = ImGuiColorEditFlags.NoSidePreview | ImGuiColorEditFlags.NoSmallPreview;
+            if (ImGui.ColorPicker3("##embedColorPicker", ref pickerColor, pickerFlags))
+            {
+                var newColor = ColorUtils.ImGuiToRgb(ColorUtils.Vector4ToImGui(new Vector4(pickerColor, 1f)));
+                SetEmbedColorOverride(newColor);
+            }
+
+            if (GetEmbedColorOverride().HasValue)
+            {
+                if (ImGui.Button("Reset to Default"))
+                {
+                    SetEmbedColorOverride(null);
+                    ImGui.CloseCurrentPopup();
+                }
+            }
+
+            ImGui.EndPopup();
+        }
+
+        ImGui.SameLine();
+    }
+
     protected float GetFontScale()
     {
         var fontScale = _config.ChatFontScale;
@@ -1022,6 +1111,8 @@ public class ChatWindow : IDisposable
                 ImGui.TextUnformatted($"{names} {verb} typing...");
             }
         }
+
+        DrawEmbedColorPicker();
 
         if (ImGui.SmallButton("B")) WrapSelection("**", "**");
         ImGui.SameLine();
@@ -2505,6 +2596,7 @@ public class ChatWindow : IDisposable
             AuthorName = authorName,
             CharacterName = characterName,
             WorldName = worldName,
+            EmbedColor = GetEmbedColorOverride(),
             Timestamp = DateTimeOffset.UtcNow
         };
     }
@@ -2762,6 +2854,11 @@ public class ChatWindow : IDisposable
             new("content", content),
             new("useCharacterName", _useCharacterName ? "true" : "false")
         };
+        if (SupportsEmbedColorSelection())
+        {
+            var color = GetEffectiveEmbedColor();
+            fields.Add(new KeyValuePair<string, string>("embedColor", color.ToString()));
+        }
         if (messageReference != null)
         {
             var referenceJson = JsonSerializer.Serialize(messageReference);
@@ -2781,6 +2878,11 @@ public class ChatWindow : IDisposable
         var form = new MultipartFormDataContent();
         form.Add(new StringContent(content), "content");
         form.Add(new StringContent(_useCharacterName ? "true" : "false"), "useCharacterName");
+        if (SupportsEmbedColorSelection())
+        {
+            var color = GetEffectiveEmbedColor().ToString();
+            form.Add(new StringContent(color), "embedColor");
+        }
         if (!string.IsNullOrEmpty(_replyToId))
         {
             var reference = new MessageBuilder()

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -21,8 +21,10 @@ public class Config : IPluginConfiguration
     public const float MaxEmojiTileSize = 64f;
     public const float MinEmojiGridHeight = 120f;
     public const float MaxEmojiGridHeight = 800f;
+    public const uint DefaultFcEmbedColor = 0x5865F2;
+    public const uint DefaultOfficerEmbedColor = 0xED4245;
 
-    public int Version { get; set; } = 13;
+    public int Version { get; set; } = 14;
 
     public bool Enabled { get; set; } = true;
     public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
@@ -42,6 +44,10 @@ public class Config : IPluginConfiguration
     public bool EnableFcChatUserSet { get; set; } = false;
     public float FcChatOpacity { get; set; } = 1f;
     public float OfficerChatOpacity { get; set; } = 1f;
+    [JsonPropertyName("fcEmbedColor")]
+    public uint? FcEmbedColor { get; set; } = DefaultFcEmbedColor;
+    [JsonPropertyName("officerEmbedColor")]
+    public uint? OfficerEmbedColor { get; set; } = DefaultOfficerEmbedColor;
     public bool ChatFadeOutEnabled { get; set; } = false;
     public int ChatFadeOutDelaySeconds { get; set; } = 10;
     public float ChatFadeOutMinimumAlpha { get; set; } = 0.3f;
@@ -412,6 +418,23 @@ public class Config : IPluginConfiguration
             Version = 13;
             ExtensionData = null;
         }
+        if (Version < 14)
+        {
+            FcEmbedColor ??= DefaultFcEmbedColor;
+            OfficerEmbedColor ??= DefaultOfficerEmbedColor;
+
+            Version = 14;
+            ExtensionData = null;
+        }
+    }
+
+    public static uint GetDefaultEmbedColor(string? channelKind)
+    {
+        return channelKind switch
+        {
+            ChannelKind.OfficerChat => DefaultOfficerEmbedColor,
+            _ => DefaultFcEmbedColor
+        };
     }
 
     internal static Vector4 SanitizeColor(Vector4 color, Vector4 fallback)

--- a/demibot/demibot/bridge.py
+++ b/demibot/demibot/bridge.py
@@ -16,6 +16,8 @@ DISCORD_EMBED_DESCRIPTION_LIMIT = 4096
 DISCORD_EMBED_TOTAL_LIMIT = 6000
 DISCORD_EMBED_COUNT_LIMIT = 10
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+DEFAULT_FC_COLOR = 0x5865F2
+DEFAULT_OFFICER_COLOR = 0xED4245
 
 
 @dataclass
@@ -182,6 +184,20 @@ def _split_embed_text(text: str) -> tuple[list[str], int]:
     return chunks, consumed
 
 
+def _sanitize_embed_color(value: int | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError):
+        return None
+    if numeric < 0:
+        return 0
+    if numeric > 0xFFFFFF:
+        return 0xFFFFFF
+    return numeric
+
+
 def build_bridge_message(
     *,
     content: str,
@@ -192,6 +208,7 @@ def build_bridge_message(
     attachments: Sequence[tuple[str, bytes, str | None]] | None = None,
     nonce: str | None = None,
     timestamp: datetime | None = None,
+    embed_color: int | None = None,
 ) -> tuple[str, list[discord.Embed], list[BridgeUpload], str]:
     """Construct the Discord payload for a bridge message."""
 
@@ -221,9 +238,13 @@ def build_bridge_message(
     )
     author_icon = membership.avatar_url if membership else None
 
-    color_value = 0x5865F2
-    if channel_kind == ChannelKind.OFFICER_CHAT:
-        color_value = 0xED4245
+    override_color = _sanitize_embed_color(embed_color)
+    color_value = override_color
+    if color_value is None:
+        if channel_kind == ChannelKind.OFFICER_CHAT:
+            color_value = DEFAULT_OFFICER_COLOR
+        else:
+            color_value = DEFAULT_FC_COLOR
     color_factory = getattr(discord, "Color", None) or getattr(discord, "Colour", None)
     color = color_factory(color_value) if callable(color_factory) else color_value
 

--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -977,6 +977,7 @@ class PostBody(BaseModel):
     message_reference: MessageReferenceDto | None = Field(
         default=None, alias="messageReference"
     )
+    embed_color: int | None = Field(default=None, alias="embedColor")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -1190,6 +1191,7 @@ class PostBody(BaseModel):
     message_reference: MessageReferenceDto | None = Field(
         default=None, alias="messageReference"
     )
+    embed_color: int | None = Field(default=None, alias="embedColor")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -1300,6 +1302,7 @@ async def save_message(
         channel_kind=gc_kind or channel_kind,
         use_character_name=bool(body.use_character_name),
         attachments=uploads_data,
+        embed_color=body.embed_color,
     )
 
     username_base = nickname or (

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -50,6 +50,7 @@ async def post_message_with_attachments(
     content: str = Form(...),
     useCharacterName: bool | None = Form(False),
     message_reference: str | None = Form(None),
+    embedColor: int | None = Form(None),
     files: list[UploadFile] | None = File(None),
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
@@ -65,6 +66,7 @@ async def post_message_with_attachments(
         content=content,
         use_character_name=useCharacterName,
         message_reference=ref,
+        embed_color=embedColor,
     )
     return await save_message(body, ctx, db, channel_kind=ChannelKind.FC_CHAT, files=files)
 

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -42,6 +42,7 @@ async def post_officer_message_with_attachments(
     content: str = Form(...),
     useCharacterName: bool | None = Form(False),
     message_reference: str | None = Form(None),
+    embedColor: int | None = Form(None),
     files: list[UploadFile] | None = File(None),
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
@@ -58,6 +59,7 @@ async def post_officer_message_with_attachments(
         content=content,
         use_character_name=useCharacterName,
         message_reference=ref,
+        embed_color=embedColor,
     )
 
     return await save_message(

--- a/demibot/demibot/http/ws_chat.py
+++ b/demibot/demibot/http/ws_chat.py
@@ -1169,6 +1169,15 @@ class ChatConnectionManager:
         use_character_name_flag = bool(
             payload.get("useCharacterName") or payload.get("use_character_name")
         )
+        raw_embed_color = payload.get("embedColor")
+        if raw_embed_color is None:
+            raw_embed_color = payload.get("embed_color")
+        embed_color_value: int | None = None
+        if raw_embed_color is not None:
+            try:
+                embed_color_value = int(raw_embed_color)
+            except (TypeError, ValueError):
+                embed_color_value = None
 
         channel_obj: discord.abc.Messageable | discord.Thread | None = None
         thread_id: int | None = None
@@ -1314,6 +1323,7 @@ class ChatConnectionManager:
             channel_kind=channel_kind_value,
             use_character_name=use_character_name_flag,
             attachments=file_data,
+            embed_color=embed_color_value,
         )
 
         username = (

--- a/tests/BridgeMessageFormatterTests.cs
+++ b/tests/BridgeMessageFormatterTests.cs
@@ -57,4 +57,16 @@ public class BridgeMessageFormatterTests
         Assert.Single(result.Mentions);
         Assert.Equal("1", result.Mentions[0].Id);
     }
+
+    [Fact]
+    public void Format_UsesEmbedColorOverride()
+    {
+        var options = CreateOptions();
+        options.EmbedColor = 0x123456;
+
+        var result = BridgeMessageFormatter.Format("Hello", Array.Empty<string>(), options);
+
+        var embed = Assert.Single(result.Embeds);
+        Assert.Equal((uint)0x123456, embed.Color);
+    }
 }

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -40,5 +40,7 @@ public class ConfigDefaultsTests
         Assert.Equal(10, cfg.ChatFadeOutDelaySeconds);
         Assert.Equal(0.3f, cfg.ChatFadeOutMinimumAlpha);
         Assert.Equal(0.35f, cfg.ChatInputSplitRatio);
+        Assert.Equal(Config.DefaultFcEmbedColor, cfg.FcEmbedColor);
+        Assert.Equal(Config.DefaultOfficerEmbedColor, cfg.OfficerEmbedColor);
     }
 }

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -215,6 +215,23 @@ def test_build_bridge_message_generates_simple_embed(sample_user, sample_members
     assert extract_bridge_nonce_from_payload(payload) == nonce
 
 
+def test_build_bridge_message_honors_embed_color(sample_user, sample_membership):
+    discord_content, embeds, uploads, nonce = build_bridge_message(
+        content="Color",
+        user=sample_user,
+        membership=sample_membership,
+        channel_kind=ChannelKind.FC_CHAT,
+        attachments=None,
+        embed_color=0x123456,
+    )
+
+    assert nonce
+    assert not discord_content
+    assert not uploads
+    embed_dict = embeds[0].to_dict()
+    assert embed_dict.get("color") == 0x123456
+
+
 @pytest.mark.parametrize(
     "provider_path",
     [

--- a/tests/test_messages_endpoint.py
+++ b/tests/test_messages_endpoint.py
@@ -57,7 +57,7 @@ async def test_post_message_accepts_channel_aliases(channel_key, monkeypatch):
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
             "/api/messages",
-            json={channel_key: "123", "content": "Hello"},
+            json={channel_key: "123", "content": "Hello", "embedColor": 0x123456},
         )
 
     app.dependency_overrides.clear()
@@ -68,6 +68,7 @@ async def test_post_message_accepts_channel_aliases(channel_key, monkeypatch):
     assert captured["channel_id"] == "123"
     assert isinstance(captured["body"], messages_routes.PostBody)
     assert captured["channel_kind"] == ChannelKind.FC_CHAT
+    assert captured["body"].embed_color == 0x123456
 
 
 @pytest.mark.asyncio
@@ -103,6 +104,7 @@ async def test_channel_messages_multipart_accepts_message_reference(monkeypatch)
             "content": "Hello",
             "useCharacterName": "true",
             "message_reference": json.dumps({"messageId": "5", "channelId": "555"}),
+            "embedColor": str(0x123456),
         }
         resp = await client.post(
             "/api/channels/555/messages",
@@ -122,6 +124,7 @@ async def test_channel_messages_multipart_accepts_message_reference(monkeypatch)
     assert body.message_reference is not None
     assert body.message_reference.channel_id == "555"
     assert body.message_reference.message_id == "5"
+    assert body.embed_color == 0x123456
 
     assert captured["channel_kind"] == ChannelKind.FC_CHAT
 

--- a/tests/test_officer_messages_endpoint.py
+++ b/tests/test_officer_messages_endpoint.py
@@ -128,6 +128,7 @@ async def test_officer_multipart_uses_officer_endpoint(monkeypatch):
             "content": "Hello",
             "useCharacterName": "true",
             "message_reference": json.dumps({"messageId": "5", "channelId": "555"}),
+            "embedColor": str(0x123456),
         }
         resp = await client.post(
             "/api/channels/555/officer-messages",
@@ -147,6 +148,7 @@ async def test_officer_multipart_uses_officer_endpoint(monkeypatch):
     assert body.message_reference is not None
     assert body.message_reference.channel_id == "555"
     assert body.message_reference.message_id == "5"
+    assert body.embed_color == 0x123456
 
     assert captured["channel_kind"] == ChannelKind.OFFICER_CHAT
 


### PR DESCRIPTION
## Summary
- extend the plugin config and chat composer with embed color overrides for FC and officer channels
- plumb the embedColor through the formatter, HTTP/multipart payloads, websocket bridge, and server routes so overrides are honored
- add unit and API coverage for the new embed color handling on both the client and server

## Testing
- pytest tests/test_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68db488e2af483289ef5fe1ffd54492e