### PR TITLE
Update plugin icon URL and bump version to 1.2.2.2

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -11,9 +11,9 @@
     <RootNamespace>DemiCatPlugin</RootNamespace>
 
     <!-- Keep these in sync with manifest -->
-    <Version>1.2.2.1</Version>
-    <AssemblyVersion>1.2.2.1</AssemblyVersion>
-    <FileVersion>1.2.2.1</FileVersion>
+    <Version>1.2.2.2</Version>
+    <AssemblyVersion>1.2.2.2</AssemblyVersion>
+    <FileVersion>1.2.2.2</FileVersion>
 
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>

--- a/DemiCatPlugin/DemiCatPlugin.json
+++ b/DemiCatPlugin/DemiCatPlugin.json
@@ -2,7 +2,7 @@
   "Author": "Demi Dev Studio",
   "Name": "DemiCat",
   "InternalName": "DemiCatPlugin",
-  "AssemblyVersion": "1.2.2.1",
+  "AssemblyVersion": "1.2.2.2",
   "Description": "DemiCat Dalamud plugin. =Mew=",
   "ApplicableVersion": "any",
   "RepoUrl": "https://github.com/jackandcarter/DemiCat",
@@ -11,7 +11,7 @@
   "LoadSync": false,
   "CanUnloadAsync": false,
   "LoadPriority": 0,
-  "IconUrl": "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/Demi_Bot_Logo.png",
+  "IconUrl": "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/DemiCatPlugin/icon.png",
   "Punchline": "Discord-linked FC tools and chat.",
   "AcceptsFeedback": true
 }

--- a/repo.json
+++ b/repo.json
@@ -5,10 +5,10 @@
     "InternalName": "DemiCatPlugin",
     "Punchline": "Discord-linked FC tools and chat.",
     "Description": "A mod to manage Discord FC communities and Events.",
-    "AssemblyVersion": "1.2.2.1",
+    "AssemblyVersion": "1.2.2.2",
     "ApplicableVersion": "any",
     "DalamudApiLevel": 13,
     "RepoUrl": "https://github.com/jackandcarter/DemiCat",
-    "IconUrl": "https://the-demiurge.com/DemiDevUnit/icon.png"
+    "IconUrl": "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/DemiCatPlugin/icon.png"
   }
 ]


### PR DESCRIPTION
## Summary
- point the plugin manifest and repo entry to the GitHub-hosted icon asset
- bump the plugin version to 1.2.2.2 and sync the project metadata for a refresh

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc7d7fa5888328906e63da55fb4915