### PR TITLE
Adjust dock context menu shortcuts for ImGui signature

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -481,14 +481,14 @@ public class MainWindow : IDisposable
         }
 
         var locked = _config.DockLocked;
-        if (ImGui.MenuItem("Lock Position", null, locked))
+        if (ImGui.MenuItem("Lock Position", default, locked))
         {
             _config.DockLocked = !_config.DockLocked;
             SaveConfig();
         }
 
         var remember = _config.DockRememberPosition;
-        if (ImGui.MenuItem("Remember Position", null, remember))
+        if (ImGui.MenuItem("Remember Position", default, remember))
         {
             var newValue = !_config.DockRememberPosition;
             _config.DockRememberPosition = newValue;
@@ -523,7 +523,7 @@ public class MainWindow : IDisposable
             }
         }
 
-        if (ImGui.MenuItem("Show Settings", null, _settings.IsOpen))
+        if (ImGui.MenuItem("Show Settings", default, _settings.IsOpen))
         {
             _settings.IsOpen = !_settings.IsOpen;
         }


### PR DESCRIPTION
## Summary
- update dock context menu menu items to pass the default shortcut placeholder required by the new ImGui signature while preserving toggle behavior

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2d8b35088328ad12ba41a065b973