### PR TITLE
Persist Syncshell transfer budgets across restarts

### DIFF
--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -327,6 +327,16 @@ class SyncshellRateLimit(Base):
     window_start: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
+class SyncshellTransferBudget(Base):
+    __tablename__ = "syncshell_transfer_budgets"
+
+    user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True
+    )
+    window_start: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    used_bytes: Mapped[int] = mapped_column(Integer, default=0)
+
+
 class SyncshellInvite(Base):
     __tablename__ = "syncshell_invites"
     __table_args__ = (

--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -19,9 +19,11 @@ from starlette.requests import Request
 
 import structlog
 
+from .deps import get_session
 from .ws import websocket_endpoint
 from .ws_chat import websocket_endpoint_chat
 from .ws_syncshell import websocket_endpoint_syncshell
+from .routes import syncshell as syncshell_module
 
 
 logger = structlog.get_logger()
@@ -79,6 +81,11 @@ def create_app() -> FastAPI:
     async def health() -> dict[str, str]:
         """Simple health check endpoint."""
         return {"status": "ok"}
+
+    @app.on_event("startup")
+    async def _load_syncshell_transfer_budgets() -> None:
+        async with get_session() as db:
+            await syncshell_module.load_transfer_budgets(db)
 
     # Dynamically include routers from all modules in the routes package
     from . import routes as routes_pkg

--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy import func, or_, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
@@ -24,6 +24,7 @@ from ...db.models import (
     SyncshellInvite,
     SyncshellMember,
     SyncshellPresence,
+    SyncshellTransferBudget,
     SyncshellScope,
     User,
 )
@@ -140,7 +141,128 @@ class _TransferBudget:
     used_bytes: int = 0
 
 
-_transfer_budgets: dict[int, _TransferBudget] = {}
+class _TransferBudgetStore:
+    def __init__(self) -> None:
+        self._cache: dict[int, _TransferBudget] = {}
+        self._loaded: bool = False
+        self._lock: asyncio.Lock = asyncio.Lock()
+
+    async def _load_unlocked(self, db: AsyncSession) -> None:
+        now = datetime.utcnow()
+        self._cache.clear()
+        result = await db.execute(select(SyncshellTransferBudget))
+        for record in result.scalars():
+            window_start = record.window_start or now
+            used_bytes = int(record.used_bytes or 0)
+            self._cache[record.user_id] = _TransferBudget(
+                window_start=window_start,
+                used_bytes=used_bytes,
+            )
+        self._loaded = True
+
+    async def load(self, db: AsyncSession) -> None:
+        async with self._lock:
+            if not self._loaded:
+                await self._load_unlocked(db)
+
+    async def update(
+        self,
+        user_id: int,
+        diff: dict[str, list[dict[str, Any]]],
+        db: AsyncSession,
+    ) -> dict[str, Any]:
+        async with self._lock:
+            if not self._loaded:
+                await self._load_unlocked(db)
+
+            now = datetime.utcnow()
+            window = timedelta(seconds=max(1, TRANSFER_BUDGET_WINDOW_SECONDS))
+            limit = max(0, TRANSFER_BUDGET_BYTES)
+
+            budget = self._cache.get(user_id)
+            record = await db.get(SyncshellTransferBudget, user_id)
+
+            if budget is None:
+                if record is not None:
+                    budget = _TransferBudget(
+                        window_start=record.window_start or now,
+                        used_bytes=int(record.used_bytes or 0),
+                    )
+                else:
+                    budget = _TransferBudget(window_start=now, used_bytes=0)
+                    record = SyncshellTransferBudget(
+                        user_id=user_id,
+                        window_start=budget.window_start,
+                        used_bytes=budget.used_bytes,
+                    )
+                    db.add(record)
+                self._cache[user_id] = budget
+            elif record is None:
+                record = SyncshellTransferBudget(
+                    user_id=user_id,
+                    window_start=budget.window_start,
+                    used_bytes=budget.used_bytes,
+                )
+                db.add(record)
+
+            if record is None:
+                # Defensive guard; SQLAlchemy session operations above should always
+                # produce a record, but keep behaviour predictable.
+                record = SyncshellTransferBudget(
+                    user_id=user_id,
+                    window_start=budget.window_start,
+                    used_bytes=budget.used_bytes,
+                )
+                db.add(record)
+
+            if now - budget.window_start >= window:
+                budget.window_start = now
+                budget.used_bytes = 0
+                record.window_start = budget.window_start
+                record.used_bytes = budget.used_bytes
+
+            incremental = 0
+            for entry in diff.get("need", []):
+                size = entry.get("size")
+                if isinstance(size, int) and size > 0:
+                    incremental += size
+
+            budget.used_bytes += incremental
+            if budget.used_bytes < 0:
+                budget.used_bytes = 0
+            record.used_bytes = budget.used_bytes
+            record.window_start = budget.window_start
+
+            await db.flush()
+
+            remaining = max(0, limit - budget.used_bytes)
+            window_end = budget.window_start + window
+
+            return {
+                "limitBytes": limit,
+                "usedBytes": budget.used_bytes,
+                "throttleAfterBytes": remaining,
+                "windowEndsAt": _to_iso(window_end),
+            }
+
+    async def reset(self, db: AsyncSession) -> None:
+        async with self._lock:
+            self._cache.clear()
+            self._loaded = False
+        await db.execute(delete(SyncshellTransferBudget))
+        await db.flush()
+
+
+_transfer_budget_store = _TransferBudgetStore()
+
+
+async def load_transfer_budgets(db: AsyncSession) -> None:
+    await _transfer_budget_store.load(db)
+
+
+async def _reset_transfer_budgets(db: AsyncSession) -> None:
+    await _transfer_budget_store.reset(db)
+
 
 _peer_discovery_lock: asyncio.Lock = asyncio.Lock()
 _peer_discovery_state: dict[tuple[int, int], dict[str, dict[str, Any]]] = {}
@@ -651,36 +773,10 @@ def _compute_manifest_diff(
     return {"need": need_list, "remove": remove_list, "conflicts": conflicts}
 
 
-def _update_transfer_budget(
-    user_id: int, diff: dict[str, list[dict[str, Any]]]
+async def _update_transfer_budget(
+    user_id: int, diff: dict[str, list[dict[str, Any]]], db: AsyncSession
 ) -> dict[str, Any]:
-    limit = max(0, TRANSFER_BUDGET_BYTES)
-    window = timedelta(seconds=max(1, TRANSFER_BUDGET_WINDOW_SECONDS))
-    now = _now_utc()
-
-    budget = _transfer_budgets.get(user_id)
-    if not budget or now - budget.window_start >= window:
-        budget = _TransferBudget(window_start=now, used_bytes=0)
-        _transfer_budgets[user_id] = budget
-
-    incremental = 0
-    for entry in diff.get("need", []):
-        size = entry.get("size")
-        if isinstance(size, int) and size > 0:
-            incremental += size
-
-    budget.used_bytes += incremental
-    if budget.used_bytes < 0:
-        budget.used_bytes = 0
-
-    remaining = max(0, limit - budget.used_bytes)
-    window_end = budget.window_start + window
-    return {
-        "limitBytes": limit,
-        "usedBytes": budget.used_bytes,
-        "throttleAfterBytes": remaining,
-        "windowEndsAt": _to_iso(window_end),
-    }
+    return await _transfer_budget_store.update(user_id, diff, db)
 
 
 async def handle_manifest_upload(
@@ -716,10 +812,12 @@ async def handle_manifest_upload(
         record = SyncshellManifest(user_id=ctx.user.id, manifest_json=manifest_json)
         db.add(record)
 
+    budget_payload = await _update_transfer_budget(ctx.user.id, diff, db)
+
     await db.commit()
 
     limits_payload = {
-        "budget": _update_transfer_budget(ctx.user.id, diff),
+        "budget": budget_payload,
         "transfer": dict(DEFAULT_TRANSFER_LIMITS),
     }
     return diff, limits_payload

--- a/tests/test_syncshell.py
+++ b/tests/test_syncshell.py
@@ -63,7 +63,7 @@ def test_pair_token_persistence_and_expiry(tmp_path):
             assert pairing and pairing.token == token
 
             manifest, _ = build_manifest_payload(tmp_path)
-            syncshell._transfer_budgets.clear()
+            await syncshell._reset_transfer_budgets(db)
             response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert response["status"] == "ok"
             assert response["diff"]["need"]
@@ -110,7 +110,7 @@ def test_manifest_rate_limit(tmp_path):
             syncshell.RATE_LIMIT = 2
             await syncshell.pair(ctx=ctx, db=db)
             manifest, _ = build_manifest_payload(tmp_path)
-            syncshell._transfer_budgets.clear()
+            await syncshell._reset_transfer_budgets(db)
             first = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert first["diff"]["need"]
             with pytest.raises(syncshell.HTTPException) as exc:
@@ -210,7 +210,7 @@ def test_asset_upload_download_and_rate_limit(tmp_path):
 
             await syncshell.pair(ctx=ctx, db=db)
             manifest, _ = build_manifest_payload(tmp_path)
-            syncshell._transfer_budgets.clear()
+            await syncshell._reset_transfer_budgets(db)
             response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert response["diff"]["need"]
             up = await syncshell.request_asset_upload(ctx=ctx, db=db)
@@ -277,7 +277,7 @@ def test_manifest_corrupt_previous_logs_warning(tmp_path, caplog):
             await db.commit()
 
             manifest, _ = build_manifest_payload(tmp_path)
-            syncshell._transfer_budgets.clear()
+            await syncshell._reset_transfer_budgets(db)
 
             caplog.set_level(logging.WARNING, logger="demibot.http.routes.syncshell")
             response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)

--- a/tests/test_syncshell_blob_store.py
+++ b/tests/test_syncshell_blob_store.py
@@ -26,7 +26,7 @@ def test_manifest_blob_hashes_persist(tmp_path):
             await syncshell.pair(ctx=ctx, db=db)
 
             manifest, blob_hash = build_manifest_payload(tmp_path)
-            syncshell._transfer_budgets.clear()
+            await syncshell._reset_transfer_budgets(db)
             response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             need_hashes = {entry["hash"] for entry in response["diff"]["need"]}
             assert blob_hash in need_hashes

--- a/tests/test_syncshell_limits.py
+++ b/tests/test_syncshell_limits.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 
 import pytest
 
@@ -26,7 +27,7 @@ def test_token_expiry(tmp_path):
             syncshell.TOKEN_TTL = 1
             await syncshell.pair(ctx=ctx, db=db)
             manifest, _ = build_manifest_payload(tmp_path)
-            syncshell._transfer_budgets.clear()
+            await syncshell._reset_transfer_budgets(db)
             response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert response["diff"]["need"]
             await asyncio.sleep(1.1)
@@ -50,10 +51,71 @@ def test_rate_limit_hits(tmp_path):
             syncshell.RATE_LIMIT = 2
             await syncshell.pair(ctx=ctx, db=db)
             manifest, _ = build_manifest_payload(tmp_path)
-            syncshell._transfer_budgets.clear()
+            await syncshell._reset_transfer_budgets(db)
             response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert response["diff"]["need"]
             assert response["limits"]["budget"]["windowEndsAt"].endswith("Z")
             with pytest.raises(syncshell.HTTPException):
                 await syncshell.resync(ctx=ctx, db=db)
+    asyncio.run(_run())
+
+
+def test_transfer_budget_persists_across_reload(tmp_path):
+    async def _run():
+        db_session._engine = None
+        db_session._Session = None
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            user = User(id=3, discord_user_id=3, global_name="BudgetUser")
+            db.add(user)
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            syncshell.TRANSFER_BUDGET_BYTES = 1024
+            syncshell.TRANSFER_BUDGET_WINDOW_SECONDS = 3600
+            await syncshell.pair(ctx=ctx, db=db)
+
+            manifest, _ = build_manifest_payload(tmp_path)
+            await syncshell._reset_transfer_budgets(db)
+            first = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            first_budget = first["limits"]["budget"]
+            assert first_budget["usedBytes"] > 0
+
+            importlib.reload(syncshell)
+
+            # Reapply test-specific limits on the reloaded module.
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            syncshell.TRANSFER_BUDGET_BYTES = 1024
+            syncshell.TRANSFER_BUDGET_WINDOW_SECONDS = 3600
+            await syncshell.load_transfer_budgets(db)
+
+            second = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            second_budget = second["limits"]["budget"]
+            assert second_budget["usedBytes"] == first_budget["usedBytes"]
+    asyncio.run(_run())
+
+
+def test_transfer_budget_throttles_when_exceeded(tmp_path):
+    async def _run():
+        db_session._engine = None
+        db_session._Session = None
+        await init_db("sqlite+aiosqlite://")
+        async with get_session() as db:
+            user = User(id=4, discord_user_id=4, global_name="Throttle")
+            db.add(user)
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            syncshell.TRANSFER_BUDGET_BYTES = 30
+            syncshell.TRANSFER_BUDGET_WINDOW_SECONDS = 3600
+            await syncshell.pair(ctx=ctx, db=db)
+
+            manifest, _ = build_manifest_payload(tmp_path)
+            await syncshell._reset_transfer_budgets(db)
+            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            budget = response["limits"]["budget"]
+            assert budget["usedBytes"] >= syncshell.TRANSFER_BUDGET_BYTES
+            assert budget["throttleAfterBytes"] == 0
     asyncio.run(_run())

--- a/tests/test_syncshell_ws.py
+++ b/tests/test_syncshell_ws.py
@@ -20,6 +20,11 @@ from .syncshell_import import syncshell
 from .syncshell_test_utils import build_manifest_payload
 
 
+async def _reset_budgets() -> None:
+    async with get_session() as db:
+        await syncshell._reset_transfer_budgets(db)
+
+
 async def _prepare_db() -> None:
     db_session._engine = None
     db_session._Session = None
@@ -53,7 +58,7 @@ def test_syncshell_websocket_hello_and_manifest(tmp_path):
     app = create_app()
     client = TestClient(app)
 
-    syncshell._transfer_budgets.clear()
+    asyncio.run(_reset_budgets())
 
     with client.websocket_connect(
         "/ws/syncshell", headers={"X-Api-Key": "syncshell-token"}


### PR DESCRIPTION
## Summary
- add a SyncshellTransferBudget model so transfer limits survive process restarts and preload it during FastAPI startup
- replace the in-memory transfer budget cache with a database-backed store used by handle_manifest_upload
- update Syncshell tests to use the new reset helper and add coverage for persistence across reloads and throttling behaviour

## Testing
- pytest tests/test_syncshell_limits.py tests/test_syncshell.py tests/test_syncshell_blob_store.py tests/test_syncshell_ws.py *(fails: missing sqlalchemy / fastapi dependencies in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc74cb9ef48328b12a87b0ef832f1f