### PR TITLE
Add shared settings header to dockable windows

### DIFF
--- a/DemiCatPlugin/DockableWindow.cs
+++ b/DemiCatPlugin/DockableWindow.cs
@@ -10,6 +10,7 @@ public abstract class DockableWindow
 
     private readonly Config _config;
     private readonly Action _openSettings;
+    private bool _hasDrawnHeaderThisFrame;
     private DateTime _lastFadeReset = DateTime.UtcNow;
     private bool _isOpen;
 
@@ -65,6 +66,7 @@ public abstract class DockableWindow
 
         var open = IsOpen;
         var colorsPushed = 0;
+        _hasDrawnHeaderThisFrame = false;
         if (UseThemedColors)
         {
             colorsPushed = PushWindowThemeColors();
@@ -81,6 +83,7 @@ public abstract class DockableWindow
                 ResetFadeTimer();
             }
 
+            DrawHeaderWithSettingsButton();
             DrawContents();
         }
         ImGui.End();
@@ -165,6 +168,36 @@ public abstract class DockableWindow
         {
             _openSettings();
         }
+    }
+
+    protected void DrawHeaderWithSettingsButton()
+    {
+        if (_hasDrawnHeaderThisFrame)
+            return;
+
+        _hasDrawnHeaderThisFrame = true;
+
+        const string label = "Settings";
+        var style = ImGui.GetStyle();
+        var buttonSize = ImGui.CalcTextSize(label);
+        buttonSize.X += style.FramePadding.X * 2f;
+        buttonSize.Y += style.FramePadding.Y * 2f;
+
+        var cursorPos = ImGui.GetCursorPos();
+        var availableWidth = ImGui.GetContentRegionAvail().X;
+        var buttonPosX = cursorPos.X + Math.Max(0f, availableWidth - buttonSize.X);
+
+        ImGui.SetCursorPosX(buttonPosX);
+        ImGui.PushID("SettingsButton");
+        if (ImGui.Button(label))
+        {
+            _openSettings();
+        }
+        ImGui.PopID();
+
+        var nextCursorY = cursorPos.Y + buttonSize.Y + style.ItemSpacing.Y;
+        ImGui.SetCursorPos(new Vector2(cursorPos.X, nextCursorY));
+        ImGui.Separator();
     }
 
     internal static Vector4 AdjustBrightness(Vector4 color, float factor)

--- a/DemiCatPlugin/DockableWindowHosts.cs
+++ b/DemiCatPlugin/DockableWindowHosts.cs
@@ -27,6 +27,8 @@ public sealed class EventsDockableWindow : DockableWindow
 
     protected override void DrawContents()
     {
+        DrawHeaderWithSettingsButton();
+
         if (!_isLinked())
         {
             DrawLinkPrompt("Link DemiCat to view events.");
@@ -56,6 +58,8 @@ public sealed class EventCreateDockableWindow : DockableWindow
 
     protected override void DrawContents()
     {
+        DrawHeaderWithSettingsButton();
+
         if (!_isLinked())
         {
             DrawLinkPrompt("Link DemiCat to create events.");
@@ -94,6 +98,8 @@ public sealed class TemplatesDockableWindow : DockableWindow
 
     protected override void DrawContents()
     {
+        DrawHeaderWithSettingsButton();
+
         if (!_isLinked())
         {
             DrawLinkPrompt("Link DemiCat to use templates.");
@@ -123,6 +129,8 @@ public sealed class NotePadDockableWindow : DockableWindow
 
     protected override void DrawContents()
     {
+        DrawHeaderWithSettingsButton();
+
         if (!Config.NotePadEnabled)
         {
             ImGui.TextUnformatted("NotePad is disabled.");
@@ -147,6 +155,8 @@ public sealed class RequestBoardDockableWindow : DockableWindow
 
     protected override void DrawContents()
     {
+        DrawHeaderWithSettingsButton();
+
         if (!_isLinked())
         {
             DrawLinkPrompt("Link DemiCat to view requests.");
@@ -171,6 +181,8 @@ public sealed class SyncshellDockableWindow : DockableWindow
 
     protected override void DrawContents()
     {
+        DrawHeaderWithSettingsButton();
+
         if (!_isLinked())
         {
             DrawLinkPrompt("Link DemiCat to use syncshell.");
@@ -218,6 +230,8 @@ public class ChatDockableWindow : DockableWindow
 
     protected override void DrawContents()
     {
+        DrawHeaderWithSettingsButton();
+
         if (!_isLinked())
         {
             DrawLinkPrompt(_linkPrompt);


### PR DESCRIPTION
## Summary
- add a reusable helper that renders a dock header with a settings button in `DockableWindow`
- call the helper from all dockable window hosts so each feature window exposes consistent settings access

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4962b1d88328a30bbaf07a9e9e2a