### PR TITLE
Add configurable Penumbra overrides to Syncshell workflow

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -27,7 +27,7 @@ public class Config : IPluginConfiguration
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
     public const string DefaultEmbedBorderGlyph = "⬛";
-    public const int CurrentVersion = 20;
+    public const int CurrentVersion = 21;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -197,6 +197,15 @@ public class Config : IPluginConfiguration
 
     [JsonPropertyName("penumbraChoices")]
     public Dictionary<string, bool> PenumbraChoices { get; set; } = new();
+
+    [JsonPropertyName("penumbraCollectionOverride")]
+    public string PenumbraCollectionOverride
+    {
+        get => _penumbraCollectionOverride;
+        set => _penumbraCollectionOverride = value?.Trim() ?? string.Empty;
+    }
+
+    private string _penumbraCollectionOverride = string.Empty;
 
     [JsonPropertyName("categories")]
     public Dictionary<string, CategoryState> Categories { get; set; } = new();
@@ -613,6 +622,14 @@ public class Config : IPluginConfiguration
             PenumbraConfigDirectory ??= string.Empty;
 
             Version = 20;
+            ExtensionData = null;
+        }
+
+        if (Version < 21)
+        {
+            PenumbraCollectionOverride ??= string.Empty;
+
+            Version = 21;
             ExtensionData = null;
         }
     }

--- a/DemiCatPlugin/SyncShell/Client.cs
+++ b/DemiCatPlugin/SyncShell/Client.cs
@@ -42,6 +42,7 @@ public sealed class SyncClient : IDisposable
     private readonly ConcurrentDictionary<string, PeerDownloadState> _downloads = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, PeerUploadState> _uploads = new(StringComparer.OrdinalIgnoreCase);
     private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private PenumbraResolveOptions? _penumbraOverrides;
 
     private Task? _runTask;
     private SyncLimits _localLimits;
@@ -110,6 +111,15 @@ public sealed class SyncClient : IDisposable
     public SyncLimits NegotiatedLimits => _negotiatedLimits;
 
     /// <summary>
+    /// Updates the Penumbra resolution overrides used when building or applying manifests.
+    /// </summary>
+    /// <param name="overrides">Overrides to apply.</param>
+    public void UpdatePenumbraOverrides(PenumbraResolveOptions? overrides)
+    {
+        Volatile.Write(ref _penumbraOverrides, overrides);
+    }
+
+    /// <summary>
     /// Starts the client background loop.
     /// </summary>
     public void Start()
@@ -159,7 +169,9 @@ public sealed class SyncClient : IDisposable
             throw new InvalidOperationException("SyncShell client is not connected.");
         }
 
-        var manifest = await _resolver.BuildManifestAsync(cancellationToken).ConfigureAwait(false);
+        var manifest = await _resolver
+            .BuildManifestAsync(Volatile.Read(ref _penumbraOverrides), cancellationToken)
+            .ConfigureAwait(false);
         await SendManifestAsync(socket, null, manifest, cancellationToken).ConfigureAwait(false);
     }
 
@@ -367,7 +379,9 @@ public sealed class SyncClient : IDisposable
         }
 
         // push initial manifest so peers can start requesting data
-        var manifest = await _resolver.BuildManifestAsync(token).ConfigureAwait(false);
+        var manifest = await _resolver
+            .BuildManifestAsync(Volatile.Read(ref _penumbraOverrides), token)
+            .ConfigureAwait(false);
         await SendManifestAsync(socket, null, manifest, token).ConfigureAwait(false);
     }
 
@@ -652,7 +666,9 @@ public sealed class SyncClient : IDisposable
     {
         try
         {
-            await _resolver.ApplyManifestAsync(peerId, manifest, token).ConfigureAwait(false);
+        await _resolver
+            .ApplyManifestAsync(peerId, manifest, Volatile.Read(ref _penumbraOverrides), token)
+            .ConfigureAwait(false);
             ApplyCompleted?.Invoke(this, new ApplyResultEventArgs(peerId, true, null));
         }
         catch (Exception ex)

--- a/DemiCatPlugin/SyncShell/PenumbraResolveOptions.cs
+++ b/DemiCatPlugin/SyncShell/PenumbraResolveOptions.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace DemiCatPlugin.SyncShell;
+
+/// <summary>
+/// Provides override information for resolving Penumbra paths and collections.
+/// </summary>
+/// <param name="ModsDirectory">Optional override for the mods root directory.</param>
+/// <param name="ConfigDirectory">Optional override for the configuration directory.</param>
+/// <param name="Collection">Optional override for the active collection identifier.</param>
+public sealed record PenumbraResolveOptions(string? ModsDirectory, string? ConfigDirectory, string? Collection)
+{
+    /// <summary>
+    /// Creates an instance populated from plugin configuration.
+    /// </summary>
+    public static PenumbraResolveOptions FromConfig(Config config)
+    {
+        if (config == null)
+            throw new ArgumentNullException(nameof(config));
+
+        var mods = string.IsNullOrWhiteSpace(config.PenumbraModsDirectory)
+            ? null
+            : config.PenumbraModsDirectory.Trim();
+        var cfg = string.IsNullOrWhiteSpace(config.PenumbraConfigDirectory)
+            ? null
+            : config.PenumbraConfigDirectory.Trim();
+        var collection = string.IsNullOrWhiteSpace(config.PenumbraCollectionOverride)
+            ? null
+            : config.PenumbraCollectionOverride.Trim();
+
+        return new PenumbraResolveOptions(mods, cfg, collection);
+    }
+}

--- a/DemiCatPlugin/SyncShell/Resolver.cs
+++ b/DemiCatPlugin/SyncShell/Resolver.cs
@@ -25,7 +25,7 @@ public interface IResolver
     /// </summary>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The populated manifest.</returns>
-    Task<SyncManifest> BuildManifestAsync(CancellationToken cancellationToken = default);
+    Task<SyncManifest> BuildManifestAsync(PenumbraResolveOptions? options = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Determines which blobs referenced by the manifest are missing from the backing <see cref="IBlobStore"/>.
@@ -40,7 +40,7 @@ public interface IResolver
     /// <param name="peerId">Identifier of the peer.</param>
     /// <param name="manifest">Manifest to apply.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task ApplyManifestAsync(string peerId, SyncManifest manifest, CancellationToken cancellationToken = default);
+    Task ApplyManifestAsync(string peerId, SyncManifest manifest, PenumbraResolveOptions? options = null, CancellationToken cancellationToken = default);
 }
 
 /// <inheritdoc />
@@ -72,7 +72,7 @@ public sealed class Resolver : IResolver
     }
 
     /// <inheritdoc />
-    public async Task<SyncManifest> BuildManifestAsync(CancellationToken cancellationToken = default)
+    public async Task<SyncManifest> BuildManifestAsync(PenumbraResolveOptions? options = null, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -84,7 +84,7 @@ public sealed class Resolver : IResolver
             },
         };
 
-        var penumbraPaths = ResolvePenumbraPaths();
+        var penumbraPaths = ResolvePenumbraPaths(options);
         if (penumbraPaths is null)
         {
             _log.Warning("Unable to resolve Penumbra directories; returning empty manifest");
@@ -162,7 +162,7 @@ public sealed class Resolver : IResolver
     }
 
     /// <inheritdoc />
-    public async Task ApplyManifestAsync(string peerId, SyncManifest manifest, CancellationToken cancellationToken = default)
+    public async Task ApplyManifestAsync(string peerId, SyncManifest manifest, PenumbraResolveOptions? options = null, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(peerId))
         {
@@ -174,7 +174,7 @@ public sealed class Resolver : IResolver
             throw new ArgumentNullException(nameof(manifest));
         }
 
-        var paths = ResolvePenumbraPaths();
+        var paths = ResolvePenumbraPaths(options);
         if (paths is null)
         {
             throw new InvalidOperationException("Penumbra directories are not available");
@@ -596,15 +596,24 @@ public sealed class Resolver : IResolver
         }
     }
 
-    private PenumbraPaths? ResolvePenumbraPaths()
+    private PenumbraPaths? ResolvePenumbraPaths(PenumbraResolveOptions? options)
     {
         string? modsDirectory = null;
         string? configDirectory = null;
 
-        var configuredMods = ValidateConfiguredDirectory(_config.PenumbraModsDirectory, "Penumbra mods directory");
-        if (!string.IsNullOrEmpty(configuredMods))
+        var overrideMods = ValidateConfiguredDirectory(options?.ModsDirectory, "Penumbra mods directory override");
+        if (!string.IsNullOrEmpty(overrideMods))
         {
-            modsDirectory = configuredMods;
+            modsDirectory = overrideMods;
+        }
+
+        if (string.IsNullOrWhiteSpace(modsDirectory))
+        {
+            var configuredMods = ValidateConfiguredDirectory(_config.PenumbraModsDirectory, "Penumbra mods directory");
+            if (!string.IsNullOrEmpty(configuredMods))
+            {
+                modsDirectory = configuredMods;
+            }
         }
 
         if (string.IsNullOrWhiteSpace(modsDirectory))
@@ -631,10 +640,19 @@ public sealed class Resolver : IResolver
             return null;
         }
 
-        var configuredConfig = ValidateConfiguredDirectory(_config.PenumbraConfigDirectory, "Penumbra config directory");
-        if (!string.IsNullOrEmpty(configuredConfig))
+        var overrideConfig = ValidateConfiguredDirectory(options?.ConfigDirectory, "Penumbra config directory override");
+        if (!string.IsNullOrEmpty(overrideConfig))
         {
-            configDirectory = configuredConfig;
+            configDirectory = overrideConfig;
+        }
+
+        if (string.IsNullOrWhiteSpace(configDirectory))
+        {
+            var configuredConfig = ValidateConfiguredDirectory(_config.PenumbraConfigDirectory, "Penumbra config directory");
+            if (!string.IsNullOrEmpty(configuredConfig))
+            {
+                configDirectory = configuredConfig;
+            }
         }
 
         if (string.IsNullOrWhiteSpace(configDirectory))
@@ -683,8 +701,185 @@ public sealed class Resolver : IResolver
             return null;
         }
 
+        var collectionOverride = options?.Collection;
+        if (string.IsNullOrWhiteSpace(collectionOverride))
+        {
+            collectionOverride = _config.PenumbraCollectionOverride;
+        }
+
+        var defaultMod = ResolveCollectionPath(configDirectory, collectionOverride, out var collectionName);
+        if (string.IsNullOrEmpty(defaultMod))
+        {
+            return null;
+        }
+
+        return new PenumbraPaths(modsDirectory, configDirectory, defaultMod, collectionName);
+    }
+
+    private string? ResolveCollectionPath(string configDirectory, string? collectionOverride, out string collectionName)
+    {
         var defaultMod = Path.Combine(configDirectory, "default_mod.json");
-        return new PenumbraPaths(modsDirectory, configDirectory, defaultMod);
+        var fallbackAvailable = File.Exists(defaultMod);
+
+        if (!string.IsNullOrWhiteSpace(collectionOverride))
+        {
+            var trimmed = collectionOverride.Trim();
+            foreach (var candidate in EnumerateCollectionPathCandidates(configDirectory, trimmed))
+            {
+                try
+                {
+                    if (File.Exists(candidate))
+                    {
+                        collectionName = NormalizeCollectionName(trimmed, candidate);
+                        return candidate;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _log.Debug(ex, "Failed to inspect Penumbra collection candidate {Candidate}", candidate);
+                }
+            }
+
+            _log.Warning("Specified Penumbra collection '{Collection}' not found; falling back to default_mod.json", trimmed);
+        }
+
+        if (fallbackAvailable)
+        {
+            collectionName = "default";
+            return defaultMod;
+        }
+
+        _log.Warning("Unable to locate default_mod.json in {ConfigDirectory}", configDirectory);
+        collectionName = string.IsNullOrWhiteSpace(collectionOverride)
+            ? "default"
+            : NormalizeCollectionName(collectionOverride, null);
+        return null;
+    }
+
+    private static string NormalizeCollectionName(string rawName, string? resolvedPath)
+    {
+        if (string.IsNullOrWhiteSpace(rawName))
+        {
+            return "default";
+        }
+
+        var name = rawName.Trim();
+        if (Path.IsPathRooted(name))
+        {
+            var fileName = Path.GetFileNameWithoutExtension(name);
+            name = string.IsNullOrWhiteSpace(fileName) ? name : fileName;
+        }
+        else if (!string.IsNullOrWhiteSpace(resolvedPath))
+        {
+            var fileName = Path.GetFileNameWithoutExtension(resolvedPath);
+            if (!string.IsNullOrWhiteSpace(fileName))
+            {
+                name = fileName;
+            }
+        }
+
+        if (name.EndsWith("_mod", StringComparison.OrdinalIgnoreCase))
+        {
+            name = name[..^4];
+        }
+
+        name = name.Replace('\', '/');
+        var slashIndex = name.LastIndexOf('/');
+        if (slashIndex >= 0)
+        {
+            name = name[(slashIndex + 1)..];
+        }
+
+        return string.IsNullOrWhiteSpace(name) ? "default" : name;
+    }
+
+    private IEnumerable<string> EnumerateCollectionPathCandidates(string configDirectory, string identifier)
+    {
+        var results = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void AddCandidate(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            var candidate = path;
+            if (!Path.IsPathRooted(candidate))
+            {
+                candidate = Path.Combine(configDirectory, candidate);
+            }
+
+            try
+            {
+                candidate = Path.GetFullPath(candidate);
+            }
+            catch
+            {
+                return;
+            }
+
+            if (seen.Add(candidate))
+            {
+                results.Add(candidate);
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(identifier))
+        {
+            return results;
+        }
+
+        var trimmed = identifier.Trim();
+        var sanitized = trimmed.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+
+        AddCandidate(trimmed);
+        if (!ReferenceEquals(trimmed, sanitized))
+        {
+            AddCandidate(sanitized);
+        }
+
+        if (!sanitized.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            AddCandidate(sanitized + ".json");
+        }
+
+        if (!sanitized.EndsWith("_mod.json", StringComparison.OrdinalIgnoreCase))
+        {
+            if (sanitized.EndsWith("_mod", StringComparison.OrdinalIgnoreCase))
+            {
+                AddCandidate(sanitized + ".json");
+            }
+            else
+            {
+                AddCandidate(sanitized + "_mod.json");
+            }
+        }
+
+        var collectionsDir = Path.Combine(configDirectory, "collections");
+        if (Directory.Exists(collectionsDir))
+        {
+            AddCandidate(Path.Combine("collections", sanitized));
+            if (!sanitized.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            {
+                AddCandidate(Path.Combine("collections", sanitized + ".json"));
+            }
+
+            if (!sanitized.EndsWith("_mod.json", StringComparison.OrdinalIgnoreCase))
+            {
+                if (sanitized.EndsWith("_mod", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddCandidate(Path.Combine("collections", sanitized + ".json"));
+                }
+                else
+                {
+                    AddCandidate(Path.Combine("collections", sanitized + "_mod.json"));
+                }
+            }
+        }
+
+        return results;
     }
 
     private string? ValidateConfiguredDirectory(string? path, string description)
@@ -808,10 +1003,7 @@ public sealed class Resolver : IResolver
         return builder.ToString();
     }
 
-    private sealed record PenumbraPaths(string ModsDirectory, string ConfigDirectory, string DefaultModPath)
-    {
-        public string CollectionName { get; } = "default";
-    }
+    private sealed record PenumbraPaths(string ModsDirectory, string ConfigDirectory, string DefaultModPath, string CollectionName);
 
     private sealed class PenumbraModState
     {

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -15,6 +15,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Services;
 using DemiCatPlugin.SyncShell;
@@ -89,6 +90,9 @@ public class SyncshellWindow : IDisposable
     private bool _membershipPanelRatiosDirty;
     private float _syncSettingsHeight = DefaultSyncSettingsHeight;
     private bool _syncSettingsHeightDirty;
+    private readonly FileDialogManager _penumbraModsDialog = new();
+    private readonly FileDialogManager _penumbraConfigDialog = new();
+    private string _penumbraCollectionOverride = string.Empty;
 
     private bool _autoSyncAllUsers;
     private bool _manualSyncAllUsers;
@@ -226,7 +230,10 @@ public class SyncshellWindow : IDisposable
         _autoSyncAllUsers = _config.SyncshellAutoSyncAllUsers;
         _manualSyncAllUsers = _config.SyncshellManualSyncAllUsers;
         _manualSyncCustom = _config.SyncshellManualSyncCustom;
+        _penumbraCollectionOverride = _config.PenumbraCollectionOverride ?? string.Empty;
         EnforceSyncPreferenceInvariant(saveIfChanged: true);
+
+        _syncClient.UpdatePenumbraOverrides(PenumbraResolveOptions.FromConfig(_config));
 
         _assetsFile = Path.Combine(configDir, "assets.json");
         _installedFile = Path.Combine(configDir, "installed.json");
@@ -246,6 +253,8 @@ public class SyncshellWindow : IDisposable
     public void Draw()
     {
         PumpClientEvents();
+        _penumbraModsDialog.Draw();
+        _penumbraConfigDialog.Draw();
 
         if (!_config.FCSyncShell)
         {
@@ -309,12 +318,16 @@ public class SyncshellWindow : IDisposable
         maxSettingsHeight = MathF.Max(MinSyncSettingsHeight, maxSettingsHeight);
         _syncSettingsHeight = Math.Clamp(_syncSettingsHeight, MinSyncSettingsHeight, maxSettingsHeight);
         ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), true);
-        ImGui.TextUnformatted("Sync Settings");
-        var autoSync = _autoSyncAllUsers;
-        if (ImGui.Checkbox("Auto Sync to all Connected Users", ref autoSync))
+        if (ImGui.BeginTabBar("syncshell-settings-tabs"))
         {
-            SetSyncPreferences(autoSync, _manualSyncAllUsers, _manualSyncCustom);
-        }
+            if (ImGui.BeginTabItem("Sync"))
+            {
+                ImGui.TextUnformatted("Sync Settings");
+                var autoSync = _autoSyncAllUsers;
+                if (ImGui.Checkbox("Auto Sync to all Connected Users", ref autoSync))
+                {
+                    SetSyncPreferences(autoSync, _manualSyncAllUsers, _manualSyncCustom);
+                }
 
         var manualAll = _manualSyncAllUsers;
         if (ImGui.Checkbox("Manual Sync (All Users)", ref manualAll))
@@ -404,6 +417,17 @@ public class SyncshellWindow : IDisposable
         if (ImGui.Button(pauseLabel))
         {
             SetSyncPaused(!_syncPaused);
+        }
+                ImGui.EndTabItem();
+            }
+
+            if (ImGui.BeginTabItem("Locations"))
+            {
+                DrawLocationsTab();
+                ImGui.EndTabItem();
+            }
+
+            ImGui.EndTabBar();
         }
         ImGui.EndChild();
 
@@ -576,6 +600,289 @@ public class SyncshellWindow : IDisposable
             SaveMembershipPanelRatios();
         }
     }
+
+    private void DrawLocationsTab()
+    {
+        ImGui.TextUnformatted("Penumbra Locations");
+        ImGui.TextDisabled("Choose the directories and collection used when syncing.");
+        ImGui.Spacing();
+
+        DrawDirectoryPicker(
+            "Penumbra Mods Directory",
+            "Leave blank to use Penumbra's configured mods directory.",
+            () => _config.PenumbraModsDirectory ?? string.Empty,
+            SetPenumbraModsDirectory,
+            _penumbraModsDialog,
+            "SyncshellMods");
+
+        DrawDirectoryPicker(
+            "Penumbra Config Directory",
+            "Should contain default_mod.json. Leave blank to auto-detect.",
+            () => _config.PenumbraConfigDirectory ?? string.Empty,
+            SetPenumbraConfigDirectory,
+            _penumbraConfigDialog,
+            "SyncshellConfig");
+
+        var collection = _penumbraCollectionOverride ?? string.Empty;
+        if (ImGui.InputText("Active collection override", ref collection, 260))
+        {
+            SetPenumbraCollectionOverride(collection);
+        }
+
+        var suggestions = EnumerateCollectionSuggestions();
+        var preview = GetCollectionPreview(_penumbraCollectionOverride, suggestions);
+        if (suggestions.Count > 0 && ImGui.BeginCombo("##syncshell-collection", preview))
+        {
+            foreach (var option in suggestions)
+            {
+                var selected = string.Equals(_penumbraCollectionOverride, option.Identifier, StringComparison.OrdinalIgnoreCase);
+                if (ImGui.Selectable(option.Display, selected))
+                {
+                    SetPenumbraCollectionOverride(option.Identifier);
+                    collection = _penumbraCollectionOverride;
+                }
+
+                if (selected)
+                {
+                    ImGui.SetItemDefaultFocus();
+                }
+            }
+
+            ImGui.EndCombo();
+        }
+
+        ImGui.TextDisabled(suggestions.Count > 0
+            ? "Select from detected collections or enter a custom value (e.g. default)."
+            : "Enter the collection name or file (e.g. default or default_mod.json).");
+    }
+
+    private void DrawDirectoryPicker(
+        string label,
+        string helpText,
+        Func<string> getter,
+        Action<string?> setter,
+        FileDialogManager dialog,
+        string idSuffix)
+    {
+        var value = getter() ?? string.Empty;
+        if (ImGui.InputText(label, ref value, 260))
+        {
+            setter(value);
+        }
+
+        ImGui.SameLine();
+        if (ImGui.Button($"Browse##{idSuffix}"))
+        {
+            OpenFolderDialog(dialog, label, getter(), setter);
+        }
+
+        var current = getter();
+        if (!string.IsNullOrEmpty(NormalizeDirectory(current)))
+        {
+            ImGui.SameLine();
+            if (ImGui.Button($"Clear##{idSuffix}"))
+            {
+                setter(string.Empty);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(helpText))
+        {
+            ImGui.TextDisabled(helpText);
+        }
+
+        current = NormalizeDirectory(getter());
+        if (!string.IsNullOrEmpty(current) && !Directory.Exists(current))
+        {
+            ImGui.TextColored(new Vector4(1f, 0.6f, 0.6f, 1f), "Directory not found; automatic detection will be used instead.");
+        }
+
+        ImGui.Spacing();
+    }
+
+    private void OpenFolderDialog(
+        FileDialogManager dialog,
+        string label,
+        string? currentPath,
+        Action<string?> setter)
+    {
+        var initial = NormalizeDirectory(currentPath);
+        if (string.IsNullOrEmpty(initial) || !Directory.Exists(initial))
+        {
+            initial = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        }
+
+        if (string.IsNullOrEmpty(initial) || !Directory.Exists(initial))
+        {
+            initial = Environment.CurrentDirectory;
+        }
+
+        dialog.OpenFolderDialog($"Select {label}", (success, selected) =>
+        {
+            if (!success || string.IsNullOrWhiteSpace(selected))
+            {
+                return;
+            }
+
+            var normalized = NormalizeDirectory(selected);
+            var framework = PluginServices.Instance?.Framework;
+            if (framework != null)
+            {
+                _ = framework.RunOnTick(() => setter(normalized));
+            }
+            else
+            {
+                setter(normalized);
+            }
+        }, initial);
+    }
+
+    private void SetPenumbraModsDirectory(string? path)
+    {
+        var normalized = NormalizeDirectory(path);
+        if (string.Equals(_config.PenumbraModsDirectory, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _config.PenumbraModsDirectory = normalized;
+        PersistPenumbraOverrides();
+    }
+
+    private void SetPenumbraConfigDirectory(string? path)
+    {
+        var normalized = NormalizeDirectory(path);
+        if (string.Equals(_config.PenumbraConfigDirectory, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _config.PenumbraConfigDirectory = normalized;
+        PersistPenumbraOverrides();
+    }
+
+    private void SetPenumbraCollectionOverride(string? value)
+    {
+        var normalized = string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+        if (string.Equals(_penumbraCollectionOverride, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _penumbraCollectionOverride = normalized;
+        _config.PenumbraCollectionOverride = normalized;
+        PersistPenumbraOverrides();
+    }
+
+    private void PersistPenumbraOverrides()
+    {
+        PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
+        _syncClient.UpdatePenumbraOverrides(PenumbraResolveOptions.FromConfig(_config));
+    }
+
+    private static string NormalizeDirectory(string? value)
+        => string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+
+    private string GetCollectionPreview(string? currentValue, IReadOnlyList<CollectionOption> options)
+    {
+        if (string.IsNullOrWhiteSpace(currentValue))
+        {
+            return "Auto-detect (default)";
+        }
+
+        foreach (var option in options)
+        {
+            if (string.Equals(option.Identifier, currentValue, StringComparison.OrdinalIgnoreCase))
+            {
+                return option.Display;
+            }
+        }
+
+        return currentValue;
+    }
+
+    private List<CollectionOption> EnumerateCollectionSuggestions()
+    {
+        var results = new List<CollectionOption>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var baseDir = NormalizeDirectory(_config.PenumbraConfigDirectory);
+        if (string.IsNullOrEmpty(baseDir) || !Directory.Exists(baseDir))
+        {
+            return results;
+        }
+
+        string Describe(string identifier, string relative)
+            => string.IsNullOrEmpty(relative) ? identifier : $"{identifier} ({relative})";
+
+        void AddSuggestion(string filePath)
+        {
+            if (!File.Exists(filePath))
+            {
+                return;
+            }
+
+            string relative;
+            try
+            {
+                relative = Path.GetRelativePath(baseDir, filePath);
+            }
+            catch
+            {
+                relative = Path.GetFileName(filePath) ?? filePath;
+            }
+
+            var identifier = Path.GetFileNameWithoutExtension(filePath);
+            if (string.IsNullOrEmpty(identifier))
+            {
+                return;
+            }
+
+            if (identifier.EndsWith("_mod", StringComparison.OrdinalIgnoreCase))
+            {
+                var trimmed = identifier[..^4];
+                if (seen.Add(trimmed))
+                {
+                    results.Add(new CollectionOption(trimmed, Describe(trimmed, relative)));
+                }
+            }
+
+            if (seen.Add(identifier))
+            {
+                results.Add(new CollectionOption(identifier, Describe(identifier, relative)));
+            }
+        }
+
+        try
+        {
+            foreach (var file in Directory.EnumerateFiles(baseDir, "*_mod.json", SearchOption.TopDirectoryOnly))
+            {
+                AddSuggestion(file);
+            }
+
+            foreach (var file in Directory.EnumerateFiles(baseDir, "*.json", SearchOption.TopDirectoryOnly))
+            {
+                AddSuggestion(file);
+            }
+
+            var collectionsDir = Path.Combine(baseDir, "collections");
+            if (Directory.Exists(collectionsDir))
+            {
+                foreach (var file in Directory.EnumerateFiles(collectionsDir, "*.json", SearchOption.TopDirectoryOnly))
+                {
+                    AddSuggestion(file);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log?.Debug(ex, "Failed to enumerate Penumbra collections in {Directory}", baseDir);
+        }
+
+        results.Sort((a, b) => string.Compare(a.Identifier, b.Identifier, StringComparison.OrdinalIgnoreCase));
+        return results;
+    }
+
+    private sealed record CollectionOption(string Identifier, string Display);
 
     private void DrawMembershipSplitter(int index, float splitterHeight, float totalPanelHeight)
     {


### PR DESCRIPTION
## Summary
- add configuration support for overriding the Penumbra collection alongside existing directory overrides
- expose a new Locations tab in the Syncshell window so users can select Penumbra directories and collections
- thread the overrides through the sync client and resolver via a dedicated options object so manifest builds and applies honor the selections

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dc6559b3bc83289a89ea4b53f41855