### PR TITLE
Add dock appearance settings and auto-show configuration

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -17,6 +17,7 @@ public class Config : IPluginConfiguration
     public const float MaxDockIconScale = 2.5f;
     public static readonly Vector4 DefaultPrimaryWindowColor = new(0.11f, 0.11f, 0.12f, 1f);
     public static readonly Vector4 DefaultSecondaryAccentColor = new(0.2f, 0.6f, 1f, 1f);
+    public static readonly Vector4 DefaultDockBackgroundColor = new(0.11f, 0.11f, 0.12f, 0.9f);
 
     // Required by Dalamud
     public const float MinEmojiTileSize = 16f;
@@ -26,7 +27,7 @@ public class Config : IPluginConfiguration
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
     public const string DefaultEmbedBorderGlyph = "⬛";
-    public const int CurrentVersion = 17;
+    public const int CurrentVersion = 18;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -96,11 +97,20 @@ public class Config : IPluginConfiguration
     [JsonPropertyName("dockBackgroundAlpha")]
     public float DockBackgroundAlpha { get; set; } = 0.9f;
 
+    [JsonPropertyName("dockBackgroundColor")]
+    public Vector4 DockBackgroundColor { get; set; } = DefaultDockBackgroundColor;
+
     [JsonPropertyName("dockPosition")]
     public Vector2 DockPosition { get; set; } = Vector2.Zero;
 
     [JsonPropertyName("dockPositionInitialized")]
     public bool DockPositionInitialized { get; set; }
+
+    [JsonPropertyName("dockRememberPosition")]
+    public bool DockRememberPosition { get; set; } = true;
+
+    [JsonPropertyName("dockAutoShow")]
+    public Dictionary<string, bool> DockAutoShow { get; set; } = new();
 
     public float ChatFontScale { get; set; } = 1f;
     public bool ChatImageAutoStretch { get; set; } = true;
@@ -510,11 +520,29 @@ public class Config : IPluginConfiguration
             {
                 DockBackgroundAlpha = 0.9f;
             }
-            DockBackgroundAlpha = Math.Clamp(DockBackgroundAlpha, 0.2f, 1f);
+            DockBackgroundAlpha = Math.Clamp(DockBackgroundAlpha, 0.1f, 1f);
             DockPositionInitialized = false;
             DockPosition = Vector2.Zero;
 
             Version = 17;
+            ExtensionData = null;
+        }
+        if (Version < 18)
+        {
+            var primary = SanitizeColor(PrimaryWindowColor, DefaultPrimaryWindowColor);
+            var backgroundAlpha = DockBackgroundAlpha;
+            if (!float.IsFinite(backgroundAlpha) || backgroundAlpha <= 0f)
+            {
+                backgroundAlpha = 0.9f;
+            }
+
+            backgroundAlpha = Math.Clamp(backgroundAlpha, 0.1f, 1f);
+            var backgroundColor = new Vector4(primary.X, primary.Y, primary.Z, backgroundAlpha);
+            DockBackgroundColor = SanitizeDockBackgroundColor(backgroundColor);
+            DockBackgroundAlpha = DockBackgroundColor.W;
+            DockAutoShow ??= new Dictionary<string, bool>();
+
+            Version = 18;
             ExtensionData = null;
         }
     }
@@ -592,6 +620,43 @@ public class Config : IPluginConfiguration
         }
     }
 
+    public bool GetDockAutoShow(string id)
+    {
+        if (DockAutoShow == null)
+        {
+            DockAutoShow = new Dictionary<string, bool>();
+        }
+
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return false;
+        }
+
+        return DockAutoShow.TryGetValue(id, out var value) && value;
+    }
+
+    public void SetDockAutoShow(string id, bool value)
+    {
+        if (DockAutoShow == null)
+        {
+            DockAutoShow = new Dictionary<string, bool>();
+        }
+
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return;
+        }
+
+        if (value)
+        {
+            DockAutoShow[id] = true;
+        }
+        else
+        {
+            DockAutoShow.Remove(id);
+        }
+    }
+
     internal static uint SanitizeRgb(uint value, uint fallback)
     {
         var sanitized = value & 0xFFFFFFu;
@@ -650,5 +715,12 @@ public class Config : IPluginConfiguration
         }
 
         return Math.Clamp(value, MinDockIconScale, MaxDockIconScale);
+    }
+
+    internal static Vector4 SanitizeDockBackgroundColor(Vector4 color)
+    {
+        var sanitized = SanitizeColor(color, DefaultDockBackgroundColor);
+        sanitized.W = Math.Clamp(sanitized.W, 0.1f, 1f);
+        return sanitized;
     }
 }

--- a/DemiCatPlugin/DockableWindow.cs
+++ b/DemiCatPlugin/DockableWindow.cs
@@ -106,6 +106,10 @@ public abstract class DockableWindow
         _lastFadeReset = DateTime.UtcNow;
     }
 
+    public virtual void OnAppearanceSettingsChanged()
+    {
+    }
+
     private float ComputeEffectiveOpacity()
     {
         var fadeAlpha = SupportsFade ? ComputeFadeAlpha() : 1f;

--- a/DemiCatPlugin/DockableWindowHosts.cs
+++ b/DemiCatPlugin/DockableWindowHosts.cs
@@ -235,6 +235,12 @@ public class ChatDockableWindow : DockableWindow
     }
 
     protected ChatWindow Chat => _chatWindow;
+
+    public override void OnAppearanceSettingsChanged()
+    {
+        base.OnAppearanceSettingsChanged();
+        _chatWindow.OnAppearanceSettingsChanged();
+    }
 }
 
 public sealed class OfficerChatDockableWindow : ChatDockableWindow

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -30,6 +30,7 @@ public class MainWindow : IDisposable
     private readonly EmojiManager _emojiManager;
     private readonly HttpClient _httpClient;
     private readonly List<DockItem> _dockItems = new();
+    private readonly HashSet<string> _autoShownDockItems = new();
 
     private readonly Action _openSettingsAction;
     private readonly EventsDockableWindow _eventsWindowHost;
@@ -255,9 +256,9 @@ public class MainWindow : IDisposable
         var totalHeight = iconAreaHeight + padding * 2f + indicatorHeight;
         var dockSize = new Vector2(totalWidth, totalHeight);
 
-        EnsureDockPositionInitialized(dockSize);
+        var dockPosition = GetDockPosition(dockSize);
 
-        ImGui.SetNextWindowPos(_config.DockPosition, ImGuiCond.Appearing);
+        ImGui.SetNextWindowPos(dockPosition, ImGuiCond.Appearing);
         ImGui.SetNextWindowSize(dockSize, ImGuiCond.Appearing);
 
         var windowFlags = ImGuiWindowFlags.NoDecoration
@@ -297,7 +298,7 @@ public class MainWindow : IDisposable
             IsOpen = false;
         }
 
-        if (!_config.DockLocked && !ImGui.IsMouseDown(ImGuiMouseButton.Left))
+        if (_config.DockRememberPosition && !_config.DockLocked && !ImGui.IsMouseDown(ImGuiMouseButton.Left))
         {
             if (!_config.DockPositionInitialized || Vector2.Distance(windowPos, _config.DockPosition) > 0.5f)
             {
@@ -314,6 +315,10 @@ public class MainWindow : IDisposable
     {
         _styleNeedsUpdate = true;
         BuildDockItems();
+        foreach (var host in _windowHosts)
+        {
+            host.OnAppearanceSettingsChanged();
+        }
     }
 
     public void ResetEventCreateRoles()
@@ -336,6 +341,18 @@ public class MainWindow : IDisposable
                 window.ResetFadeTimer();
             }
         }
+    }
+
+    public void RefreshDockAutoShow()
+    {
+        _autoShownDockItems.Clear();
+    }
+
+    public void ResetDockPosition()
+    {
+        _config.DockPositionInitialized = false;
+        _config.DockPosition = Vector2.Zero;
+        SaveConfig();
     }
 
     public void Dispose()
@@ -455,6 +472,23 @@ public class MainWindow : IDisposable
             SaveConfig();
         }
 
+        var remember = _config.DockRememberPosition;
+        if (ImGui.MenuItem("Remember Position", null, remember))
+        {
+            var newValue = !_config.DockRememberPosition;
+            _config.DockRememberPosition = newValue;
+            if (newValue)
+            {
+                ResetDockPosition();
+            }
+            else
+            {
+                _config.DockPositionInitialized = false;
+                _config.DockPosition = Vector2.Zero;
+                SaveConfig();
+            }
+        }
+
         var iconScaleValue = _config.DockIconScale;
         if (ImGui.SliderFloat("Icon Scale", ref iconScaleValue, Config.MinDockIconScale, Config.MaxDockIconScale, "%.2f"))
         {
@@ -462,11 +496,16 @@ public class MainWindow : IDisposable
             SaveConfig();
         }
 
-        var alpha = _config.DockBackgroundAlpha;
-        if (ImGui.SliderFloat("Background Alpha", ref alpha, 0.2f, 1f, "%.2f"))
+        var dockColor = _config.DockBackgroundColor;
+        if (ImGui.ColorEdit4("Background Color", ref dockColor, ImGuiColorEditFlags.NoInputs | ImGuiColorEditFlags.AlphaBar))
         {
-            _config.DockBackgroundAlpha = Math.Clamp(alpha, 0f, 1f);
-            SaveConfig();
+            var sanitized = Config.SanitizeDockBackgroundColor(dockColor);
+            if (!ColorsAlmostEqual(sanitized, _config.DockBackgroundColor))
+            {
+                _config.DockBackgroundColor = sanitized;
+                _config.DockBackgroundAlpha = sanitized.W;
+                SaveConfig();
+            }
         }
 
         if (ImGui.MenuItem("Show Settings", null, _settings.IsOpen))
@@ -498,10 +537,39 @@ public class MainWindow : IDisposable
     private float GetSpacing(float iconScale)
         => BaseSpacing * iconScale;
 
+    private Vector2 GetDockPosition(Vector2 dockSize)
+    {
+        if (_config.DockRememberPosition)
+        {
+            EnsureDockPositionInitialized(dockSize);
+            return _config.DockPosition;
+        }
+
+        return CalculateDefaultDockPosition(dockSize);
+    }
+
     private Vector4 GetDockBackgroundColor()
     {
-        var color = Config.SanitizeColor(_config.PrimaryWindowColor, Config.DefaultPrimaryWindowColor);
-        return DockableWindow.WithAlpha(color, Math.Clamp(_config.DockBackgroundAlpha, 0.2f, 1f));
+        var sanitized = Config.SanitizeDockBackgroundColor(_config.DockBackgroundColor);
+        var changed = false;
+        if (!ColorsAlmostEqual(sanitized, _config.DockBackgroundColor))
+        {
+            _config.DockBackgroundColor = sanitized;
+            changed = true;
+        }
+
+        if (Math.Abs(sanitized.W - _config.DockBackgroundAlpha) > 0.0001f)
+        {
+            _config.DockBackgroundAlpha = sanitized.W;
+            changed = true;
+        }
+
+        if (changed)
+        {
+            SaveConfig();
+        }
+
+        return sanitized;
     }
 
     private Vector4 GetDockStripColor(Vector4 background)
@@ -510,6 +578,9 @@ public class MainWindow : IDisposable
         strip.W = background.W;
         return strip;
     }
+
+    private static bool ColorsAlmostEqual(Vector4 a, Vector4 b)
+        => Vector4.DistanceSquared(a, b) <= 0.0001f;
 
     private void EnsureDockIconTexture()
     {
@@ -648,10 +719,13 @@ public class MainWindow : IDisposable
             () => _settings.IsOpen,
             v => _settings.IsOpen = v,
             () => { }));
+
+        _autoShownDockItems.RemoveWhere(id => _dockItems.All(item => item.Id != id));
     }
 
     private void DrawFeatureWindows()
     {
+        EnsureAutoShownWindows();
         foreach (var item in _dockItems)
         {
             if (!item.IsVisible() && item.GetIsOpen())
@@ -667,22 +741,49 @@ public class MainWindow : IDisposable
         }
     }
 
+    private void EnsureAutoShownWindows()
+    {
+        foreach (var item in _dockItems)
+        {
+            if (!_config.GetDockAutoShow(item.Id))
+            {
+                continue;
+            }
+
+            if (_autoShownDockItems.Contains(item.Id))
+            {
+                continue;
+            }
+
+            if (!item.IsVisible() || !item.IsEnabled())
+            {
+                continue;
+            }
+
+            item.SetIsOpen(true);
+            _autoShownDockItems.Add(item.Id);
+        }
+    }
+
     private void EnsureDockPositionInitialized(Vector2 dockSize)
     {
-        if (_config.DockPositionInitialized)
+        if (!_config.DockRememberPosition || _config.DockPositionInitialized)
         {
             return;
         }
 
-        var viewport = ImGui.GetMainViewport();
-        var available = viewport.WorkSize;
-        var desired = new Vector2(
-            viewport.WorkPos.X + (available.X - dockSize.X) * 0.5f,
-            viewport.WorkPos.Y + available.Y - dockSize.Y - 30f);
-
-        _config.DockPosition = desired;
+        _config.DockPosition = CalculateDefaultDockPosition(dockSize);
         _config.DockPositionInitialized = true;
         SaveConfig();
+    }
+
+    private Vector2 CalculateDefaultDockPosition(Vector2 dockSize)
+    {
+        var viewport = ImGui.GetMainViewport();
+        var available = viewport.WorkSize;
+        return new Vector2(
+            viewport.WorkPos.X + (available.X - dockSize.X) * 0.5f,
+            viewport.WorkPos.Y + available.Y - dockSize.Y - 30f);
     }
 
     private void SaveConfig()

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -360,9 +360,13 @@ public class SettingsWindow : IDisposable
 
         ImGui.Spacing();
 
+        DrawDockSettings();
+
+        ImGui.Spacing();
+
         ImGui.BeginDisabled(fadeOutEnabled);
         var fcOpacity = _config.FcChatOpacity * 100f;
-        if (ImGui.SliderFloat("FC Chat Opacity", ref fcOpacity, 0f, 100f, "%.0f%%"))
+        if (ImGui.SliderFloat("FC Chat window opacity", ref fcOpacity, 0f, 100f, "%.0f%%"))
         {
             _config.FcChatOpacity = Math.Clamp(fcOpacity / 100f, 0f, 1f);
             SaveConfig();
@@ -374,7 +378,7 @@ public class SettingsWindow : IDisposable
 
         ImGui.BeginDisabled(fadeOutEnabled);
         var officerOpacity = _config.OfficerChatOpacity * 100f;
-        if (ImGui.SliderFloat("Officer Tab Opacity", ref officerOpacity, 0f, 100f, "%.0f%%"))
+        if (ImGui.SliderFloat("Officer Chat window opacity", ref officerOpacity, 0f, 100f, "%.0f%%"))
         {
             _config.OfficerChatOpacity = Math.Clamp(officerOpacity / 100f, 0f, 1f);
             SaveConfig();
@@ -433,6 +437,106 @@ public class SettingsWindow : IDisposable
         ImGui.SameLine();
         DrawFadePreview("##fadePreview", _config.ChatFadeOutMinimumAlpha);
         ImGui.EndDisabled();
+    }
+
+    private void DrawDockSettings()
+    {
+        ImGui.Separator();
+        ImGui.TextUnformatted("Dock");
+        ImGui.Spacing();
+
+        var dockLocked = _config.DockLocked;
+        if (ImGui.Checkbox("Lock dock position", ref dockLocked))
+        {
+            _config.DockLocked = dockLocked;
+            SaveConfig();
+        }
+
+        var rememberPosition = _config.DockRememberPosition;
+        if (ImGui.Checkbox("Remember dock position between sessions", ref rememberPosition))
+        {
+            _config.DockRememberPosition = rememberPosition;
+            SaveConfig();
+            if (rememberPosition)
+            {
+                MainWindow?.ResetDockPosition();
+            }
+        }
+
+        var iconScale = _config.DockIconScale;
+        if (ImGui.SliderFloat("Dock icon scale", ref iconScale, Config.MinDockIconScale, Config.MaxDockIconScale, "%.2fx"))
+        {
+            _config.DockIconScale = Config.SanitizeDockIconScale(iconScale);
+            SaveConfig();
+        }
+
+        var dockColor = _config.DockBackgroundColor;
+        if (ImGui.ColorEdit4("Dock background color", ref dockColor, ImGuiColorEditFlags.AlphaBar | ImGuiColorEditFlags.AlphaPreviewHalf))
+        {
+            var sanitized = Config.SanitizeDockBackgroundColor(dockColor);
+            if (!ColorsAlmostEqual(sanitized, _config.DockBackgroundColor))
+            {
+                _config.DockBackgroundColor = sanitized;
+                _config.DockBackgroundAlpha = sanitized.W;
+                SaveConfig();
+                MainWindow?.OnAppearanceSettingsChanged();
+            }
+        }
+
+        ImGui.Spacing();
+        ImGui.TextUnformatted("Auto-open windows");
+        ImGui.Spacing();
+
+        var options = new List<(string Id, string Label, bool Available)>
+        {
+            ("events", "Events", _config.Events),
+            ("create", "Create Event", _config.Events),
+            ("templates", "Templates", _config.Templates),
+            ("requests", "Request Board", _config.Requests),
+            ("notepad", "NotePad", _config.NotePadEnabled)
+        };
+
+        if (MainWindow?.ChatWindowHost != null && ChatWindow != null)
+        {
+            var chatLabel = ChatWindow is FcChatWindow ? "FC Chat" : "Chat";
+            options.Add(("chat", chatLabel, true));
+        }
+
+        if (OfficerChatWindow != null)
+        {
+            options.Add(("officer", "Officer Chat", MainWindow?.HasOfficerAccess ?? false));
+        }
+
+        var syncshellAvailable = _config.FCSyncShell && (MainWindow?.SyncshellWindowHost != null);
+        options.Add(("syncshell", "Syncshell", syncshellAvailable));
+
+        foreach (var option in options)
+        {
+            var autoShow = _config.GetDockAutoShow(option.Id);
+            var available = option.Available;
+
+            if (!available)
+            {
+                ImGui.BeginDisabled();
+            }
+
+            var label = $"Auto-open {option.Label}";
+            if (ImGui.Checkbox(label, ref autoShow))
+            {
+                _config.SetDockAutoShow(option.Id, autoShow);
+                SaveConfig();
+                MainWindow?.RefreshDockAutoShow();
+            }
+
+            if (!available)
+            {
+                ImGui.EndDisabled();
+                if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                {
+                    ImGui.SetTooltip("Enable this feature to auto-open the window.");
+                }
+            }
+        }
     }
 
     private void RefreshChatWindows()

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Numerics;
 using DemiCatPlugin;
 using Xunit;
 
@@ -48,5 +49,12 @@ public class ConfigDefaultsTests
         Assert.False(cfg.OfficerEmbedBorder.Enabled);
         Assert.Equal(Config.DefaultEmbedBorderGlyph, cfg.OfficerEmbedBorder.Glyph);
         Assert.Equal(Config.DefaultOfficerEmbedColor, cfg.OfficerEmbedBorder.Color);
+        Assert.True(cfg.DockRememberPosition);
+        Assert.False(cfg.DockLocked);
+        Assert.Equal(1f, cfg.DockIconScale);
+        Assert.Equal(Config.DefaultDockBackgroundColor, cfg.DockBackgroundColor);
+        Assert.Equal(cfg.DockBackgroundColor.W, cfg.DockBackgroundAlpha, 3);
+        Assert.NotNull(cfg.DockAutoShow);
+        Assert.Empty(cfg.DockAutoShow);
     }
 }


### PR DESCRIPTION
## Summary
- extend the plugin configuration with dock color, persistence, and auto-show options plus a migration for the new schema
- expose dock styling and auto-open controls in the appearance tab alongside updated chat opacity sliders
- update the dock renderer and hosted windows to react to appearance changes and honor auto-show preferences

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcfd96cd08328b28faf0c8654399a