### PR TITLE
Add dock icon drag-and-drop reordering

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -27,7 +27,7 @@ public class Config : IPluginConfiguration
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
     public const string DefaultEmbedBorderGlyph = "⬛";
-    public const int CurrentVersion = 18;
+    public const int CurrentVersion = 19;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -111,6 +111,9 @@ public class Config : IPluginConfiguration
 
     [JsonPropertyName("dockAutoShow")]
     public Dictionary<string, bool> DockAutoShow { get; set; } = new();
+
+    [JsonPropertyName("dockOrder")]
+    public List<string> DockOrder { get; set; } = new();
 
     public float ChatFontScale { get; set; } = 1f;
     public bool ChatImageAutoStretch { get; set; } = true;
@@ -543,6 +546,13 @@ public class Config : IPluginConfiguration
             DockAutoShow ??= new Dictionary<string, bool>();
 
             Version = 18;
+            ExtensionData = null;
+        }
+        if (Version < 19)
+        {
+            DockOrder ??= new List<string>();
+
+            Version = 19;
             ExtensionData = null;
         }
     }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Numerics;
+using System.Text;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures;
 using DemiCatPlugin.Emoji;
@@ -16,6 +17,7 @@ public class MainWindow : IDisposable
     private const float BaseSpacing = 8f;
     private const float IndicatorRadius = 4f;
     private const string DockWindowTitle = "DemiCat Dock";
+    private const string DockDragDropPayloadType = "DemiCatDockItem";
 
     private readonly Config _config;
     private readonly UiRenderer _ui;
@@ -31,6 +33,7 @@ public class MainWindow : IDisposable
     private readonly List<DockItem> _dockItems = new();
     private readonly HashSet<string> _autoShownDockItems = new();
     private readonly DockIconLoader _dockIconLoader;
+    private string? _draggingDockItemId;
 
     private readonly Action _openSettingsAction;
     private readonly EventsDockableWindow _eventsWindowHost;
@@ -380,7 +383,7 @@ public class MainWindow : IDisposable
     }
 
     private void DrawDockStrip(
-        IReadOnlyList<DockItem> items,
+        IList<DockItem> items,
         Vector2 iconSize,
         float spacing,
         float indicatorHeight,
@@ -398,6 +401,9 @@ public class MainWindow : IDisposable
         drawList.AddRectFilled(stripMin, stripMax, ImGui.ColorConvertFloat4ToU32(stripColor), MathF.Max(spacing * 2f, 18f));
 
         ImGui.SetCursorScreenPos(iconStart);
+
+        string? pendingSourceId = null;
+        string? pendingTargetId = null;
 
         for (var i = 0; i < items.Count; i++)
         {
@@ -431,6 +437,32 @@ public class MainWindow : IDisposable
                 ImGui.SetTooltip(item.Tooltip);
             }
 
+            if (ImGui.BeginDragDropSource())
+            {
+                _draggingDockItemId = item.Id;
+                var payloadBytes = Encoding.UTF8.GetBytes(item.Id);
+                ImGui.SetDragDropPayload(DockDragDropPayloadType, payloadBytes);
+                ImGui.TextUnformatted(item.Tooltip);
+                ImGui.EndDragDropSource();
+            }
+
+            if (ImGui.BeginDragDropTarget())
+            {
+                var payload = ImGui.AcceptDragDropPayload(DockDragDropPayloadType);
+                if (!payload.Equals(default(ImGuiPayloadPtr)))
+                {
+                    var sourceId = _draggingDockItemId;
+                    if (!string.IsNullOrEmpty(sourceId) &&
+                        !string.Equals(sourceId, item.Id, StringComparison.Ordinal))
+                    {
+                        pendingSourceId = sourceId;
+                        pendingTargetId = item.Id;
+                    }
+                }
+
+                ImGui.EndDragDropTarget();
+            }
+
             if (item.GetIsOpen())
             {
                 var rectMin = ImGui.GetItemRectMin();
@@ -443,6 +475,16 @@ public class MainWindow : IDisposable
         }
 
         ImGui.Dummy(new Vector2(0f, indicatorHeight));
+
+        if (pendingSourceId != null && pendingTargetId != null)
+        {
+            ReorderDockItems(pendingSourceId, pendingTargetId);
+        }
+
+        if (!ImGui.IsMouseDown(ImGuiMouseButton.Left))
+        {
+            _draggingDockItemId = null;
+        }
     }
 
     private bool DrawDockButton(DockItem item, Vector2 iconSize)
@@ -705,7 +747,86 @@ public class MainWindow : IDisposable
             v => _settings.IsOpen = v,
             () => { }));
 
+        ApplyDockOrder();
         _autoShownDockItems.RemoveWhere(id => _dockItems.All(item => item.Id != id));
+    }
+
+    private void ApplyDockOrder()
+    {
+        if (_dockItems.Count == 0)
+        {
+            return;
+        }
+
+        var itemLookup = _dockItems.ToDictionary(item => item.Id, item => item, StringComparer.Ordinal);
+        var storedOrder = _config.DockOrder ?? new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var resolvedOrder = new List<string>(storedOrder.Count + _dockItems.Count);
+
+        foreach (var id in storedOrder)
+        {
+            if (itemLookup.ContainsKey(id) && seen.Add(id))
+            {
+                resolvedOrder.Add(id);
+            }
+        }
+
+        foreach (var item in _dockItems)
+        {
+            if (seen.Add(item.Id))
+            {
+                resolvedOrder.Add(item.Id);
+            }
+        }
+
+        UpdateDockOrder(resolvedOrder);
+
+        var indexLookup = resolvedOrder
+            .Select((id, index) => new KeyValuePair<string, int>(id, index))
+            .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal);
+
+        _dockItems.Sort((a, b) => indexLookup[a.Id].CompareTo(indexLookup[b.Id]));
+    }
+
+    private void UpdateDockOrder(List<string> newOrder)
+    {
+        var existing = _config.DockOrder ?? new List<string>();
+        var changed = existing.Count != newOrder.Count || !existing.SequenceEqual(newOrder);
+        _config.DockOrder = newOrder;
+
+        if (changed)
+        {
+            SaveConfig();
+        }
+    }
+
+    private void ReorderDockItems(string sourceId, string targetId)
+    {
+        if (string.Equals(sourceId, targetId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var sourceIndex = _dockItems.FindIndex(item => string.Equals(item.Id, sourceId, StringComparison.Ordinal));
+        var targetIndex = _dockItems.FindIndex(item => string.Equals(item.Id, targetId, StringComparison.Ordinal));
+
+        if (sourceIndex < 0 || targetIndex < 0)
+        {
+            return;
+        }
+
+        var movedItem = _dockItems[sourceIndex];
+        _dockItems.RemoveAt(sourceIndex);
+
+        if (sourceIndex < targetIndex)
+        {
+            targetIndex--;
+        }
+
+        _dockItems.Insert(targetIndex, movedItem);
+        _draggingDockItemId = null;
+
+        UpdateDockOrder(_dockItems.Select(item => item.Id).ToList());
     }
 
     private ISharedImmediateTexture? GetDockIconOrPlaceholder(string id)


### PR DESCRIPTION
## Summary
- add a DockOrder list to the plugin configuration with a version 19 migration
- build dock items in default order, then apply and persist any saved ordering
- enable drag-and-drop reordering in the dock strip and save the new order immediately

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3bbdf48083288394de3aeab12e1f