### PR TITLE
Adjust test frameworks to async RunOnTick

### DIFF
--- a/tests/ApiHelpersTests.cs
+++ b/tests/ApiHelpersTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -17,8 +18,13 @@ public class ApiHelpersTests
 
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
 
-        public void RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
-            => action();
+        public Task RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private sealed class TestLog : IPluginLog

--- a/tests/ChatWindowChannelFetchTests.cs
+++ b/tests/ChatWindowChannelFetchTests.cs
@@ -161,7 +161,13 @@ public class ChatWindowChannelFetchTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+        public Task RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private sealed class TestLog : IPluginLog

--- a/tests/ChatWindowFormattingTests.cs
+++ b/tests/ChatWindowFormattingTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using System.Net;
 using System.Reflection;
@@ -188,7 +189,13 @@ public class ChatWindowFormattingTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+        public Task RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private class TestLog : IPluginLog

--- a/tests/ChatWindowMentionTests.cs
+++ b/tests/ChatWindowMentionTests.cs
@@ -300,7 +300,13 @@ public class ChatWindowMentionTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+        public Task RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private class TestLog : IPluginLog

--- a/tests/ChatWindowMessageLimitTests.cs
+++ b/tests/ChatWindowMessageLimitTests.cs
@@ -285,7 +285,13 @@ public class ChatWindowMessageLimitTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+        public Task RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private class TestLog : IPluginLog

--- a/tests/ChatWindowWebSocketTests.cs
+++ b/tests/ChatWindowWebSocketTests.cs
@@ -849,7 +849,13 @@ public class ChatWindowWebSocketTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+        public Task RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private class TestLog : IPluginLog

--- a/tests/DiscordPresenceServiceTests.cs
+++ b/tests/DiscordPresenceServiceTests.cs
@@ -43,7 +43,13 @@ public class DiscordPresenceServiceTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+        public Task RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private sealed class RecordingLog : IPluginLog

--- a/tests/DockVisibilityTokenLifecycleTests.cs
+++ b/tests/DockVisibilityTokenLifecycleTests.cs
@@ -30,11 +30,12 @@ public class DockVisibilityTokenLifecycleTests
             pluginInterfaceMock
                 .Setup(pi => pi.SavePluginConfig(It.IsAny<IPluginConfiguration>()));
 
-            var logMock = new Mock<IPluginLog>();
-            var frameworkMock = new Mock<IFramework>();
-            frameworkMock
-                .Setup(f => f.RunOnTick(It.IsAny<Action>(), It.IsAny<FrameworkUpdatePriority>()))
-                .Callback<Action, FrameworkUpdatePriority>((action, _) => action());
+        var logMock = new Mock<IPluginLog>();
+        var frameworkMock = new Mock<IFramework>();
+        frameworkMock
+            .Setup(f => f.RunOnTick(It.IsAny<Action>(), It.IsAny<FrameworkUpdatePriority>()))
+            .Callback<Action, FrameworkUpdatePriority>((action, _) => action())
+            .Returns(Task.CompletedTask);
 
             var chatGuiMock = new Mock<IChatGui>();
             chatGuiMock.Setup(c => c.RemoveChatLinkHandler(It.IsAny<uint>()));

--- a/tests/EmojiPopupGuildTests.cs
+++ b/tests/EmojiPopupGuildTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -33,8 +34,13 @@ public class EmojiFormatterTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
-            => action();
+        public Task RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private sealed class TestLog : IPluginLog

--- a/tests/EmojiServiceTests.cs
+++ b/tests/EmojiServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -39,8 +40,13 @@ public class EmojiManagerTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
-            => action();
+        public Task RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private sealed class TestLog : IPluginLog

--- a/tests/MentionRoleFilteringTests.cs
+++ b/tests/MentionRoleFilteringTests.cs
@@ -130,7 +130,13 @@ public class MentionRoleFilteringTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+        public Task RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private sealed class TestLog : IPluginLog

--- a/tests/OfficerChatWindowTests.cs
+++ b/tests/OfficerChatWindowTests.cs
@@ -212,7 +212,13 @@ public class OfficerChatWindowTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+        public Task RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private class TestLog : IPluginLog

--- a/tests/PluginChannelValidationTests.cs
+++ b/tests/PluginChannelValidationTests.cs
@@ -37,7 +37,8 @@ public class PluginChannelValidationTests
         var frameworkMock = new Mock<IFramework>();
         frameworkMock
             .Setup(f => f.RunOnTick(It.IsAny<Action>(), It.IsAny<FrameworkUpdatePriority>()))
-            .Callback<Action, FrameworkUpdatePriority>((action, _) => action());
+            .Callback<Action, FrameworkUpdatePriority>((action, _) => action())
+            .Returns(Task.CompletedTask);
 
         var toastMock = new Mock<IToastGui>();
 
@@ -172,7 +173,8 @@ public class PluginChannelValidationTests
         var frameworkMock = new Mock<IFramework>();
         frameworkMock
             .Setup(f => f.RunOnTick(It.IsAny<Action>(), It.IsAny<FrameworkUpdatePriority>()))
-            .Callback<Action, FrameworkUpdatePriority>((action, _) => action());
+            .Callback<Action, FrameworkUpdatePriority>((action, _) => action())
+            .Returns(Task.CompletedTask);
 
         var toastMock = new Mock<IToastGui>();
 

--- a/tests/PluginStartWatchersTests.cs
+++ b/tests/PluginStartWatchersTests.cs
@@ -118,7 +118,8 @@ public class PluginStartWatchersTests
         var frameworkMock = new Mock<IFramework>();
         frameworkMock
             .Setup(f => f.RunOnTick(It.IsAny<Action>(), It.IsAny<FrameworkUpdatePriority>()))
-            .Callback<Action, FrameworkUpdatePriority>((action, _) => action());
+            .Callback<Action, FrameworkUpdatePriority>((action, _) => action())
+            .Returns(Task.CompletedTask);
 
         var config = new Config
         {

--- a/tests/PresenceServiceLifecycleTests.cs
+++ b/tests/PresenceServiceLifecycleTests.cs
@@ -135,8 +135,13 @@ public class PresenceServiceLifecycleTests : IDisposable
 
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
 
-        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
-            => action();
+        public Task RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private sealed class TestLog : IPluginLog

--- a/tests/RefreshRolesTests.cs
+++ b/tests/RefreshRolesTests.cs
@@ -155,7 +155,13 @@ public class RefreshRolesTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+        public Task RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private sealed class TestLog : IPluginLog

--- a/tests/SettingsWindowIdentityTests.cs
+++ b/tests/SettingsWindowIdentityTests.cs
@@ -25,7 +25,8 @@ public class SettingsWindowIdentityTests
         var frameworkMock = new Mock<IFramework>();
         frameworkMock
             .Setup(f => f.RunOnTick(It.IsAny<Action>(), It.IsAny<FrameworkUpdatePriority>()))
-            .Callback<Action, FrameworkUpdatePriority>((action, _) => action());
+            .Callback<Action, FrameworkUpdatePriority>((action, _) => action())
+            .Returns(Task.CompletedTask);
 
         var pluginInterfaceMock = new Mock<IDalamudPluginInterface>();
         pluginInterfaceMock.Setup(pi => pi.SavePluginConfig(It.IsAny<IPluginConfiguration>()));
@@ -90,7 +91,8 @@ public class SettingsWindowIdentityTests
         var frameworkMock = new Mock<IFramework>();
         frameworkMock
             .Setup(f => f.RunOnTick(It.IsAny<Action>(), It.IsAny<FrameworkUpdatePriority>()))
-            .Callback<Action, FrameworkUpdatePriority>((action, _) => action());
+            .Callback<Action, FrameworkUpdatePriority>((action, _) => action())
+            .Returns(Task.CompletedTask);
 
         var pluginInterfaceMock = new Mock<IDalamudPluginInterface>();
         pluginInterfaceMock.Setup(pi => pi.SavePluginConfig(It.IsAny<IPluginConfiguration>()));

--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -38,8 +38,13 @@ public class TemplateButtonRoundTripTests
     {
         public event FrameworkUpdateDelegate? Update { add { } remove { } }
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
-        public void RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
-            => action();
+        public Task RunOnTick(System.Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private sealed class TestLog : IPluginLog

--- a/tests/UiRendererShutdownTests.cs
+++ b/tests/UiRendererShutdownTests.cs
@@ -268,7 +268,13 @@ public class UiRendererShutdownTests
 
         public FrameworkUpdateType CurrentUpdateType => FrameworkUpdateType.None;
 
-        public void RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
+        public Task RunOnTick(Action action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task RunOnTick(Func<Task> action, FrameworkUpdatePriority priority = FrameworkUpdatePriority.Normal) => action();
     }
 
     private sealed class NullPluginLog : IPluginLog


### PR DESCRIPTION
## Summary
- update each IFramework test stub to return Task from RunOnTick and add a Func<Task> overload for async helpers
- adjust Moq setups of IFramework.RunOnTick to invoke callbacks and return Task.CompletedTask

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc3e0d76d08328b04fee65f6994858