### PR TITLE
Add configurable Penumbra path overrides

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -27,7 +27,7 @@ public class Config : IPluginConfiguration
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
     public const string DefaultEmbedBorderGlyph = "⬛";
-    public const int CurrentVersion = 19;
+    public const int CurrentVersion = 20;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -188,6 +188,12 @@ public class Config : IPluginConfiguration
 
     [JsonPropertyName("autoApply")]
     public Dictionary<string, bool> AutoApply { get; set; } = new();
+
+    [JsonPropertyName("penumbraModsDirectory")]
+    public string PenumbraModsDirectory { get; set; } = string.Empty;
+
+    [JsonPropertyName("penumbraConfigDirectory")]
+    public string PenumbraConfigDirectory { get; set; } = string.Empty;
 
     [JsonPropertyName("penumbraChoices")]
     public Dictionary<string, bool> PenumbraChoices { get; set; } = new();
@@ -600,6 +606,14 @@ public class Config : IPluginConfiguration
             Version = 19;
             ExtensionData = null;
             PluginServices.Instance?.PluginInterface.SavePluginConfig(this);
+        }
+        if (Version < 20)
+        {
+            PenumbraModsDirectory ??= string.Empty;
+            PenumbraConfigDirectory ??= string.Empty;
+
+            Version = 20;
+            ExtensionData = null;
         }
     }
 

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -8,7 +8,9 @@ using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
+using System.IO;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 
@@ -26,6 +28,8 @@ public class SettingsWindow : IDisposable
 
     private string _apiKey = string.Empty;
     private string _apiBaseUrl = string.Empty;
+    private string _penumbraModsDirectory = string.Empty;
+    private string _penumbraConfigDirectory = string.Empty;
     private string _syncStatus = string.Empty;
     private bool _syncInProgress;
     private readonly Dictionary<string, bool> _categoryToggles = new();
@@ -35,6 +39,9 @@ public class SettingsWindow : IDisposable
     private bool _settingsLoaded;
     private bool _isLinked;
     private static readonly int[] FadeDurations = { 5, 10, 15, 20, 30 };
+
+    private readonly FileDialogManager _penumbraModsDialog = new();
+    private readonly FileDialogManager _penumbraConfigDialog = new();
 
     public bool IsOpen;
 
@@ -54,6 +61,8 @@ public class SettingsWindow : IDisposable
         _startNetworking = startNetworking;
         _apiKey = tokenManager.Token ?? string.Empty;
         _apiBaseUrl = config.ApiBaseUrl;
+        _penumbraModsDirectory = config.PenumbraModsDirectory ?? string.Empty;
+        _penumbraConfigDirectory = config.PenumbraConfigDirectory ?? string.Empty;
         _devWindow = new DeveloperWindow(config, pluginInterface);
         _log = log;
         _isLinked = _tokenManager.State == LinkState.Linked;
@@ -103,6 +112,9 @@ public class SettingsWindow : IDisposable
 
     private void DrawGeneralTab()
     {
+        _penumbraModsDialog.Draw();
+        _penumbraConfigDialog.Draw();
+
         DrawConnectionIndicator(_isLinked);
         ImGui.Spacing();
 
@@ -200,6 +212,8 @@ public class SettingsWindow : IDisposable
             if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
                 ImGui.SetTooltip("Enable FC SyncShell to display transfer progress overlay.");
         }
+
+        DrawPenumbraDirectorySettings();
 
         foreach (var kvp in _categoryToggles.ToList())
         {
@@ -862,6 +876,10 @@ public class SettingsWindow : IDisposable
         _config.Categories.Clear();
         _config.AutoApply.Clear();
         _config.PenumbraChoices.Clear();
+        _config.PenumbraModsDirectory = string.Empty;
+        _config.PenumbraConfigDirectory = string.Empty;
+        _penumbraModsDirectory = string.Empty;
+        _penumbraConfigDirectory = string.Empty;
         _config.NotePadLastSectionId = null;
         _config.NotePadLastPageId = null;
 
@@ -1162,6 +1180,141 @@ public class SettingsWindow : IDisposable
             }
         }
     }
+
+    private void DrawPenumbraDirectorySettings()
+    {
+        ImGui.Separator();
+        ImGui.TextUnformatted("Penumbra Directories");
+        ImGui.TextDisabled("Override the Penumbra folders used by SyncShell.");
+        ImGui.Spacing();
+
+        DrawDirectoryPicker(
+            "Penumbra Mods Directory",
+            "Leave blank to use Penumbra's configured mods directory.",
+            () => _penumbraModsDirectory,
+            SetPenumbraModsDirectory,
+            _penumbraModsDialog,
+            "PenumbraMods");
+
+        DrawDirectoryPicker(
+            "Penumbra Config Directory",
+            "Should contain default_mod.json. Leave blank to auto-detect.",
+            () => _penumbraConfigDirectory,
+            SetPenumbraConfigDirectory,
+            _penumbraConfigDialog,
+            "PenumbraConfig");
+    }
+
+    private void DrawDirectoryPicker(
+        string label,
+        string helpText,
+        Func<string> getter,
+        Action<string> setter,
+        FileDialogManager dialog,
+        string idSuffix)
+    {
+        var value = getter() ?? string.Empty;
+        if (ImGui.InputText(label, ref value, 260))
+        {
+            setter(value);
+        }
+
+        ImGui.SameLine();
+        if (ImGui.Button($"Browse##{idSuffix}"))
+        {
+            OpenFolderDialog(dialog, label, getter(), setter);
+        }
+
+        var current = getter();
+        if (!string.IsNullOrEmpty(NormalizeDirectory(current)))
+        {
+            ImGui.SameLine();
+            if (ImGui.Button($"Clear##{idSuffix}"))
+            {
+                setter(string.Empty);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(helpText))
+        {
+            ImGui.TextDisabled(helpText);
+        }
+
+        current = getter();
+        var normalized = NormalizeDirectory(current);
+        if (!string.IsNullOrEmpty(normalized) && !Directory.Exists(normalized))
+        {
+            ImGui.TextColored(new Vector4(1f, 0.6f, 0.6f, 1f), "Directory not found; automatic detection will be used instead.");
+        }
+
+        ImGui.Spacing();
+    }
+
+    private void OpenFolderDialog(
+        FileDialogManager dialog,
+        string label,
+        string? currentPath,
+        Action<string> setter)
+    {
+        var initial = NormalizeDirectory(currentPath);
+        if (string.IsNullOrEmpty(initial) || !Directory.Exists(initial))
+        {
+            initial = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        }
+
+        if (string.IsNullOrEmpty(initial) || !Directory.Exists(initial))
+        {
+            initial = Environment.CurrentDirectory;
+        }
+
+        dialog.OpenFolderDialog($"Select {label}", (success, selected) =>
+        {
+            if (!success || string.IsNullOrWhiteSpace(selected))
+            {
+                return;
+            }
+
+            var normalized = NormalizeDirectory(selected);
+            var framework = PluginServices.Instance?.Framework;
+            if (framework != null)
+            {
+                _ = framework.RunOnTick(() => setter(normalized));
+            }
+            else
+            {
+                setter(normalized);
+            }
+        }, initial);
+    }
+
+    private void SetPenumbraModsDirectory(string? path)
+    {
+        var normalized = NormalizeDirectory(path);
+        if (string.Equals(_penumbraModsDirectory, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _penumbraModsDirectory = normalized;
+        _config.PenumbraModsDirectory = normalized;
+        SaveConfig();
+    }
+
+    private void SetPenumbraConfigDirectory(string? path)
+    {
+        var normalized = NormalizeDirectory(path);
+        if (string.Equals(_penumbraConfigDirectory, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _penumbraConfigDirectory = normalized;
+        _config.PenumbraConfigDirectory = normalized;
+        SaveConfig();
+    }
+
+    private static string NormalizeDirectory(string? value)
+        => string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
 
     private void ClearCachedData()
     {

--- a/DemiCatPlugin/SyncShell/Resolver.cs
+++ b/DemiCatPlugin/SyncShell/Resolver.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Services;
+using DemiCatPlugin;
 
 namespace DemiCatPlugin.SyncShell;
 
@@ -54,6 +55,7 @@ public sealed class Resolver : IResolver
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "XIVLauncherCN", "pluginConfigs", "Penumbra"),
     };
 
+    private readonly Config _config;
     private readonly IBlobStore _blobStore;
     private readonly IPluginLog _log;
     private readonly IDalamudPluginInterface? _pluginInterface;
@@ -61,8 +63,9 @@ public sealed class Resolver : IResolver
     /// <summary>
     /// Initialises a new instance of the <see cref="Resolver"/> class.
     /// </summary>
-    public Resolver(IBlobStore blobStore, IPluginLog log, IDalamudPluginInterface? pluginInterface = null)
+    public Resolver(Config config, IBlobStore blobStore, IPluginLog log, IDalamudPluginInterface? pluginInterface = null)
     {
+        _config = config ?? throw new ArgumentNullException(nameof(config));
         _blobStore = blobStore ?? throw new ArgumentNullException(nameof(blobStore));
         _log = log ?? throw new ArgumentNullException(nameof(log));
         _pluginInterface = pluginInterface ?? PluginServices.Instance?.PluginInterface;
@@ -598,13 +601,22 @@ public sealed class Resolver : IResolver
         string? modsDirectory = null;
         string? configDirectory = null;
 
-        try
+        var configuredMods = ValidateConfiguredDirectory(_config.PenumbraModsDirectory, "Penumbra mods directory");
+        if (!string.IsNullOrEmpty(configuredMods))
         {
-            modsDirectory = TryInvokeIpc<string>("Penumbra.GetModsDirectory");
+            modsDirectory = configuredMods;
         }
-        catch (Exception ex)
+
+        if (string.IsNullOrWhiteSpace(modsDirectory))
         {
-            _log.Warning(ex, "Failed to retrieve Penumbra mods directory via IPC");
+            try
+            {
+                modsDirectory = TryInvokeIpc<string>("Penumbra.GetModsDirectory");
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Failed to retrieve Penumbra mods directory via IPC");
+            }
         }
 
         if (string.IsNullOrWhiteSpace(modsDirectory))
@@ -619,14 +631,23 @@ public sealed class Resolver : IResolver
             return null;
         }
 
-        try
+        var configuredConfig = ValidateConfiguredDirectory(_config.PenumbraConfigDirectory, "Penumbra config directory");
+        if (!string.IsNullOrEmpty(configuredConfig))
         {
-            configDirectory = TryInvokeIpc<string>("Penumbra.GetConfigurationDirectory")
-                ?? TryInvokeIpc<string>("Penumbra.GetConfigDirectory");
+            configDirectory = configuredConfig;
         }
-        catch (Exception ex)
+
+        if (string.IsNullOrWhiteSpace(configDirectory))
         {
-            _log.Debug(ex, "Failed to retrieve Penumbra config directory via IPC");
+            try
+            {
+                configDirectory = TryInvokeIpc<string>("Penumbra.GetConfigurationDirectory")
+                    ?? TryInvokeIpc<string>("Penumbra.GetConfigDirectory");
+            }
+            catch (Exception ex)
+            {
+                _log.Debug(ex, "Failed to retrieve Penumbra config directory via IPC");
+            }
         }
 
         if (string.IsNullOrWhiteSpace(configDirectory) || !Directory.Exists(configDirectory))
@@ -664,6 +685,31 @@ public sealed class Resolver : IResolver
 
         var defaultMod = Path.Combine(configDirectory, "default_mod.json");
         return new PenumbraPaths(modsDirectory, configDirectory, defaultMod);
+    }
+
+    private string? ValidateConfiguredDirectory(string? path, string description)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var trimmed = path.Trim();
+        try
+        {
+            if (!Directory.Exists(trimmed))
+            {
+                _log.Warning($"Configured {description} '{trimmed}' does not exist; falling back to automatic detection.");
+                return null;
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, $"Configured {description} '{trimmed}' is invalid; falling back to automatic detection.");
+            return null;
+        }
+
+        return trimmed;
     }
 
     private T? TryInvokeIpc<T>(string channel)

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -173,7 +173,7 @@ public class SyncshellWindow : IDisposable
 
         _tokenManager = TokenManager.Instance ?? throw new InvalidOperationException("Token manager unavailable");
         var log = services?.Log ?? new NullPluginLog();
-        _resolver = new Resolver(_blobStore, log, services?.PluginInterface);
+        _resolver = new Resolver(config, _blobStore, log, services?.PluginInterface);
         _syncClient = new SyncClient(_config, _tokenManager, _resolver, _blobStore);
         _syncClient.TransferProgress += HandleTransferProgress;
         _syncClient.ApplyCompleted += HandleApplyCompleted;

--- a/tests/SyncShellResolverTests.cs
+++ b/tests/SyncShellResolverTests.cs
@@ -11,6 +11,7 @@ using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Services;
 using DemiCatPlugin.SyncShell;
+using DemiCatPlugin;
 using Moq;
 using Xunit;
 
@@ -84,7 +85,7 @@ public class SyncShellResolverTests
             glamState,
             customizeState);
 
-        var resolver = new Resolver(blobStore.Object, Mock.Of<IPluginLog>(), pluginInterface.Object);
+        var resolver = new Resolver(new Config(), blobStore.Object, Mock.Of<IPluginLog>(), pluginInterface.Object);
 
         var manifest = await resolver.BuildManifestAsync().ConfigureAwait(false);
 
@@ -120,6 +121,34 @@ public class SyncShellResolverTests
     }
 
     [Fact]
+    public async Task BuildManifestAsync_UsesConfiguredDirectoriesWhenPluginInterfaceUnavailable()
+    {
+        using var temp = new TempDirectory();
+        var modsDirectory = Path.Combine(temp.Path, "mods");
+        var configDirectory = Path.Combine(temp.Path, "config");
+        Directory.CreateDirectory(modsDirectory);
+        Directory.CreateDirectory(configDirectory);
+        await File.WriteAllTextAsync(Path.Combine(configDirectory, "default_mod.json"), "{}").ConfigureAwait(false);
+
+        var config = new Config
+        {
+            PenumbraModsDirectory = modsDirectory,
+            PenumbraConfigDirectory = configDirectory,
+        };
+
+        var blobStore = new Mock<IBlobStore>();
+        blobStore.Setup(bs => bs.Has(It.IsAny<string>())).Returns(true);
+
+        var resolver = new Resolver(config, blobStore.Object, Mock.Of<IPluginLog>(), null);
+        var manifest = await resolver.BuildManifestAsync().ConfigureAwait(false);
+
+        var collection = Assert.Single(manifest.Collections);
+        Assert.Equal("default", collection.CollectionId);
+        Assert.Empty(collection.Mods);
+        Assert.Empty(collection.Patches);
+    }
+
+    [Fact]
     public void GetMissingBlobs_ReturnsOnlyHashesNotPresent()
     {
         var blobStore = new Mock<IBlobStore>();
@@ -148,7 +177,7 @@ public class SyncShellResolverTests
             }
         };
 
-        var resolver = new Resolver(blobStore.Object, Mock.Of<IPluginLog>(), null);
+        var resolver = new Resolver(new Config(), blobStore.Object, Mock.Of<IPluginLog>(), null);
         var missing = resolver.GetMissingBlobs(manifest).ToList();
 
         Assert.Single(missing);
@@ -225,7 +254,7 @@ public class SyncShellResolverTests
             .Setup(pi => pi.GetIpcSubscriber<string, object?>(It.Is<string>(c => c == "Customize.ApplyProfile")))
             .Returns(customizeApplyMock.Object);
 
-        var resolver = new Resolver(blobStore, Mock.Of<IPluginLog>(), pluginInterface.Object);
+        var resolver = new Resolver(new Config(), blobStore, Mock.Of<IPluginLog>(), pluginInterface.Object);
         await resolver.ApplyManifestAsync("peer-one", manifest).ConfigureAwait(false);
 
         var appliedFile = Path.Combine(modsDirectory, "SyncShell", "peer-one", "mod-one", "assets", "file.bin");


### PR DESCRIPTION
## Summary
- store optional Penumbra mods and configuration directory overrides in the plugin config and migrate existing installs
- expose browseable folder selectors in the general settings tab so users can manage those overrides without editing files manually
- teach the SyncShell resolver and tests to respect the configured directories before falling back to IPC or auto-detection

## Testing
- `dotnet test` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc58ea85b88328967a2d26279b6535