### PR TITLE
Prevent duplicate transfer budget inserts

### DIFF
--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -14,6 +14,9 @@ from uuid import uuid4
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy import delete, func, or_, select
+from sqlalchemy.dialects.mysql import insert as mysql_insert
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import RequestContext, api_key_auth, get_db
@@ -180,9 +183,9 @@ class _TransferBudgetStore:
             limit = max(0, TRANSFER_BUDGET_BYTES)
 
             budget = self._cache.get(user_id)
-            record = await db.get(SyncshellTransferBudget, user_id)
 
             if budget is None:
+                record = await db.get(SyncshellTransferBudget, user_id)
                 if record is not None:
                     budget = _TransferBudget(
                         window_start=record.window_start or now,
@@ -190,36 +193,11 @@ class _TransferBudgetStore:
                     )
                 else:
                     budget = _TransferBudget(window_start=now, used_bytes=0)
-                    record = SyncshellTransferBudget(
-                        user_id=user_id,
-                        window_start=budget.window_start,
-                        used_bytes=budget.used_bytes,
-                    )
-                    db.add(record)
                 self._cache[user_id] = budget
-            elif record is None:
-                record = SyncshellTransferBudget(
-                    user_id=user_id,
-                    window_start=budget.window_start,
-                    used_bytes=budget.used_bytes,
-                )
-                db.add(record)
-
-            if record is None:
-                # Defensive guard; SQLAlchemy session operations above should always
-                # produce a record, but keep behaviour predictable.
-                record = SyncshellTransferBudget(
-                    user_id=user_id,
-                    window_start=budget.window_start,
-                    used_bytes=budget.used_bytes,
-                )
-                db.add(record)
 
             if now - budget.window_start >= window:
                 budget.window_start = now
                 budget.used_bytes = 0
-                record.window_start = budget.window_start
-                record.used_bytes = budget.used_bytes
 
             incremental = 0
             for entry in diff.get("need", []):
@@ -230,10 +208,13 @@ class _TransferBudgetStore:
             budget.used_bytes += incremental
             if budget.used_bytes < 0:
                 budget.used_bytes = 0
-            record.used_bytes = budget.used_bytes
-            record.window_start = budget.window_start
 
-            await db.flush()
+            await self._persist_budget_record(
+                db,
+                user_id=user_id,
+                window_start=budget.window_start,
+                used_bytes=budget.used_bytes,
+            )
 
             remaining = max(0, limit - budget.used_bytes)
             window_end = budget.window_start + window
@@ -244,6 +225,61 @@ class _TransferBudgetStore:
                 "throttleAfterBytes": remaining,
                 "windowEndsAt": _to_iso(window_end),
             }
+
+    async def _persist_budget_record(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: int,
+        window_start: datetime,
+        used_bytes: int,
+    ) -> None:
+        values = {
+            "user_id": user_id,
+            "window_start": window_start,
+            "used_bytes": used_bytes,
+        }
+
+        bind = db.get_bind()
+        dialect = bind.dialect.name if bind is not None else ""
+
+        if dialect == "sqlite":
+            stmt = sqlite_insert(SyncshellTransferBudget).values(**values)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[SyncshellTransferBudget.user_id],
+                set_={
+                    "window_start": window_start,
+                    "used_bytes": used_bytes,
+                },
+            )
+            await db.execute(stmt)
+        elif dialect == "postgresql":
+            stmt = pg_insert(SyncshellTransferBudget).values(**values)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[SyncshellTransferBudget.user_id],
+                set_={
+                    "window_start": window_start,
+                    "used_bytes": used_bytes,
+                },
+            )
+            await db.execute(stmt)
+        elif dialect in {"mysql", "mariadb"}:
+            stmt = mysql_insert(SyncshellTransferBudget).values(**values)
+            stmt = stmt.on_duplicate_key_update(
+                window_start=window_start,
+                used_bytes=used_bytes,
+            )
+            await db.execute(stmt)
+        else:
+            record = await db.get(SyncshellTransferBudget, user_id)
+            if record is None:
+                record = SyncshellTransferBudget(**values)
+                db.add(record)
+            else:
+                record.window_start = window_start
+                record.used_bytes = used_bytes
+
+        await db.flush()
 
     async def reset(self, db: AsyncSession) -> None:
         async with self._lock:

--- a/tests/test_syncshell.py
+++ b/tests/test_syncshell.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from datetime import datetime
+from typing import Any
 
 import pytest
 
@@ -116,6 +117,43 @@ def test_manifest_rate_limit(tmp_path):
             with pytest.raises(syncshell.HTTPException) as exc:
                 await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
             assert exc.value.status_code == 429
+    asyncio.run(_run())
+
+
+def test_manifest_concurrent_upload_budget_upsert(tmp_path):
+    async def _run():
+        session_factory = await _prepare_db()
+        manifest: dict[str, Any] | None = None
+
+        async with session_factory as db:
+            user = User(id=1, discord_user_id=1, global_name="Test")
+            db.add(user)
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            await syncshell.pair(ctx=ctx, db=db)
+
+            manifest, _ = build_manifest_payload(tmp_path)
+            await syncshell._reset_transfer_budgets(db)
+            db.add(SyncshellManifest(user_id=user.id, manifest_json="{}"))
+            await db.commit()
+            user_id = user.id
+
+        assert manifest is not None
+
+        async def _upload_once() -> dict[str, Any]:
+            async with get_session() as db:
+                db_user = await db.get(User, user_id)
+                assert db_user is not None
+                local_ctx = RequestContext(user=db_user, guild=None, key=object(), roles=[])
+                return await syncshell.upload_manifest(manifest, ctx=local_ctx, db=db)
+
+        first, second = await asyncio.gather(_upload_once(), _upload_once())
+
+        assert first["status"] == "ok"
+        assert second["status"] == "ok"
+
     asyncio.run(_run())
 
 


### PR DESCRIPTION
## Summary
- ensure syncshell transfer budget updates use dialect-specific upserts while keeping the in-memory cache aligned with the stored row
- add a regression test that concurrently uploads manifests for the same user to confirm duplicate inserts no longer raise IntegrityError

## Testing
- pytest tests/test_syncshell.py::test_manifest_concurrent_upload_budget_upsert


------
https://chatgpt.com/codex/tasks/task_e_68dc79c11bdc8328b0b038b48a6ed347