### PR TITLE
Add syncshell scope permissions and UI controls

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -131,6 +131,7 @@ public class SyncshellWindow : IDisposable
     private readonly Dictionary<string, Config.SyncshellInviteState> _inviteStateByTarget = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, Config.SyncshellInviteState> _inviteStateByRequestId = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<string> _pendingApprovalInFlight = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _scopeUpdateInFlight = new(StringComparer.OrdinalIgnoreCase);
     private string _inviteTarget = string.Empty;
     private readonly List<MemberPresenceEntry> _inviteSuggestions = new();
     private int _inviteSuggestionIndex = -1;
@@ -1157,7 +1158,58 @@ public class SyncshellWindow : IDisposable
                 ImGui.SameLine();
                 ImGui.TextDisabled("[Token not linked]");
             }
+
+            DrawMemberScopeControls(member);
         }
+    }
+
+    private void DrawMemberScopeControls(MemberPresenceEntry member)
+    {
+        if (string.IsNullOrWhiteSpace(member.Id))
+        {
+            return;
+        }
+
+        ImGui.Indent();
+        ImGui.PushID($"syncshell-scope-{member.Id}");
+
+        var inFlight = _scopeUpdateInFlight.Contains(member.Id);
+        if (inFlight)
+        {
+            ImGui.BeginDisabled();
+        }
+
+        var shareAppearance = member.Scope.Appearance;
+        if (ImGui.Checkbox("Share appearance", ref shareAppearance))
+        {
+            RequestScopeUpdate(member, shareAppearance, member.Scope.Assets);
+        }
+        if (shareAppearance)
+        {
+            ImGui.SameLine();
+            ImGui.TextColored(new Vector4(1f, 0.82f, 0.4f, 1f), "Shares character appearance data.");
+        }
+
+        var shareAssets = member.Scope.Assets;
+        if (ImGui.Checkbox("Share assets", ref shareAssets))
+        {
+            RequestScopeUpdate(member, member.Scope.Appearance, shareAssets);
+        }
+        if (shareAssets)
+        {
+            ImGui.SameLine();
+            ImGui.TextColored(new Vector4(1f, 0.6f, 0.6f, 1f), "Allows this member to download your mod files.");
+        }
+
+        if (inFlight)
+        {
+            ImGui.EndDisabled();
+            ImGui.TextDisabled("Updating member permissions...");
+        }
+
+        ImGui.PopID();
+        ImGui.Unindent();
+        ImGui.Spacing();
     }
 
     private void DrawInviteEntryContent()
@@ -1814,6 +1866,170 @@ public class SyncshellWindow : IDisposable
         Interlocked.CompareExchange(ref _membershipRefreshRequested, 1, 0);
     }
 
+    private void RequestScopeUpdate(MemberPresenceEntry member, bool shareAppearance, bool shareAssets)
+    {
+        if (string.IsNullOrWhiteSpace(member.Id))
+        {
+            return;
+        }
+
+        var memberId = member.Id.Trim();
+        if (memberId.Length == 0)
+        {
+            return;
+        }
+
+        if (!_scopeUpdateInFlight.Add(memberId))
+        {
+            return;
+        }
+
+        var previousAppearance = member.Scope.Appearance;
+        var previousAssets = member.Scope.Assets;
+
+        member.Scope.Hashes = true;
+        member.Scope.Appearance = shareAppearance;
+        member.Scope.Assets = shareAssets;
+
+        _ = UpdateMemberScopeAsync(
+            memberId,
+            shareAppearance,
+            shareAssets,
+            previousAppearance,
+            previousAssets,
+            member);
+    }
+
+    private async Task UpdateMemberScopeAsync(
+        string memberId,
+        bool shareAppearance,
+        bool shareAssets,
+        bool previousAppearance,
+        bool previousAssets,
+        MemberPresenceEntry member)
+    {
+        try
+        {
+            if (!_tokenManager.IsReady() || !ApiHelpers.ValidateApiBaseUrl(_config))
+            {
+                throw new HttpRequestException("SyncShell pairing is unavailable.");
+            }
+
+            var baseUrl = _config.ApiBaseUrl.TrimEnd('/');
+            var response = await SendWithPairingRetryAsync(() =>
+            {
+                var payload = new { appearance = shareAppearance, assets = shareAssets };
+                var request = new HttpRequestMessage(
+                    HttpMethod.Post,
+                    $"{baseUrl}/api/syncshell/members/{memberId}/scope")
+                {
+                    Content = new StringContent(
+                        JsonSerializer.Serialize(payload),
+                        Encoding.UTF8,
+                        "application/json"),
+                };
+                ApiHelpers.AddAuthHeader(request, _tokenManager);
+                return request;
+            }).ConfigureAwait(false);
+
+            if (response == null)
+            {
+                throw new HttpRequestException("SyncShell pairing is unavailable.");
+            }
+
+            bool? responseAppearance = null;
+            bool? responseAssets = null;
+
+            using (response)
+            {
+                if (!response.IsSuccessStatusCode)
+                {
+                    var detail = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw new HttpRequestException(
+                        $"Failed to update member scope: {(int)response.StatusCode} {detail}",
+                        null,
+                        response.StatusCode);
+                }
+
+                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(content))
+                {
+                    try
+                    {
+                        using var document = JsonDocument.Parse(content);
+                        if (document.RootElement.TryGetProperty("scope", out var scopeElement) &&
+                            scopeElement.ValueKind == JsonValueKind.Array)
+                        {
+                            var appearance = false;
+                            var assets = false;
+                            var hashes = false;
+                            foreach (var scopeValue in scopeElement.EnumerateArray())
+                            {
+                                if (scopeValue.ValueKind != JsonValueKind.String)
+                                    continue;
+
+                                switch (scopeValue.GetString()?.Trim().ToLowerInvariant())
+                                {
+                                    case "hashes":
+                                        hashes = true;
+                                        break;
+                                    case "appearance":
+                                        appearance = true;
+                                        break;
+                                    case "assets":
+                                        assets = true;
+                                        break;
+                                }
+                            }
+
+                            if (hashes)
+                            {
+                                responseAppearance = appearance;
+                                responseAssets = assets;
+                            }
+                            else
+                            {
+                                responseAppearance = false;
+                                responseAssets = false;
+                            }
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Ignore malformed responses and rely on optimistic state.
+                    }
+                }
+            }
+
+            _uiThreadActions.Enqueue(() =>
+            {
+                if (responseAppearance.HasValue)
+                {
+                    member.Scope.Appearance = responseAppearance.Value;
+                }
+                if (responseAssets.HasValue)
+                {
+                    member.Scope.Assets = responseAssets.Value;
+                }
+                _scopeUpdateInFlight.Remove(memberId);
+                RequestMembershipRefresh();
+            });
+        }
+        catch (Exception ex)
+        {
+            var services = PluginServices.Instance;
+            services?.Log.Warning(ex, "Failed to update SyncShell member scope");
+
+            _uiThreadActions.Enqueue(() =>
+            {
+                member.Scope.Appearance = previousAppearance;
+                member.Scope.Assets = previousAssets;
+                _scopeUpdateInFlight.Remove(memberId);
+                services?.ToastGui.ShowError("Failed to update member scope – check logs.");
+            });
+        }
+    }
+
     private async Task RefreshMembershipOverviewAsync(bool force = false)
     {
         if (_disposed || !_config.FCSyncShell)
@@ -2086,7 +2302,7 @@ public class SyncshellWindow : IDisposable
 
     private static MemberPresenceEntry ParseMemberEntry(JsonElement element)
     {
-        return new MemberPresenceEntry
+        var entry = new MemberPresenceEntry
         {
             Id = GetString(element, "id", "memberId", "userId"),
             DisplayName = GetString(element, "displayName", "name", "nickname"),
@@ -2096,6 +2312,34 @@ public class SyncshellWindow : IDisposable
             SyncedAt = GetDateTime(element, "syncedAt", "since", "synced_at"),
             TokenLinked = GetBoolean(element, "tokenLinked", "token_linked"),
         };
+
+        if (TryGetProperty(element, "scope", out var scopeElement) && scopeElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var scopeValue in scopeElement.EnumerateArray())
+            {
+                if (scopeValue.ValueKind != JsonValueKind.String)
+                    continue;
+
+                var value = scopeValue.GetString();
+                if (string.IsNullOrWhiteSpace(value))
+                    continue;
+
+                switch (value.Trim().ToLowerInvariant())
+                {
+                    case "hashes":
+                        entry.Scope.Hashes = true;
+                        break;
+                    case "appearance":
+                        entry.Scope.Appearance = true;
+                        break;
+                    case "assets":
+                        entry.Scope.Assets = true;
+                        break;
+                }
+            }
+        }
+
+        return entry;
     }
 
     private static PendingApprovalEntry ParsePendingApproval(JsonElement element)
@@ -4820,6 +5064,17 @@ public class SyncshellWindow : IDisposable
         SimpleHeels,
     }
 
+    private sealed class MemberScope
+    {
+        public bool Hashes { get; set; } = true;
+
+        public bool Appearance { get; set; }
+            = false;
+
+        public bool Assets { get; set; }
+            = false;
+    }
+
     private sealed class MemberPresenceEntry
     {
         public string Id { get; set; } = string.Empty;
@@ -4840,6 +5095,8 @@ public class SyncshellWindow : IDisposable
 
         public bool TokenLinked { get; set; }
             = false;
+
+        public MemberScope Scope { get; } = new MemberScope();
     }
 
     private sealed class PendingApprovalEntry

--- a/demibot/demibot/db/migrations/versions/0054_add_syncshell_member_scope.py
+++ b/demibot/demibot/db/migrations/versions/0054_add_syncshell_member_scope.py
@@ -1,0 +1,33 @@
+"""0054_add_syncshell_member_scope
+
+Revision ID: 0054_add_syncshell_member_scope
+Revises: 0053_add_notepad_tables
+Create Date: 2024-07-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0054_add_syncshell_member_scope"
+down_revision: Union[str, None] = "0053_add_notepad_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "syncshell_members",
+        sa.Column("scope", sa.Integer(), nullable=False, server_default=sa.text("1")),
+    )
+    op.execute("UPDATE syncshell_members SET scope = 1 WHERE scope IS NULL")
+    op.alter_column("syncshell_members", "scope", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("syncshell_members", "scope")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import Enum, IntFlag
 from typing import Optional
 
 from sqlalchemy import (
@@ -66,6 +66,12 @@ class ChannelKind(str, Enum):
     FC_CHAT = "fc_chat"
     OFFICER_CHAT = "officer_chat"
     OFFICER_VISIBLE = "officer_visible"
+
+
+class SyncshellScope(IntFlag):
+    HASHES = 1
+    APPEARANCE = 2
+    ASSETS = 4
 
 
 class Guild(Base):
@@ -373,6 +379,11 @@ class SyncshellMember(Base):
         BIGINT(unsigned=True), ForeignKey("users.id"), index=True
     )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    scope: Mapped[int] = mapped_column(
+        Integer,
+        default=int(SyncshellScope.HASHES),
+        nullable=False,
+    )
 
 
 class SyncshellPresence(Base):

--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -23,6 +23,7 @@ from ...db.models import (
     SyncshellInvite,
     SyncshellMember,
     SyncshellPresence,
+    SyncshellScope,
     User,
 )
 from ..vault import presign_upload, presign_download
@@ -63,6 +64,35 @@ _peer_discovery_lock: asyncio.Lock = asyncio.Lock()
 _peer_discovery_state: dict[tuple[int, int], dict[str, dict[str, Any]]] = {}
 
 
+@dataclass(frozen=True)
+class _MemberGrant:
+    member_id: int
+    scope: SyncshellScope
+
+
+def _scope_from_value(value: int | None) -> SyncshellScope:
+    try:
+        scope = SyncshellScope(value or 0)
+    except ValueError:
+        scope = SyncshellScope.HASHES
+    if not scope & SyncshellScope.HASHES:
+        scope |= SyncshellScope.HASHES
+    return scope
+
+
+def _scope_has(scope: SyncshellScope, flag: SyncshellScope) -> bool:
+    return bool(scope & flag)
+
+
+def _scope_to_strings(scope: SyncshellScope) -> list[str]:
+    values = ["hashes"]
+    if _scope_has(scope, SyncshellScope.APPEARANCE):
+        values.append("appearance")
+    if _scope_has(scope, SyncshellScope.ASSETS):
+        values.append("assets")
+    return values
+
+
 def _clone_discovery_asset(asset: dict[str, Any]) -> dict[str, Any]:
     clone = dict(asset)
     items = clone.get("items")
@@ -86,6 +116,50 @@ def _snapshot_discovery_assets(
     assets: dict[str, dict[str, Any]]
 ) -> dict[str, dict[str, Any]]:
     return {key: _clone_discovery_asset(value) for key, value in assets.items()}
+
+
+def _filter_discovery_asset_for_scope(
+    payload: dict[str, Any], scope: SyncshellScope
+) -> dict[str, Any] | None:
+    kind = str(payload.get("kind") or "").upper()
+    if kind == "APPEARANCE" and not _scope_has(scope, SyncshellScope.APPEARANCE):
+        return None
+
+    filtered = {k: v for k, v in payload.items() if k != "items"}
+
+    if not _scope_has(scope, SyncshellScope.ASSETS):
+        if kind in {"FILE", "PATCH"}:
+            return None
+        return filtered
+
+    items = payload.get("items")
+    if isinstance(items, list):
+        child_items: list[dict[str, Any]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            filtered_child = _filter_discovery_asset_for_scope(item, scope)
+            if filtered_child is not None:
+                child_items.append(filtered_child)
+        if child_items:
+            filtered["items"] = child_items
+    return filtered
+
+
+def _filter_discovery_assets_for_scope(
+    assets: dict[str, dict[str, Any]], scope: SyncshellScope
+) -> dict[str, dict[str, Any]]:
+    if _scope_has(scope, SyncshellScope.ASSETS) and _scope_has(
+        scope, SyncshellScope.APPEARANCE
+    ):
+        return _snapshot_discovery_assets(assets)
+
+    filtered: dict[str, dict[str, Any]] = {}
+    for asset_id, payload in assets.items():
+        filtered_payload = _filter_discovery_asset_for_scope(payload, scope)
+        if filtered_payload is not None:
+            filtered[asset_id] = filtered_payload
+    return filtered
 
 
 def _normalise_dependencies(value: Any) -> list[str]:
@@ -263,18 +337,49 @@ async def compute_discovery_delta(
 
 
 async def get_memberships_for_recipient(
-    member_user_id: int, db: AsyncSession
-) -> list[int]:
+    user_id: int, db: AsyncSession
+) -> list[_MemberGrant]:
     result = await db.execute(
-        select(SyncshellMember.user_id).where(
-            SyncshellMember.member_user_id == member_user_id
+        select(SyncshellMember.member_user_id, SyncshellMember.scope).where(
+            SyncshellMember.user_id == user_id
         )
     )
-    return list(result.scalars().all())
+    grants: list[_MemberGrant] = []
+    for member_id, scope_value in result.all():
+        if member_id is None:
+            continue
+        grants.append(
+            _MemberGrant(member_id=member_id, scope=_scope_from_value(scope_value))
+        )
+    return grants
 
 
 def peer_delta_timestamp() -> str:
     return _to_iso(datetime.utcnow())
+
+
+def _scope_from_request_flags(appearance: bool, assets: bool) -> SyncshellScope:
+    scope = SyncshellScope.HASHES
+    if appearance:
+        scope |= SyncshellScope.APPEARANCE
+    if assets:
+        scope |= SyncshellScope.ASSETS
+    return scope
+
+
+async def _user_has_asset_scope(
+    user_id: int, db: AsyncSession, *, as_member: bool
+) -> bool:
+    stmt = select(SyncshellMember.scope)
+    if as_member:
+        stmt = stmt.where(SyncshellMember.member_user_id == user_id)
+    else:
+        stmt = stmt.where(SyncshellMember.user_id == user_id)
+    result = await db.execute(stmt)
+    for value in result.scalars():
+        if _scope_has(_scope_from_value(value), SyncshellScope.ASSETS):
+            return True
+    return False
 
 
 def _now_utc() -> datetime:
@@ -578,6 +683,16 @@ class PresenceUpdateRequest(BaseModel):
     )
 
 
+class ScopeUpdateRequest(BaseModel):
+    appearance: bool = Field(
+        default=False,
+        description="Whether the member may access appearance metadata",
+    )
+    assets: bool = Field(
+        default=False, description="Whether the member may access mod assets"
+    )
+
+
 async def _require_pairing(ctx: RequestContext, db: AsyncSession) -> None:
     pairing = await db.get(SyncshellPairing, ctx.user.id)
     if not pairing or pairing.expires_at < datetime.utcnow():
@@ -601,6 +716,7 @@ async def _ensure_membership(
                 user_id=user_id,
                 member_user_id=member_user_id,
                 created_at=datetime.utcnow(),
+                scope=int(SyncshellScope.HASHES),
             )
         )
 
@@ -895,13 +1011,20 @@ async def list_members(
     await _require_pairing(ctx, db)
     await _check_rate_limit(ctx.user.id, db)
     result = await db.execute(
-        select(SyncshellMember.member_user_id).where(
+        select(SyncshellMember.member_user_id, SyncshellMember.scope).where(
             SyncshellMember.user_id == ctx.user.id
         )
     )
-    member_ids = result.scalars().all()
-    if not member_ids:
+    member_rows = result.all()
+    if not member_rows:
         return {"members": []}
+
+    member_ids = [member_id for member_id, _ in member_rows]
+    scopes = {
+        member_id: _scope_from_value(scope_value)
+        for member_id, scope_value in member_rows
+        if member_id is not None
+    }
 
     user_result = await db.execute(select(User).where(User.id.in_(member_ids)))
     users = {user.id: user for user in user_result.scalars().all()}
@@ -924,10 +1047,39 @@ async def list_members(
                 "active": bool(presence.active) if presence else False,
                 "lastSeen": _to_iso(presence.last_seen) if presence else None,
                 "tokenLinked": presence is not None,
+                "scope": _scope_to_strings(
+                    scopes.get(member_id, SyncshellScope.HASHES)
+                ),
             }
         )
     members.sort(key=lambda entry: entry["displayName"].lower())
     return {"members": members}
+
+
+@router.post("/members/{member_id}/scope")
+async def update_member_scope(
+    member_id: int,
+    payload: ScopeUpdateRequest,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
+
+    membership_result = await db.execute(
+        select(SyncshellMember).where(
+            SyncshellMember.user_id == ctx.user.id,
+            SyncshellMember.member_user_id == member_id,
+        )
+    )
+    membership = membership_result.scalars().first()
+    if membership is None:
+        raise HTTPException(status_code=404, detail="member not found")
+
+    new_scope = _scope_from_request_flags(payload.appearance, payload.assets)
+    membership.scope = int(new_scope)
+    await db.commit()
+    return {"status": "ok", "scope": _scope_to_strings(new_scope)}
 
 
 @router.get("/memberships")
@@ -939,11 +1091,17 @@ async def list_memberships(
     await _check_rate_limit(ctx.user.id, db)
 
     member_result = await db.execute(
-        select(SyncshellMember.member_user_id).where(
+        select(SyncshellMember.member_user_id, SyncshellMember.scope).where(
             SyncshellMember.user_id == ctx.user.id
         )
     )
-    member_ids = list(member_result.scalars().all())
+    member_rows = member_result.all()
+    member_ids = [member_id for member_id, _ in member_rows]
+    scopes = {
+        member_id: _scope_from_value(scope_value)
+        for member_id, scope_value in member_rows
+        if member_id is not None
+    }
 
     presence_map: dict[int, SyncshellPresence] = {}
     if member_ids:
@@ -975,6 +1133,9 @@ async def list_memberships(
             "syncStatus": sync_status,
             "lastSeen": last_seen,
             "tokenLinked": presence is not None,
+            "scope": _scope_to_strings(
+                scopes.get(member_id, SyncshellScope.HASHES)
+            ),
         }
         if synced_at:
             entry["syncedAt"] = synced_at
@@ -1196,6 +1357,8 @@ async def request_asset_upload(
     """Return a pre-signed URL for chunked asset upload."""
     await _require_pairing(ctx, db)
     await _check_rate_limit(ctx.user.id, db)
+    if not await _user_has_asset_scope(ctx.user.id, db, as_member=False):
+        raise HTTPException(status_code=403, detail="asset scope required")
     try:
         url = await presign_upload()
     except Exception as e:  # pragma: no cover - network failure
@@ -1212,6 +1375,8 @@ async def request_asset_download(
     """Return a pre-signed URL for asset download."""
     await _require_pairing(ctx, db)
     await _check_rate_limit(ctx.user.id, db)
+    if not await _user_has_asset_scope(ctx.user.id, db, as_member=True):
+        raise HTTPException(status_code=403, detail="asset scope required")
     try:
         url = await presign_download(asset_id)
     except Exception as e:  # pragma: no cover - network failure

--- a/demibot/demibot/http/ws_syncshell.py
+++ b/demibot/demibot/http/ws_syncshell.py
@@ -58,16 +58,19 @@ async def _broadcast_peer_delta(
     uploader_id: int,
     peer_identifier: str,
     assets: dict[str, dict[str, Any]],
-    member_ids: list[int],
+    member_grants: list[syncshell_routes._MemberGrant],
 ) -> None:
-    if not member_ids:
+    if not member_grants:
         return
-    for member_id in member_ids:
-        connections = await _get_connections(member_id)
+    for grant in member_grants:
+        connections = await _get_connections(grant.member_id)
         if not connections:
             continue
+        filtered_assets = syncshell_routes._filter_discovery_assets_for_scope(
+            assets, grant.scope
+        )
         updated, removed = await syncshell_routes.compute_discovery_delta(
-            member_id, uploader_id, assets
+            grant.member_id, uploader_id, filtered_assets
         )
         if not updated and not removed:
             continue
@@ -86,11 +89,12 @@ async def _broadcast_peer_delta(
                 await peer_socket.send_json(payload)
             except Exception:
                 LOGGER.warning(
-                    "syncshell failed delivering peer delta to user %s", member_id
+                    "syncshell failed delivering peer delta to user %s",
+                    grant.member_id,
                 )
                 dead.append(peer_socket)
         for peer_socket in dead:
-            await _unregister_connection(member_id, peer_socket)
+            await _unregister_connection(grant.member_id, peer_socket)
 
 
 async def _handle_manifest_message(
@@ -102,7 +106,7 @@ async def _handle_manifest_message(
         return True
 
     discovery_assets: dict[str, dict[str, Any]] = {}
-    member_ids: list[int] = []
+    member_grants: list[syncshell_routes._MemberGrant] = []
     try:
         async with get_session() as db:
             diff, limits = await syncshell_routes.handle_manifest_upload(
@@ -111,7 +115,7 @@ async def _handle_manifest_message(
             discovery_assets = syncshell_routes.build_discovery_assets(
                 manifest_payload, ctx.user
             )
-            member_ids = await syncshell_routes.get_memberships_for_recipient(
+            member_grants = await syncshell_routes.get_memberships_for_recipient(
                 ctx.user.id, db
             )
     except HTTPException as exc:
@@ -153,7 +157,9 @@ async def _handle_manifest_message(
         },
     }
     await websocket.send_json(want_message)
-    await _broadcast_peer_delta(ctx.user.id, peer_id, discovery_assets, member_ids)
+    await _broadcast_peer_delta(
+        ctx.user.id, peer_id, discovery_assets, member_grants
+    )
     return True
 
 

--- a/tests/test_syncshell.py
+++ b/tests/test_syncshell.py
@@ -1,11 +1,18 @@
 import asyncio
 import logging
+from datetime import datetime
 
 import pytest
 
 from demibot.db.session import init_db, get_session
 import demibot.db.session as db_session
-from demibot.db.models import User, SyncshellPairing, SyncshellManifest
+from demibot.db.models import (
+    User,
+    SyncshellPairing,
+    SyncshellManifest,
+    SyncshellMember,
+    SyncshellScope,
+)
 from demibot.http.deps import RequestContext
 
 from .syncshell_import import syncshell
@@ -24,7 +31,27 @@ def test_pair_token_persistence_and_expiry(tmp_path):
         session_factory = await _prepare_db()
         async with session_factory as db:
             user = User(id=1, discord_user_id=1, global_name="Test")
-            db.add(user)
+            member = User(id=2, discord_user_id=2, global_name="Member")
+            db.add_all([user, member])
+            await db.commit()
+
+            now = datetime.utcnow()
+            db.add_all(
+                [
+                    SyncshellMember(
+                        user_id=user.id,
+                        member_user_id=member.id,
+                        created_at=now,
+                        scope=int(SyncshellScope.HASHES | SyncshellScope.ASSETS),
+                    ),
+                    SyncshellMember(
+                        user_id=member.id,
+                        member_user_id=user.id,
+                        created_at=now,
+                        scope=int(SyncshellScope.HASHES | SyncshellScope.ASSETS),
+                    ),
+                ]
+            )
             await db.commit()
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
@@ -55,7 +82,27 @@ def test_manifest_rate_limit(tmp_path):
         session_factory = await _prepare_db()
         async with session_factory as db:
             user = User(id=1, discord_user_id=1, global_name="Test")
-            db.add(user)
+            member = User(id=2, discord_user_id=2, global_name="Member")
+            db.add_all([user, member])
+            await db.commit()
+
+            now = datetime.utcnow()
+            db.add_all(
+                [
+                    SyncshellMember(
+                        user_id=user.id,
+                        member_user_id=member.id,
+                        created_at=now,
+                        scope=int(SyncshellScope.HASHES | SyncshellScope.ASSETS),
+                    ),
+                    SyncshellMember(
+                        user_id=member.id,
+                        member_user_id=user.id,
+                        created_at=now,
+                        scope=int(SyncshellScope.HASHES | SyncshellScope.ASSETS),
+                    ),
+                ]
+            )
             await db.commit()
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
@@ -96,7 +143,27 @@ def test_asset_upload_download_and_rate_limit(tmp_path):
         session_factory = await _prepare_db()
         async with session_factory as db:
             user = User(id=1, discord_user_id=1, global_name="Test")
-            db.add(user)
+            member = User(id=2, discord_user_id=2, global_name="Member")
+            db.add_all([user, member])
+            await db.commit()
+
+            now = datetime.utcnow()
+            db.add_all(
+                [
+                    SyncshellMember(
+                        user_id=user.id,
+                        member_user_id=member.id,
+                        created_at=now,
+                        scope=int(SyncshellScope.HASHES | SyncshellScope.ASSETS),
+                    ),
+                    SyncshellMember(
+                        user_id=member.id,
+                        member_user_id=user.id,
+                        created_at=now,
+                        scope=int(SyncshellScope.HASHES | SyncshellScope.ASSETS),
+                    ),
+                ]
+            )
             await db.commit()
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
@@ -124,6 +191,41 @@ def test_asset_upload_download_and_rate_limit(tmp_path):
             with pytest.raises(syncshell.HTTPException) as exc:
                 await syncshell.request_asset_upload(ctx=ctx, db=db)
             assert exc.value.status_code == 429
+    asyncio.run(_run())
+
+
+def test_asset_scope_required_for_presign(tmp_path):
+    async def _run():
+        session_factory = await _prepare_db()
+        async with session_factory as db:
+            owner = User(id=1, discord_user_id=1, global_name="Owner")
+            grantor = User(id=2, discord_user_id=2, global_name="Grantor")
+            db.add_all([owner, grantor])
+            await db.commit()
+
+            db.add(
+                SyncshellMember(
+                    user_id=grantor.id,
+                    member_user_id=owner.id,
+                    created_at=datetime.utcnow(),
+                    scope=int(SyncshellScope.HASHES),
+                )
+            )
+            await db.commit()
+
+            ctx = RequestContext(user=owner, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            syncshell.RATE_LIMIT = 4
+            await syncshell.pair(ctx=ctx, db=db)
+
+            with pytest.raises(syncshell.HTTPException) as download_error:
+                await syncshell.request_asset_download("hash", ctx=ctx, db=db)
+            assert download_error.value.status_code == 403
+
+            with pytest.raises(syncshell.HTTPException) as upload_error:
+                await syncshell.request_asset_upload(ctx=ctx, db=db)
+            assert upload_error.value.status_code == 403
+
     asyncio.run(_run())
 
 


### PR DESCRIPTION
## Summary
- add a SyncshellScope bitmask and migration so syncshell member records track directional permissions
- filter discovery payloads per member scope, add a scope update endpoint, and gate asset presign routes on granted access
- surface scope toggles with warnings in the plugin UI and adjust syncshell tests for the new permissions model

## Testing
- pytest *(fails: missing optional dependencies such as sqlalchemy/fastapi in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6df0c25483289b4b280d8b546f12