### PR TITLE
Preserve embed styling when editing messages

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -49,6 +49,8 @@ public class ChatWindow : IDisposable
     protected string? _editingMessageId;
     protected string _editingChannelId = string.Empty;
     protected string _editContent = string.Empty;
+    protected uint? _editEmbedColor;
+    protected EmbedBorderRenderDto? _editEmbedBorder;
     private static readonly string[] DefaultReactions = new[] { "👍", "👎", "❤️" };
     private static readonly ImGuiMouseCursor ResizeNsCursor = ResolveResizeNsCursor();
     private readonly EmojiManager _emojiManager;
@@ -910,6 +912,16 @@ public class ChatWindow : IDisposable
                     _editingMessageId = msg.Id;
                     _editingChannelId = msg.ChannelId;
                     _editContent = msg.Content ?? string.Empty;
+                    var firstEmbed = msg.Embeds?.FirstOrDefault();
+                    _editEmbedColor = firstEmbed?.Color;
+                    _editEmbedBorder = firstEmbed?.Border != null
+                        ? new EmbedBorderRenderDto
+                        {
+                            Enabled = firstEmbed.Border.Enabled,
+                            Glyph = firstEmbed.Border.Glyph,
+                            Color = firstEmbed.Border.Color
+                        }
+                        : null;
                     ImGui.OpenPopup("editMessage");
                 }
                 if (ImGui.MenuItem("Delete"))
@@ -1059,12 +1071,16 @@ public class ChatWindow : IDisposable
                 {
                     _ = EditMessage(_editingMessageId, _editingChannelId, _editContent);
                 }
+                _editEmbedColor = null;
+                _editEmbedBorder = null;
                 _editingMessageId = null;
                 ImGui.CloseCurrentPopup();
             }
             ImGui.SameLine();
             if (ImGui.Button("Cancel"))
             {
+                _editEmbedColor = null;
+                _editEmbedBorder = null;
                 _editingMessageId = null;
                 ImGui.CloseCurrentPopup();
             }
@@ -2975,6 +2991,27 @@ public class ChatWindow : IDisposable
         }
     }
 
+    protected object CreateEditMessageBody(string content)
+    {
+        object? borderPayload = null;
+        if (_editEmbedBorder != null)
+        {
+            borderPayload = new
+            {
+                enabled = _editEmbedBorder.Enabled,
+                glyph = _editEmbedBorder.Glyph,
+                color = _editEmbedBorder.Color
+            };
+        }
+
+        return new
+        {
+            content,
+            embedColor = _editEmbedColor,
+            embedBorder = borderPayload
+        };
+    }
+
     protected virtual async Task EditMessage(string messageId, string channelId, string content)
     {
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
@@ -2989,7 +3026,7 @@ public class ChatWindow : IDisposable
 
         try
         {
-            var body = new { content };
+            var body = CreateEditMessageBody(content);
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{channelId}/messages/{messageId}";
             var request = new HttpRequestMessage(HttpMethod.Patch, url);
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -240,7 +240,7 @@ public class OfficerChatWindow : ChatWindow
 
         try
         {
-            var body = new { content };
+            var body = CreateEditMessageBody(content);
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}{MessagesPath}/{messageId}";
             var request = new HttpRequestMessage(HttpMethod.Patch, url)
             {

--- a/demibot/demibot/http/routes/_messages_common.py
+++ b/demibot/demibot/http/routes/_messages_common.py
@@ -1717,6 +1717,8 @@ async def edit_message(
     db: AsyncSession,
     *,
     is_officer: bool,
+    embed_color: object = MISSING,
+    embed_border: object = MISSING,
 ) -> dict:
     if is_officer and "officer" not in _role_set(ctx):
         raise HTTPException(status_code=403)
@@ -1754,6 +1756,74 @@ async def edit_message(
     )
     existing_nonce = getattr(mapping, "nonce", None) if mapping else None
 
+    def _coerce_embed_color_value(value: object) -> int | None:
+        if value is None or isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                return int(stripped, 0)
+            except ValueError:
+                return None
+        return None
+
+    def _coerce_embed_border_value(value: object) -> dict[str, object] | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            try:
+                value = json.loads(stripped)
+            except (TypeError, ValueError, json.JSONDecodeError):
+                return None
+        if not isinstance(value, Mapping):
+            return None
+        enabled = value.get("enabled")
+        glyph = value.get("glyph")
+        color_value = _coerce_embed_color_value(value.get("color"))
+        if not isinstance(enabled, bool) or not isinstance(glyph, str):
+            return None
+        border_dict: dict[str, object] = {"enabled": enabled, "glyph": glyph}
+        if color_value is not None or "color" in value:
+            border_dict["color"] = color_value
+        return border_dict
+
+    existing_embed_color: int | None = None
+    existing_embed_border: dict[str, object] | None = None
+    if msg.embeds_json:
+        try:
+            embed_data = json.loads(msg.embeds_json)
+        except Exception:
+            embed_data = None
+        if isinstance(embed_data, list):
+            for entry in embed_data:
+                if not isinstance(entry, Mapping):
+                    continue
+                color_candidate = _coerce_embed_color_value(entry.get("color"))
+                if color_candidate is not None:
+                    existing_embed_color = color_candidate
+                border_candidate = _coerce_embed_border_value(entry.get("border"))
+                if border_candidate is not None:
+                    existing_embed_border = border_candidate
+                break
+
+    resolved_embed_color = (
+        existing_embed_color
+        if embed_color is MISSING
+        else _coerce_embed_color_value(embed_color)
+    )
+    resolved_embed_border = (
+        existing_embed_border
+        if embed_border is MISSING
+        else _coerce_embed_border_value(embed_border)
+    )
+
     bridge_content, embeds, _, nonce = build_bridge_message(
         content=content,
         user=ctx.user,
@@ -1762,7 +1832,8 @@ async def edit_message(
         use_character_name=use_character_name_flag,
         attachments=None,
         nonce=existing_nonce,
-        embed_border=None,
+        embed_color=resolved_embed_color,
+        embed_border=resolved_embed_border,
     )
 
     now = datetime.utcnow()

--- a/demibot/demibot/http/routes/messages.py
+++ b/demibot/demibot/http/routes/messages.py
@@ -153,7 +153,50 @@ async def patch_message(
     content = body.get("content")
     if content is None:
         raise HTTPException(status_code=400, detail="content required")
-    return await edit_message_common(channel_id, message_id, content, ctx, db, is_officer=False)
+
+    embed_color = None
+    embed_color_provided = False
+    if "embedColor" in body:
+        embed_color = body["embedColor"]
+        embed_color_provided = True
+    elif "embed_color" in body:
+        embed_color = body["embed_color"]
+        embed_color_provided = True
+
+    embed_border = None
+    embed_border_provided = False
+    if "embedBorder" in body:
+        embed_border = body["embedBorder"]
+        embed_border_provided = True
+    elif "embed_border" in body:
+        embed_border = body["embed_border"]
+        embed_border_provided = True
+
+    if embed_border_provided and isinstance(embed_border, str):
+        stripped = embed_border.strip()
+        if stripped:
+            try:
+                embed_border = json.loads(stripped)
+            except json.JSONDecodeError:
+                embed_border = None
+        else:
+            embed_border = None
+
+    kwargs: dict[str, object] = {}
+    if embed_color_provided:
+        kwargs["embed_color"] = embed_color
+    if embed_border_provided:
+        kwargs["embed_border"] = embed_border
+
+    return await edit_message_common(
+        channel_id,
+        message_id,
+        content,
+        ctx,
+        db,
+        is_officer=False,
+        **kwargs,
+    )
 
 
 @router.delete("/channels/{channel_id}/messages/{message_id}")

--- a/tests/test_messages_common.py
+++ b/tests/test_messages_common.py
@@ -3148,6 +3148,90 @@ def test_posted_message_mapping_and_webhook_usage(monkeypatch):
     asyncio.run(_run())
 
 
+def test_edit_message_reuses_existing_embed_style(monkeypatch):
+    async def _run():
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            await db.execute(text("DELETE FROM posted_messages"))
+            await db.execute(text("DELETE FROM messages"))
+            await db.execute(text("DELETE FROM memberships"))
+            await db.execute(text("DELETE FROM users"))
+            await db.execute(text("DELETE FROM guilds"))
+
+            guild = Guild(id=1, discord_guild_id=100, name="Guild")
+            user = User(id=1, discord_user_id=200, global_name="User")
+            membership = Membership(
+                id=1,
+                guild_id=guild.id,
+                user_id=user.id,
+                nickname="Member",
+                avatar_url=None,
+            )
+            message = Message(
+                discord_message_id=300,
+                channel_id=400,
+                guild_id=guild.id,
+                author_id=user.id,
+                author_name="User",
+                author_avatar_url=None,
+                content_raw="hello",
+                content_display="hello",
+                content="hello",
+                embeds_json=json.dumps(
+                    [
+                        {
+                            "id": "embed1",
+                            "description": "hello",
+                            "color": 0x102030,
+                            "border": {
+                                "enabled": True,
+                                "glyph": "circle",
+                                "color": 0x556677,
+                            },
+                        }
+                    ]
+                ),
+                created_at=datetime.utcnow(),
+            )
+
+            db.add_all([guild, user, membership, message])
+            await db.commit()
+
+            captured: dict[str, object | None] = {}
+
+            def fake_build_bridge_message(**kwargs):
+                captured.update(kwargs)
+                return "bridge", [], [], "nonce"
+
+            async def dummy_broadcast(*args, **kwargs):
+                return None
+
+            monkeypatch.setattr(mc, "build_bridge_message", fake_build_bridge_message)
+            monkeypatch.setattr(mc.manager, "broadcast_text", dummy_broadcast)
+            monkeypatch.setattr(mc, "discord_client", None)
+
+            ctx = RequestContext(user=user, guild=guild, key=DummyKey(), roles=[])
+
+            result = await mc.edit_message(
+                str(message.channel_id),
+                str(message.discord_message_id),
+                "updated",
+                ctx,
+                db,
+                is_officer=False,
+            )
+
+            assert result["ok"] is True
+            assert captured.get("embed_color") == 0x102030
+            assert captured.get("embed_border") == {
+                "enabled": True,
+                "glyph": "circle",
+                "color": 0x556677,
+            }
+
+    asyncio.run(_run())
+
+
 def test_bridge_nonce_persisted_and_reused(monkeypatch):
     async def _run():
         await init_db("sqlite+aiosqlite://")

--- a/tests/test_messages_endpoint.py
+++ b/tests/test_messages_endpoint.py
@@ -153,6 +153,63 @@ async def test_channel_messages_multipart_accepts_message_reference(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_patch_message_forwards_embed_style(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_edit_message(
+        channel_id,
+        message_id,
+        content,
+        ctx,
+        db,
+        *,
+        is_officer,
+        embed_color=None,
+        embed_border=None,
+    ):
+        captured["channel_id"] = channel_id
+        captured["message_id"] = message_id
+        captured["content"] = content
+        captured["is_officer"] = is_officer
+        captured["embed_color"] = embed_color
+        captured["embed_border"] = embed_border
+        return {"ok": True}
+
+    monkeypatch.setattr(messages_routes, "edit_message_common", fake_edit_message)
+
+    ctx = RequestContext(
+        user=SimpleNamespace(id=1),
+        guild=SimpleNamespace(id=2),
+        key=None,
+        roles=["chat"],
+    )
+
+    body = {
+        "content": "updated",
+        "embedColor": 0x112233,
+        "embedBorder": {
+            "enabled": True,
+            "glyph": "circle",
+            "color": 0x556677,
+        },
+    }
+
+    resp = await messages_routes.patch_message("55", "66", body, ctx, db=None)
+
+    assert resp == {"ok": True}
+    assert captured["channel_id"] == "55"
+    assert captured["message_id"] == "66"
+    assert captured["content"] == "updated"
+    assert captured["is_officer"] is False
+    assert captured["embed_color"] == 0x112233
+    assert captured["embed_border"] == {
+        "enabled": True,
+        "glyph": "circle",
+        "color": 0x556677,
+    }
+
+
+@pytest.mark.asyncio
 async def test_cache_and_store_webhook_preserves_kind():
     await init_db("sqlite+aiosqlite://")
     messages_common._channel_webhooks.clear()


### PR DESCRIPTION
## Summary
- allow the chat message PATCH route to forward optional embed styling fields to the common edit handler
- reuse stored embed color/border values when rebuilding edited messages and include them when the plugin issues edits
- exercise the new behavior with endpoint and common edit tests that cover custom embed styling

## Testing
- pytest tests/test_messages_endpoint.py::test_patch_message_forwards_embed_style
- pytest tests/test_messages_common.py::test_edit_message_reuses_existing_embed_style

------
https://chatgpt.com/codex/tasks/task_e_68db5a9e517c83289d154a21aabc79fb