### PR TITLE
Handle notepad section order after soft deletes

### DIFF
--- a/demibot/demibot/http/routes/notepad.py
+++ b/demibot/demibot/http/routes/notepad.py
@@ -161,7 +161,6 @@ async def create_section(
     max_order = await db.scalar(
         select(func.max(NoteSection.sort_order)).where(
             NoteSection.guild_id == ctx.guild.id,
-            NoteSection.is_deleted.is_(False),
         )
     )
     next_order = (max_order if max_order is not None else -1) + 1

--- a/tests/test_notepad_routes.py
+++ b/tests/test_notepad_routes.py
@@ -284,3 +284,45 @@ async def test_reorder_sections_with_soft_deleted(tmp_path, monkeypatch):
 
     assert active_orders == [0, 1]
     assert all(order >= len(active_orders) for order in deleted_orders)
+
+
+@pytest.mark.anyio
+async def test_create_section_after_soft_delete(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "notepad_soft_delete.db"
+    await init_db(f"sqlite+aiosqlite:///{db_path}")
+
+    async with get_session() as db:
+        guild = Guild(id=1, discord_guild_id=1, name="Guild")
+        user = User(id=1, discord_user_id=10, global_name="Officer")
+        db.add_all([guild, user])
+        await db.commit()
+
+    ctx = StubContext(
+        guild=SimpleNamespace(id=1),
+        user=SimpleNamespace(id=1),
+        roles=["officer"],
+    )
+
+    async def fake_broadcast(message: str, guild_id: int, path: str):
+        return None
+
+    monkeypatch.setattr(notepad.manager, "broadcast_text", fake_broadcast)
+
+    async with get_session() as db:
+        first_section = await notepad.create_section(
+            body=NoteSectionCreateBody(name="Raid"),
+            ctx=ctx,
+            db=db,
+        )
+
+    async with get_session() as db:
+        await notepad.delete_section(section_id=first_section.id, ctx=ctx, db=db)
+
+    async with get_session() as db:
+        second_section = await notepad.create_section(
+            body=NoteSectionCreateBody(name="Raid 2"),
+            ctx=ctx,
+            db=db,
+        )
+
+    assert second_section.order == first_section.order + 1


### PR DESCRIPTION
## Summary
- update the notepad section creation query to consider soft-deleted rows when calculating the next sort order
- add a regression test that soft deletes the only section and verifies the next creation succeeds with a new order

## Testing
- pytest tests/test_notepad_routes.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68db65d2088483288ee1188a86381b0a