### PR TITLE
Prevent chat dock toggles from stopping chat watchers

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -444,6 +444,8 @@ public class ChatWindow : IDisposable
     {
     }
 
+    public bool IsNetworkingActive => _networkingActive;
+
     protected void MarkNetworkingStarted()
     {
         _networkingActive = true;

--- a/DemiCatPlugin/DockableWindowHosts.cs
+++ b/DemiCatPlugin/DockableWindowHosts.cs
@@ -210,12 +210,10 @@ public class ChatDockableWindow : DockableWindow
 
     protected override void OnOpened()
     {
-        _chatWindow.StartNetworking();
-    }
-
-    protected override void OnClosed()
-    {
-        _chatWindow.StopNetworking();
+        if (!_chatWindow.IsNetworkingActive)
+        {
+            _chatWindow.StartNetworking();
+        }
     }
 
     protected override void DrawContents()

--- a/tests/ChatDockableWindowLifecycleTests.cs
+++ b/tests/ChatDockableWindowLifecycleTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using DemiCatPlugin;
+using Xunit;
+
+public class ChatDockableWindowLifecycleTests
+{
+    [Fact]
+    public void ChatAndOfficerNetworkingPersistsWhenDockToggled()
+    {
+        var config = new Config
+        {
+            ApiBaseUrl = "https://example.com",
+            GuildId = "guild",
+            SyncedChat = true,
+            EnableFcChat = true,
+            Officer = true,
+            IsOfficerToken = true
+        };
+
+        using var httpClient = new HttpClient(new FakeHandler());
+        var tokenManager = new TokenManager();
+        var channelService = new ChannelService(config, httpClient, tokenManager);
+
+        var chatWindow = new TestChatWindow(config, httpClient, tokenManager, channelService);
+        var officerWindow = new TestOfficerChatWindow(config, httpClient, tokenManager, channelService);
+
+        var chatDock = new ChatDockableWindow(
+            config,
+            "Free Company Chat",
+            chatWindow,
+            () => true,
+            () => 1f,
+            "Link DemiCat to use chat.",
+            () => { });
+
+        var officerDock = new OfficerChatDockableWindow(
+            config,
+            officerWindow,
+            () => true,
+            () => true,
+            () => { });
+
+        chatWindow.StartNetworking();
+        officerWindow.StartNetworking();
+
+        Assert.Equal(1, chatWindow.StartCalls);
+        Assert.Equal(1, officerWindow.StartCalls);
+        Assert.True(chatWindow.IsNetworkingActive);
+        Assert.True(officerWindow.IsNetworkingActive);
+
+        chatDock.IsOpen = true;
+        chatDock.IsOpen = false;
+        chatDock.IsOpen = true;
+
+        officerDock.IsOpen = true;
+        officerDock.IsOpen = false;
+        officerDock.IsOpen = true;
+
+        Assert.Equal(1, chatWindow.StartCalls);
+        Assert.Equal(1, officerWindow.StartCalls);
+        Assert.True(chatWindow.IsNetworkingActive);
+        Assert.True(officerWindow.IsNetworkingActive);
+    }
+
+    private sealed class TestChatWindow : ChatWindow
+    {
+        public TestChatWindow(
+            Config config,
+            HttpClient httpClient,
+            TokenManager tokenManager,
+            ChannelService channelService)
+            : base(config, httpClient, presence: null, tokenManager, channelService)
+        {
+        }
+
+        public int StartCalls { get; private set; }
+
+        public override void StartNetworking()
+        {
+            StartCalls++;
+            MarkNetworkingStarted();
+        }
+    }
+
+    private sealed class TestOfficerChatWindow : OfficerChatWindow
+    {
+        public TestOfficerChatWindow(
+            Config config,
+            HttpClient httpClient,
+            TokenManager tokenManager,
+            ChannelService channelService)
+            : base(config, httpClient, presence: null, tokenManager, channelService)
+        {
+        }
+
+        public int StartCalls { get; private set; }
+
+        public override void StartNetworking()
+        {
+            StartCalls++;
+            MarkNetworkingStarted();
+        }
+    }
+
+    private sealed class FakeHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]")
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose the chat window networking state so dock hosts can detect an active bridge
- avoid restarting or stopping chat networking when toggling the dock, leaving lifecycle control with the plugin watchers
- add a regression test to ensure chat and officer watchers keep running after the dock is closed and reopened

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd73770308328b3cb6fd10c75e4c2