### PR TITLE
Ensure dock icon texture wrap is preserved

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -610,8 +610,9 @@ public class MainWindow : IDisposable
                 return;
 
             var pixel = new byte[] { 255, 255, 255, 255 };
-            wrap = provider.CreateFromRaw(RawImageSpecification.Rgba32(1, 1), pixel);
-            _dockIconTexture = new ForwardingSharedImmediateTexture(wrap);
+            var createdWrap = provider.CreateFromRaw(RawImageSpecification.Rgba32(1, 1), pixel);
+            wrap = createdWrap;
+            _dockIconTexture = new ForwardingSharedImmediateTexture(createdWrap);
             wrap = null;
         }
         catch


### PR DESCRIPTION
## Summary
- ensure the raw texture wrap variable captures the handle returned by `CreateFromRaw`
- pass the captured handle to `ForwardingSharedImmediateTexture` and clear the local after successful wrapping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc34b3a7748328a5ddd3fd491d887b