### PR TITLE
Clone embed border settings before mutating

### DIFF
--- a/DemiCatPlugin/BridgeMessageFormatter.cs
+++ b/DemiCatPlugin/BridgeMessageFormatter.cs
@@ -32,6 +32,7 @@ public static class BridgeMessageFormatter
         public string? AuthorAvatarUrl { get; init; }
         public uint? EmbedColor { get; init; }
         public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
+        public Config.EmbedBorderSettings? EmbedBorder { get; init; }
     }
 
     public sealed class BridgeFormattedAttachment
@@ -82,15 +83,23 @@ public static class BridgeMessageFormatter
             errors.Add($"Message exceeds Discord's {DiscordContentLimit} character limit.");
         }
 
-        var embedChunks = SplitIntoEmbedChunks(displayContent, warnings, errors);
-        var embeds = BuildEmbeds(embedChunks, options, warnings);
+        var borderResult = EmbedBorderBuilder.Apply(displayContent, options.EmbedBorder, options.ChannelKind, DiscordEmbedDescriptionLimit);
+        if (!string.IsNullOrEmpty(borderResult.Warning))
+        {
+            warnings.Add(borderResult.Warning!);
+        }
+
+        var borderedDisplayContent = borderResult.Applied ? borderResult.Text : displayContent;
+
+        var embedChunks = SplitIntoEmbedChunks(borderedDisplayContent, warnings, errors);
+        var embeds = BuildEmbeds(embedChunks, options, warnings, borderResult);
 
         var attachments = ProcessAttachments(attachmentPaths, warnings, errors);
 
         return new BridgeFormattedMessage
         {
             Content = content,
-            DisplayContent = displayContent,
+            DisplayContent = borderedDisplayContent,
             Embeds = embeds,
             Attachments = attachments,
             Warnings = warnings,
@@ -106,7 +115,8 @@ public static class BridgeMessageFormatter
     private static IReadOnlyList<EmbedDto> BuildEmbeds(
         IReadOnlyList<string> chunks,
         BridgeFormatterOptions options,
-        List<string> warnings)
+        List<string> warnings,
+        EmbedBorderBuilder.Result borderResult)
     {
         var list = new List<EmbedDto>();
         var chunkCount = chunks.Count > 0 ? chunks.Count : 1;
@@ -128,6 +138,15 @@ public static class BridgeMessageFormatter
                 AuthorIconUrl = options.AuthorAvatarUrl,
                 Color = DetermineColor(options)
             };
+            if (borderResult.Applied && borderResult.Border != null && i == 0)
+            {
+                embed.Border = new EmbedBorderRenderDto
+                {
+                    Enabled = true,
+                    Glyph = EmbedBorderBuilder.GetGlyphName(borderResult.Border.Glyph),
+                    Color = borderResult.Border.Color
+                };
+            }
             list.Add(embed);
         }
 

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -167,46 +167,61 @@ public class ChatWindow : IDisposable
         }
     }
 
-    private void DrawEmbedColorPicker()
+    private void SetEmbedBorderSettings(Config.EmbedBorderSettings settings)
+    {
+        if (settings == null)
+        {
+            return;
+        }
+
+        var current = _config.GetEmbedBorderSettingsCopy(_channelKind);
+        if (current.Enabled == settings.Enabled && current.Glyph == settings.Glyph && current.Color == settings.Color)
+        {
+            return;
+        }
+
+        _config.SetEmbedBorderSettings(_channelKind, settings);
+        SaveConfig();
+        InvalidatePreview();
+    }
+
+    private string SerializeBorderSettingsForPayload()
+    {
+        var border = _config.GetEmbedBorderSettingsCopy(_channelKind);
+        var payload = new
+        {
+            enabled = border.Enabled,
+            glyph = EmbedBorderBuilder.GetGlyphName(border.Glyph),
+            color = border.Color
+        };
+        return JsonSerializer.Serialize(payload);
+    }
+
+    private void DrawEmbedStyleControls()
     {
         if (!SupportsEmbedColorSelection())
         {
             return;
         }
 
-        ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted("Embed Color:");
-        ImGui.SameLine();
-
-        var effectiveColor = GetEffectiveEmbedColor();
-        var colorVec = ColorUtils.RgbToVector4(effectiveColor);
-        var buttonSize = new Vector2(ImGui.GetFrameHeight() * 2.2f, ImGui.GetFrameHeight());
-        var popupId = $"embedColorPicker##{_channelKind}";
-        if (ImGui.ColorButton($"##embedColorButton_{_channelKind}", colorVec, ImGuiColorEditFlags.NoAlpha, buttonSize))
+        var context = new EmbedStyleControls.Context
         {
-            ImGui.OpenPopup(popupId);
+            ChannelKind = _channelKind,
+            EffectiveEmbedColor = GetEffectiveEmbedColor(),
+            EmbedColorOverride = GetEmbedColorOverride(),
+            Border = _config.GetEmbedBorderSettingsCopy(_channelKind)
+        };
+
+        var result = EmbedStyleControls.Draw(context);
+
+        if (result.EmbedColorChanged)
+        {
+            SetEmbedColorOverride(result.EmbedColorOverride);
         }
 
-        if (ImGui.BeginPopup(popupId))
+        if (result.BorderChanged)
         {
-            var pickerColor = new Vector3(colorVec.X, colorVec.Y, colorVec.Z);
-            var pickerFlags = ImGuiColorEditFlags.NoSidePreview | ImGuiColorEditFlags.NoSmallPreview;
-            if (ImGui.ColorPicker3("##embedColorPicker", ref pickerColor, pickerFlags))
-            {
-                var newColor = ColorUtils.ImGuiToRgb(ColorUtils.Vector4ToImGui(new Vector4(pickerColor, 1f)));
-                SetEmbedColorOverride(newColor);
-            }
-
-            if (GetEmbedColorOverride().HasValue)
-            {
-                if (ImGui.Button("Reset to Default"))
-                {
-                    SetEmbedColorOverride(null);
-                    ImGui.CloseCurrentPopup();
-                }
-            }
-
-            ImGui.EndPopup();
+            SetEmbedBorderSettings(result.Border);
         }
 
         ImGui.SameLine();
@@ -1112,7 +1127,7 @@ public class ChatWindow : IDisposable
             }
         }
 
-        DrawEmbedColorPicker();
+        DrawEmbedStyleControls();
 
         if (ImGui.SmallButton("B")) WrapSelection("**", "**");
         ImGui.SameLine();
@@ -2597,6 +2612,7 @@ public class ChatWindow : IDisposable
             CharacterName = characterName,
             WorldName = worldName,
             EmbedColor = GetEmbedColorOverride(),
+            EmbedBorder = _config.GetEmbedBorderSettingsCopy(_channelKind),
             Timestamp = DateTimeOffset.UtcNow
         };
     }
@@ -2858,6 +2874,7 @@ public class ChatWindow : IDisposable
         {
             var color = GetEffectiveEmbedColor();
             fields.Add(new KeyValuePair<string, string>("embedColor", color.ToString()));
+            fields.Add(new KeyValuePair<string, string>("embedBorder", SerializeBorderSettingsForPayload()));
         }
         if (messageReference != null)
         {
@@ -2882,6 +2899,7 @@ public class ChatWindow : IDisposable
         {
             var color = GetEffectiveEmbedColor().ToString();
             form.Add(new StringContent(color), "embedColor");
+            form.Add(new StringContent(SerializeBorderSettingsForPayload(), Encoding.UTF8), "embedBorder");
         }
         if (!string.IsNullOrEmpty(_replyToId))
         {

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -23,8 +23,45 @@ public class Config : IPluginConfiguration
     public const float MaxEmojiGridHeight = 800f;
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
+    public const int CurrentVersion = 15;
 
-    public int Version { get; set; } = 14;
+    public int Version { get; set; } = CurrentVersion;
+
+    public enum EmbedBorderGlyph
+    {
+        Square,
+        Circle,
+        Triangle
+    }
+
+    public sealed class EmbedBorderSettings
+    {
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
+        [JsonPropertyName("glyph")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public EmbedBorderGlyph Glyph { get; set; } = EmbedBorderGlyph.Square;
+
+        [JsonPropertyName("color")]
+        public uint Color { get; set; }
+
+        public EmbedBorderSettings Clone()
+            => new()
+            {
+                Enabled = Enabled,
+                Glyph = Glyph,
+                Color = Color
+            };
+
+        public static EmbedBorderSettings CreateDefault(string? channelKind)
+            => new()
+            {
+                Enabled = false,
+                Glyph = EmbedBorderGlyph.Square,
+                Color = GetDefaultEmbedColor(channelKind)
+            };
+    }
 
     public bool Enabled { get; set; } = true;
     public string ApiBaseUrl { get; set; } = "http://127.0.0.1:5050";
@@ -102,6 +139,11 @@ public class Config : IPluginConfiguration
 
     [JsonPropertyName("syncshellManualSyncCustom")]
     public bool SyncshellManualSyncCustom { get; set; }
+    [JsonPropertyName("fcEmbedBorder")]
+    public EmbedBorderSettings FcEmbedBorder { get; set; } = EmbedBorderSettings.CreateDefault(ChannelKind.FcChat);
+
+    [JsonPropertyName("officerEmbedBorder")]
+    public EmbedBorderSettings OfficerEmbedBorder { get; set; } = EmbedBorderSettings.CreateDefault(ChannelKind.OfficerChat);
     public bool UseCharacterName { get; set; } = false;
     public List<string> Roles { get; set; } = new();
     [JsonPropertyName("mentionRoleIds")]
@@ -426,6 +468,16 @@ public class Config : IPluginConfiguration
             Version = 14;
             ExtensionData = null;
         }
+        if (Version < 15)
+        {
+            FcEmbedBorder ??= EmbedBorderSettings.CreateDefault(ChannelKind.FcChat);
+            OfficerEmbedBorder ??= EmbedBorderSettings.CreateDefault(ChannelKind.OfficerChat);
+            FcEmbedBorder.Color = SanitizeRgb(FcEmbedBorder.Color, GetDefaultEmbedColor(ChannelKind.FcChat));
+            OfficerEmbedBorder.Color = SanitizeRgb(OfficerEmbedBorder.Color, GetDefaultEmbedColor(ChannelKind.OfficerChat));
+
+            Version = 15;
+            ExtensionData = null;
+        }
     }
 
     public static uint GetDefaultEmbedColor(string? channelKind)
@@ -435,6 +487,62 @@ public class Config : IPluginConfiguration
             ChannelKind.OfficerChat => DefaultOfficerEmbedColor,
             _ => DefaultFcEmbedColor
         };
+    }
+
+    public EmbedBorderSettings GetEmbedBorderSettings(string? channelKind)
+    {
+        return channelKind switch
+        {
+            ChannelKind.OfficerChat => OfficerEmbedBorder ?? EmbedBorderSettings.CreateDefault(channelKind),
+            ChannelKind.FcChat => FcEmbedBorder ?? EmbedBorderSettings.CreateDefault(channelKind),
+            _ => EmbedBorderSettings.CreateDefault(channelKind)
+        };
+    }
+
+    public EmbedBorderSettings GetEmbedBorderSettingsCopy(string? channelKind)
+    {
+        var settings = GetEmbedBorderSettings(channelKind);
+        if (settings != null)
+        {
+            settings = settings.Clone();
+        }
+        else
+        {
+            settings = EmbedBorderSettings.CreateDefault(channelKind);
+        }
+        settings.Color = SanitizeRgb(settings.Color, GetDefaultEmbedColor(channelKind));
+        return settings;
+    }
+
+    public void SetEmbedBorderSettings(string? channelKind, EmbedBorderSettings settings)
+    {
+        if (settings == null)
+        {
+            return;
+        }
+
+        settings = settings.Clone();
+        settings.Color = SanitizeRgb(settings.Color, GetDefaultEmbedColor(channelKind));
+        switch (channelKind)
+        {
+            case ChannelKind.OfficerChat:
+                OfficerEmbedBorder = settings;
+                break;
+            case ChannelKind.FcChat:
+                FcEmbedBorder = settings;
+                break;
+        }
+    }
+
+    internal static uint SanitizeRgb(uint value, uint fallback)
+    {
+        var sanitized = value & 0xFFFFFFu;
+        if (sanitized == value)
+        {
+            return sanitized;
+        }
+
+        return fallback & 0xFFFFFFu;
     }
 
     internal static Vector4 SanitizeColor(Vector4 color, Vector4 fallback)

--- a/DemiCatPlugin/EmbedBorderBuilder.cs
+++ b/DemiCatPlugin/EmbedBorderBuilder.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DemiCatPlugin;
+
+public static class EmbedBorderBuilder
+{
+    private const int MaxLineLength = 120;
+    private const int Padding = 1;
+    private static readonly IReadOnlyDictionary<Config.EmbedBorderGlyph, string> GlyphSymbols = new Dictionary<Config.EmbedBorderGlyph, string>
+    {
+        [Config.EmbedBorderGlyph.Square] = "■",
+        [Config.EmbedBorderGlyph.Circle] = "●",
+        [Config.EmbedBorderGlyph.Triangle] = "▲"
+    };
+
+    public sealed class BorderState
+    {
+        public Config.EmbedBorderGlyph Glyph { get; init; }
+        public uint Color { get; init; }
+    }
+
+    public sealed class Result
+    {
+        public string Text { get; init; } = string.Empty;
+        public bool Applied { get; init; }
+        public BorderState? Border { get; init; }
+        public string? Warning { get; init; }
+    }
+
+    public static Result Apply(string? content, Config.EmbedBorderSettings? settings, string? channelKind, int maxLength)
+    {
+        var normalized = content ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(normalized) || settings == null || !settings.Enabled)
+        {
+            return new Result { Text = normalized, Applied = false };
+        }
+
+        var sanitized = settings.Clone();
+        sanitized.Color = Config.SanitizeRgb(sanitized.Color, Config.GetDefaultEmbedColor(channelKind));
+        var glyphSymbol = GetGlyphSymbol(sanitized.Glyph);
+        var lines = normalized.Split('\n');
+        if (lines.Length == 0)
+        {
+            lines = new[] { string.Empty };
+        }
+
+        if (lines.Any(line => line.Length > MaxLineLength))
+        {
+            return new Result
+            {
+                Text = normalized,
+                Applied = false,
+                Warning = $"Embed border disabled because a line exceeds {MaxLineLength} characters."
+            };
+        }
+
+        var width = Math.Max(1, lines.Max(line => line.Length));
+        var horizontalGlyphCount = width + (Padding + 1) * 2;
+        var builder = new StringBuilder();
+        AppendRepeated(builder, glyphSymbol, horizontalGlyphCount);
+        builder.Append('\n');
+        foreach (var line in lines)
+        {
+            builder.Append(glyphSymbol);
+            builder.Append(' ');
+            builder.Append(line.PadRight(width));
+            builder.Append(' ');
+            builder.Append(glyphSymbol);
+            builder.Append('\n');
+        }
+        AppendRepeated(builder, glyphSymbol, horizontalGlyphCount);
+
+        var bordered = builder.ToString();
+        if (bordered.Length > 0 && bordered[^1] == '\n')
+        {
+            bordered = bordered[..^1];
+        }
+
+        if (bordered.Length > maxLength)
+        {
+            return new Result
+            {
+                Text = normalized,
+                Applied = false,
+                Warning = "Embed border disabled because it exceeds Discord's embed length limit."
+            };
+        }
+
+        return new Result
+        {
+            Text = bordered,
+            Applied = true,
+            Border = new BorderState
+            {
+                Glyph = sanitized.Glyph,
+                Color = sanitized.Color
+            }
+        };
+    }
+
+    public static bool TryStrip(string text, string? glyphName, out string stripped)
+    {
+        stripped = text ?? string.Empty;
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        if (!TryParseGlyph(glyphName, out var glyph))
+        {
+            return false;
+        }
+
+        var symbol = GetGlyphSymbol(glyph);
+        var lines = text.Split('\n');
+        if (lines.Length < 3)
+        {
+            return false;
+        }
+
+        if (!IsHorizontalLine(lines[0], symbol) || !IsHorizontalLine(lines[^1], symbol))
+        {
+            return false;
+        }
+
+        var inner = new List<string>();
+        for (var i = 1; i < lines.Length - 1; i++)
+        {
+            var line = lines[i];
+            var prefix = symbol + " ";
+            var suffix = " " + symbol;
+            if (!line.StartsWith(prefix, StringComparison.Ordinal) || !line.EndsWith(suffix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var innerSpan = line.Substring(prefix.Length, line.Length - prefix.Length - suffix.Length);
+            inner.Add(innerSpan.TrimEnd());
+        }
+
+        stripped = string.Join('\n', inner);
+        return true;
+    }
+
+    public static string GetGlyphName(Config.EmbedBorderGlyph glyph)
+        => glyph switch
+        {
+            Config.EmbedBorderGlyph.Circle => "circle",
+            Config.EmbedBorderGlyph.Triangle => "triangle",
+            _ => "square"
+        };
+
+    public static bool TryParseGlyph(string? glyphName, out Config.EmbedBorderGlyph glyph)
+    {
+        glyph = Config.EmbedBorderGlyph.Square;
+        if (string.IsNullOrWhiteSpace(glyphName))
+        {
+            return false;
+        }
+
+        switch (glyphName.Trim().ToLowerInvariant())
+        {
+            case "circle":
+                glyph = Config.EmbedBorderGlyph.Circle;
+                return true;
+            case "triangle":
+                glyph = Config.EmbedBorderGlyph.Triangle;
+                return true;
+            case "square":
+                glyph = Config.EmbedBorderGlyph.Square;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public static string GetGlyphSymbol(Config.EmbedBorderGlyph glyph)
+    {
+        if (GlyphSymbols.TryGetValue(glyph, out var symbol))
+        {
+            return symbol;
+        }
+
+        return GlyphSymbols[Config.EmbedBorderGlyph.Square];
+    }
+
+    private static bool IsHorizontalLine(string line, string symbol)
+    {
+        if (string.IsNullOrEmpty(line))
+        {
+            return false;
+        }
+
+        var glyphLength = symbol.Length;
+        if (glyphLength <= 0 || line.Length % glyphLength != 0)
+        {
+            return false;
+        }
+
+        var count = line.Length / glyphLength;
+        var builder = new StringBuilder(line.Length);
+        AppendRepeated(builder, symbol, count);
+        return builder.ToString().Equals(line, StringComparison.Ordinal);
+    }
+
+    private static void AppendRepeated(StringBuilder builder, string symbol, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            builder.Append(symbol);
+        }
+    }
+}

--- a/DemiCatPlugin/EmbedDto.cs
+++ b/DemiCatPlugin/EmbedDto.cs
@@ -28,6 +28,14 @@ public class EmbedDto
     public ulong? ChannelId { get; set; }
     public string? GuildId { get; set; }
     public List<ulong>? Mentions { get; set; }
+    public EmbedBorderRenderDto? Border { get; set; }
+}
+
+public class EmbedBorderRenderDto
+{
+    public bool Enabled { get; set; }
+    public string Glyph { get; set; } = string.Empty;
+    public uint Color { get; set; }
 }
 
 public class EmbedFieldDto

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -20,6 +20,10 @@ public static class EmbedPreviewRenderer
         const float contentPadding = 8f;
         const float verticalPadding = 4f;
 
+        var borderInfo = dto.Border;
+        var borderEnabled = borderInfo?.Enabled == true;
+        var borderColor = borderInfo?.Color ?? 0u;
+
         var indent = contentPadding + (dto.Color.HasValue ? stripeWidth : 0f);
         var avail = ImGui.GetContentRegionAvail().X;
         if (avail <= 0)
@@ -185,12 +189,20 @@ public static class EmbedPreviewRenderer
         ImGui.Unindent(indent);
 
         ImGui.EndChild();
+        var rectMin = ImGui.GetItemRectMin();
+        var rectMax = ImGui.GetItemRectMax();
         if (dto.Color.HasValue)
         {
-            var min = ImGui.GetItemRectMin();
-            var max = ImGui.GetItemRectMax();
             var color = ColorUtils.RgbToImGui(dto.Color.Value);
-            ImGui.GetWindowDrawList().AddRectFilled(min, new Vector2(min.X + stripeWidth, max.Y), color);
+            ImGui.GetWindowDrawList().AddRectFilled(rectMin, new Vector2(rectMin.X + stripeWidth, rectMax.Y), color);
+        }
+
+        if (borderEnabled && rectMax.X > rectMin.X && rectMax.Y > rectMin.Y)
+        {
+            var drawList = ImGui.GetWindowDrawList();
+            var color = ColorUtils.RgbToImGui(borderColor);
+            var inset = new Vector2(1f, 1f);
+            drawList.AddRect(rectMin + inset, rectMax - inset, color, 0f, ImDrawFlags.None, 1.5f);
         }
     }
 

--- a/DemiCatPlugin/EmbedStyleControls.cs
+++ b/DemiCatPlugin/EmbedStyleControls.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility;
+
+namespace DemiCatPlugin;
+
+public static class EmbedStyleControls
+{
+    public sealed class Context
+    {
+        public string ChannelKind { get; init; } = string.Empty;
+        public uint EffectiveEmbedColor { get; init; }
+        public uint? EmbedColorOverride { get; init; }
+        public Config.EmbedBorderSettings Border { get; init; } = Config.EmbedBorderSettings.CreateDefault(ChannelKind.Chat);
+    }
+
+    public sealed class Result
+    {
+        public bool EmbedColorChanged { get; init; }
+        public uint? EmbedColorOverride { get; init; }
+        public bool BorderChanged { get; init; }
+        public Config.EmbedBorderSettings Border { get; init; } = Config.EmbedBorderSettings.CreateDefault(ChannelKind.Chat);
+    }
+
+    public static Result Draw(Context context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var embedColorChanged = false;
+        var borderChanged = false;
+        var colorOverride = context.EmbedColorOverride;
+        var border = context.Border?.Clone() ?? Config.EmbedBorderSettings.CreateDefault(context.ChannelKind);
+
+        ImGui.AlignTextToFramePadding();
+        ImGui.TextUnformatted("Embed Color:");
+        ImGui.SameLine();
+
+        var effectiveColor = ColorUtils.RgbToVector4(context.EffectiveEmbedColor);
+        var buttonSize = new Vector2(ImGui.GetFrameHeight() * 2.2f, ImGui.GetFrameHeight());
+        var popupId = $"embedColorPicker##{context.ChannelKind}";
+        if (ImGui.ColorButton($"##embedColorButton_{context.ChannelKind}", effectiveColor, ImGuiColorEditFlags.NoAlpha, buttonSize))
+        {
+            ImGui.OpenPopup(popupId);
+        }
+
+        if (ImGui.BeginPopup(popupId))
+        {
+            var pickerColor = new Vector3(effectiveColor.X, effectiveColor.Y, effectiveColor.Z);
+            var pickerFlags = ImGuiColorEditFlags.NoSidePreview | ImGuiColorEditFlags.NoSmallPreview;
+            if (ImGui.ColorPicker3("##embedColorPicker", ref pickerColor, pickerFlags))
+            {
+                var newColor = ColorUtils.ImGuiToRgb(ColorUtils.Vector4ToImGui(new Vector4(pickerColor, 1f)));
+                colorOverride = newColor;
+                embedColorChanged = true;
+            }
+
+            if (colorOverride.HasValue)
+            {
+                if (ImGui.Button("Reset to Default"))
+                {
+                    colorOverride = null;
+                    embedColorChanged = true;
+                    ImGui.CloseCurrentPopup();
+                }
+            }
+
+            ImGui.EndPopup();
+        }
+
+        ImGui.SameLine();
+        ImGui.TextUnformatted("Border:");
+        ImGui.SameLine();
+
+        var enabled = border.Enabled;
+        if (ImGui.Checkbox($"##embedBorderEnabled_{context.ChannelKind}", ref enabled))
+        {
+            border.Enabled = enabled;
+            borderChanged = true;
+        }
+
+        ImGui.SameLine();
+        var comboWidth = 120f * ImGuiHelpers.GlobalScale;
+        if (!enabled)
+        {
+            ImGui.BeginDisabled();
+        }
+
+        ImGui.SetNextItemWidth(comboWidth);
+        var label = GetGlyphLabel(border.Glyph);
+        if (ImGui.BeginCombo($"##embedBorderGlyph_{context.ChannelKind}", label))
+        {
+            foreach (Config.EmbedBorderGlyph glyph in Enum.GetValues<Config.EmbedBorderGlyph>())
+            {
+                var isSelected = border.Glyph == glyph;
+                if (ImGui.Selectable(GetGlyphLabel(glyph), isSelected))
+                {
+                    border.Glyph = glyph;
+                    borderChanged = true;
+                }
+            }
+
+            ImGui.EndCombo();
+        }
+
+        ImGui.SameLine();
+        var borderColor = ColorUtils.RgbToVector4(border.Color);
+        var borderPopupId = $"embedBorderColorPicker##{context.ChannelKind}";
+        if (ImGui.ColorButton($"##embedBorderColor_{context.ChannelKind}", borderColor, ImGuiColorEditFlags.NoAlpha, buttonSize))
+        {
+            ImGui.OpenPopup(borderPopupId);
+        }
+
+        if (ImGui.BeginPopup(borderPopupId))
+        {
+            var pickerColor = new Vector3(borderColor.X, borderColor.Y, borderColor.Z);
+            var pickerFlags = ImGuiColorEditFlags.NoSidePreview | ImGuiColorEditFlags.NoSmallPreview;
+            if (ImGui.ColorPicker3("##embedBorderColorPicker", ref pickerColor, pickerFlags))
+            {
+                var newColor = ColorUtils.ImGuiToRgb(ColorUtils.Vector4ToImGui(new Vector4(pickerColor, 1f)));
+                border.Color = Config.SanitizeRgb(newColor, context.EffectiveEmbedColor);
+                borderChanged = true;
+            }
+
+            if (ImGui.Button("Use Embed Color"))
+            {
+                border.Color = Config.SanitizeRgb(context.EffectiveEmbedColor, context.EffectiveEmbedColor);
+                borderChanged = true;
+                ImGui.CloseCurrentPopup();
+            }
+
+            ImGui.EndPopup();
+        }
+
+        if (!enabled)
+        {
+            ImGui.EndDisabled();
+        }
+
+        return new Result
+        {
+            EmbedColorChanged = embedColorChanged,
+            EmbedColorOverride = colorOverride,
+            BorderChanged = borderChanged,
+            Border = border
+        };
+    }
+
+    private static string GetGlyphLabel(Config.EmbedBorderGlyph glyph)
+        => glyph switch
+        {
+            Config.EmbedBorderGlyph.Circle => "Circle",
+            Config.EmbedBorderGlyph.Triangle => "Triangle",
+            _ => "Square"
+        };
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ DemiCat/
 - **SyncShell** – Work-in-progress replacement for the Mare Synchronos mod-sharing plugin. Syncs Penumbra mod lists to replicate player appearances and is disabled by default while under development (see `DemiCatPlugin/SyncshellWindow.cs`).
 - **FC Chat** – Mirror Discord conversations directly in game.
   - Use **Attach** to open a file picker and add attachments. Selected files appear below the input with remove buttons, and invalid files display an error tooltip.
+  - Adjust embed styling above the preview: toggle a decorative border, pick a square/circle/triangle glyph, and choose a highlight color. Borders render using plain Unicode glyphs on Discord, so the color accent is limited to the in-game and DemiBot previews when the chosen shade cannot be reproduced remotely.
 - **Officer** – Administrative tools for event staff and moderators.
   - Officer chat window now includes a padded area beneath the input box reserved for future features.
 

--- a/demibot/demibot/bridge.py
+++ b/demibot/demibot/bridge.py
@@ -18,6 +18,12 @@ DISCORD_EMBED_COUNT_LIMIT = 10
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
 DEFAULT_FC_COLOR = 0x5865F2
 DEFAULT_OFFICER_COLOR = 0xED4245
+MAX_BORDER_LINE_LENGTH = 120
+GLYPH_SYMBOLS = {
+    "square": "■",
+    "circle": "●",
+    "triangle": "▲",
+}
 
 
 @dataclass
@@ -198,6 +204,74 @@ def _sanitize_embed_color(value: int | None) -> int | None:
     return numeric
 
 
+def _sanitize_embed_border(
+    settings: Mapping[str, object] | None, *, channel_kind: ChannelKind
+) -> tuple[bool, str, int]:
+    if not isinstance(settings, Mapping):
+        default_color = (
+            DEFAULT_OFFICER_COLOR
+            if channel_kind == ChannelKind.OFFICER_CHAT
+            else DEFAULT_FC_COLOR
+        )
+        return False, "square", default_color
+
+    enabled = bool(settings.get("enabled"))
+    glyph_value = str(settings.get("glyph") or "square").lower()
+    if glyph_value not in GLYPH_SYMBOLS:
+        glyph_value = "square"
+
+    color_value = _sanitize_embed_color(settings.get("color"))
+    if color_value is None:
+        color_value = (
+            DEFAULT_OFFICER_COLOR
+            if channel_kind == ChannelKind.OFFICER_CHAT
+            else DEFAULT_FC_COLOR
+        )
+    color_value &= 0xFFFFFF
+    return enabled, glyph_value, color_value
+
+
+def _apply_embed_border(
+    text: str,
+    settings: Mapping[str, object] | None,
+    *,
+    channel_kind: ChannelKind,
+) -> tuple[str, bool, str | None]:
+    if not text.strip():
+        return text, False, None
+
+    enabled, glyph, _ = _sanitize_embed_border(settings, channel_kind=channel_kind)
+    if not enabled:
+        return text, False, None
+
+    lines = text.split("\n")
+    if any(len(line) > MAX_BORDER_LINE_LENGTH for line in lines):
+        return (
+            text,
+            False,
+            f"Embed border disabled because a line exceeds {MAX_BORDER_LINE_LENGTH} characters.",
+        )
+
+    width = max(1, max(len(line) for line in lines))
+    glyph_symbol = GLYPH_SYMBOLS.get(glyph, GLYPH_SYMBOLS["square"])
+    horizontal_count = width + (1 + 1) * 2
+    top = glyph_symbol * horizontal_count
+    bordered_lines = [top]
+    for line in lines:
+        bordered_lines.append(f"{glyph_symbol} {line.ljust(width)} {glyph_symbol}")
+    bordered_lines.append(top)
+    bordered = "\n".join(bordered_lines)
+
+    if len(bordered) > DISCORD_EMBED_DESCRIPTION_LIMIT:
+        return (
+            text,
+            False,
+            "Embed border disabled because it exceeds Discord's embed length limit.",
+        )
+
+    return bordered, True, None
+
+
 def build_bridge_message(
     *,
     content: str,
@@ -209,6 +283,7 @@ def build_bridge_message(
     nonce: str | None = None,
     timestamp: datetime | None = None,
     embed_color: int | None = None,
+    embed_border: Mapping[str, object] | None = None,
 ) -> tuple[str, list[discord.Embed], list[BridgeUpload], str]:
     """Construct the Discord payload for a bridge message."""
 
@@ -228,7 +303,12 @@ def build_bridge_message(
     character_name = user.character_name if use_character_name else None
     world_name = user.world if use_character_name else None
 
-    chunks, represented = _split_embed_text(normalized)
+    bordered_text, border_applied, _ = _apply_embed_border(
+        normalized, embed_border, channel_kind=channel_kind
+    )
+    embed_source = bordered_text if border_applied else normalized
+
+    chunks, represented = _split_embed_text(embed_source)
     if not chunks:
         chunks = [""]
 
@@ -257,7 +337,7 @@ def build_bridge_message(
             embed.set_image(url=f"attachment://{image_filename}")
         embeds.append(embed)
 
-    leftover = normalized[represented:]
+    leftover = embed_source[represented:]
     if leftover.startswith("\n"):
         leftover = leftover[1:]
     discord_content = leftover[:DISCORD_CONTENT_LIMIT]

--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -52,7 +52,7 @@ try:  # pragma: no cover - optional dependency in tests
 except Exception:  # pragma: no cover - fallback when discord.utils missing
     MISSING = object()
 from fastapi import HTTPException, UploadFile
-from pydantic import BaseModel, Field, ConfigDict, model_validator
+from pydantic import BaseModel, Field, ConfigDict, model_validator, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -978,6 +978,7 @@ class PostBody(BaseModel):
         default=None, alias="messageReference"
     )
     embed_color: int | None = Field(default=None, alias="embedColor")
+    embed_border: dict | None = Field(default=None, alias="embedBorder")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -993,6 +994,19 @@ class PostBody(BaseModel):
             if channel_value is not None:
                 values["channel_id"] = channel_value
         return values
+
+    @field_validator("embed_border", mode="before")
+    @classmethod
+    def _parse_embed_border(cls, value: object) -> object:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                return json.loads(stripped)
+            except json.JSONDecodeError:
+                return None
+        return value
 
 
 async def fetch_messages(
@@ -1303,6 +1317,7 @@ async def save_message(
         use_character_name=bool(body.use_character_name),
         attachments=uploads_data,
         embed_color=body.embed_color,
+        embed_border=body.embed_border,
     )
 
     username_base = nickname or (
@@ -1747,6 +1762,7 @@ async def edit_message(
         use_character_name=use_character_name_flag,
         attachments=None,
         nonce=existing_nonce,
+        embed_border=None,
     )
 
     now = datetime.utcnow()

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -51,6 +51,7 @@ async def post_message_with_attachments(
     useCharacterName: bool | None = Form(False),
     message_reference: str | None = Form(None),
     embedColor: int | None = Form(None),
+    embedBorder: str | None = Form(None),
     files: list[UploadFile] | None = File(None),
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
@@ -67,6 +68,7 @@ async def post_message_with_attachments(
         use_character_name=useCharacterName,
         message_reference=ref,
         embed_color=embedColor,
+        embed_border=embedBorder,
     )
     return await save_message(body, ctx, db, channel_kind=ChannelKind.FC_CHAT, files=files)
 

--- a/demibot/demibot/http/routes/officer_messages.py
+++ b/demibot/demibot/http/routes/officer_messages.py
@@ -43,6 +43,7 @@ async def post_officer_message_with_attachments(
     useCharacterName: bool | None = Form(False),
     message_reference: str | None = Form(None),
     embedColor: int | None = Form(None),
+    embedBorder: str | None = Form(None),
     files: list[UploadFile] | None = File(None),
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
@@ -60,6 +61,7 @@ async def post_officer_message_with_attachments(
         use_character_name=useCharacterName,
         message_reference=ref,
         embed_color=embedColor,
+        embed_border=embedBorder,
     )
 
     return await save_message(

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -47,6 +47,13 @@ class EmbedAuthorDto(CamelModel):
     url: Optional[str] = None
     icon_url: Optional[str] = Field(default=None, alias="iconUrl")
 
+
+class EmbedBorderDto(CamelModel):
+    enabled: bool
+    glyph: str
+    color: int
+
+
 class EmbedDto(CamelModel):
     id: str
     timestamp: Optional[datetime] = None
@@ -70,6 +77,7 @@ class EmbedDto(CamelModel):
     buttons: List[EmbedButtonDto] | None = None
     channel_id: Optional[int] = Field(default=None, alias="channelId")
     mentions: List[int] | None = None
+    border: Optional[EmbedBorderDto] = None
 
 # ---- Chat ----
 

--- a/demibot/demibot/http/ws_chat.py
+++ b/demibot/demibot/http/ws_chat.py
@@ -1178,6 +1178,17 @@ class ChatConnectionManager:
                 embed_color_value = int(raw_embed_color)
             except (TypeError, ValueError):
                 embed_color_value = None
+        raw_embed_border = payload.get("embedBorder")
+        if raw_embed_border is None:
+            raw_embed_border = payload.get("embed_border")
+        embed_border_value: Mapping[str, object] | None = None
+        if isinstance(raw_embed_border, str):
+            try:
+                embed_border_value = json.loads(raw_embed_border)
+            except json.JSONDecodeError:
+                embed_border_value = None
+        elif isinstance(raw_embed_border, Mapping):
+            embed_border_value = raw_embed_border
 
         channel_obj: discord.abc.Messageable | discord.Thread | None = None
         thread_id: int | None = None
@@ -1324,6 +1335,7 @@ class ChatConnectionManager:
             use_character_name=use_character_name_flag,
             attachments=file_data,
             embed_color=embed_color_value,
+            embed_border=embed_border_value,
         )
 
         username = (

--- a/tests/BridgeMessageFormatterTests.cs
+++ b/tests/BridgeMessageFormatterTests.cs
@@ -17,7 +17,8 @@ public class BridgeMessageFormatterTests
             Timestamp = FixedTimestamp,
             AuthorName = "You",
             CharacterName = "Tester",
-            WorldName = "World"
+            WorldName = "World",
+            EmbedBorder = Config.EmbedBorderSettings.CreateDefault(ChannelKind.FcChat)
         };
 
     [Fact]
@@ -68,5 +69,52 @@ public class BridgeMessageFormatterTests
 
         var embed = Assert.Single(result.Embeds);
         Assert.Equal((uint)0x123456, embed.Color);
+    }
+
+    [Fact]
+    public void Format_AppliesEmbedBorderWhenWithinLimits()
+    {
+        var options = CreateOptions();
+        options.EmbedBorder = new Config.EmbedBorderSettings
+        {
+            Enabled = true,
+            Glyph = Config.EmbedBorderGlyph.Circle,
+            Color = 0x112233
+        };
+
+        var result = BridgeMessageFormatter.Format("Hi", Array.Empty<string>(), options);
+
+        var embed = Assert.Single(result.Embeds);
+        var border = Assert.NotNull(embed.Border);
+        Assert.True(border.Enabled);
+        Assert.Equal("circle", border.Glyph);
+        Assert.Equal((uint)0x112233 & 0xFFFFFFu, border.Color);
+
+        var expected = EmbedBorderBuilder.Apply("Hi", options.EmbedBorder, ChannelKind.FcChat, 4096);
+        Assert.True(expected.Applied);
+        Assert.Equal(expected.Text, embed.Description);
+        Assert.Equal(expected.Text, result.DisplayContent);
+        Assert.DoesNotContain(result.Warnings, w => w.Contains("border", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Format_DisablesBorderWhenLineTooLong()
+    {
+        var options = CreateOptions();
+        options.EmbedBorder = new Config.EmbedBorderSettings
+        {
+            Enabled = true,
+            Glyph = Config.EmbedBorderGlyph.Square,
+            Color = 0x445566
+        };
+
+        var input = new string('x', 200);
+        var result = BridgeMessageFormatter.Format(input, Array.Empty<string>(), options);
+
+        var embed = Assert.Single(result.Embeds);
+        Assert.Null(embed.Border);
+        Assert.Equal(input, embed.Description);
+        Assert.Equal(input, result.DisplayContent);
+        Assert.Contains(result.Warnings, w => w.Contains("border", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/tests/ChatWindowPreviewTests.cs
+++ b/tests/ChatWindowPreviewTests.cs
@@ -14,7 +14,8 @@ public class ChatWindowPreviewTests
         var options = new BridgeMessageFormatter.BridgeFormatterOptions
         {
             AuthorName = "Tester",
-            Timestamp = FixedTimestamp
+            Timestamp = FixedTimestamp,
+            EmbedBorder = Config.EmbedBorderSettings.CreateDefault(ChannelKind.FcChat)
         };
         var message = BridgeMessageFormatter.Format("Hello world", Array.Empty<string>(), options);
 
@@ -29,7 +30,8 @@ public class ChatWindowPreviewTests
         var options = new BridgeMessageFormatter.BridgeFormatterOptions
         {
             AuthorName = "Tester",
-            Timestamp = FixedTimestamp
+            Timestamp = FixedTimestamp,
+            EmbedBorder = Config.EmbedBorderSettings.CreateDefault(ChannelKind.FcChat)
         };
         var longBody = new string('A', 50000);
         var message = BridgeMessageFormatter.Format(longBody, Array.Empty<string>(), options);

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -42,5 +42,11 @@ public class ConfigDefaultsTests
         Assert.Equal(0.35f, cfg.ChatInputSplitRatio);
         Assert.Equal(Config.DefaultFcEmbedColor, cfg.FcEmbedColor);
         Assert.Equal(Config.DefaultOfficerEmbedColor, cfg.OfficerEmbedColor);
+        Assert.False(cfg.FcEmbedBorder.Enabled);
+        Assert.Equal(Config.EmbedBorderGlyph.Square, cfg.FcEmbedBorder.Glyph);
+        Assert.Equal(Config.DefaultFcEmbedColor, cfg.FcEmbedBorder.Color);
+        Assert.False(cfg.OfficerEmbedBorder.Enabled);
+        Assert.Equal(Config.EmbedBorderGlyph.Square, cfg.OfficerEmbedBorder.Glyph);
+        Assert.Equal(Config.DefaultOfficerEmbedColor, cfg.OfficerEmbedBorder.Color);
     }
 }

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -148,6 +148,7 @@ from demibot.bridge import (
     BRIDGE_MARKER,
     BridgeUpload,
     DISCORD_CONTENT_LIMIT,
+    _apply_embed_border,
     build_bridge_message,
     extract_bridge_nonce_from_payload,
 )
@@ -230,6 +231,28 @@ def test_build_bridge_message_honors_embed_color(sample_user, sample_membership)
     assert not uploads
     embed_dict = embeds[0].to_dict()
     assert embed_dict.get("color") == 0x123456
+
+
+def test_build_bridge_message_applies_embed_border(sample_user, sample_membership):
+    settings = {"enabled": True, "glyph": "circle", "color": 0x334455}
+    discord_content, embeds, uploads, nonce = build_bridge_message(
+        content="Border",
+        user=sample_user,
+        membership=sample_membership,
+        channel_kind=ChannelKind.FC_CHAT,
+        attachments=None,
+        embed_border=settings,
+    )
+
+    assert nonce
+    assert not discord_content
+    embed_dict = embeds[0].to_dict()
+    bordered, applied, warning = _apply_embed_border(
+        "Border", settings, channel_kind=ChannelKind.FC_CHAT
+    )
+    assert warning is None
+    assert applied is True
+    assert embed_dict.get("description") == bordered
 
 
 @pytest.mark.parametrize(

--- a/tests/test_chat_ws.py
+++ b/tests/test_chat_ws.py
@@ -351,6 +351,8 @@ def test_chat_ws_send_uses_channel_field(monkeypatch):
             use_character_name=False,
             attachments=None,
             nonce=None,
+            embed_color=None,
+            embed_border=None,
         ):
             return content, [], [], nonce or "nonce"
 
@@ -454,6 +456,8 @@ def test_chat_ws_thread_send_includes_thread_param(monkeypatch):
             use_character_name=False,
             attachments=None,
             nonce=None,
+            embed_color=None,
+            embed_border=None,
         ):
             return content, [], [], nonce or "nonce"
 

--- a/tests/test_messages_endpoint.py
+++ b/tests/test_messages_endpoint.py
@@ -57,7 +57,12 @@ async def test_post_message_accepts_channel_aliases(channel_key, monkeypatch):
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.post(
             "/api/messages",
-            json={channel_key: "123", "content": "Hello", "embedColor": 0x123456},
+            json={
+                channel_key: "123",
+                "content": "Hello",
+                "embedColor": 0x123456,
+                "embedBorder": {"enabled": True, "glyph": "triangle", "color": 0x445566},
+            },
         )
 
     app.dependency_overrides.clear()
@@ -69,6 +74,11 @@ async def test_post_message_accepts_channel_aliases(channel_key, monkeypatch):
     assert isinstance(captured["body"], messages_routes.PostBody)
     assert captured["channel_kind"] == ChannelKind.FC_CHAT
     assert captured["body"].embed_color == 0x123456
+    assert captured["body"].embed_border == {
+        "enabled": True,
+        "glyph": "triangle",
+        "color": 0x445566,
+    }
 
 
 @pytest.mark.asyncio
@@ -105,6 +115,9 @@ async def test_channel_messages_multipart_accepts_message_reference(monkeypatch)
             "useCharacterName": "true",
             "message_reference": json.dumps({"messageId": "5", "channelId": "555"}),
             "embedColor": str(0x123456),
+            "embedBorder": json.dumps(
+                {"enabled": True, "glyph": "square", "color": 0x654321}
+            ),
         }
         resp = await client.post(
             "/api/channels/555/messages",
@@ -125,6 +138,11 @@ async def test_channel_messages_multipart_accepts_message_reference(monkeypatch)
     assert body.message_reference.channel_id == "555"
     assert body.message_reference.message_id == "5"
     assert body.embed_color == 0x123456
+    assert body.embed_border == {
+        "enabled": True,
+        "glyph": "square",
+        "color": 0x654321,
+    }
 
     assert captured["channel_kind"] == ChannelKind.FC_CHAT
 

--- a/tests/test_officer_messages_endpoint.py
+++ b/tests/test_officer_messages_endpoint.py
@@ -129,6 +129,9 @@ async def test_officer_multipart_uses_officer_endpoint(monkeypatch):
             "useCharacterName": "true",
             "message_reference": json.dumps({"messageId": "5", "channelId": "555"}),
             "embedColor": str(0x123456),
+            "embedBorder": json.dumps(
+                {"enabled": True, "glyph": "triangle", "color": 0x112233}
+            ),
         }
         resp = await client.post(
             "/api/channels/555/officer-messages",
@@ -149,6 +152,11 @@ async def test_officer_multipart_uses_officer_endpoint(monkeypatch):
     assert body.message_reference.channel_id == "555"
     assert body.message_reference.message_id == "5"
     assert body.embed_color == 0x123456
+    assert body.embed_border == {
+        "enabled": True,
+        "glyph": "triangle",
+        "color": 0x112233,
+    }
 
     assert captured["channel_kind"] == ChannelKind.OFFICER_CHAT
 


### PR DESCRIPTION
## Summary
- clone embed border settings before returning them from the config helper so callers never mutate shared state
- clone settings again when persisting to the config to avoid holding references that external code might still change

## Testing
- pytest tests/test_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68db521885e08328aa5bb27b597abf53