### PR TITLE
Enforce syncshell transfer budget exhaustion handling

### DIFF
--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -150,6 +150,63 @@ class _TransferBudgetStore:
         self._loaded: bool = False
         self._lock: asyncio.Lock = asyncio.Lock()
 
+    async def _get_budget_locked(
+        self, user_id: int, db: AsyncSession, *, now: datetime
+    ) -> tuple[_TransferBudget, bool]:
+        budget = self._cache.get(user_id)
+        created = False
+
+        if budget is None:
+            record = await db.get(SyncshellTransferBudget, user_id)
+            if record is not None:
+                budget = _TransferBudget(
+                    window_start=record.window_start or now,
+                    used_bytes=int(record.used_bytes or 0),
+                )
+            else:
+                budget = _TransferBudget(window_start=now, used_bytes=0)
+                created = True
+            self._cache[user_id] = budget
+
+        return budget, created
+
+    async def _refresh_window_locked(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: int,
+        budget: _TransferBudget,
+        now: datetime,
+        window: timedelta,
+    ) -> bool:
+        if now - budget.window_start >= window:
+            budget.window_start = now
+            budget.used_bytes = 0
+            await self._persist_budget_record(
+                db,
+                user_id=user_id,
+                window_start=budget.window_start,
+                used_bytes=budget.used_bytes,
+            )
+            return True
+        return False
+
+    @staticmethod
+    def _serialise_budget_payload(
+        *,
+        budget: _TransferBudget,
+        limit: int,
+        window: timedelta,
+    ) -> dict[str, Any]:
+        remaining = max(0, limit - budget.used_bytes)
+        window_end = budget.window_start + window
+        return {
+            "limitBytes": limit,
+            "usedBytes": budget.used_bytes,
+            "throttleAfterBytes": remaining,
+            "windowEndsAt": _to_iso(window_end),
+        }
+
     async def _load_unlocked(self, db: AsyncSession) -> None:
         now = datetime.utcnow()
         self._cache.clear()
@@ -182,22 +239,15 @@ class _TransferBudgetStore:
             window = timedelta(seconds=max(1, TRANSFER_BUDGET_WINDOW_SECONDS))
             limit = max(0, TRANSFER_BUDGET_BYTES)
 
-            budget = self._cache.get(user_id)
+            budget, created = await self._get_budget_locked(user_id, db, now=now)
 
-            if budget is None:
-                record = await db.get(SyncshellTransferBudget, user_id)
-                if record is not None:
-                    budget = _TransferBudget(
-                        window_start=record.window_start or now,
-                        used_bytes=int(record.used_bytes or 0),
-                    )
-                else:
-                    budget = _TransferBudget(window_start=now, used_bytes=0)
-                self._cache[user_id] = budget
-
-            if now - budget.window_start >= window:
-                budget.window_start = now
-                budget.used_bytes = 0
+            refreshed = await self._refresh_window_locked(
+                db,
+                user_id=user_id,
+                budget=budget,
+                now=now,
+                window=window,
+            )
 
             incremental = 0
             for entry in diff.get("need", []):
@@ -209,22 +259,48 @@ class _TransferBudgetStore:
             if budget.used_bytes < 0:
                 budget.used_bytes = 0
 
-            await self._persist_budget_record(
-                db,
-                user_id=user_id,
-                window_start=budget.window_start,
-                used_bytes=budget.used_bytes,
+            if created or incremental != 0:
+                await self._persist_budget_record(
+                    db,
+                    user_id=user_id,
+                    window_start=budget.window_start,
+                    used_bytes=budget.used_bytes,
+                )
+
+            return self._serialise_budget_payload(
+                budget=budget, limit=limit, window=window
             )
 
-            remaining = max(0, limit - budget.used_bytes)
-            window_end = budget.window_start + window
+    async def get_payload(self, user_id: int, db: AsyncSession) -> dict[str, Any]:
+        async with self._lock:
+            if not self._loaded:
+                await self._load_unlocked(db)
 
-            return {
-                "limitBytes": limit,
-                "usedBytes": budget.used_bytes,
-                "throttleAfterBytes": remaining,
-                "windowEndsAt": _to_iso(window_end),
-            }
+            now = datetime.utcnow()
+            window = timedelta(seconds=max(1, TRANSFER_BUDGET_WINDOW_SECONDS))
+            limit = max(0, TRANSFER_BUDGET_BYTES)
+
+            budget, created = await self._get_budget_locked(user_id, db, now=now)
+
+            refreshed = await self._refresh_window_locked(
+                db,
+                user_id=user_id,
+                budget=budget,
+                now=now,
+                window=window,
+            )
+
+            if created and not refreshed:
+                await self._persist_budget_record(
+                    db,
+                    user_id=user_id,
+                    window_start=budget.window_start,
+                    used_bytes=budget.used_bytes,
+                )
+
+            return self._serialise_budget_payload(
+                budget=budget, limit=limit, window=window
+            )
 
     async def _persist_budget_record(
         self,
@@ -815,6 +891,27 @@ async def _update_transfer_budget(
     return await _transfer_budget_store.update(user_id, diff, db)
 
 
+async def _get_transfer_budget_payload(user_id: int, db: AsyncSession) -> dict[str, Any]:
+    return await _transfer_budget_store.get_payload(user_id, db)
+
+
+def _ensure_budget_remaining(budget_payload: dict[str, Any]) -> None:
+    throttle_after = budget_payload.get("throttleAfterBytes")
+    try:
+        remaining = int(throttle_after)
+    except (TypeError, ValueError):
+        return
+    if remaining <= 0:
+        raise HTTPException(status_code=429, detail="transfer budget exhausted")
+
+
+async def _require_available_budget(user_id: int, db: AsyncSession) -> dict[str, Any]:
+    budget_payload = await _get_transfer_budget_payload(user_id, db)
+    await db.commit()
+    _ensure_budget_remaining(budget_payload)
+    return budget_payload
+
+
 async def handle_manifest_upload(
     manifest: dict[str, Any], ctx: RequestContext, db: AsyncSession
 ) -> tuple[dict[str, list[dict[str, Any]]], dict[str, Any]]:
@@ -851,6 +948,8 @@ async def handle_manifest_upload(
     budget_payload = await _update_transfer_budget(ctx.user.id, diff, db)
 
     await db.commit()
+
+    _ensure_budget_remaining(budget_payload)
 
     limits_payload = {
         "budget": budget_payload,
@@ -1580,6 +1679,7 @@ async def request_asset_upload(
     """Return a pre-signed URL for chunked asset upload."""
     await _require_pairing(ctx, db)
     await _check_rate_limit(ctx.user.id, db)
+    await _require_available_budget(ctx.user.id, db)
     if not await _user_has_asset_scope(ctx.user.id, db, as_member=False):
         raise HTTPException(status_code=403, detail="asset scope required")
     try:
@@ -1598,6 +1698,7 @@ async def request_asset_download(
     """Return a pre-signed URL for asset download."""
     await _require_pairing(ctx, db)
     await _check_rate_limit(ctx.user.id, db)
+    await _require_available_budget(ctx.user.id, db)
     if not await _user_has_asset_scope(ctx.user.id, db, as_member=True):
         raise HTTPException(status_code=403, detail="asset scope required")
     try:

--- a/tests/test_syncshell.py
+++ b/tests/test_syncshell.py
@@ -261,6 +261,77 @@ def test_asset_upload_download_and_rate_limit(tmp_path):
     asyncio.run(_run())
 
 
+def test_asset_presign_rejected_when_budget_exhausted(tmp_path):
+    async def _run():
+        session_factory = await _prepare_db()
+        async with session_factory as db:
+            user = User(id=10, discord_user_id=10, global_name="Budgetless")
+            member = User(id=11, discord_user_id=11, global_name="Member")
+            db.add_all([user, member])
+            await db.commit()
+
+            now = datetime.utcnow()
+            db.add_all(
+                [
+                    SyncshellMember(
+                        user_id=user.id,
+                        member_user_id=member.id,
+                        created_at=now,
+                        scope=int(SyncshellScope.HASHES | SyncshellScope.ASSETS),
+                    ),
+                    SyncshellMember(
+                        user_id=member.id,
+                        member_user_id=user.id,
+                        created_at=now,
+                        scope=int(SyncshellScope.HASHES | SyncshellScope.ASSETS),
+                    ),
+                ]
+            )
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            original_budget = syncshell.TRANSFER_BUDGET_BYTES
+            original_window = syncshell.TRANSFER_BUDGET_WINDOW_SECONDS
+            syncshell.TRANSFER_BUDGET_BYTES = 30
+            syncshell.TRANSFER_BUDGET_WINDOW_SECONDS = 3600
+
+            async def fail_upload():
+                raise AssertionError("presign_upload should not be called")
+
+            async def fail_download(asset_id):
+                raise AssertionError("presign_download should not be called")
+
+            original_presign_upload = syncshell.presign_upload
+            original_presign_download = syncshell.presign_download
+            syncshell.presign_upload = fail_upload
+            syncshell.presign_download = fail_download
+
+            try:
+                await syncshell.pair(ctx=ctx, db=db)
+                manifest, _ = build_manifest_payload(tmp_path)
+                await syncshell._reset_transfer_budgets(db)
+
+                with pytest.raises(syncshell.HTTPException) as manifest_exc:
+                    await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+                assert manifest_exc.value.status_code == 429
+
+                with pytest.raises(syncshell.HTTPException) as upload_exc:
+                    await syncshell.request_asset_upload(ctx=ctx, db=db)
+                assert upload_exc.value.status_code == 429
+
+                with pytest.raises(syncshell.HTTPException) as download_exc:
+                    await syncshell.request_asset_download("asset", ctx=ctx, db=db)
+                assert download_exc.value.status_code == 429
+            finally:
+                syncshell.TRANSFER_BUDGET_BYTES = original_budget
+                syncshell.TRANSFER_BUDGET_WINDOW_SECONDS = original_window
+                syncshell.presign_upload = original_presign_upload
+                syncshell.presign_download = original_presign_download
+
+    asyncio.run(_run())
+
+
 def test_asset_scope_required_for_presign(tmp_path):
     async def _run():
         session_factory = await _prepare_db()

--- a/tests/test_syncshell_limits.py
+++ b/tests/test_syncshell_limits.py
@@ -114,8 +114,11 @@ def test_transfer_budget_throttles_when_exceeded(tmp_path):
 
             manifest, _ = build_manifest_payload(tmp_path)
             await syncshell._reset_transfer_budgets(db)
-            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
-            budget = response["limits"]["budget"]
+            with pytest.raises(syncshell.HTTPException) as exc:
+                await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+            assert exc.value.status_code == 429
+
+            budget = await syncshell._get_transfer_budget_payload(ctx.user.id, db)
             assert budget["usedBytes"] >= syncshell.TRANSFER_BUDGET_BYTES
             assert budget["throttleAfterBytes"] == 0
     asyncio.run(_run())

--- a/tests/test_syncshell_ws.py
+++ b/tests/test_syncshell_ws.py
@@ -2,7 +2,9 @@ import asyncio
 import json
 from datetime import datetime, timedelta
 
+import pytest
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from demibot.http.api import create_app
 from demibot.db.models import (
@@ -102,3 +104,47 @@ def test_syncshell_websocket_hello_and_manifest(tmp_path):
 
     stored_manifest = asyncio.run(_fetch_manifest())
     assert stored_manifest["protocolVersion"] == 1
+
+
+def test_syncshell_websocket_manifest_rejected_when_budget_exhausted(tmp_path):
+    asyncio.run(_prepare_db())
+
+    manifest, _ = build_manifest_payload(tmp_path)
+    original_budget = syncshell.TRANSFER_BUDGET_BYTES
+    original_window = syncshell.TRANSFER_BUDGET_WINDOW_SECONDS
+    syncshell.TRANSFER_BUDGET_BYTES = 30
+    syncshell.TRANSFER_BUDGET_WINDOW_SECONDS = 3600
+
+    app = create_app()
+    client = TestClient(app)
+
+    try:
+        asyncio.run(_reset_budgets())
+
+        with client.websocket_connect(
+            "/ws/syncshell", headers={"X-Api-Key": "syncshell-token"}
+        ) as websocket:
+            websocket.send_json(
+                {
+                    "type": "hello",
+                    "payload": {
+                        "version": 1,
+                        "limits": {
+                            "bytesPerSecond": 512 * 1024,
+                            "chunkSizeBytes": 64 * 1024,
+                            "maxOutstandingWants": 64,
+                        },
+                    },
+                }
+            )
+            websocket.receive_json()
+
+            websocket.send_json({"type": "manifest", "payload": {"manifest": manifest}})
+            with pytest.raises(WebSocketDisconnect) as disconnect:
+                websocket.receive_json()
+            assert disconnect.value.code == 1008
+            assert disconnect.value.reason == "transfer budget exhausted"
+    finally:
+        syncshell.TRANSFER_BUDGET_BYTES = original_budget
+        syncshell.TRANSFER_BUDGET_WINDOW_SECONDS = original_window
+        asyncio.run(_reset_budgets())


### PR DESCRIPTION
## Summary
- extend the transfer budget store so callers can inspect the current window without mutating usage
- raise HTTP 429 when manifest uploads or asset presign requests would exceed the remaining transfer budget, including over WebSocket
- add coverage for exhausted budget handling in HTTP and WebSocket manifest processing plus asset presign rejection tests

## Testing
- pytest tests/test_syncshell_limits.py tests/test_syncshell.py::test_asset_presign_rejected_when_budget_exhausted tests/test_syncshell_ws.py::test_syncshell_websocket_manifest_rejected_when_budget_exhausted *(fails: missing optional dependencies such as SQLAlchemy and FastAPI in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7d29111c8328a2ef6ac838d8a6be