### PR TITLE
Wrap dock icon texture creation in MainWindow

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -602,6 +602,7 @@ public class MainWindow : IDisposable
         if (_dockIconTexture != null)
             return;
 
+        ISharedImmediateTextureWrap? wrap = null;
         try
         {
             var provider = PluginServices.Instance?.TextureProvider;
@@ -609,11 +610,14 @@ public class MainWindow : IDisposable
                 return;
 
             var pixel = new byte[] { 255, 255, 255, 255 };
-            _dockIconTexture = provider.CreateFromRaw(RawImageSpecification.Rgba32(1, 1), pixel);
+            wrap = provider.CreateFromRaw(RawImageSpecification.Rgba32(1, 1), pixel);
+            _dockIconTexture = new ForwardingSharedImmediateTexture(wrap);
+            wrap = null;
         }
         catch
         {
             _dockIconTexture = null;
+            wrap?.Dispose();
         }
     }
 


### PR DESCRIPTION
## Summary
- create the dock icon texture using a ForwardingSharedImmediateTexture wrapper
- dispose the raw texture wrap if initialization fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2cc4f0308328be7ae0ba49cfc7f3