### PR TITLE
Remove settings button from dockable windows

### DIFF
--- a/DemiCatPlugin/DockableWindow.cs
+++ b/DemiCatPlugin/DockableWindow.cs
@@ -9,21 +9,18 @@ public abstract class DockableWindow
     private static readonly TimeSpan FadeDuration = TimeSpan.FromSeconds(1.5);
 
     private readonly Config _config;
-    private readonly Action _openSettings;
     private bool _hasDrawnHeaderThisFrame;
     private DateTime _lastFadeReset = DateTime.UtcNow;
     private bool _isOpen;
 
-    protected DockableWindow(Config config, string windowTitle, Action openSettings)
+    protected DockableWindow(Config config, string windowTitle)
     {
         _config = config;
         WindowTitle = windowTitle;
-        _openSettings = openSettings;
     }
 
     protected Config Config => _config;
     protected string WindowTitle { get; }
-    protected Action OpenSettings => _openSettings;
 
     protected virtual ImGuiWindowFlags WindowFlags => ImGuiWindowFlags.NoCollapse;
     protected virtual bool UseThemedColors => true;
@@ -163,11 +160,8 @@ public abstract class DockableWindow
     protected void DrawLinkPrompt(string message)
     {
         ImGui.TextColored(new Vector4(1f, 0.85f, 0f, 1f), message);
-        ImGui.SameLine();
-        if (ImGui.Button("Open Settings"))
-        {
-            _openSettings();
-        }
+        ImGui.Spacing();
+        ImGui.TextWrapped("Use the DemiCat dock icon to open the settings window when configuration is required.");
     }
 
     protected void DrawHeaderWithSettingsButton()
@@ -177,27 +171,12 @@ public abstract class DockableWindow
 
         _hasDrawnHeaderThisFrame = true;
 
-        const string label = "Settings";
         var style = ImGui.GetStyle();
-        var buttonSize = ImGui.CalcTextSize(label);
-        buttonSize.X += style.FramePadding.X * 2f;
-        buttonSize.Y += style.FramePadding.Y * 2f;
-
         var cursorPos = ImGui.GetCursorPos();
-        var availableWidth = ImGui.GetContentRegionAvail().X;
-        var buttonPosX = cursorPos.X + Math.Max(0f, availableWidth - buttonSize.X);
-
-        ImGui.SetCursorPosX(buttonPosX);
-        ImGui.PushID("SettingsButton");
-        if (ImGui.Button(label))
-        {
-            _openSettings();
-        }
-        ImGui.PopID();
-
-        var nextCursorY = cursorPos.Y + buttonSize.Y + style.ItemSpacing.Y;
-        ImGui.SetCursorPos(new Vector2(cursorPos.X, nextCursorY));
+        var headerHeight = ImGui.GetFrameHeight() + style.ItemSpacing.Y;
+        ImGui.SetCursorPos(new Vector2(cursorPos.X, cursorPos.Y + headerHeight));
         ImGui.Separator();
+        ImGui.Spacing();
     }
 
     internal static Vector4 AdjustBrightness(Vector4 color, float factor)

--- a/DemiCatPlugin/DockableWindowHosts.cs
+++ b/DemiCatPlugin/DockableWindowHosts.cs
@@ -8,8 +8,8 @@ public sealed class EventsDockableWindow : DockableWindow
     private readonly UiRenderer _ui;
     private readonly Func<bool> _isLinked;
 
-    public EventsDockableWindow(Config config, UiRenderer ui, Func<bool> isLinked, Action openSettings)
-        : base(config, "DemiCat Events", openSettings)
+    public EventsDockableWindow(Config config, UiRenderer ui, Func<bool> isLinked)
+        : base(config, "DemiCat Events")
     {
         _ui = ui;
         _isLinked = isLinked;
@@ -44,8 +44,8 @@ public sealed class EventCreateDockableWindow : DockableWindow
     private readonly EventCreateWindow _window;
     private readonly Func<bool> _isLinked;
 
-    public EventCreateDockableWindow(Config config, EventCreateWindow window, Func<bool> isLinked, Action openSettings)
-        : base(config, "Create Event", openSettings)
+    public EventCreateDockableWindow(Config config, EventCreateWindow window, Func<bool> isLinked)
+        : base(config, "Create Event")
     {
         _window = window;
         _isLinked = isLinked;
@@ -76,8 +76,8 @@ public sealed class TemplatesDockableWindow : DockableWindow
     private readonly Func<bool> _isLinked;
     private bool _activated;
 
-    public TemplatesDockableWindow(Config config, TemplatesWindow window, Func<bool> isLinked, Action openSettings)
-        : base(config, "Templates", openSettings)
+    public TemplatesDockableWindow(Config config, TemplatesWindow window, Func<bool> isLinked)
+        : base(config, "Templates")
     {
         _window = window;
         _isLinked = isLinked;
@@ -121,8 +121,8 @@ public sealed class NotePadDockableWindow : DockableWindow
 {
     private readonly NotePadWindow _window;
 
-    public NotePadDockableWindow(Config config, NotePadWindow window, Action openSettings)
-        : base(config, "NotePad", openSettings)
+    public NotePadDockableWindow(Config config, NotePadWindow window)
+        : base(config, "NotePad")
     {
         _window = window;
     }
@@ -133,7 +133,7 @@ public sealed class NotePadDockableWindow : DockableWindow
 
         if (!Config.NotePadEnabled)
         {
-            ImGui.TextUnformatted("NotePad is disabled.");
+            ImGui.TextWrapped("NotePad is disabled. Enable it from the settings accessed via the DemiCat dock icon.");
             return;
         }
 
@@ -146,8 +146,8 @@ public sealed class RequestBoardDockableWindow : DockableWindow
     private readonly RequestBoardWindow _window;
     private readonly Func<bool> _isLinked;
 
-    public RequestBoardDockableWindow(Config config, RequestBoardWindow window, Func<bool> isLinked, Action openSettings)
-        : base(config, "Request Board", openSettings)
+    public RequestBoardDockableWindow(Config config, RequestBoardWindow window, Func<bool> isLinked)
+        : base(config, "Request Board")
     {
         _window = window;
         _isLinked = isLinked;
@@ -172,8 +172,8 @@ public sealed class SyncshellDockableWindow : DockableWindow
     private readonly SyncshellWindow _window;
     private readonly Func<bool> _isLinked;
 
-    public SyncshellDockableWindow(Config config, SyncshellWindow window, Func<bool> isLinked, Action openSettings)
-        : base(config, "Syncshell", openSettings)
+    public SyncshellDockableWindow(Config config, SyncshellWindow window, Func<bool> isLinked)
+        : base(config, "Syncshell")
     {
         _window = window;
         _isLinked = isLinked;
@@ -206,9 +206,8 @@ public class ChatDockableWindow : DockableWindow
         ChatWindow chatWindow,
         Func<bool> isLinked,
         Func<float> opacityProvider,
-        string linkPrompt,
-        Action openSettings)
-        : base(config, windowTitle, openSettings)
+        string linkPrompt)
+        : base(config, windowTitle)
     {
         _chatWindow = chatWindow;
         _isLinked = isLinked;
@@ -264,16 +263,14 @@ public sealed class OfficerChatDockableWindow : ChatDockableWindow
         Config config,
         OfficerChatWindow officerChat,
         Func<bool> isLinked,
-        Func<bool> hasOfficerAccess,
-        Action openSettings)
+        Func<bool> hasOfficerAccess)
         : base(
             config,
             "Officer Chat",
             officerChat,
             isLinked,
             () => config.OfficerChatOpacity,
-            "Link DemiCat to use officer chat.",
-            openSettings)
+            "Link DemiCat to use officer chat.")
     {
         _officerChat = officerChat;
         _hasOfficerAccess = hasOfficerAccess;

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -34,7 +34,6 @@ public class MainWindow : IDisposable
     private string? _draggingDockItemId;
     private readonly HashSet<string> _autoShownDockItems = new();
 
-    private readonly Action _openSettingsAction;
     private readonly EventsDockableWindow _eventsWindowHost;
     private readonly EventCreateDockableWindow _eventCreateWindowHost;
     private readonly TemplatesDockableWindow _templatesWindowHost;
@@ -133,13 +132,12 @@ public class MainWindow : IDisposable
         _syncshell = _syncshellEnabled ? new SyncshellWindow(config, httpClient) : null;
         _isOpen = config.DockVisible;
 
-        _openSettingsAction = () => _settings.IsOpen = true;
-        _eventsWindowHost = new EventsDockableWindow(config, ui, IsLinked, _openSettingsAction);
-        _eventCreateWindowHost = new EventCreateDockableWindow(config, _create, IsLinked, _openSettingsAction);
-        _templatesWindowHost = new TemplatesDockableWindow(config, _templates, IsLinked, _openSettingsAction);
-        _notePadWindowHost = new NotePadDockableWindow(config, _notePad, _openSettingsAction);
-        _requestBoardWindowHost = new RequestBoardDockableWindow(config, _requestBoard, IsLinked, _openSettingsAction);
-        _officerWindowHost = new OfficerChatDockableWindow(config, _officer, IsLinked, () => HasOfficerAccess, _openSettingsAction);
+        _eventsWindowHost = new EventsDockableWindow(config, ui, IsLinked);
+        _eventCreateWindowHost = new EventCreateDockableWindow(config, _create, IsLinked);
+        _templatesWindowHost = new TemplatesDockableWindow(config, _templates, IsLinked);
+        _notePadWindowHost = new NotePadDockableWindow(config, _notePad);
+        _requestBoardWindowHost = new RequestBoardDockableWindow(config, _requestBoard, IsLinked);
+        _officerWindowHost = new OfficerChatDockableWindow(config, _officer, IsLinked, () => HasOfficerAccess);
 
         _windowHosts.Add(_eventsWindowHost);
         _windowHosts.Add(_eventCreateWindowHost);
@@ -162,14 +160,13 @@ public class MainWindow : IDisposable
                 _chat,
                 IsLinked,
                 opacityProvider,
-                linkPrompt,
-                _openSettingsAction);
+                linkPrompt);
             _windowHosts.Add(_chatWindowHost);
         }
 
         if (_syncshell != null)
         {
-            _syncshellWindowHost = new SyncshellDockableWindow(_config, _syncshell, IsLinked, _openSettingsAction);
+            _syncshellWindowHost = new SyncshellDockableWindow(_config, _syncshell, IsLinked);
             _windowHosts.Add(_syncshellWindowHost);
         }
 
@@ -194,7 +191,7 @@ public class MainWindow : IDisposable
         {
             _syncshell?.Dispose();
             _syncshell = new SyncshellWindow(_config, _httpClient);
-            _syncshellWindowHost = new SyncshellDockableWindow(_config, _syncshell, IsLinked, _openSettingsAction);
+            _syncshellWindowHost = new SyncshellDockableWindow(_config, _syncshell, IsLinked);
             _windowHosts.Add(_syncshellWindowHost);
             BuildDockItems();
             PluginServices.Instance?.Framework.RunOnTick(() => { });


### PR DESCRIPTION
## Summary
- remove the dockable window settings button and show explanatory text directing users to the dock icon
- drop the open-settings action plumbing from dockable window hosts and the main window

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc78f2c4188328a3f074341366e847