### PR TITLE
Handle syncshell transfer budget load failures during startup

### DIFF
--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -85,7 +85,14 @@ def create_app() -> FastAPI:
     @app.on_event("startup")
     async def _load_syncshell_transfer_budgets() -> None:
         async with get_session() as db:
-            await syncshell_module.load_transfer_budgets(db)
+            try:
+                await syncshell_module.load_transfer_budgets(db)
+            except Exception as exc:  # pragma: no cover - exercised in tests
+                logger.warning(
+                    "syncshell.transfer_budgets_load_failed",
+                    error=str(exc),
+                )
+                await syncshell_module._transfer_budget_store.reset(db)
 
     # Dynamically include routers from all modules in the routes package
     from . import routes as routes_pkg

--- a/tests/test_api_startup.py
+++ b/tests/test_api_startup.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from demibot.http import api as api_module
+from demibot.http.routes import syncshell as syncshell_module
+
+
+class _DummySessionContext:
+    async def __aenter__(self) -> object:  # pragma: no cover - trivial
+        return object()
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+        return None
+
+
+class _FakeLogger:
+    def __init__(self) -> None:
+        self.warnings: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.warnings.append((event, kwargs))
+
+
+def test_startup_logs_warning_when_transfer_budget_load_fails(monkeypatch):
+    fake_logger = _FakeLogger()
+    monkeypatch.setattr(api_module, "logger", fake_logger)
+
+    async def failing_loader(db) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(syncshell_module, "load_transfer_budgets", failing_loader)
+
+    reset_mock = AsyncMock()
+    monkeypatch.setattr(syncshell_module._transfer_budget_store, "reset", reset_mock)
+
+    monkeypatch.setattr(api_module, "get_session", lambda: _DummySessionContext())
+    monkeypatch.setattr(api_module.pkgutil, "iter_modules", lambda *args, **kwargs: [])
+
+    app = api_module.create_app()
+
+    asyncio.run(app.router.startup())
+
+    assert fake_logger.warnings
+    event, data = fake_logger.warnings[0]
+    assert event == "syncshell.transfer_budgets_load_failed"
+    assert "error" in data
+    assert "boom" in str(data["error"])
+
+    reset_mock.assert_awaited_once()
+
+    asyncio.run(app.router.shutdown())


### PR DESCRIPTION
## Summary
- guard the syncshell transfer budget preload with a try/except and reset the cache on failure
- add a unit test that simulates a loader failure and ensures a warning is logged while startup continues

## Testing
- pytest tests/test_api_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68dc7fe47d6c8328b743b2abb4501506