### PR TITLE
Replace deprecated toast info calls in NotePadWindow

### DIFF
--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -764,7 +764,7 @@ public sealed class NotePadWindow : IDisposable
 
         if (!string.Equals(trimmed, clamped, StringComparison.Ordinal))
         {
-            PluginServices.Instance?.ToastGui.ShowInfo($"Section name truncated to {MaxTitleLength} characters.");
+            PluginServices.Instance?.ToastGui.ShowNormal($"Section name truncated to {MaxTitleLength} characters.");
         }
 
         var success = await _service.RenameSectionAsync(sectionId, clamped, CancellationToken.None).ConfigureAwait(false);
@@ -787,7 +787,7 @@ public sealed class NotePadWindow : IDisposable
 
         if (!string.Equals(trimmed, clamped, StringComparison.Ordinal))
         {
-            PluginServices.Instance?.ToastGui.ShowInfo($"Page title truncated to {MaxTitleLength} characters.");
+            PluginServices.Instance?.ToastGui.ShowNormal($"Page title truncated to {MaxTitleLength} characters.");
         }
 
         var success = await _service.RenamePageAsync(sectionId, pageId, clamped, CancellationToken.None).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- switch NotePadWindow truncation toasts to the supported ShowNormal API
- ensure section and page rename feedback remains unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db6258b8348328952caff91591cbcb