### PR TITLE
Fix NotePad tab width styling for Dalamud API 13

### DIFF
--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -147,11 +147,13 @@ public sealed class NotePadWindow : IDisposable
                 var tabFlags = selected ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None;
 
                 var textSize = ImGui.CalcTextSize(title);
-                var padding = ImGui.GetStyle().FramePadding.X + 6f;
+                var style = ImGui.GetStyle();
+                var padding = style.FramePadding.X + 6f;
                 var minWidth = textSize.X + padding * 2f;
 
                 var color = ParseColor(section.Color);
-                ImGui.PushStyleVar(ImGuiStyleVar.TabMinWidthForCloseButton, minWidth);
+                var previousTabMinWidth = style.TabMinWidthForCloseButton;
+                style.TabMinWidthForCloseButton = Math.Max(previousTabMinWidth, minWidth);
                 ImGui.PushStyleColor(ImGuiCol.Tab, AdjustTabColor(color, 0.7f));
                 ImGui.PushStyleColor(ImGuiCol.TabActive, AdjustTabColor(color, 1f));
                 ImGui.PushStyleColor(ImGuiCol.TabHovered, AdjustTabColor(color, 1.2f));
@@ -175,7 +177,7 @@ public sealed class NotePadWindow : IDisposable
                 }
 
                 ImGui.PopStyleColor(3);
-                ImGui.PopStyleVar();
+                style.TabMinWidthForCloseButton = previousTabMinWidth;
 
                 if (ImGui.BeginDragDropSource())
                 {


### PR DESCRIPTION
## Summary
- replace the removed `ImGuiStyleVar.TabMinWidthForCloseButton` usage by adjusting `ImGuiStyle.TabMinWidthForCloseButton` directly when drawing NotePad tabs

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: Dalamud and related assemblies are not available at the configured `DalamudLibPath` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db60e49e0c8328b4704efdf2deaf00