### PR TITLE
Add dock icon loader and wire textures into main window

### DIFF
--- a/DemiCatPlugin/DockIconLoader.cs
+++ b/DemiCatPlugin/DockIconLoader.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Dalamud.Interface.Textures;
+using Dalamud.Interface.Textures.TextureWraps;
+using Dalamud.Plugin.Services;
+using StbImageSharp;
+
+namespace DemiCatPlugin;
+
+internal sealed class DockIconLoader : IDisposable
+{
+    private static readonly string[] ExpectedIconIds =
+    {
+        "events",
+        "create",
+        "templates",
+        "notepad",
+        "requests",
+        "chat",
+        "officer",
+        "syncshell",
+        "settings"
+    };
+
+    private readonly Dictionary<string, ISharedImmediateTexture> _icons = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ISharedImmediateTexture? _placeholder;
+    private readonly IPluginLog? _log;
+    private bool _disposed;
+
+    public DockIconLoader()
+    {
+        var services = PluginServices.Instance ?? throw new InvalidOperationException("Plugin services are not initialized.");
+        _log = services.Log;
+
+        _placeholder = CreatePlaceholderTexture(services.TextureProvider);
+        LoadDockIcons(services.PluginInterface.AssemblyLocation.Directory, services.TextureProvider);
+    }
+
+    public ISharedImmediateTexture? Placeholder => _placeholder;
+
+    public ISharedImmediateTexture? Get(string id)
+    {
+        if (string.IsNullOrEmpty(id))
+            return null;
+
+        return _icons.TryGetValue(id, out var texture) ? texture : null;
+    }
+
+    private void LoadDockIcons(DirectoryInfo? assemblyDirectory, ITextureProvider textureProvider)
+    {
+        if (assemblyDirectory == null)
+        {
+            _log?.Warning("Unable to resolve plugin assembly directory when loading dock icons.");
+            return;
+        }
+
+        var dockDirectory = Path.Combine(assemblyDirectory.FullName, "Dock");
+        if (!Directory.Exists(dockDirectory))
+        {
+            _log?.Warning("Dock icon directory not found: {Directory}", dockDirectory);
+            return;
+        }
+
+        foreach (var file in Directory.EnumerateFiles(dockDirectory, "*.png", SearchOption.TopDirectoryOnly))
+        {
+            var id = Path.GetFileNameWithoutExtension(file);
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+
+            var normalizedId = id.ToLowerInvariant();
+            try
+            {
+                using var stream = File.OpenRead(file);
+                var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
+                var texture = textureProvider.CreateFromRaw(
+                    RawImageSpecification.Rgba32(image.Width, image.Height),
+                    image.Data);
+
+                if (_icons.TryGetValue(normalizedId, out var existing))
+                {
+                    existing.Dispose();
+                }
+
+                _icons[normalizedId] = texture;
+            }
+            catch (Exception ex)
+            {
+                _log?.Warning(ex, "Failed to load dock icon from {Path}", file);
+            }
+        }
+
+        ValidateExpectedIcons(dockDirectory);
+    }
+
+    private void ValidateExpectedIcons(string dockDirectory)
+    {
+        var missing = ExpectedIconIds.Where(id => !_icons.ContainsKey(id)).ToList();
+        if (missing.Count > 0)
+        {
+            _log?.Warning("Missing dock icon assets in {Directory}: {Icons}", dockDirectory, string.Join(", ", missing));
+        }
+        else
+        {
+            _log?.Debug("Loaded dock icons: {Icons}", string.Join(", ", _icons.Keys.OrderBy(id => id)));
+        }
+    }
+
+    private ISharedImmediateTexture? CreatePlaceholderTexture(ITextureProvider provider)
+    {
+        try
+        {
+            var pixel = new byte[] { 255, 255, 255, 255 };
+            return provider.CreateFromRaw(RawImageSpecification.Rgba32(1, 1), pixel);
+        }
+        catch (Exception ex)
+        {
+            _log?.Warning(ex, "Failed to create dock icon placeholder texture.");
+            return null;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        foreach (var texture in _icons.Values)
+        {
+            texture.Dispose();
+        }
+
+        _icons.Clear();
+        _placeholder?.Dispose();
+        _disposed = true;
+    }
+}

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -5,7 +5,6 @@ using System.Net.Http;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures;
-using Dalamud.Interface.Textures.TextureWraps;
 using DemiCatPlugin.Emoji;
 
 namespace DemiCatPlugin;
@@ -31,6 +30,7 @@ public class MainWindow : IDisposable
     private readonly HttpClient _httpClient;
     private readonly List<DockItem> _dockItems = new();
     private readonly HashSet<string> _autoShownDockItems = new();
+    private readonly DockIconLoader _dockIconLoader;
 
     private readonly Action _openSettingsAction;
     private readonly EventsDockableWindow _eventsWindowHost;
@@ -43,7 +43,6 @@ public class MainWindow : IDisposable
     private readonly ChatDockableWindow? _chatWindowHost;
     private SyncshellDockableWindow? _syncshellWindowHost;
 
-    private ISharedImmediateTexture? _dockIconTexture;
     private SyncshellWindow? _syncshell;
     private bool _syncshellEnabled;
     private bool _styleNeedsUpdate = true;
@@ -173,7 +172,7 @@ public class MainWindow : IDisposable
 
         Instance = this;
 
-        EnsureDockIconTexture();
+        _dockIconLoader = new DockIconLoader();
         BuildDockItems();
     }
 
@@ -368,7 +367,7 @@ public class MainWindow : IDisposable
             Instance = null;
         }
 
-        _dockIconTexture?.Dispose();
+        _dockIconLoader.Dispose();
         _syncshell?.Dispose();
     }
 
@@ -588,26 +587,6 @@ public class MainWindow : IDisposable
     private static bool ColorsAlmostEqual(Vector4 a, Vector4 b)
         => Vector4.DistanceSquared(a, b) <= 0.0001f;
 
-    private void EnsureDockIconTexture()
-    {
-        if (_dockIconTexture != null)
-            return;
-
-        try
-        {
-            var provider = PluginServices.Instance?.TextureProvider;
-            if (provider == null)
-                return;
-
-            var pixel = new byte[] { 255, 255, 255, 255 };
-            _dockIconTexture = provider.CreateFromRaw(RawImageSpecification.Rgba32(1, 1), pixel);
-        }
-        catch
-        {
-            _dockIconTexture = null;
-        }
-    }
-
     private void BuildDockItems()
     {
         _dockItems.Clear();
@@ -619,7 +598,7 @@ public class MainWindow : IDisposable
 
         _dockItems.Add(new DockItem(
             "events",
-            _dockIconTexture,
+            GetDockIconOrPlaceholder("events"),
             accent,
             "Events",
             () => _config.Events,
@@ -630,7 +609,7 @@ public class MainWindow : IDisposable
 
         _dockItems.Add(new DockItem(
             "create",
-            _dockIconTexture,
+            GetDockIconOrPlaceholder("create"),
             positive,
             "Create Event",
             () => _config.Events,
@@ -641,7 +620,7 @@ public class MainWindow : IDisposable
 
         _dockItems.Add(new DockItem(
             "templates",
-            _dockIconTexture,
+            GetDockIconOrPlaceholder("templates"),
             mutedAccent,
             "Templates",
             () => _config.Templates,
@@ -652,7 +631,7 @@ public class MainWindow : IDisposable
 
         _dockItems.Add(new DockItem(
             "notepad",
-            _dockIconTexture,
+            GetDockIconOrPlaceholder("notepad"),
             neutral,
             "NotePad",
             () => true,
@@ -663,7 +642,7 @@ public class MainWindow : IDisposable
 
         _dockItems.Add(new DockItem(
             "requests",
-            _dockIconTexture,
+            GetDockIconOrPlaceholder("requests"),
             warning,
             "Request Board",
             () => _config.Requests,
@@ -677,7 +656,7 @@ public class MainWindow : IDisposable
         {
             _dockItems.Add(new DockItem(
                 "chat",
-                _dockIconTexture,
+                GetDockIconOrPlaceholder("chat"),
                 accent,
                 chat is FcChatWindow ? "FC Chat" : "Chat",
                 () => true,
@@ -689,7 +668,7 @@ public class MainWindow : IDisposable
 
         _dockItems.Add(new DockItem(
             "officer",
-            _dockIconTexture,
+            GetDockIconOrPlaceholder("officer"),
             positive,
             "Officer Chat",
             () => HasOfficerAccess,
@@ -700,7 +679,7 @@ public class MainWindow : IDisposable
 
         _dockItems.Add(new DockItem(
             "syncshell",
-            _dockIconTexture,
+            GetDockIconOrPlaceholder("syncshell"),
             accent,
             "Syncshell",
             () => _config.FCSyncShell && _syncshellWindowHost != null,
@@ -717,7 +696,7 @@ public class MainWindow : IDisposable
 
         _dockItems.Add(new DockItem(
             "settings",
-            _dockIconTexture,
+            GetDockIconOrPlaceholder("settings"),
             neutral,
             "Settings",
             () => true,
@@ -727,6 +706,11 @@ public class MainWindow : IDisposable
             () => { }));
 
         _autoShownDockItems.RemoveWhere(id => _dockItems.All(item => item.Id != id));
+    }
+
+    private ISharedImmediateTexture? GetDockIconOrPlaceholder(string id)
+    {
+        return _dockIconLoader.Get(id) ?? _dockIconLoader.Placeholder;
     }
 
     private void DrawFeatureWindows()


### PR DESCRIPTION
## Summary
- add a dedicated dock icon loader that converts Dock/*.png into shared textures and logs missing assets
- update MainWindow to consume the loader, assign textures to each DockItem, and dispose of them when the window is torn down
- retain the tinted placeholder only as a fallback when an icon file is absent or fails to load

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc38e7af18832896ff3ad64b5522c2