### PR TITLE
Fix dock icon texture wrap type

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -602,7 +602,7 @@ public class MainWindow : IDisposable
         if (_dockIconTexture != null)
             return;
 
-        ISharedImmediateTextureWrap? wrap = null;
+        IDalamudTextureWrap? wrap = null;
         try
         {
             var provider = PluginServices.Instance?.TextureProvider;


### PR DESCRIPTION
## Summary
- update the temporary dock icon texture wrap declaration to use `IDalamudTextureWrap`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc34504844832889feb8789445ae2d