### PR TITLE
Allow selecting emoji glyphs for embed borders

### DIFF
--- a/DemiCatPlugin/BridgeMessageFormatter.cs
+++ b/DemiCatPlugin/BridgeMessageFormatter.cs
@@ -143,7 +143,7 @@ public static class BridgeMessageFormatter
                 embed.Border = new EmbedBorderRenderDto
                 {
                     Enabled = true,
-                    Glyph = EmbedBorderBuilder.GetGlyphName(borderResult.Border.Glyph),
+                    Glyph = EmbedBorderBuilder.GetGlyphSymbol(borderResult.Border.Glyph),
                     Color = borderResult.Border.Color
                 };
             }

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -178,12 +178,16 @@ public class ChatWindow : IDisposable
         }
 
         var current = _config.GetEmbedBorderSettingsCopy(_channelKind);
-        if (current.Enabled == settings.Enabled && current.Glyph == settings.Glyph && current.Color == settings.Color)
+        var currentGlyph = EmbedBorderBuilder.GetGlyphSymbol(current.Glyph);
+        var newGlyph = EmbedBorderBuilder.GetGlyphSymbol(settings.Glyph);
+        if (current.Enabled == settings.Enabled && string.Equals(currentGlyph, newGlyph, StringComparison.Ordinal) && current.Color == settings.Color)
         {
             return;
         }
 
-        _config.SetEmbedBorderSettings(_channelKind, settings);
+        var sanitized = settings.Clone();
+        sanitized.Glyph = newGlyph;
+        _config.SetEmbedBorderSettings(_channelKind, sanitized);
         SaveConfig();
         InvalidatePreview();
     }
@@ -194,7 +198,7 @@ public class ChatWindow : IDisposable
         var payload = new
         {
             enabled = border.Enabled,
-            glyph = EmbedBorderBuilder.GetGlyphName(border.Glyph),
+            glyph = EmbedBorderBuilder.GetGlyphSymbol(border.Glyph),
             color = border.Color
         };
         return JsonSerializer.Serialize(payload);
@@ -212,7 +216,10 @@ public class ChatWindow : IDisposable
             ChannelKindKey = _channelKind,
             EffectiveEmbedColor = GetEffectiveEmbedColor(),
             EmbedColorOverride = GetEmbedColorOverride(),
-            Border = _config.GetEmbedBorderSettingsCopy(_channelKind)
+            Border = _config.GetEmbedBorderSettingsCopy(_channelKind),
+            EmojiManager = _emojiManager,
+            EmojiTileSize = Config.SanitizeEmojiTileSize(_config.EmojiTileSize),
+            EmojiGridHeight = Config.SanitizeEmojiGridHeight(_config.EmojiGridHeight)
         };
 
         var result = EmbedStyleControls.Draw(context);

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -23,16 +23,10 @@ public class Config : IPluginConfiguration
     public const float MaxEmojiGridHeight = 800f;
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
-    public const int CurrentVersion = 15;
+    public const string DefaultEmbedBorderGlyph = "⬛";
+    public const int CurrentVersion = 16;
 
     public int Version { get; set; } = CurrentVersion;
-
-    public enum EmbedBorderGlyph
-    {
-        Square,
-        Circle,
-        Triangle
-    }
 
     public sealed class EmbedBorderSettings
     {
@@ -40,8 +34,7 @@ public class Config : IPluginConfiguration
         public bool Enabled { get; set; }
 
         [JsonPropertyName("glyph")]
-        [JsonConverter(typeof(JsonStringEnumConverter))]
-        public EmbedBorderGlyph Glyph { get; set; } = EmbedBorderGlyph.Square;
+        public string Glyph { get; set; } = DefaultEmbedBorderGlyph;
 
         [JsonPropertyName("color")]
         public uint Color { get; set; }
@@ -50,7 +43,7 @@ public class Config : IPluginConfiguration
             => new()
             {
                 Enabled = Enabled,
-                Glyph = Glyph,
+                Glyph = SanitizeEmbedBorderGlyph(Glyph),
                 Color = Color
             };
 
@@ -58,7 +51,7 @@ public class Config : IPluginConfiguration
             => new()
             {
                 Enabled = false,
-                Glyph = EmbedBorderGlyph.Square,
+                Glyph = DefaultEmbedBorderGlyph,
                 Color = GetDefaultEmbedColor(channelKind)
             };
     }
@@ -478,6 +471,16 @@ public class Config : IPluginConfiguration
             Version = 15;
             ExtensionData = null;
         }
+        if (Version < 16)
+        {
+            FcEmbedBorder ??= EmbedBorderSettings.CreateDefault(ChannelKind.FcChat);
+            OfficerEmbedBorder ??= EmbedBorderSettings.CreateDefault(ChannelKind.OfficerChat);
+            FcEmbedBorder.Glyph = SanitizeEmbedBorderGlyph(FcEmbedBorder.Glyph);
+            OfficerEmbedBorder.Glyph = SanitizeEmbedBorderGlyph(OfficerEmbedBorder.Glyph);
+
+            Version = 16;
+            ExtensionData = null;
+        }
     }
 
     public static uint GetDefaultEmbedColor(string? channelKind)
@@ -486,6 +489,23 @@ public class Config : IPluginConfiguration
         {
             ChannelKind.OfficerChat => DefaultOfficerEmbedColor,
             _ => DefaultFcEmbedColor
+        };
+    }
+
+    public static string SanitizeEmbedBorderGlyph(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return DefaultEmbedBorderGlyph;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed switch
+        {
+            "Square" or "square" => "⬛",
+            "Circle" or "circle" => "⚫",
+            "Triangle" or "triangle" => "🔺",
+            _ => trimmed
         };
     }
 
@@ -511,6 +531,7 @@ public class Config : IPluginConfiguration
             settings = EmbedBorderSettings.CreateDefault(channelKind);
         }
         settings.Color = SanitizeRgb(settings.Color, GetDefaultEmbedColor(channelKind));
+        settings.Glyph = SanitizeEmbedBorderGlyph(settings.Glyph);
         return settings;
     }
 
@@ -523,6 +544,7 @@ public class Config : IPluginConfiguration
 
         settings = settings.Clone();
         settings.Color = SanitizeRgb(settings.Color, GetDefaultEmbedColor(channelKind));
+        settings.Glyph = SanitizeEmbedBorderGlyph(settings.Glyph);
         switch (channelKind)
         {
             case ChannelKind.OfficerChat:

--- a/DemiCatPlugin/EmbedBorderBuilder.cs
+++ b/DemiCatPlugin/EmbedBorderBuilder.cs
@@ -9,16 +9,9 @@ public static class EmbedBorderBuilder
 {
     private const int MaxLineLength = 120;
     private const int Padding = 1;
-    private static readonly IReadOnlyDictionary<Config.EmbedBorderGlyph, string> GlyphSymbols = new Dictionary<Config.EmbedBorderGlyph, string>
-    {
-        [Config.EmbedBorderGlyph.Square] = "■",
-        [Config.EmbedBorderGlyph.Circle] = "●",
-        [Config.EmbedBorderGlyph.Triangle] = "▲"
-    };
-
     public sealed class BorderState
     {
-        public Config.EmbedBorderGlyph Glyph { get; init; }
+        public string Glyph { get; init; } = Config.DefaultEmbedBorderGlyph;
         public uint Color { get; init; }
     }
 
@@ -95,21 +88,16 @@ public static class EmbedBorderBuilder
             Applied = true,
             Border = new BorderState
             {
-                Glyph = sanitized.Glyph,
+                Glyph = glyphSymbol,
                 Color = sanitized.Color
             }
         };
     }
 
-    public static bool TryStrip(string text, string? glyphName, out string stripped)
+    public static bool TryStrip(string text, string? glyph, out string stripped)
     {
         stripped = text ?? string.Empty;
         if (string.IsNullOrEmpty(text))
-        {
-            return false;
-        }
-
-        if (!TryParseGlyph(glyphName, out var glyph))
         {
             return false;
         }
@@ -145,46 +133,10 @@ public static class EmbedBorderBuilder
         return true;
     }
 
-    public static string GetGlyphName(Config.EmbedBorderGlyph glyph)
-        => glyph switch
-        {
-            Config.EmbedBorderGlyph.Circle => "circle",
-            Config.EmbedBorderGlyph.Triangle => "triangle",
-            _ => "square"
-        };
-
-    public static bool TryParseGlyph(string? glyphName, out Config.EmbedBorderGlyph glyph)
+    public static string GetGlyphSymbol(string? glyph)
     {
-        glyph = Config.EmbedBorderGlyph.Square;
-        if (string.IsNullOrWhiteSpace(glyphName))
-        {
-            return false;
-        }
-
-        switch (glyphName.Trim().ToLowerInvariant())
-        {
-            case "circle":
-                glyph = Config.EmbedBorderGlyph.Circle;
-                return true;
-            case "triangle":
-                glyph = Config.EmbedBorderGlyph.Triangle;
-                return true;
-            case "square":
-                glyph = Config.EmbedBorderGlyph.Square;
-                return true;
-            default:
-                return false;
-        }
-    }
-
-    public static string GetGlyphSymbol(Config.EmbedBorderGlyph glyph)
-    {
-        if (GlyphSymbols.TryGetValue(glyph, out var symbol))
-        {
-            return symbol;
-        }
-
-        return GlyphSymbols[Config.EmbedBorderGlyph.Square];
+        var symbol = Config.SanitizeEmbedBorderGlyph(glyph);
+        return string.IsNullOrEmpty(symbol) ? Config.DefaultEmbedBorderGlyph : symbol;
     }
 
     private static bool IsHorizontalLine(string line, string symbol)

--- a/DemiCatPlugin/EmbedStyleControls.cs
+++ b/DemiCatPlugin/EmbedStyleControls.cs
@@ -1,18 +1,25 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
+using DemiCatPlugin.Emoji;
 
 namespace DemiCatPlugin;
 
 public static class EmbedStyleControls
 {
+    private static readonly Dictionary<string, string> GlyphSearchTerms = new();
+
     public sealed class Context
     {
         public string ChannelKindKey { get; init; } = string.Empty;
         public uint EffectiveEmbedColor { get; init; }
         public uint? EmbedColorOverride { get; init; }
         public Config.EmbedBorderSettings Border { get; init; } = Config.EmbedBorderSettings.CreateDefault(global::DemiCatPlugin.ChannelKind.Chat);
+        public EmojiManager? EmojiManager { get; init; }
+        public float EmojiTileSize { get; init; } = Config.MinEmojiTileSize;
+        public float EmojiGridHeight { get; init; } = Config.MinEmojiGridHeight;
     }
 
     public sealed class Result
@@ -83,27 +90,34 @@ public static class EmbedStyleControls
         }
 
         ImGui.SameLine();
-        var comboWidth = 120f * ImGuiHelpers.GlobalScale;
         if (!enabled)
         {
             ImGui.BeginDisabled();
         }
 
-        ImGui.SetNextItemWidth(comboWidth);
-        var label = GetGlyphLabel(border.Glyph);
-        if (ImGui.BeginCombo($"##embedBorderGlyph_{context.ChannelKindKey}", label))
+        var glyphSymbol = EmbedBorderBuilder.GetGlyphSymbol(border.Glyph);
+        var glyphPopupId = $"embedBorderGlyphPopup##{context.ChannelKindKey}";
+        var glyphButtonSize = new Vector2(ImGui.GetFrameHeight() * 1.8f, ImGui.GetFrameHeight());
+        using (context.EmojiManager?.PushEmojiFont())
         {
-            foreach (Config.EmbedBorderGlyph glyph in Enum.GetValues<Config.EmbedBorderGlyph>())
+            if (ImGui.Button($"{glyphSymbol}##embedBorderGlyph_{context.ChannelKindKey}", glyphButtonSize))
             {
-                var isSelected = border.Glyph == glyph;
-                if (ImGui.Selectable(GetGlyphLabel(glyph), isSelected))
-                {
-                    border.Glyph = glyph;
-                    borderChanged = true;
-                }
+                ImGui.OpenPopup(glyphPopupId);
             }
+        }
 
-            ImGui.EndCombo();
+        var selectedGlyph = DrawGlyphPopup(glyphPopupId, context);
+        if (!string.IsNullOrEmpty(selectedGlyph) && !string.Equals(selectedGlyph, glyphSymbol, StringComparison.Ordinal))
+        {
+            border.Glyph = selectedGlyph;
+            borderChanged = true;
+            glyphSymbol = selectedGlyph;
+        }
+
+        var tooltip = TryGetEmojiName(context, glyphSymbol);
+        if (!string.IsNullOrEmpty(tooltip) && ImGui.IsItemHovered())
+        {
+            ImGui.SetTooltip(tooltip);
         }
 
         ImGui.SameLine();
@@ -149,11 +163,149 @@ public static class EmbedStyleControls
         };
     }
 
-    private static string GetGlyphLabel(Config.EmbedBorderGlyph glyph)
-        => glyph switch
+    private static string? DrawGlyphPopup(string popupId, Context context)
+    {
+        string? selected = null;
+        if (!ImGui.BeginPopup(popupId))
         {
-            Config.EmbedBorderGlyph.Circle => "Circle",
-            Config.EmbedBorderGlyph.Triangle => "Triangle",
-            _ => "Square"
-        };
+            return null;
+        }
+
+        var manager = context.EmojiManager;
+        var searchKey = GetSearchKey(context);
+        if (manager == null || !manager.CanLoadStandard)
+        {
+            ImGui.TextDisabled("Emoji list unavailable. Link DemiCat to load emoji.");
+        }
+        else
+        {
+            if (!GlyphSearchTerms.TryGetValue(searchKey, out var search))
+            {
+                search = string.Empty;
+            }
+
+            if (ImGui.InputTextWithHint($"##borderEmojiSearch_{searchKey}", "Search…", ref search, 64))
+            {
+                GlyphSearchTerms[searchKey] = search;
+            }
+
+            ImGui.Separator();
+
+            _ = manager.EnsureUnicodeAsync();
+            var status = manager.UnicodeStatus;
+            var items = manager.Unicode;
+            IReadOnlyList<UnicodeEmoji> filtered = items;
+
+            if (!string.IsNullOrWhiteSpace(search) && items.Count > 0)
+            {
+                var matches = new List<UnicodeEmoji>();
+                foreach (var emoji in items)
+                {
+                    if (emoji.Name.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                        emoji.Emoji.Contains(search, StringComparison.OrdinalIgnoreCase))
+                    {
+                        matches.Add(emoji);
+                    }
+                }
+                filtered = matches;
+            }
+
+            if (filtered.Count == 0)
+            {
+                if (status.Loading)
+                {
+                    ImGui.TextDisabled("Loading emoji…");
+                }
+                else if (status.HasError && !string.IsNullOrEmpty(status.Error))
+                {
+                    ImGui.TextWrapped(status.Error);
+                }
+                else
+                {
+                    ImGui.TextDisabled(string.IsNullOrWhiteSpace(search) ? "No emoji available." : "No matches.");
+                }
+            }
+            else
+            {
+                var tileSize = Math.Clamp(context.EmojiTileSize, Config.MinEmojiTileSize, Config.MaxEmojiTileSize);
+                var childSize = context.EmojiGridHeight > 0f ? new Vector2(0f, context.EmojiGridHeight) : Vector2.Zero;
+                ImGui.BeginChild($"##borderEmojiGrid_{searchKey}", childSize, false);
+
+                var avail = Math.Max(1f, ImGui.GetContentRegionAvail().X);
+                var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (tileSize + 4f)));
+                var column = 0;
+
+                using var font = manager.PushEmojiFont();
+                for (var i = 0; i < filtered.Count; i++)
+                {
+                    if (column >= columns)
+                    {
+                        ImGui.NewLine();
+                        column = 0;
+                    }
+
+                    var emoji = filtered[i];
+                    ImGui.PushID(i);
+                    if (ImGui.Button(emoji.Emoji, new Vector2(tileSize, tileSize)))
+                    {
+                        selected = emoji.Emoji;
+                    }
+                    if (!string.IsNullOrEmpty(emoji.Name) && ImGui.IsItemHovered())
+                    {
+                        ImGui.SetTooltip(emoji.Name);
+                    }
+                    ImGui.PopID();
+
+                    column++;
+                    if (column < columns)
+                    {
+                        ImGui.SameLine();
+                    }
+
+                    if (!string.IsNullOrEmpty(selected))
+                    {
+                        break;
+                    }
+                }
+
+                ImGui.EndChild();
+            }
+        }
+
+        if (!string.IsNullOrEmpty(selected))
+        {
+            GlyphSearchTerms[searchKey] = string.Empty;
+            ImGui.CloseCurrentPopup();
+        }
+
+        ImGui.EndPopup();
+        return string.IsNullOrEmpty(selected) ? null : Config.SanitizeEmbedBorderGlyph(selected);
+    }
+
+    private static string GetSearchKey(Context context)
+        => string.IsNullOrWhiteSpace(context.ChannelKindKey) ? "default" : context.ChannelKindKey;
+
+    private static string? TryGetEmojiName(Context context, string glyph)
+    {
+        if (string.IsNullOrEmpty(glyph))
+        {
+            return null;
+        }
+
+        var manager = context.EmojiManager;
+        if (manager == null)
+        {
+            return null;
+        }
+
+        foreach (var emoji in manager.Unicode)
+        {
+            if (emoji.Emoji.Equals(glyph, StringComparison.Ordinal))
+            {
+                return emoji.Name;
+            }
+        }
+
+        return null;
+    }
 }

--- a/tests/BridgeMessageFormatterTests.cs
+++ b/tests/BridgeMessageFormatterTests.cs
@@ -78,7 +78,7 @@ public class BridgeMessageFormatterTests
         options.EmbedBorder = new Config.EmbedBorderSettings
         {
             Enabled = true,
-            Glyph = Config.EmbedBorderGlyph.Circle,
+            Glyph = Config.SanitizeEmbedBorderGlyph("⚫"),
             Color = 0x112233
         };
 
@@ -87,7 +87,7 @@ public class BridgeMessageFormatterTests
         var embed = Assert.Single(result.Embeds);
         var border = Assert.NotNull(embed.Border);
         Assert.True(border.Enabled);
-        Assert.Equal("circle", border.Glyph);
+        Assert.Equal(Config.SanitizeEmbedBorderGlyph("⚫"), border.Glyph);
         Assert.Equal((uint)0x112233 & 0xFFFFFFu, border.Color);
 
         var expected = EmbedBorderBuilder.Apply("Hi", options.EmbedBorder, ChannelKind.FcChat, 4096);
@@ -104,7 +104,7 @@ public class BridgeMessageFormatterTests
         options.EmbedBorder = new Config.EmbedBorderSettings
         {
             Enabled = true,
-            Glyph = Config.EmbedBorderGlyph.Square,
+            Glyph = Config.DefaultEmbedBorderGlyph,
             Color = 0x445566
         };
 

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -43,10 +43,10 @@ public class ConfigDefaultsTests
         Assert.Equal(Config.DefaultFcEmbedColor, cfg.FcEmbedColor);
         Assert.Equal(Config.DefaultOfficerEmbedColor, cfg.OfficerEmbedColor);
         Assert.False(cfg.FcEmbedBorder.Enabled);
-        Assert.Equal(Config.EmbedBorderGlyph.Square, cfg.FcEmbedBorder.Glyph);
+        Assert.Equal(Config.DefaultEmbedBorderGlyph, cfg.FcEmbedBorder.Glyph);
         Assert.Equal(Config.DefaultFcEmbedColor, cfg.FcEmbedBorder.Color);
         Assert.False(cfg.OfficerEmbedBorder.Enabled);
-        Assert.Equal(Config.EmbedBorderGlyph.Square, cfg.OfficerEmbedBorder.Glyph);
+        Assert.Equal(Config.DefaultEmbedBorderGlyph, cfg.OfficerEmbedBorder.Glyph);
         Assert.Equal(Config.DefaultOfficerEmbedColor, cfg.OfficerEmbedBorder.Color);
     }
 }


### PR DESCRIPTION
## Summary
- store embed border glyphs as persisted emoji strings and migrate existing config data
- update embed border builder, chat UI, and bridge formatter to use arbitrary Unicode emoji for borders
- add an emoji-driven picker to embed style controls and refresh unit tests for the new glyph handling

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc2a0b6848328a16f6aff0ac626e2