### PR TITLE
Dispose dock icon wrap safely

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -368,7 +368,16 @@ public class MainWindow : IDisposable
             Instance = null;
         }
 
-        _dockIconTexture?.Dispose();
+        try
+        {
+            (_dockIconTexture?.GetWrapOrEmpty() as IDisposable)?.Dispose();
+        }
+        catch
+        {
+            // Suppress disposal failures; Dalamud will clean these up on exit.
+        }
+
+        _dockIconTexture = null;
         _syncshell?.Dispose();
     }
 


### PR DESCRIPTION
## Summary
- update the dock icon texture disposal to release the underlying wrap when it implements IDisposable
- guard disposal with a try/catch similar to the WebTextureCache pattern and clear the cached texture reference afterwards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc26419d588328a966298a4049da56