### PR TITLE
Add Syncshell transfer budgets migration

### DIFF
--- a/demibot/demibot/db/migrations/versions/0055_add_syncshell_transfer_budgets.py
+++ b/demibot/demibot/db/migrations/versions/0055_add_syncshell_transfer_budgets.py
@@ -1,0 +1,40 @@
+"""0055_add_syncshell_transfer_budgets
+
+Revision ID: 0055_add_syncshell_transfer_budgets
+Revises: 0054_add_syncshell_member_scope
+Create Date: 2024-07-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0055_add_syncshell_transfer_budgets"
+down_revision: Union[str, None] = "0054_add_syncshell_member_scope"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "syncshell_transfer_budgets",
+        sa.Column("user_id", mysql.BIGINT(unsigned=True), primary_key=True),
+        sa.Column("window_start", sa.DateTime(), nullable=False),
+        sa.Column(
+            "used_bytes",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("syncshell_transfer_budgets")


### PR DESCRIPTION
## Summary
- add a new Alembic revision that creates the syncshell_transfer_budgets table with the expected schema and defaults

## Testing
- python - <<'PY'
import sys
from pathlib import Path
from alembic.config import Config
from alembic import command

sys.path.insert(0, str(Path('demibot').resolve()))

config = Config()
config.set_main_option("script_location", str(Path("demibot/demibot/db/migrations").resolve()))
config.set_main_option("sqlalchemy.url", "sqlite:///./migration_test.db")
command.upgrade(config, "head")
PY


------
https://chatgpt.com/codex/tasks/task_e_68dc7c1c53508328bffeaea51374a0c9