### PR TITLE
Expand unicode emoji data and tests

### DIFF
--- a/demibot/demibot/data/unicode_emojis.json
+++ b/demibot/demibot/data/unicode_emojis.json
@@ -1,5 +1,18867 @@
 [
-  {"emoji": "😀", "name": "grinning face", "imageUrl": "https://cdn.jsdelivr.net/gh/twitter/twemoji@v14.0.2/assets/72x72/1f600.png"},
-  {"emoji": "😃", "name": "grinning face with big eyes", "imageUrl": "https://cdn.jsdelivr.net/gh/twitter/twemoji@v14.0.2/assets/72x72/1f603.png"},
-  {"emoji": "😄", "name": "grinning face with smiling eyes", "imageUrl": "https://cdn.jsdelivr.net/gh/twitter/twemoji@v14.0.2/assets/72x72/1f604.png"}
+  {
+    "emoji": "😀",
+    "name": "grinning face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f600.png"
+  },
+  {
+    "emoji": "😃",
+    "name": "grinning face with big eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f603.png"
+  },
+  {
+    "emoji": "😄",
+    "name": "grinning face with smiling eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f604.png"
+  },
+  {
+    "emoji": "😁",
+    "name": "beaming face with smiling eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f601.png"
+  },
+  {
+    "emoji": "😆",
+    "name": "grinning squinting face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f606.png"
+  },
+  {
+    "emoji": "😅",
+    "name": "grinning face with sweat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f605.png"
+  },
+  {
+    "emoji": "🤣",
+    "name": "rolling on the floor laughing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f923.png"
+  },
+  {
+    "emoji": "😂",
+    "name": "face with tears of joy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f602.png"
+  },
+  {
+    "emoji": "🙂",
+    "name": "slightly smiling face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f642.png"
+  },
+  {
+    "emoji": "🙃",
+    "name": "upside-down face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f643.png"
+  },
+  {
+    "emoji": "🫠",
+    "name": "melting face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fae0.png"
+  },
+  {
+    "emoji": "😉",
+    "name": "winking face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f609.png"
+  },
+  {
+    "emoji": "😊",
+    "name": "smiling face with smiling eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f60a.png"
+  },
+  {
+    "emoji": "😇",
+    "name": "smiling face with halo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f607.png"
+  },
+  {
+    "emoji": "🥰",
+    "name": "smiling face with hearts",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f970.png"
+  },
+  {
+    "emoji": "😍",
+    "name": "smiling face with heart-eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f60d.png"
+  },
+  {
+    "emoji": "🤩",
+    "name": "star-struck",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f929.png"
+  },
+  {
+    "emoji": "😘",
+    "name": "face blowing a kiss",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f618.png"
+  },
+  {
+    "emoji": "😗",
+    "name": "kissing face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f617.png"
+  },
+  {
+    "emoji": "☺️",
+    "name": "smiling face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/263a-fe0f.png"
+  },
+  {
+    "emoji": "😚",
+    "name": "kissing face with closed eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f61a.png"
+  },
+  {
+    "emoji": "😙",
+    "name": "kissing face with smiling eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f619.png"
+  },
+  {
+    "emoji": "🥲",
+    "name": "smiling face with tear",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f972.png"
+  },
+  {
+    "emoji": "😋",
+    "name": "face savoring food",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f60b.png"
+  },
+  {
+    "emoji": "😛",
+    "name": "face with tongue",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f61b.png"
+  },
+  {
+    "emoji": "😜",
+    "name": "winking face with tongue",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f61c.png"
+  },
+  {
+    "emoji": "🤪",
+    "name": "zany face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f92a.png"
+  },
+  {
+    "emoji": "😝",
+    "name": "squinting face with tongue",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f61d.png"
+  },
+  {
+    "emoji": "🤑",
+    "name": "money-mouth face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f911.png"
+  },
+  {
+    "emoji": "🤗",
+    "name": "smiling face with open hands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f917.png"
+  },
+  {
+    "emoji": "🤭",
+    "name": "face with hand over mouth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f92d.png"
+  },
+  {
+    "emoji": "🫢",
+    "name": "face with open eyes and hand over mouth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fae2.png"
+  },
+  {
+    "emoji": "🫣",
+    "name": "face with peeking eye",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fae3.png"
+  },
+  {
+    "emoji": "🤫",
+    "name": "shushing face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f92b.png"
+  },
+  {
+    "emoji": "🤔",
+    "name": "thinking face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f914.png"
+  },
+  {
+    "emoji": "🫡",
+    "name": "saluting face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fae1.png"
+  },
+  {
+    "emoji": "🤐",
+    "name": "zipper-mouth face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f910.png"
+  },
+  {
+    "emoji": "🤨",
+    "name": "face with raised eyebrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f928.png"
+  },
+  {
+    "emoji": "😐",
+    "name": "neutral face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f610.png"
+  },
+  {
+    "emoji": "😑",
+    "name": "expressionless face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f611.png"
+  },
+  {
+    "emoji": "😶",
+    "name": "face without mouth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f636.png"
+  },
+  {
+    "emoji": "🫥",
+    "name": "dotted line face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fae5.png"
+  },
+  {
+    "emoji": "😶‍🌫️",
+    "name": "face in clouds",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f636-200d-1f32b-fe0f.png"
+  },
+  {
+    "emoji": "😏",
+    "name": "smirking face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f60f.png"
+  },
+  {
+    "emoji": "😒",
+    "name": "unamused face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f612.png"
+  },
+  {
+    "emoji": "🙄",
+    "name": "face with rolling eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f644.png"
+  },
+  {
+    "emoji": "😬",
+    "name": "grimacing face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f62c.png"
+  },
+  {
+    "emoji": "😮‍💨",
+    "name": "face exhaling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f62e-200d-1f4a8.png"
+  },
+  {
+    "emoji": "🤥",
+    "name": "lying face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f925.png"
+  },
+  {
+    "emoji": "🫨",
+    "name": "shaking face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fae8.png"
+  },
+  {
+    "emoji": "🙂‍↔️",
+    "name": "head shaking horizontally",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f642-200d-2194-fe0f.png"
+  },
+  {
+    "emoji": "🙂‍↕️",
+    "name": "head shaking vertically",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f642-200d-2195-fe0f.png"
+  },
+  {
+    "emoji": "😌",
+    "name": "relieved face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f60c.png"
+  },
+  {
+    "emoji": "😔",
+    "name": "pensive face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f614.png"
+  },
+  {
+    "emoji": "😪",
+    "name": "sleepy face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f62a.png"
+  },
+  {
+    "emoji": "🤤",
+    "name": "drooling face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f924.png"
+  },
+  {
+    "emoji": "😴",
+    "name": "sleeping face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f634.png"
+  },
+  {
+    "emoji": "😷",
+    "name": "face with medical mask",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f637.png"
+  },
+  {
+    "emoji": "🤒",
+    "name": "face with thermometer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f912.png"
+  },
+  {
+    "emoji": "🤕",
+    "name": "face with head-bandage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f915.png"
+  },
+  {
+    "emoji": "🤢",
+    "name": "nauseated face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f922.png"
+  },
+  {
+    "emoji": "🤮",
+    "name": "face vomiting",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f92e.png"
+  },
+  {
+    "emoji": "🤧",
+    "name": "sneezing face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f927.png"
+  },
+  {
+    "emoji": "🥵",
+    "name": "hot face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f975.png"
+  },
+  {
+    "emoji": "🥶",
+    "name": "cold face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f976.png"
+  },
+  {
+    "emoji": "🥴",
+    "name": "woozy face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f974.png"
+  },
+  {
+    "emoji": "😵",
+    "name": "face with crossed-out eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f635.png"
+  },
+  {
+    "emoji": "😵‍💫",
+    "name": "face with spiral eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f635-200d-1f4ab.png"
+  },
+  {
+    "emoji": "🤯",
+    "name": "exploding head",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f92f.png"
+  },
+  {
+    "emoji": "🤠",
+    "name": "cowboy hat face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f920.png"
+  },
+  {
+    "emoji": "🥳",
+    "name": "partying face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f973.png"
+  },
+  {
+    "emoji": "🥸",
+    "name": "disguised face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f978.png"
+  },
+  {
+    "emoji": "😎",
+    "name": "smiling face with sunglasses",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f60e.png"
+  },
+  {
+    "emoji": "🤓",
+    "name": "nerd face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f913.png"
+  },
+  {
+    "emoji": "🧐",
+    "name": "face with monocle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d0.png"
+  },
+  {
+    "emoji": "😕",
+    "name": "confused face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f615.png"
+  },
+  {
+    "emoji": "🫤",
+    "name": "face with diagonal mouth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fae4.png"
+  },
+  {
+    "emoji": "😟",
+    "name": "worried face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f61f.png"
+  },
+  {
+    "emoji": "🙁",
+    "name": "slightly frowning face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f641.png"
+  },
+  {
+    "emoji": "☹️",
+    "name": "frowning face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2639-fe0f.png"
+  },
+  {
+    "emoji": "😮",
+    "name": "face with open mouth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f62e.png"
+  },
+  {
+    "emoji": "😯",
+    "name": "hushed face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f62f.png"
+  },
+  {
+    "emoji": "😲",
+    "name": "astonished face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f632.png"
+  },
+  {
+    "emoji": "😳",
+    "name": "flushed face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f633.png"
+  },
+  {
+    "emoji": "🥺",
+    "name": "pleading face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f97a.png"
+  },
+  {
+    "emoji": "🥹",
+    "name": "face holding back tears",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f979.png"
+  },
+  {
+    "emoji": "😦",
+    "name": "frowning face with open mouth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f626.png"
+  },
+  {
+    "emoji": "😧",
+    "name": "anguished face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f627.png"
+  },
+  {
+    "emoji": "😨",
+    "name": "fearful face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f628.png"
+  },
+  {
+    "emoji": "😰",
+    "name": "anxious face with sweat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f630.png"
+  },
+  {
+    "emoji": "😥",
+    "name": "sad but relieved face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f625.png"
+  },
+  {
+    "emoji": "😢",
+    "name": "crying face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f622.png"
+  },
+  {
+    "emoji": "😭",
+    "name": "loudly crying face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f62d.png"
+  },
+  {
+    "emoji": "😱",
+    "name": "face screaming in fear",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f631.png"
+  },
+  {
+    "emoji": "😖",
+    "name": "confounded face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f616.png"
+  },
+  {
+    "emoji": "😣",
+    "name": "persevering face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f623.png"
+  },
+  {
+    "emoji": "😞",
+    "name": "disappointed face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f61e.png"
+  },
+  {
+    "emoji": "😓",
+    "name": "downcast face with sweat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f613.png"
+  },
+  {
+    "emoji": "😩",
+    "name": "weary face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f629.png"
+  },
+  {
+    "emoji": "😫",
+    "name": "tired face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f62b.png"
+  },
+  {
+    "emoji": "🥱",
+    "name": "yawning face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f971.png"
+  },
+  {
+    "emoji": "😤",
+    "name": "face with steam from nose",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f624.png"
+  },
+  {
+    "emoji": "😡",
+    "name": "enraged face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f621.png"
+  },
+  {
+    "emoji": "😠",
+    "name": "angry face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f620.png"
+  },
+  {
+    "emoji": "🤬",
+    "name": "face with symbols on mouth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f92c.png"
+  },
+  {
+    "emoji": "😈",
+    "name": "smiling face with horns",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f608.png"
+  },
+  {
+    "emoji": "👿",
+    "name": "angry face with horns",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47f.png"
+  },
+  {
+    "emoji": "💀",
+    "name": "skull",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f480.png"
+  },
+  {
+    "emoji": "☠️",
+    "name": "skull and crossbones",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2620-fe0f.png"
+  },
+  {
+    "emoji": "💩",
+    "name": "pile of poo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4a9.png"
+  },
+  {
+    "emoji": "🤡",
+    "name": "clown face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f921.png"
+  },
+  {
+    "emoji": "👹",
+    "name": "ogre",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f479.png"
+  },
+  {
+    "emoji": "👺",
+    "name": "goblin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47a.png"
+  },
+  {
+    "emoji": "👻",
+    "name": "ghost",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47b.png"
+  },
+  {
+    "emoji": "👽",
+    "name": "alien",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47d.png"
+  },
+  {
+    "emoji": "👾",
+    "name": "alien monster",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47e.png"
+  },
+  {
+    "emoji": "🤖",
+    "name": "robot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f916.png"
+  },
+  {
+    "emoji": "😺",
+    "name": "grinning cat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f63a.png"
+  },
+  {
+    "emoji": "😸",
+    "name": "grinning cat with smiling eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f638.png"
+  },
+  {
+    "emoji": "😹",
+    "name": "cat with tears of joy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f639.png"
+  },
+  {
+    "emoji": "😻",
+    "name": "smiling cat with heart-eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f63b.png"
+  },
+  {
+    "emoji": "😼",
+    "name": "cat with wry smile",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f63c.png"
+  },
+  {
+    "emoji": "😽",
+    "name": "kissing cat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f63d.png"
+  },
+  {
+    "emoji": "🙀",
+    "name": "weary cat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f640.png"
+  },
+  {
+    "emoji": "😿",
+    "name": "crying cat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f63f.png"
+  },
+  {
+    "emoji": "😾",
+    "name": "pouting cat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f63e.png"
+  },
+  {
+    "emoji": "🙈",
+    "name": "see-no-evil monkey",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f648.png"
+  },
+  {
+    "emoji": "🙉",
+    "name": "hear-no-evil monkey",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f649.png"
+  },
+  {
+    "emoji": "🙊",
+    "name": "speak-no-evil monkey",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64a.png"
+  },
+  {
+    "emoji": "💌",
+    "name": "love letter",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48c.png"
+  },
+  {
+    "emoji": "💘",
+    "name": "heart with arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f498.png"
+  },
+  {
+    "emoji": "💝",
+    "name": "heart with ribbon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f49d.png"
+  },
+  {
+    "emoji": "💖",
+    "name": "sparkling heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f496.png"
+  },
+  {
+    "emoji": "💗",
+    "name": "growing heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f497.png"
+  },
+  {
+    "emoji": "💓",
+    "name": "beating heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f493.png"
+  },
+  {
+    "emoji": "💞",
+    "name": "revolving hearts",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f49e.png"
+  },
+  {
+    "emoji": "💕",
+    "name": "two hearts",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f495.png"
+  },
+  {
+    "emoji": "💟",
+    "name": "heart decoration",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f49f.png"
+  },
+  {
+    "emoji": "❣️",
+    "name": "heart exclamation",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2763-fe0f.png"
+  },
+  {
+    "emoji": "💔",
+    "name": "broken heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f494.png"
+  },
+  {
+    "emoji": "❤️‍🔥",
+    "name": "heart on fire",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2764-fe0f-200d-1f525.png"
+  },
+  {
+    "emoji": "❤️‍🩹",
+    "name": "mending heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2764-fe0f-200d-1fa79.png"
+  },
+  {
+    "emoji": "❤️",
+    "name": "red heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2764-fe0f.png"
+  },
+  {
+    "emoji": "🩷",
+    "name": "pink heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa77.png"
+  },
+  {
+    "emoji": "🧡",
+    "name": "orange heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9e1.png"
+  },
+  {
+    "emoji": "💛",
+    "name": "yellow heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f49b.png"
+  },
+  {
+    "emoji": "💚",
+    "name": "green heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f49a.png"
+  },
+  {
+    "emoji": "💙",
+    "name": "blue heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f499.png"
+  },
+  {
+    "emoji": "🩵",
+    "name": "light blue heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa75.png"
+  },
+  {
+    "emoji": "💜",
+    "name": "purple heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f49c.png"
+  },
+  {
+    "emoji": "🤎",
+    "name": "brown heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90e.png"
+  },
+  {
+    "emoji": "🖤",
+    "name": "black heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5a4.png"
+  },
+  {
+    "emoji": "🩶",
+    "name": "grey heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa76.png"
+  },
+  {
+    "emoji": "🤍",
+    "name": "white heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90d.png"
+  },
+  {
+    "emoji": "💋",
+    "name": "kiss mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48b.png"
+  },
+  {
+    "emoji": "💯",
+    "name": "hundred points",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4af.png"
+  },
+  {
+    "emoji": "💢",
+    "name": "anger symbol",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4a2.png"
+  },
+  {
+    "emoji": "💥",
+    "name": "collision",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4a5.png"
+  },
+  {
+    "emoji": "💫",
+    "name": "dizzy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ab.png"
+  },
+  {
+    "emoji": "💦",
+    "name": "sweat droplets",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4a6.png"
+  },
+  {
+    "emoji": "💨",
+    "name": "dashing away",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4a8.png"
+  },
+  {
+    "emoji": "🕳️",
+    "name": "hole",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f573-fe0f.png"
+  },
+  {
+    "emoji": "💬",
+    "name": "speech balloon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ac.png"
+  },
+  {
+    "emoji": "👁️‍🗨️",
+    "name": "eye in speech bubble",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f441-fe0f-200d-1f5e8-fe0f.png"
+  },
+  {
+    "emoji": "🗨️",
+    "name": "left speech bubble",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5e8-fe0f.png"
+  },
+  {
+    "emoji": "🗯️",
+    "name": "right anger bubble",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5ef-fe0f.png"
+  },
+  {
+    "emoji": "💭",
+    "name": "thought balloon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ad.png"
+  },
+  {
+    "emoji": "💤",
+    "name": "ZZZ",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4a4.png"
+  },
+  {
+    "emoji": "👋",
+    "name": "waving hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44b.png"
+  },
+  {
+    "emoji": "👋🏻",
+    "name": "waving hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44b-1f3fb.png"
+  },
+  {
+    "emoji": "👋🏼",
+    "name": "waving hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44b-1f3fc.png"
+  },
+  {
+    "emoji": "👋🏽",
+    "name": "waving hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44b-1f3fd.png"
+  },
+  {
+    "emoji": "👋🏾",
+    "name": "waving hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44b-1f3fe.png"
+  },
+  {
+    "emoji": "👋🏿",
+    "name": "waving hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44b-1f3ff.png"
+  },
+  {
+    "emoji": "🤚",
+    "name": "raised back of hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91a.png"
+  },
+  {
+    "emoji": "🤚🏻",
+    "name": "raised back of hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91a-1f3fb.png"
+  },
+  {
+    "emoji": "🤚🏼",
+    "name": "raised back of hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91a-1f3fc.png"
+  },
+  {
+    "emoji": "🤚🏽",
+    "name": "raised back of hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91a-1f3fd.png"
+  },
+  {
+    "emoji": "🤚🏾",
+    "name": "raised back of hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91a-1f3fe.png"
+  },
+  {
+    "emoji": "🤚🏿",
+    "name": "raised back of hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91a-1f3ff.png"
+  },
+  {
+    "emoji": "🖐️",
+    "name": "hand with fingers splayed",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f590-fe0f.png"
+  },
+  {
+    "emoji": "🖐🏻",
+    "name": "hand with fingers splayed: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f590-1f3fb.png"
+  },
+  {
+    "emoji": "🖐🏼",
+    "name": "hand with fingers splayed: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f590-1f3fc.png"
+  },
+  {
+    "emoji": "🖐🏽",
+    "name": "hand with fingers splayed: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f590-1f3fd.png"
+  },
+  {
+    "emoji": "🖐🏾",
+    "name": "hand with fingers splayed: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f590-1f3fe.png"
+  },
+  {
+    "emoji": "🖐🏿",
+    "name": "hand with fingers splayed: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f590-1f3ff.png"
+  },
+  {
+    "emoji": "✋",
+    "name": "raised hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270b.png"
+  },
+  {
+    "emoji": "✋🏻",
+    "name": "raised hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270b-1f3fb.png"
+  },
+  {
+    "emoji": "✋🏼",
+    "name": "raised hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270b-1f3fc.png"
+  },
+  {
+    "emoji": "✋🏽",
+    "name": "raised hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270b-1f3fd.png"
+  },
+  {
+    "emoji": "✋🏾",
+    "name": "raised hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270b-1f3fe.png"
+  },
+  {
+    "emoji": "✋🏿",
+    "name": "raised hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270b-1f3ff.png"
+  },
+  {
+    "emoji": "🖖",
+    "name": "vulcan salute",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f596.png"
+  },
+  {
+    "emoji": "🖖🏻",
+    "name": "vulcan salute: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f596-1f3fb.png"
+  },
+  {
+    "emoji": "🖖🏼",
+    "name": "vulcan salute: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f596-1f3fc.png"
+  },
+  {
+    "emoji": "🖖🏽",
+    "name": "vulcan salute: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f596-1f3fd.png"
+  },
+  {
+    "emoji": "🖖🏾",
+    "name": "vulcan salute: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f596-1f3fe.png"
+  },
+  {
+    "emoji": "🖖🏿",
+    "name": "vulcan salute: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f596-1f3ff.png"
+  },
+  {
+    "emoji": "🫱",
+    "name": "rightwards hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1.png"
+  },
+  {
+    "emoji": "🫱🏻",
+    "name": "rightwards hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fb.png"
+  },
+  {
+    "emoji": "🫱🏼",
+    "name": "rightwards hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fc.png"
+  },
+  {
+    "emoji": "🫱🏽",
+    "name": "rightwards hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fd.png"
+  },
+  {
+    "emoji": "🫱🏾",
+    "name": "rightwards hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fe.png"
+  },
+  {
+    "emoji": "🫱🏿",
+    "name": "rightwards hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3ff.png"
+  },
+  {
+    "emoji": "🫲",
+    "name": "leftwards hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf2.png"
+  },
+  {
+    "emoji": "🫲🏻",
+    "name": "leftwards hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf2-1f3fb.png"
+  },
+  {
+    "emoji": "🫲🏼",
+    "name": "leftwards hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf2-1f3fc.png"
+  },
+  {
+    "emoji": "🫲🏽",
+    "name": "leftwards hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf2-1f3fd.png"
+  },
+  {
+    "emoji": "🫲🏾",
+    "name": "leftwards hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf2-1f3fe.png"
+  },
+  {
+    "emoji": "🫲🏿",
+    "name": "leftwards hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf2-1f3ff.png"
+  },
+  {
+    "emoji": "🫳",
+    "name": "palm down hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf3.png"
+  },
+  {
+    "emoji": "🫳🏻",
+    "name": "palm down hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf3-1f3fb.png"
+  },
+  {
+    "emoji": "🫳🏼",
+    "name": "palm down hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf3-1f3fc.png"
+  },
+  {
+    "emoji": "🫳🏽",
+    "name": "palm down hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf3-1f3fd.png"
+  },
+  {
+    "emoji": "🫳🏾",
+    "name": "palm down hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf3-1f3fe.png"
+  },
+  {
+    "emoji": "🫳🏿",
+    "name": "palm down hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf3-1f3ff.png"
+  },
+  {
+    "emoji": "🫴",
+    "name": "palm up hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf4.png"
+  },
+  {
+    "emoji": "🫴🏻",
+    "name": "palm up hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf4-1f3fb.png"
+  },
+  {
+    "emoji": "🫴🏼",
+    "name": "palm up hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf4-1f3fc.png"
+  },
+  {
+    "emoji": "🫴🏽",
+    "name": "palm up hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf4-1f3fd.png"
+  },
+  {
+    "emoji": "🫴🏾",
+    "name": "palm up hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf4-1f3fe.png"
+  },
+  {
+    "emoji": "🫴🏿",
+    "name": "palm up hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf4-1f3ff.png"
+  },
+  {
+    "emoji": "🫷",
+    "name": "leftwards pushing hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf7.png"
+  },
+  {
+    "emoji": "🫷🏻",
+    "name": "leftwards pushing hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf7-1f3fb.png"
+  },
+  {
+    "emoji": "🫷🏼",
+    "name": "leftwards pushing hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf7-1f3fc.png"
+  },
+  {
+    "emoji": "🫷🏽",
+    "name": "leftwards pushing hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf7-1f3fd.png"
+  },
+  {
+    "emoji": "🫷🏾",
+    "name": "leftwards pushing hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf7-1f3fe.png"
+  },
+  {
+    "emoji": "🫷🏿",
+    "name": "leftwards pushing hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf7-1f3ff.png"
+  },
+  {
+    "emoji": "🫸",
+    "name": "rightwards pushing hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf8.png"
+  },
+  {
+    "emoji": "🫸🏻",
+    "name": "rightwards pushing hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf8-1f3fb.png"
+  },
+  {
+    "emoji": "🫸🏼",
+    "name": "rightwards pushing hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf8-1f3fc.png"
+  },
+  {
+    "emoji": "🫸🏽",
+    "name": "rightwards pushing hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf8-1f3fd.png"
+  },
+  {
+    "emoji": "🫸🏾",
+    "name": "rightwards pushing hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf8-1f3fe.png"
+  },
+  {
+    "emoji": "🫸🏿",
+    "name": "rightwards pushing hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf8-1f3ff.png"
+  },
+  {
+    "emoji": "👌",
+    "name": "OK hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44c.png"
+  },
+  {
+    "emoji": "👌🏻",
+    "name": "OK hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44c-1f3fb.png"
+  },
+  {
+    "emoji": "👌🏼",
+    "name": "OK hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44c-1f3fc.png"
+  },
+  {
+    "emoji": "👌🏽",
+    "name": "OK hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44c-1f3fd.png"
+  },
+  {
+    "emoji": "👌🏾",
+    "name": "OK hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44c-1f3fe.png"
+  },
+  {
+    "emoji": "👌🏿",
+    "name": "OK hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44c-1f3ff.png"
+  },
+  {
+    "emoji": "🤌",
+    "name": "pinched fingers",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90c.png"
+  },
+  {
+    "emoji": "🤌🏻",
+    "name": "pinched fingers: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90c-1f3fb.png"
+  },
+  {
+    "emoji": "🤌🏼",
+    "name": "pinched fingers: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90c-1f3fc.png"
+  },
+  {
+    "emoji": "🤌🏽",
+    "name": "pinched fingers: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90c-1f3fd.png"
+  },
+  {
+    "emoji": "🤌🏾",
+    "name": "pinched fingers: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90c-1f3fe.png"
+  },
+  {
+    "emoji": "🤌🏿",
+    "name": "pinched fingers: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90c-1f3ff.png"
+  },
+  {
+    "emoji": "🤏",
+    "name": "pinching hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90f.png"
+  },
+  {
+    "emoji": "🤏🏻",
+    "name": "pinching hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90f-1f3fb.png"
+  },
+  {
+    "emoji": "🤏🏼",
+    "name": "pinching hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90f-1f3fc.png"
+  },
+  {
+    "emoji": "🤏🏽",
+    "name": "pinching hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90f-1f3fd.png"
+  },
+  {
+    "emoji": "🤏🏾",
+    "name": "pinching hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90f-1f3fe.png"
+  },
+  {
+    "emoji": "🤏🏿",
+    "name": "pinching hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f90f-1f3ff.png"
+  },
+  {
+    "emoji": "✌️",
+    "name": "victory hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270c-fe0f.png"
+  },
+  {
+    "emoji": "✌🏻",
+    "name": "victory hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270c-1f3fb.png"
+  },
+  {
+    "emoji": "✌🏼",
+    "name": "victory hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270c-1f3fc.png"
+  },
+  {
+    "emoji": "✌🏽",
+    "name": "victory hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270c-1f3fd.png"
+  },
+  {
+    "emoji": "✌🏾",
+    "name": "victory hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270c-1f3fe.png"
+  },
+  {
+    "emoji": "✌🏿",
+    "name": "victory hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270c-1f3ff.png"
+  },
+  {
+    "emoji": "🤞",
+    "name": "crossed fingers",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91e.png"
+  },
+  {
+    "emoji": "🤞🏻",
+    "name": "crossed fingers: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91e-1f3fb.png"
+  },
+  {
+    "emoji": "🤞🏼",
+    "name": "crossed fingers: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91e-1f3fc.png"
+  },
+  {
+    "emoji": "🤞🏽",
+    "name": "crossed fingers: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91e-1f3fd.png"
+  },
+  {
+    "emoji": "🤞🏾",
+    "name": "crossed fingers: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91e-1f3fe.png"
+  },
+  {
+    "emoji": "🤞🏿",
+    "name": "crossed fingers: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91e-1f3ff.png"
+  },
+  {
+    "emoji": "🫰",
+    "name": "hand with index finger and thumb crossed",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf0.png"
+  },
+  {
+    "emoji": "🫰🏻",
+    "name": "hand with index finger and thumb crossed: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf0-1f3fb.png"
+  },
+  {
+    "emoji": "🫰🏼",
+    "name": "hand with index finger and thumb crossed: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf0-1f3fc.png"
+  },
+  {
+    "emoji": "🫰🏽",
+    "name": "hand with index finger and thumb crossed: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf0-1f3fd.png"
+  },
+  {
+    "emoji": "🫰🏾",
+    "name": "hand with index finger and thumb crossed: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf0-1f3fe.png"
+  },
+  {
+    "emoji": "🫰🏿",
+    "name": "hand with index finger and thumb crossed: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf0-1f3ff.png"
+  },
+  {
+    "emoji": "🤟",
+    "name": "love-you gesture",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91f.png"
+  },
+  {
+    "emoji": "🤟🏻",
+    "name": "love-you gesture: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91f-1f3fb.png"
+  },
+  {
+    "emoji": "🤟🏼",
+    "name": "love-you gesture: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91f-1f3fc.png"
+  },
+  {
+    "emoji": "🤟🏽",
+    "name": "love-you gesture: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91f-1f3fd.png"
+  },
+  {
+    "emoji": "🤟🏾",
+    "name": "love-you gesture: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91f-1f3fe.png"
+  },
+  {
+    "emoji": "🤟🏿",
+    "name": "love-you gesture: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91f-1f3ff.png"
+  },
+  {
+    "emoji": "🤘",
+    "name": "sign of the horns",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f918.png"
+  },
+  {
+    "emoji": "🤘🏻",
+    "name": "sign of the horns: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f918-1f3fb.png"
+  },
+  {
+    "emoji": "🤘🏼",
+    "name": "sign of the horns: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f918-1f3fc.png"
+  },
+  {
+    "emoji": "🤘🏽",
+    "name": "sign of the horns: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f918-1f3fd.png"
+  },
+  {
+    "emoji": "🤘🏾",
+    "name": "sign of the horns: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f918-1f3fe.png"
+  },
+  {
+    "emoji": "🤘🏿",
+    "name": "sign of the horns: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f918-1f3ff.png"
+  },
+  {
+    "emoji": "🤙",
+    "name": "call me hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f919.png"
+  },
+  {
+    "emoji": "🤙🏻",
+    "name": "call me hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f919-1f3fb.png"
+  },
+  {
+    "emoji": "🤙🏼",
+    "name": "call me hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f919-1f3fc.png"
+  },
+  {
+    "emoji": "🤙🏽",
+    "name": "call me hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f919-1f3fd.png"
+  },
+  {
+    "emoji": "🤙🏾",
+    "name": "call me hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f919-1f3fe.png"
+  },
+  {
+    "emoji": "🤙🏿",
+    "name": "call me hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f919-1f3ff.png"
+  },
+  {
+    "emoji": "👈",
+    "name": "backhand index pointing left",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f448.png"
+  },
+  {
+    "emoji": "👈🏻",
+    "name": "backhand index pointing left: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f448-1f3fb.png"
+  },
+  {
+    "emoji": "👈🏼",
+    "name": "backhand index pointing left: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f448-1f3fc.png"
+  },
+  {
+    "emoji": "👈🏽",
+    "name": "backhand index pointing left: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f448-1f3fd.png"
+  },
+  {
+    "emoji": "👈🏾",
+    "name": "backhand index pointing left: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f448-1f3fe.png"
+  },
+  {
+    "emoji": "👈🏿",
+    "name": "backhand index pointing left: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f448-1f3ff.png"
+  },
+  {
+    "emoji": "👉",
+    "name": "backhand index pointing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f449.png"
+  },
+  {
+    "emoji": "👉🏻",
+    "name": "backhand index pointing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f449-1f3fb.png"
+  },
+  {
+    "emoji": "👉🏼",
+    "name": "backhand index pointing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f449-1f3fc.png"
+  },
+  {
+    "emoji": "👉🏽",
+    "name": "backhand index pointing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f449-1f3fd.png"
+  },
+  {
+    "emoji": "👉🏾",
+    "name": "backhand index pointing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f449-1f3fe.png"
+  },
+  {
+    "emoji": "👉🏿",
+    "name": "backhand index pointing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f449-1f3ff.png"
+  },
+  {
+    "emoji": "👆",
+    "name": "backhand index pointing up",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f446.png"
+  },
+  {
+    "emoji": "👆🏻",
+    "name": "backhand index pointing up: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f446-1f3fb.png"
+  },
+  {
+    "emoji": "👆🏼",
+    "name": "backhand index pointing up: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f446-1f3fc.png"
+  },
+  {
+    "emoji": "👆🏽",
+    "name": "backhand index pointing up: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f446-1f3fd.png"
+  },
+  {
+    "emoji": "👆🏾",
+    "name": "backhand index pointing up: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f446-1f3fe.png"
+  },
+  {
+    "emoji": "👆🏿",
+    "name": "backhand index pointing up: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f446-1f3ff.png"
+  },
+  {
+    "emoji": "🖕",
+    "name": "middle finger",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f595.png"
+  },
+  {
+    "emoji": "🖕🏻",
+    "name": "middle finger: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f595-1f3fb.png"
+  },
+  {
+    "emoji": "🖕🏼",
+    "name": "middle finger: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f595-1f3fc.png"
+  },
+  {
+    "emoji": "🖕🏽",
+    "name": "middle finger: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f595-1f3fd.png"
+  },
+  {
+    "emoji": "🖕🏾",
+    "name": "middle finger: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f595-1f3fe.png"
+  },
+  {
+    "emoji": "🖕🏿",
+    "name": "middle finger: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f595-1f3ff.png"
+  },
+  {
+    "emoji": "👇",
+    "name": "backhand index pointing down",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f447.png"
+  },
+  {
+    "emoji": "👇🏻",
+    "name": "backhand index pointing down: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f447-1f3fb.png"
+  },
+  {
+    "emoji": "👇🏼",
+    "name": "backhand index pointing down: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f447-1f3fc.png"
+  },
+  {
+    "emoji": "👇🏽",
+    "name": "backhand index pointing down: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f447-1f3fd.png"
+  },
+  {
+    "emoji": "👇🏾",
+    "name": "backhand index pointing down: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f447-1f3fe.png"
+  },
+  {
+    "emoji": "👇🏿",
+    "name": "backhand index pointing down: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f447-1f3ff.png"
+  },
+  {
+    "emoji": "☝️",
+    "name": "index pointing up",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/261d-fe0f.png"
+  },
+  {
+    "emoji": "☝🏻",
+    "name": "index pointing up: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/261d-1f3fb.png"
+  },
+  {
+    "emoji": "☝🏼",
+    "name": "index pointing up: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/261d-1f3fc.png"
+  },
+  {
+    "emoji": "☝🏽",
+    "name": "index pointing up: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/261d-1f3fd.png"
+  },
+  {
+    "emoji": "☝🏾",
+    "name": "index pointing up: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/261d-1f3fe.png"
+  },
+  {
+    "emoji": "☝🏿",
+    "name": "index pointing up: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/261d-1f3ff.png"
+  },
+  {
+    "emoji": "🫵",
+    "name": "index pointing at the viewer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf5.png"
+  },
+  {
+    "emoji": "🫵🏻",
+    "name": "index pointing at the viewer: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf5-1f3fb.png"
+  },
+  {
+    "emoji": "🫵🏼",
+    "name": "index pointing at the viewer: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf5-1f3fc.png"
+  },
+  {
+    "emoji": "🫵🏽",
+    "name": "index pointing at the viewer: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf5-1f3fd.png"
+  },
+  {
+    "emoji": "🫵🏾",
+    "name": "index pointing at the viewer: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf5-1f3fe.png"
+  },
+  {
+    "emoji": "🫵🏿",
+    "name": "index pointing at the viewer: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf5-1f3ff.png"
+  },
+  {
+    "emoji": "👍",
+    "name": "thumbs up",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44d.png"
+  },
+  {
+    "emoji": "👍🏻",
+    "name": "thumbs up: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44d-1f3fb.png"
+  },
+  {
+    "emoji": "👍🏼",
+    "name": "thumbs up: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44d-1f3fc.png"
+  },
+  {
+    "emoji": "👍🏽",
+    "name": "thumbs up: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44d-1f3fd.png"
+  },
+  {
+    "emoji": "👍🏾",
+    "name": "thumbs up: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44d-1f3fe.png"
+  },
+  {
+    "emoji": "👍🏿",
+    "name": "thumbs up: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44d-1f3ff.png"
+  },
+  {
+    "emoji": "👎",
+    "name": "thumbs down",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44e.png"
+  },
+  {
+    "emoji": "👎🏻",
+    "name": "thumbs down: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44e-1f3fb.png"
+  },
+  {
+    "emoji": "👎🏼",
+    "name": "thumbs down: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44e-1f3fc.png"
+  },
+  {
+    "emoji": "👎🏽",
+    "name": "thumbs down: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44e-1f3fd.png"
+  },
+  {
+    "emoji": "👎🏾",
+    "name": "thumbs down: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44e-1f3fe.png"
+  },
+  {
+    "emoji": "👎🏿",
+    "name": "thumbs down: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44e-1f3ff.png"
+  },
+  {
+    "emoji": "✊",
+    "name": "raised fist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270a.png"
+  },
+  {
+    "emoji": "✊🏻",
+    "name": "raised fist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270a-1f3fb.png"
+  },
+  {
+    "emoji": "✊🏼",
+    "name": "raised fist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270a-1f3fc.png"
+  },
+  {
+    "emoji": "✊🏽",
+    "name": "raised fist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270a-1f3fd.png"
+  },
+  {
+    "emoji": "✊🏾",
+    "name": "raised fist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270a-1f3fe.png"
+  },
+  {
+    "emoji": "✊🏿",
+    "name": "raised fist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270a-1f3ff.png"
+  },
+  {
+    "emoji": "👊",
+    "name": "oncoming fist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44a.png"
+  },
+  {
+    "emoji": "👊🏻",
+    "name": "oncoming fist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44a-1f3fb.png"
+  },
+  {
+    "emoji": "👊🏼",
+    "name": "oncoming fist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44a-1f3fc.png"
+  },
+  {
+    "emoji": "👊🏽",
+    "name": "oncoming fist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44a-1f3fd.png"
+  },
+  {
+    "emoji": "👊🏾",
+    "name": "oncoming fist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44a-1f3fe.png"
+  },
+  {
+    "emoji": "👊🏿",
+    "name": "oncoming fist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44a-1f3ff.png"
+  },
+  {
+    "emoji": "🤛",
+    "name": "left-facing fist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91b.png"
+  },
+  {
+    "emoji": "🤛🏻",
+    "name": "left-facing fist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91b-1f3fb.png"
+  },
+  {
+    "emoji": "🤛🏼",
+    "name": "left-facing fist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91b-1f3fc.png"
+  },
+  {
+    "emoji": "🤛🏽",
+    "name": "left-facing fist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91b-1f3fd.png"
+  },
+  {
+    "emoji": "🤛🏾",
+    "name": "left-facing fist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91b-1f3fe.png"
+  },
+  {
+    "emoji": "🤛🏿",
+    "name": "left-facing fist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91b-1f3ff.png"
+  },
+  {
+    "emoji": "🤜",
+    "name": "right-facing fist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91c.png"
+  },
+  {
+    "emoji": "🤜🏻",
+    "name": "right-facing fist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91c-1f3fb.png"
+  },
+  {
+    "emoji": "🤜🏼",
+    "name": "right-facing fist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91c-1f3fc.png"
+  },
+  {
+    "emoji": "🤜🏽",
+    "name": "right-facing fist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91c-1f3fd.png"
+  },
+  {
+    "emoji": "🤜🏾",
+    "name": "right-facing fist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91c-1f3fe.png"
+  },
+  {
+    "emoji": "🤜🏿",
+    "name": "right-facing fist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91c-1f3ff.png"
+  },
+  {
+    "emoji": "👏",
+    "name": "clapping hands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44f.png"
+  },
+  {
+    "emoji": "👏🏻",
+    "name": "clapping hands: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44f-1f3fb.png"
+  },
+  {
+    "emoji": "👏🏼",
+    "name": "clapping hands: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44f-1f3fc.png"
+  },
+  {
+    "emoji": "👏🏽",
+    "name": "clapping hands: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44f-1f3fd.png"
+  },
+  {
+    "emoji": "👏🏾",
+    "name": "clapping hands: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44f-1f3fe.png"
+  },
+  {
+    "emoji": "👏🏿",
+    "name": "clapping hands: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f44f-1f3ff.png"
+  },
+  {
+    "emoji": "🙌",
+    "name": "raising hands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64c.png"
+  },
+  {
+    "emoji": "🙌🏻",
+    "name": "raising hands: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64c-1f3fb.png"
+  },
+  {
+    "emoji": "🙌🏼",
+    "name": "raising hands: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64c-1f3fc.png"
+  },
+  {
+    "emoji": "🙌🏽",
+    "name": "raising hands: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64c-1f3fd.png"
+  },
+  {
+    "emoji": "🙌🏾",
+    "name": "raising hands: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64c-1f3fe.png"
+  },
+  {
+    "emoji": "🙌🏿",
+    "name": "raising hands: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64c-1f3ff.png"
+  },
+  {
+    "emoji": "🫶",
+    "name": "heart hands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf6.png"
+  },
+  {
+    "emoji": "🫶🏻",
+    "name": "heart hands: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf6-1f3fb.png"
+  },
+  {
+    "emoji": "🫶🏼",
+    "name": "heart hands: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf6-1f3fc.png"
+  },
+  {
+    "emoji": "🫶🏽",
+    "name": "heart hands: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf6-1f3fd.png"
+  },
+  {
+    "emoji": "🫶🏾",
+    "name": "heart hands: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf6-1f3fe.png"
+  },
+  {
+    "emoji": "🫶🏿",
+    "name": "heart hands: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf6-1f3ff.png"
+  },
+  {
+    "emoji": "👐",
+    "name": "open hands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f450.png"
+  },
+  {
+    "emoji": "👐🏻",
+    "name": "open hands: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f450-1f3fb.png"
+  },
+  {
+    "emoji": "👐🏼",
+    "name": "open hands: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f450-1f3fc.png"
+  },
+  {
+    "emoji": "👐🏽",
+    "name": "open hands: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f450-1f3fd.png"
+  },
+  {
+    "emoji": "👐🏾",
+    "name": "open hands: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f450-1f3fe.png"
+  },
+  {
+    "emoji": "👐🏿",
+    "name": "open hands: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f450-1f3ff.png"
+  },
+  {
+    "emoji": "🤲",
+    "name": "palms up together",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f932.png"
+  },
+  {
+    "emoji": "🤲🏻",
+    "name": "palms up together: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f932-1f3fb.png"
+  },
+  {
+    "emoji": "🤲🏼",
+    "name": "palms up together: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f932-1f3fc.png"
+  },
+  {
+    "emoji": "🤲🏽",
+    "name": "palms up together: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f932-1f3fd.png"
+  },
+  {
+    "emoji": "🤲🏾",
+    "name": "palms up together: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f932-1f3fe.png"
+  },
+  {
+    "emoji": "🤲🏿",
+    "name": "palms up together: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f932-1f3ff.png"
+  },
+  {
+    "emoji": "🤝",
+    "name": "handshake",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91d.png"
+  },
+  {
+    "emoji": "🤝🏻",
+    "name": "handshake: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91d-1f3fb.png"
+  },
+  {
+    "emoji": "🤝🏼",
+    "name": "handshake: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91d-1f3fc.png"
+  },
+  {
+    "emoji": "🤝🏽",
+    "name": "handshake: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91d-1f3fd.png"
+  },
+  {
+    "emoji": "🤝🏾",
+    "name": "handshake: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91d-1f3fe.png"
+  },
+  {
+    "emoji": "🤝🏿",
+    "name": "handshake: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f91d-1f3ff.png"
+  },
+  {
+    "emoji": "🫱🏻‍🫲🏼",
+    "name": "handshake: light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fb-200d-1faf2-1f3fc.png"
+  },
+  {
+    "emoji": "🫱🏻‍🫲🏽",
+    "name": "handshake: light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fb-200d-1faf2-1f3fd.png"
+  },
+  {
+    "emoji": "🫱🏻‍🫲🏾",
+    "name": "handshake: light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fb-200d-1faf2-1f3fe.png"
+  },
+  {
+    "emoji": "🫱🏻‍🫲🏿",
+    "name": "handshake: light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fb-200d-1faf2-1f3ff.png"
+  },
+  {
+    "emoji": "🫱🏼‍🫲🏻",
+    "name": "handshake: medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fc-200d-1faf2-1f3fb.png"
+  },
+  {
+    "emoji": "🫱🏼‍🫲🏽",
+    "name": "handshake: medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fc-200d-1faf2-1f3fd.png"
+  },
+  {
+    "emoji": "🫱🏼‍🫲🏾",
+    "name": "handshake: medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fc-200d-1faf2-1f3fe.png"
+  },
+  {
+    "emoji": "🫱🏼‍🫲🏿",
+    "name": "handshake: medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fc-200d-1faf2-1f3ff.png"
+  },
+  {
+    "emoji": "🫱🏽‍🫲🏻",
+    "name": "handshake: medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fd-200d-1faf2-1f3fb.png"
+  },
+  {
+    "emoji": "🫱🏽‍🫲🏼",
+    "name": "handshake: medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fd-200d-1faf2-1f3fc.png"
+  },
+  {
+    "emoji": "🫱🏽‍🫲🏾",
+    "name": "handshake: medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fd-200d-1faf2-1f3fe.png"
+  },
+  {
+    "emoji": "🫱🏽‍🫲🏿",
+    "name": "handshake: medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fd-200d-1faf2-1f3ff.png"
+  },
+  {
+    "emoji": "🫱🏾‍🫲🏻",
+    "name": "handshake: medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fe-200d-1faf2-1f3fb.png"
+  },
+  {
+    "emoji": "🫱🏾‍🫲🏼",
+    "name": "handshake: medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fe-200d-1faf2-1f3fc.png"
+  },
+  {
+    "emoji": "🫱🏾‍🫲🏽",
+    "name": "handshake: medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fe-200d-1faf2-1f3fd.png"
+  },
+  {
+    "emoji": "🫱🏾‍🫲🏿",
+    "name": "handshake: medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3fe-200d-1faf2-1f3ff.png"
+  },
+  {
+    "emoji": "🫱🏿‍🫲🏻",
+    "name": "handshake: dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3ff-200d-1faf2-1f3fb.png"
+  },
+  {
+    "emoji": "🫱🏿‍🫲🏼",
+    "name": "handshake: dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3ff-200d-1faf2-1f3fc.png"
+  },
+  {
+    "emoji": "🫱🏿‍🫲🏽",
+    "name": "handshake: dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3ff-200d-1faf2-1f3fd.png"
+  },
+  {
+    "emoji": "🫱🏿‍🫲🏾",
+    "name": "handshake: dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faf1-1f3ff-200d-1faf2-1f3fe.png"
+  },
+  {
+    "emoji": "🙏",
+    "name": "folded hands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64f.png"
+  },
+  {
+    "emoji": "🙏🏻",
+    "name": "folded hands: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64f-1f3fb.png"
+  },
+  {
+    "emoji": "🙏🏼",
+    "name": "folded hands: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64f-1f3fc.png"
+  },
+  {
+    "emoji": "🙏🏽",
+    "name": "folded hands: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64f-1f3fd.png"
+  },
+  {
+    "emoji": "🙏🏾",
+    "name": "folded hands: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64f-1f3fe.png"
+  },
+  {
+    "emoji": "🙏🏿",
+    "name": "folded hands: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64f-1f3ff.png"
+  },
+  {
+    "emoji": "✍️",
+    "name": "writing hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270d-fe0f.png"
+  },
+  {
+    "emoji": "✍🏻",
+    "name": "writing hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270d-1f3fb.png"
+  },
+  {
+    "emoji": "✍🏼",
+    "name": "writing hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270d-1f3fc.png"
+  },
+  {
+    "emoji": "✍🏽",
+    "name": "writing hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270d-1f3fd.png"
+  },
+  {
+    "emoji": "✍🏾",
+    "name": "writing hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270d-1f3fe.png"
+  },
+  {
+    "emoji": "✍🏿",
+    "name": "writing hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270d-1f3ff.png"
+  },
+  {
+    "emoji": "💅",
+    "name": "nail polish",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f485.png"
+  },
+  {
+    "emoji": "💅🏻",
+    "name": "nail polish: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f485-1f3fb.png"
+  },
+  {
+    "emoji": "💅🏼",
+    "name": "nail polish: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f485-1f3fc.png"
+  },
+  {
+    "emoji": "💅🏽",
+    "name": "nail polish: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f485-1f3fd.png"
+  },
+  {
+    "emoji": "💅🏾",
+    "name": "nail polish: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f485-1f3fe.png"
+  },
+  {
+    "emoji": "💅🏿",
+    "name": "nail polish: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f485-1f3ff.png"
+  },
+  {
+    "emoji": "🤳",
+    "name": "selfie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f933.png"
+  },
+  {
+    "emoji": "🤳🏻",
+    "name": "selfie: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f933-1f3fb.png"
+  },
+  {
+    "emoji": "🤳🏼",
+    "name": "selfie: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f933-1f3fc.png"
+  },
+  {
+    "emoji": "🤳🏽",
+    "name": "selfie: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f933-1f3fd.png"
+  },
+  {
+    "emoji": "🤳🏾",
+    "name": "selfie: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f933-1f3fe.png"
+  },
+  {
+    "emoji": "🤳🏿",
+    "name": "selfie: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f933-1f3ff.png"
+  },
+  {
+    "emoji": "💪",
+    "name": "flexed biceps",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4aa.png"
+  },
+  {
+    "emoji": "💪🏻",
+    "name": "flexed biceps: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4aa-1f3fb.png"
+  },
+  {
+    "emoji": "💪🏼",
+    "name": "flexed biceps: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4aa-1f3fc.png"
+  },
+  {
+    "emoji": "💪🏽",
+    "name": "flexed biceps: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4aa-1f3fd.png"
+  },
+  {
+    "emoji": "💪🏾",
+    "name": "flexed biceps: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4aa-1f3fe.png"
+  },
+  {
+    "emoji": "💪🏿",
+    "name": "flexed biceps: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4aa-1f3ff.png"
+  },
+  {
+    "emoji": "🦾",
+    "name": "mechanical arm",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9be.png"
+  },
+  {
+    "emoji": "🦿",
+    "name": "mechanical leg",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9bf.png"
+  },
+  {
+    "emoji": "🦵",
+    "name": "leg",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b5.png"
+  },
+  {
+    "emoji": "🦵🏻",
+    "name": "leg: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b5-1f3fb.png"
+  },
+  {
+    "emoji": "🦵🏼",
+    "name": "leg: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b5-1f3fc.png"
+  },
+  {
+    "emoji": "🦵🏽",
+    "name": "leg: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b5-1f3fd.png"
+  },
+  {
+    "emoji": "🦵🏾",
+    "name": "leg: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b5-1f3fe.png"
+  },
+  {
+    "emoji": "🦵🏿",
+    "name": "leg: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b5-1f3ff.png"
+  },
+  {
+    "emoji": "🦶",
+    "name": "foot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b6.png"
+  },
+  {
+    "emoji": "🦶🏻",
+    "name": "foot: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b6-1f3fb.png"
+  },
+  {
+    "emoji": "🦶🏼",
+    "name": "foot: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b6-1f3fc.png"
+  },
+  {
+    "emoji": "🦶🏽",
+    "name": "foot: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b6-1f3fd.png"
+  },
+  {
+    "emoji": "🦶🏾",
+    "name": "foot: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b6-1f3fe.png"
+  },
+  {
+    "emoji": "🦶🏿",
+    "name": "foot: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b6-1f3ff.png"
+  },
+  {
+    "emoji": "👂",
+    "name": "ear",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f442.png"
+  },
+  {
+    "emoji": "👂🏻",
+    "name": "ear: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f442-1f3fb.png"
+  },
+  {
+    "emoji": "👂🏼",
+    "name": "ear: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f442-1f3fc.png"
+  },
+  {
+    "emoji": "👂🏽",
+    "name": "ear: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f442-1f3fd.png"
+  },
+  {
+    "emoji": "👂🏾",
+    "name": "ear: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f442-1f3fe.png"
+  },
+  {
+    "emoji": "👂🏿",
+    "name": "ear: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f442-1f3ff.png"
+  },
+  {
+    "emoji": "🦻",
+    "name": "ear with hearing aid",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9bb.png"
+  },
+  {
+    "emoji": "🦻🏻",
+    "name": "ear with hearing aid: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9bb-1f3fb.png"
+  },
+  {
+    "emoji": "🦻🏼",
+    "name": "ear with hearing aid: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9bb-1f3fc.png"
+  },
+  {
+    "emoji": "🦻🏽",
+    "name": "ear with hearing aid: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9bb-1f3fd.png"
+  },
+  {
+    "emoji": "🦻🏾",
+    "name": "ear with hearing aid: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9bb-1f3fe.png"
+  },
+  {
+    "emoji": "🦻🏿",
+    "name": "ear with hearing aid: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9bb-1f3ff.png"
+  },
+  {
+    "emoji": "👃",
+    "name": "nose",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f443.png"
+  },
+  {
+    "emoji": "👃🏻",
+    "name": "nose: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f443-1f3fb.png"
+  },
+  {
+    "emoji": "👃🏼",
+    "name": "nose: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f443-1f3fc.png"
+  },
+  {
+    "emoji": "👃🏽",
+    "name": "nose: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f443-1f3fd.png"
+  },
+  {
+    "emoji": "👃🏾",
+    "name": "nose: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f443-1f3fe.png"
+  },
+  {
+    "emoji": "👃🏿",
+    "name": "nose: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f443-1f3ff.png"
+  },
+  {
+    "emoji": "🧠",
+    "name": "brain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9e0.png"
+  },
+  {
+    "emoji": "🫀",
+    "name": "anatomical heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac0.png"
+  },
+  {
+    "emoji": "🫁",
+    "name": "lungs",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac1.png"
+  },
+  {
+    "emoji": "🦷",
+    "name": "tooth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b7.png"
+  },
+  {
+    "emoji": "🦴",
+    "name": "bone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b4.png"
+  },
+  {
+    "emoji": "👀",
+    "name": "eyes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f440.png"
+  },
+  {
+    "emoji": "👁️",
+    "name": "eye",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f441-fe0f.png"
+  },
+  {
+    "emoji": "👅",
+    "name": "tongue",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f445.png"
+  },
+  {
+    "emoji": "👄",
+    "name": "mouth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f444.png"
+  },
+  {
+    "emoji": "🫦",
+    "name": "biting lip",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fae6.png"
+  },
+  {
+    "emoji": "👶",
+    "name": "baby",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f476.png"
+  },
+  {
+    "emoji": "👶🏻",
+    "name": "baby: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f476-1f3fb.png"
+  },
+  {
+    "emoji": "👶🏼",
+    "name": "baby: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f476-1f3fc.png"
+  },
+  {
+    "emoji": "👶🏽",
+    "name": "baby: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f476-1f3fd.png"
+  },
+  {
+    "emoji": "👶🏾",
+    "name": "baby: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f476-1f3fe.png"
+  },
+  {
+    "emoji": "👶🏿",
+    "name": "baby: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f476-1f3ff.png"
+  },
+  {
+    "emoji": "🧒",
+    "name": "child",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d2.png"
+  },
+  {
+    "emoji": "🧒🏻",
+    "name": "child: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d2-1f3fb.png"
+  },
+  {
+    "emoji": "🧒🏼",
+    "name": "child: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d2-1f3fc.png"
+  },
+  {
+    "emoji": "🧒🏽",
+    "name": "child: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d2-1f3fd.png"
+  },
+  {
+    "emoji": "🧒🏾",
+    "name": "child: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d2-1f3fe.png"
+  },
+  {
+    "emoji": "🧒🏿",
+    "name": "child: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d2-1f3ff.png"
+  },
+  {
+    "emoji": "👦",
+    "name": "boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f466.png"
+  },
+  {
+    "emoji": "👦🏻",
+    "name": "boy: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f466-1f3fb.png"
+  },
+  {
+    "emoji": "👦🏼",
+    "name": "boy: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f466-1f3fc.png"
+  },
+  {
+    "emoji": "👦🏽",
+    "name": "boy: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f466-1f3fd.png"
+  },
+  {
+    "emoji": "👦🏾",
+    "name": "boy: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f466-1f3fe.png"
+  },
+  {
+    "emoji": "👦🏿",
+    "name": "boy: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f466-1f3ff.png"
+  },
+  {
+    "emoji": "👧",
+    "name": "girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f467.png"
+  },
+  {
+    "emoji": "👧🏻",
+    "name": "girl: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f467-1f3fb.png"
+  },
+  {
+    "emoji": "👧🏼",
+    "name": "girl: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f467-1f3fc.png"
+  },
+  {
+    "emoji": "👧🏽",
+    "name": "girl: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f467-1f3fd.png"
+  },
+  {
+    "emoji": "👧🏾",
+    "name": "girl: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f467-1f3fe.png"
+  },
+  {
+    "emoji": "👧🏿",
+    "name": "girl: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f467-1f3ff.png"
+  },
+  {
+    "emoji": "🧑",
+    "name": "person",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1.png"
+  },
+  {
+    "emoji": "🧑🏻",
+    "name": "person: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏼",
+    "name": "person: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏽",
+    "name": "person: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏾",
+    "name": "person: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏿",
+    "name": "person: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "👱",
+    "name": "person: blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471.png"
+  },
+  {
+    "emoji": "👱🏻",
+    "name": "person: light skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fb.png"
+  },
+  {
+    "emoji": "👱🏼",
+    "name": "person: medium-light skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fc.png"
+  },
+  {
+    "emoji": "👱🏽",
+    "name": "person: medium skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fd.png"
+  },
+  {
+    "emoji": "👱🏾",
+    "name": "person: medium-dark skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fe.png"
+  },
+  {
+    "emoji": "👱🏿",
+    "name": "person: dark skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3ff.png"
+  },
+  {
+    "emoji": "👨",
+    "name": "man",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468.png"
+  },
+  {
+    "emoji": "👨🏻",
+    "name": "man: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏼",
+    "name": "man: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏽",
+    "name": "man: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏾",
+    "name": "man: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏿",
+    "name": "man: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff.png"
+  },
+  {
+    "emoji": "🧔",
+    "name": "person: beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4.png"
+  },
+  {
+    "emoji": "🧔🏻",
+    "name": "person: light skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fb.png"
+  },
+  {
+    "emoji": "🧔🏼",
+    "name": "person: medium-light skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fc.png"
+  },
+  {
+    "emoji": "🧔🏽",
+    "name": "person: medium skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fd.png"
+  },
+  {
+    "emoji": "🧔🏾",
+    "name": "person: medium-dark skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fe.png"
+  },
+  {
+    "emoji": "🧔🏿",
+    "name": "person: dark skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3ff.png"
+  },
+  {
+    "emoji": "🧔‍♂️",
+    "name": "man: beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧔🏻‍♂️",
+    "name": "man: light skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧔🏼‍♂️",
+    "name": "man: medium-light skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧔🏽‍♂️",
+    "name": "man: medium skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧔🏾‍♂️",
+    "name": "man: medium-dark skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧔🏿‍♂️",
+    "name": "man: dark skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧔‍♀️",
+    "name": "woman: beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧔🏻‍♀️",
+    "name": "woman: light skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧔🏼‍♀️",
+    "name": "woman: medium-light skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧔🏽‍♀️",
+    "name": "woman: medium skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧔🏾‍♀️",
+    "name": "woman: medium-dark skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧔🏿‍♀️",
+    "name": "woman: dark skin tone, beard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d4-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👨‍🦰",
+    "name": "man: red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👨🏻‍🦰",
+    "name": "man: light skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👨🏼‍🦰",
+    "name": "man: medium-light skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👨🏽‍🦰",
+    "name": "man: medium skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👨🏾‍🦰",
+    "name": "man: medium-dark skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👨🏿‍🦰",
+    "name": "man: dark skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👨‍🦱",
+    "name": "man: curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👨🏻‍🦱",
+    "name": "man: light skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👨🏼‍🦱",
+    "name": "man: medium-light skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👨🏽‍🦱",
+    "name": "man: medium skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👨🏾‍🦱",
+    "name": "man: medium-dark skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👨🏿‍🦱",
+    "name": "man: dark skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👨‍🦳",
+    "name": "man: white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👨🏻‍🦳",
+    "name": "man: light skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👨🏼‍🦳",
+    "name": "man: medium-light skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👨🏽‍🦳",
+    "name": "man: medium skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👨🏾‍🦳",
+    "name": "man: medium-dark skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👨🏿‍🦳",
+    "name": "man: dark skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👨‍🦲",
+    "name": "man: bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👨🏻‍🦲",
+    "name": "man: light skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👨🏼‍🦲",
+    "name": "man: medium-light skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👨🏽‍🦲",
+    "name": "man: medium skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👨🏾‍🦲",
+    "name": "man: medium-dark skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👨🏿‍🦲",
+    "name": "man: dark skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👩",
+    "name": "woman",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469.png"
+  },
+  {
+    "emoji": "👩🏻",
+    "name": "woman: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏼",
+    "name": "woman: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏽",
+    "name": "woman: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏾",
+    "name": "woman: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏿",
+    "name": "woman: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩‍🦰",
+    "name": "woman: red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👩🏻‍🦰",
+    "name": "woman: light skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👩🏼‍🦰",
+    "name": "woman: medium-light skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👩🏽‍🦰",
+    "name": "woman: medium skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👩🏾‍🦰",
+    "name": "woman: medium-dark skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👩🏿‍🦰",
+    "name": "woman: dark skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f9b0.png"
+  },
+  {
+    "emoji": "🧑‍🦰",
+    "name": "person: red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9b0.png"
+  },
+  {
+    "emoji": "🧑🏻‍🦰",
+    "name": "person: light skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f9b0.png"
+  },
+  {
+    "emoji": "🧑🏼‍🦰",
+    "name": "person: medium-light skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f9b0.png"
+  },
+  {
+    "emoji": "🧑🏽‍🦰",
+    "name": "person: medium skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f9b0.png"
+  },
+  {
+    "emoji": "🧑🏾‍🦰",
+    "name": "person: medium-dark skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f9b0.png"
+  },
+  {
+    "emoji": "🧑🏿‍🦰",
+    "name": "person: dark skin tone, red hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f9b0.png"
+  },
+  {
+    "emoji": "👩‍🦱",
+    "name": "woman: curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👩🏻‍🦱",
+    "name": "woman: light skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👩🏼‍🦱",
+    "name": "woman: medium-light skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👩🏽‍🦱",
+    "name": "woman: medium skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👩🏾‍🦱",
+    "name": "woman: medium-dark skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👩🏿‍🦱",
+    "name": "woman: dark skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f9b1.png"
+  },
+  {
+    "emoji": "🧑‍🦱",
+    "name": "person: curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9b1.png"
+  },
+  {
+    "emoji": "🧑🏻‍🦱",
+    "name": "person: light skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f9b1.png"
+  },
+  {
+    "emoji": "🧑🏼‍🦱",
+    "name": "person: medium-light skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f9b1.png"
+  },
+  {
+    "emoji": "🧑🏽‍🦱",
+    "name": "person: medium skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f9b1.png"
+  },
+  {
+    "emoji": "🧑🏾‍🦱",
+    "name": "person: medium-dark skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f9b1.png"
+  },
+  {
+    "emoji": "🧑🏿‍🦱",
+    "name": "person: dark skin tone, curly hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f9b1.png"
+  },
+  {
+    "emoji": "👩‍🦳",
+    "name": "woman: white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👩🏻‍🦳",
+    "name": "woman: light skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👩🏼‍🦳",
+    "name": "woman: medium-light skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👩🏽‍🦳",
+    "name": "woman: medium skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👩🏾‍🦳",
+    "name": "woman: medium-dark skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👩🏿‍🦳",
+    "name": "woman: dark skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f9b3.png"
+  },
+  {
+    "emoji": "🧑‍🦳",
+    "name": "person: white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9b3.png"
+  },
+  {
+    "emoji": "🧑🏻‍🦳",
+    "name": "person: light skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f9b3.png"
+  },
+  {
+    "emoji": "🧑🏼‍🦳",
+    "name": "person: medium-light skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f9b3.png"
+  },
+  {
+    "emoji": "🧑🏽‍🦳",
+    "name": "person: medium skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f9b3.png"
+  },
+  {
+    "emoji": "🧑🏾‍🦳",
+    "name": "person: medium-dark skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f9b3.png"
+  },
+  {
+    "emoji": "🧑🏿‍🦳",
+    "name": "person: dark skin tone, white hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f9b3.png"
+  },
+  {
+    "emoji": "👩‍🦲",
+    "name": "woman: bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👩🏻‍🦲",
+    "name": "woman: light skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👩🏼‍🦲",
+    "name": "woman: medium-light skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👩🏽‍🦲",
+    "name": "woman: medium skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👩🏾‍🦲",
+    "name": "woman: medium-dark skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👩🏿‍🦲",
+    "name": "woman: dark skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f9b2.png"
+  },
+  {
+    "emoji": "🧑‍🦲",
+    "name": "person: bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9b2.png"
+  },
+  {
+    "emoji": "🧑🏻‍🦲",
+    "name": "person: light skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f9b2.png"
+  },
+  {
+    "emoji": "🧑🏼‍🦲",
+    "name": "person: medium-light skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f9b2.png"
+  },
+  {
+    "emoji": "🧑🏽‍🦲",
+    "name": "person: medium skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f9b2.png"
+  },
+  {
+    "emoji": "🧑🏾‍🦲",
+    "name": "person: medium-dark skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f9b2.png"
+  },
+  {
+    "emoji": "🧑🏿‍🦲",
+    "name": "person: dark skin tone, bald",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f9b2.png"
+  },
+  {
+    "emoji": "👱‍♀️",
+    "name": "woman: blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👱🏻‍♀️",
+    "name": "woman: light skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👱🏼‍♀️",
+    "name": "woman: medium-light skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👱🏽‍♀️",
+    "name": "woman: medium skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👱🏾‍♀️",
+    "name": "woman: medium-dark skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👱🏿‍♀️",
+    "name": "woman: dark skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👱‍♂️",
+    "name": "man: blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👱🏻‍♂️",
+    "name": "man: light skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👱🏼‍♂️",
+    "name": "man: medium-light skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👱🏽‍♂️",
+    "name": "man: medium skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👱🏾‍♂️",
+    "name": "man: medium-dark skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👱🏿‍♂️",
+    "name": "man: dark skin tone, blond hair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f471-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧓",
+    "name": "older person",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d3.png"
+  },
+  {
+    "emoji": "🧓🏻",
+    "name": "older person: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d3-1f3fb.png"
+  },
+  {
+    "emoji": "🧓🏼",
+    "name": "older person: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d3-1f3fc.png"
+  },
+  {
+    "emoji": "🧓🏽",
+    "name": "older person: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d3-1f3fd.png"
+  },
+  {
+    "emoji": "🧓🏾",
+    "name": "older person: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d3-1f3fe.png"
+  },
+  {
+    "emoji": "🧓🏿",
+    "name": "older person: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d3-1f3ff.png"
+  },
+  {
+    "emoji": "👴",
+    "name": "old man",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f474.png"
+  },
+  {
+    "emoji": "👴🏻",
+    "name": "old man: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f474-1f3fb.png"
+  },
+  {
+    "emoji": "👴🏼",
+    "name": "old man: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f474-1f3fc.png"
+  },
+  {
+    "emoji": "👴🏽",
+    "name": "old man: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f474-1f3fd.png"
+  },
+  {
+    "emoji": "👴🏾",
+    "name": "old man: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f474-1f3fe.png"
+  },
+  {
+    "emoji": "👴🏿",
+    "name": "old man: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f474-1f3ff.png"
+  },
+  {
+    "emoji": "👵",
+    "name": "old woman",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f475.png"
+  },
+  {
+    "emoji": "👵🏻",
+    "name": "old woman: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f475-1f3fb.png"
+  },
+  {
+    "emoji": "👵🏼",
+    "name": "old woman: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f475-1f3fc.png"
+  },
+  {
+    "emoji": "👵🏽",
+    "name": "old woman: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f475-1f3fd.png"
+  },
+  {
+    "emoji": "👵🏾",
+    "name": "old woman: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f475-1f3fe.png"
+  },
+  {
+    "emoji": "👵🏿",
+    "name": "old woman: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f475-1f3ff.png"
+  },
+  {
+    "emoji": "🙍",
+    "name": "person frowning",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d.png"
+  },
+  {
+    "emoji": "🙍🏻",
+    "name": "person frowning: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fb.png"
+  },
+  {
+    "emoji": "🙍🏼",
+    "name": "person frowning: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fc.png"
+  },
+  {
+    "emoji": "🙍🏽",
+    "name": "person frowning: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fd.png"
+  },
+  {
+    "emoji": "🙍🏾",
+    "name": "person frowning: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fe.png"
+  },
+  {
+    "emoji": "🙍🏿",
+    "name": "person frowning: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3ff.png"
+  },
+  {
+    "emoji": "🙍‍♂️",
+    "name": "man frowning",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙍🏻‍♂️",
+    "name": "man frowning: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙍🏼‍♂️",
+    "name": "man frowning: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙍🏽‍♂️",
+    "name": "man frowning: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙍🏾‍♂️",
+    "name": "man frowning: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙍🏿‍♂️",
+    "name": "man frowning: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙍‍♀️",
+    "name": "woman frowning",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙍🏻‍♀️",
+    "name": "woman frowning: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙍🏼‍♀️",
+    "name": "woman frowning: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙍🏽‍♀️",
+    "name": "woman frowning: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙍🏾‍♀️",
+    "name": "woman frowning: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙍🏿‍♀️",
+    "name": "woman frowning: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64d-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙎",
+    "name": "person pouting",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e.png"
+  },
+  {
+    "emoji": "🙎🏻",
+    "name": "person pouting: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fb.png"
+  },
+  {
+    "emoji": "🙎🏼",
+    "name": "person pouting: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fc.png"
+  },
+  {
+    "emoji": "🙎🏽",
+    "name": "person pouting: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fd.png"
+  },
+  {
+    "emoji": "🙎🏾",
+    "name": "person pouting: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fe.png"
+  },
+  {
+    "emoji": "🙎🏿",
+    "name": "person pouting: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3ff.png"
+  },
+  {
+    "emoji": "🙎‍♂️",
+    "name": "man pouting",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙎🏻‍♂️",
+    "name": "man pouting: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙎🏼‍♂️",
+    "name": "man pouting: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙎🏽‍♂️",
+    "name": "man pouting: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙎🏾‍♂️",
+    "name": "man pouting: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙎🏿‍♂️",
+    "name": "man pouting: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙎‍♀️",
+    "name": "woman pouting",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙎🏻‍♀️",
+    "name": "woman pouting: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙎🏼‍♀️",
+    "name": "woman pouting: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙎🏽‍♀️",
+    "name": "woman pouting: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙎🏾‍♀️",
+    "name": "woman pouting: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙎🏿‍♀️",
+    "name": "woman pouting: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64e-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙅",
+    "name": "person gesturing NO",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645.png"
+  },
+  {
+    "emoji": "🙅🏻",
+    "name": "person gesturing NO: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fb.png"
+  },
+  {
+    "emoji": "🙅🏼",
+    "name": "person gesturing NO: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fc.png"
+  },
+  {
+    "emoji": "🙅🏽",
+    "name": "person gesturing NO: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fd.png"
+  },
+  {
+    "emoji": "🙅🏾",
+    "name": "person gesturing NO: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fe.png"
+  },
+  {
+    "emoji": "🙅🏿",
+    "name": "person gesturing NO: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3ff.png"
+  },
+  {
+    "emoji": "🙅‍♂️",
+    "name": "man gesturing NO",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙅🏻‍♂️",
+    "name": "man gesturing NO: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙅🏼‍♂️",
+    "name": "man gesturing NO: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙅🏽‍♂️",
+    "name": "man gesturing NO: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙅🏾‍♂️",
+    "name": "man gesturing NO: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙅🏿‍♂️",
+    "name": "man gesturing NO: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙅‍♀️",
+    "name": "woman gesturing NO",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙅🏻‍♀️",
+    "name": "woman gesturing NO: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙅🏼‍♀️",
+    "name": "woman gesturing NO: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙅🏽‍♀️",
+    "name": "woman gesturing NO: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙅🏾‍♀️",
+    "name": "woman gesturing NO: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙅🏿‍♀️",
+    "name": "woman gesturing NO: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f645-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙆",
+    "name": "person gesturing OK",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646.png"
+  },
+  {
+    "emoji": "🙆🏻",
+    "name": "person gesturing OK: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fb.png"
+  },
+  {
+    "emoji": "🙆🏼",
+    "name": "person gesturing OK: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fc.png"
+  },
+  {
+    "emoji": "🙆🏽",
+    "name": "person gesturing OK: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fd.png"
+  },
+  {
+    "emoji": "🙆🏾",
+    "name": "person gesturing OK: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fe.png"
+  },
+  {
+    "emoji": "🙆🏿",
+    "name": "person gesturing OK: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3ff.png"
+  },
+  {
+    "emoji": "🙆‍♂️",
+    "name": "man gesturing OK",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙆🏻‍♂️",
+    "name": "man gesturing OK: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙆🏼‍♂️",
+    "name": "man gesturing OK: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙆🏽‍♂️",
+    "name": "man gesturing OK: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙆🏾‍♂️",
+    "name": "man gesturing OK: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙆🏿‍♂️",
+    "name": "man gesturing OK: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙆‍♀️",
+    "name": "woman gesturing OK",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙆🏻‍♀️",
+    "name": "woman gesturing OK: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙆🏼‍♀️",
+    "name": "woman gesturing OK: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙆🏽‍♀️",
+    "name": "woman gesturing OK: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙆🏾‍♀️",
+    "name": "woman gesturing OK: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙆🏿‍♀️",
+    "name": "woman gesturing OK: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f646-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💁",
+    "name": "person tipping hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481.png"
+  },
+  {
+    "emoji": "💁🏻",
+    "name": "person tipping hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fb.png"
+  },
+  {
+    "emoji": "💁🏼",
+    "name": "person tipping hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fc.png"
+  },
+  {
+    "emoji": "💁🏽",
+    "name": "person tipping hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fd.png"
+  },
+  {
+    "emoji": "💁🏾",
+    "name": "person tipping hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fe.png"
+  },
+  {
+    "emoji": "💁🏿",
+    "name": "person tipping hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3ff.png"
+  },
+  {
+    "emoji": "💁‍♂️",
+    "name": "man tipping hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💁🏻‍♂️",
+    "name": "man tipping hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💁🏼‍♂️",
+    "name": "man tipping hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💁🏽‍♂️",
+    "name": "man tipping hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💁🏾‍♂️",
+    "name": "man tipping hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💁🏿‍♂️",
+    "name": "man tipping hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💁‍♀️",
+    "name": "woman tipping hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💁🏻‍♀️",
+    "name": "woman tipping hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💁🏼‍♀️",
+    "name": "woman tipping hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💁🏽‍♀️",
+    "name": "woman tipping hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💁🏾‍♀️",
+    "name": "woman tipping hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💁🏿‍♀️",
+    "name": "woman tipping hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f481-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙋",
+    "name": "person raising hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b.png"
+  },
+  {
+    "emoji": "🙋🏻",
+    "name": "person raising hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fb.png"
+  },
+  {
+    "emoji": "🙋🏼",
+    "name": "person raising hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fc.png"
+  },
+  {
+    "emoji": "🙋🏽",
+    "name": "person raising hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fd.png"
+  },
+  {
+    "emoji": "🙋🏾",
+    "name": "person raising hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fe.png"
+  },
+  {
+    "emoji": "🙋🏿",
+    "name": "person raising hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3ff.png"
+  },
+  {
+    "emoji": "🙋‍♂️",
+    "name": "man raising hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙋🏻‍♂️",
+    "name": "man raising hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙋🏼‍♂️",
+    "name": "man raising hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙋🏽‍♂️",
+    "name": "man raising hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙋🏾‍♂️",
+    "name": "man raising hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙋🏿‍♂️",
+    "name": "man raising hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙋‍♀️",
+    "name": "woman raising hand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙋🏻‍♀️",
+    "name": "woman raising hand: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙋🏼‍♀️",
+    "name": "woman raising hand: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙋🏽‍♀️",
+    "name": "woman raising hand: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙋🏾‍♀️",
+    "name": "woman raising hand: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙋🏿‍♀️",
+    "name": "woman raising hand: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f64b-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧏",
+    "name": "deaf person",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf.png"
+  },
+  {
+    "emoji": "🧏🏻",
+    "name": "deaf person: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fb.png"
+  },
+  {
+    "emoji": "🧏🏼",
+    "name": "deaf person: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fc.png"
+  },
+  {
+    "emoji": "🧏🏽",
+    "name": "deaf person: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fd.png"
+  },
+  {
+    "emoji": "🧏🏾",
+    "name": "deaf person: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fe.png"
+  },
+  {
+    "emoji": "🧏🏿",
+    "name": "deaf person: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3ff.png"
+  },
+  {
+    "emoji": "🧏‍♂️",
+    "name": "deaf man",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧏🏻‍♂️",
+    "name": "deaf man: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧏🏼‍♂️",
+    "name": "deaf man: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧏🏽‍♂️",
+    "name": "deaf man: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧏🏾‍♂️",
+    "name": "deaf man: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧏🏿‍♂️",
+    "name": "deaf man: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧏‍♀️",
+    "name": "deaf woman",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧏🏻‍♀️",
+    "name": "deaf woman: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧏🏼‍♀️",
+    "name": "deaf woman: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧏🏽‍♀️",
+    "name": "deaf woman: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧏🏾‍♀️",
+    "name": "deaf woman: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧏🏿‍♀️",
+    "name": "deaf woman: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cf-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙇",
+    "name": "person bowing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647.png"
+  },
+  {
+    "emoji": "🙇🏻",
+    "name": "person bowing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fb.png"
+  },
+  {
+    "emoji": "🙇🏼",
+    "name": "person bowing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fc.png"
+  },
+  {
+    "emoji": "🙇🏽",
+    "name": "person bowing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fd.png"
+  },
+  {
+    "emoji": "🙇🏾",
+    "name": "person bowing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fe.png"
+  },
+  {
+    "emoji": "🙇🏿",
+    "name": "person bowing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3ff.png"
+  },
+  {
+    "emoji": "🙇‍♂️",
+    "name": "man bowing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙇🏻‍♂️",
+    "name": "man bowing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙇🏼‍♂️",
+    "name": "man bowing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙇🏽‍♂️",
+    "name": "man bowing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙇🏾‍♂️",
+    "name": "man bowing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙇🏿‍♂️",
+    "name": "man bowing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🙇‍♀️",
+    "name": "woman bowing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙇🏻‍♀️",
+    "name": "woman bowing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙇🏼‍♀️",
+    "name": "woman bowing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙇🏽‍♀️",
+    "name": "woman bowing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙇🏾‍♀️",
+    "name": "woman bowing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🙇🏿‍♀️",
+    "name": "woman bowing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f647-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤦",
+    "name": "person facepalming",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926.png"
+  },
+  {
+    "emoji": "🤦🏻",
+    "name": "person facepalming: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fb.png"
+  },
+  {
+    "emoji": "🤦🏼",
+    "name": "person facepalming: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fc.png"
+  },
+  {
+    "emoji": "🤦🏽",
+    "name": "person facepalming: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fd.png"
+  },
+  {
+    "emoji": "🤦🏾",
+    "name": "person facepalming: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fe.png"
+  },
+  {
+    "emoji": "🤦🏿",
+    "name": "person facepalming: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3ff.png"
+  },
+  {
+    "emoji": "🤦‍♂️",
+    "name": "man facepalming",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤦🏻‍♂️",
+    "name": "man facepalming: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤦🏼‍♂️",
+    "name": "man facepalming: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤦🏽‍♂️",
+    "name": "man facepalming: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤦🏾‍♂️",
+    "name": "man facepalming: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤦🏿‍♂️",
+    "name": "man facepalming: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤦‍♀️",
+    "name": "woman facepalming",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤦🏻‍♀️",
+    "name": "woman facepalming: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤦🏼‍♀️",
+    "name": "woman facepalming: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤦🏽‍♀️",
+    "name": "woman facepalming: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤦🏾‍♀️",
+    "name": "woman facepalming: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤦🏿‍♀️",
+    "name": "woman facepalming: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f926-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤷",
+    "name": "person shrugging",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937.png"
+  },
+  {
+    "emoji": "🤷🏻",
+    "name": "person shrugging: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fb.png"
+  },
+  {
+    "emoji": "🤷🏼",
+    "name": "person shrugging: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fc.png"
+  },
+  {
+    "emoji": "🤷🏽",
+    "name": "person shrugging: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fd.png"
+  },
+  {
+    "emoji": "🤷🏾",
+    "name": "person shrugging: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fe.png"
+  },
+  {
+    "emoji": "🤷🏿",
+    "name": "person shrugging: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3ff.png"
+  },
+  {
+    "emoji": "🤷‍♂️",
+    "name": "man shrugging",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤷🏻‍♂️",
+    "name": "man shrugging: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤷🏼‍♂️",
+    "name": "man shrugging: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤷🏽‍♂️",
+    "name": "man shrugging: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤷🏾‍♂️",
+    "name": "man shrugging: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤷🏿‍♂️",
+    "name": "man shrugging: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤷‍♀️",
+    "name": "woman shrugging",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤷🏻‍♀️",
+    "name": "woman shrugging: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤷🏼‍♀️",
+    "name": "woman shrugging: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤷🏽‍♀️",
+    "name": "woman shrugging: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤷🏾‍♀️",
+    "name": "woman shrugging: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤷🏿‍♀️",
+    "name": "woman shrugging: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f937-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧑‍⚕️",
+    "name": "health worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏻‍⚕️",
+    "name": "health worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏼‍⚕️",
+    "name": "health worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏽‍⚕️",
+    "name": "health worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏾‍⚕️",
+    "name": "health worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏿‍⚕️",
+    "name": "health worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👨‍⚕️",
+    "name": "man health worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👨🏻‍⚕️",
+    "name": "man health worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👨🏼‍⚕️",
+    "name": "man health worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👨🏽‍⚕️",
+    "name": "man health worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👨🏾‍⚕️",
+    "name": "man health worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👨🏿‍⚕️",
+    "name": "man health worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👩‍⚕️",
+    "name": "woman health worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👩🏻‍⚕️",
+    "name": "woman health worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👩🏼‍⚕️",
+    "name": "woman health worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👩🏽‍⚕️",
+    "name": "woman health worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👩🏾‍⚕️",
+    "name": "woman health worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "👩🏿‍⚕️",
+    "name": "woman health worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2695-fe0f.png"
+  },
+  {
+    "emoji": "🧑‍🎓",
+    "name": "student",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f393.png"
+  },
+  {
+    "emoji": "🧑🏻‍🎓",
+    "name": "student: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f393.png"
+  },
+  {
+    "emoji": "🧑🏼‍🎓",
+    "name": "student: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f393.png"
+  },
+  {
+    "emoji": "🧑🏽‍🎓",
+    "name": "student: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f393.png"
+  },
+  {
+    "emoji": "🧑🏾‍🎓",
+    "name": "student: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f393.png"
+  },
+  {
+    "emoji": "🧑🏿‍🎓",
+    "name": "student: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f393.png"
+  },
+  {
+    "emoji": "👨‍🎓",
+    "name": "man student",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f393.png"
+  },
+  {
+    "emoji": "👨🏻‍🎓",
+    "name": "man student: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f393.png"
+  },
+  {
+    "emoji": "👨🏼‍🎓",
+    "name": "man student: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f393.png"
+  },
+  {
+    "emoji": "👨🏽‍🎓",
+    "name": "man student: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f393.png"
+  },
+  {
+    "emoji": "👨🏾‍🎓",
+    "name": "man student: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f393.png"
+  },
+  {
+    "emoji": "👨🏿‍🎓",
+    "name": "man student: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f393.png"
+  },
+  {
+    "emoji": "👩‍🎓",
+    "name": "woman student",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f393.png"
+  },
+  {
+    "emoji": "👩🏻‍🎓",
+    "name": "woman student: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f393.png"
+  },
+  {
+    "emoji": "👩🏼‍🎓",
+    "name": "woman student: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f393.png"
+  },
+  {
+    "emoji": "👩🏽‍🎓",
+    "name": "woman student: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f393.png"
+  },
+  {
+    "emoji": "👩🏾‍🎓",
+    "name": "woman student: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f393.png"
+  },
+  {
+    "emoji": "👩🏿‍🎓",
+    "name": "woman student: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f393.png"
+  },
+  {
+    "emoji": "🧑‍🏫",
+    "name": "teacher",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f3eb.png"
+  },
+  {
+    "emoji": "🧑🏻‍🏫",
+    "name": "teacher: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f3eb.png"
+  },
+  {
+    "emoji": "🧑🏼‍🏫",
+    "name": "teacher: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f3eb.png"
+  },
+  {
+    "emoji": "🧑🏽‍🏫",
+    "name": "teacher: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f3eb.png"
+  },
+  {
+    "emoji": "🧑🏾‍🏫",
+    "name": "teacher: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f3eb.png"
+  },
+  {
+    "emoji": "🧑🏿‍🏫",
+    "name": "teacher: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👨‍🏫",
+    "name": "man teacher",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👨🏻‍🏫",
+    "name": "man teacher: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👨🏼‍🏫",
+    "name": "man teacher: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👨🏽‍🏫",
+    "name": "man teacher: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👨🏾‍🏫",
+    "name": "man teacher: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👨🏿‍🏫",
+    "name": "man teacher: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👩‍🏫",
+    "name": "woman teacher",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👩🏻‍🏫",
+    "name": "woman teacher: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👩🏼‍🏫",
+    "name": "woman teacher: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👩🏽‍🏫",
+    "name": "woman teacher: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👩🏾‍🏫",
+    "name": "woman teacher: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f3eb.png"
+  },
+  {
+    "emoji": "👩🏿‍🏫",
+    "name": "woman teacher: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f3eb.png"
+  },
+  {
+    "emoji": "🧑‍⚖️",
+    "name": "judge",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏻‍⚖️",
+    "name": "judge: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏼‍⚖️",
+    "name": "judge: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏽‍⚖️",
+    "name": "judge: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏾‍⚖️",
+    "name": "judge: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏿‍⚖️",
+    "name": "judge: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👨‍⚖️",
+    "name": "man judge",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👨🏻‍⚖️",
+    "name": "man judge: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👨🏼‍⚖️",
+    "name": "man judge: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👨🏽‍⚖️",
+    "name": "man judge: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👨🏾‍⚖️",
+    "name": "man judge: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👨🏿‍⚖️",
+    "name": "man judge: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👩‍⚖️",
+    "name": "woman judge",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👩🏻‍⚖️",
+    "name": "woman judge: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👩🏼‍⚖️",
+    "name": "woman judge: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👩🏽‍⚖️",
+    "name": "woman judge: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👩🏾‍⚖️",
+    "name": "woman judge: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "👩🏿‍⚖️",
+    "name": "woman judge: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2696-fe0f.png"
+  },
+  {
+    "emoji": "🧑‍🌾",
+    "name": "farmer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f33e.png"
+  },
+  {
+    "emoji": "🧑🏻‍🌾",
+    "name": "farmer: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f33e.png"
+  },
+  {
+    "emoji": "🧑🏼‍🌾",
+    "name": "farmer: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f33e.png"
+  },
+  {
+    "emoji": "🧑🏽‍🌾",
+    "name": "farmer: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f33e.png"
+  },
+  {
+    "emoji": "🧑🏾‍🌾",
+    "name": "farmer: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f33e.png"
+  },
+  {
+    "emoji": "🧑🏿‍🌾",
+    "name": "farmer: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f33e.png"
+  },
+  {
+    "emoji": "👨‍🌾",
+    "name": "man farmer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f33e.png"
+  },
+  {
+    "emoji": "👨🏻‍🌾",
+    "name": "man farmer: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f33e.png"
+  },
+  {
+    "emoji": "👨🏼‍🌾",
+    "name": "man farmer: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f33e.png"
+  },
+  {
+    "emoji": "👨🏽‍🌾",
+    "name": "man farmer: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f33e.png"
+  },
+  {
+    "emoji": "👨🏾‍🌾",
+    "name": "man farmer: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f33e.png"
+  },
+  {
+    "emoji": "👨🏿‍🌾",
+    "name": "man farmer: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f33e.png"
+  },
+  {
+    "emoji": "👩‍🌾",
+    "name": "woman farmer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f33e.png"
+  },
+  {
+    "emoji": "👩🏻‍🌾",
+    "name": "woman farmer: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f33e.png"
+  },
+  {
+    "emoji": "👩🏼‍🌾",
+    "name": "woman farmer: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f33e.png"
+  },
+  {
+    "emoji": "👩🏽‍🌾",
+    "name": "woman farmer: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f33e.png"
+  },
+  {
+    "emoji": "👩🏾‍🌾",
+    "name": "woman farmer: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f33e.png"
+  },
+  {
+    "emoji": "👩🏿‍🌾",
+    "name": "woman farmer: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f33e.png"
+  },
+  {
+    "emoji": "🧑‍🍳",
+    "name": "cook",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f373.png"
+  },
+  {
+    "emoji": "🧑🏻‍🍳",
+    "name": "cook: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f373.png"
+  },
+  {
+    "emoji": "🧑🏼‍🍳",
+    "name": "cook: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f373.png"
+  },
+  {
+    "emoji": "🧑🏽‍🍳",
+    "name": "cook: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f373.png"
+  },
+  {
+    "emoji": "🧑🏾‍🍳",
+    "name": "cook: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f373.png"
+  },
+  {
+    "emoji": "🧑🏿‍🍳",
+    "name": "cook: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f373.png"
+  },
+  {
+    "emoji": "👨‍🍳",
+    "name": "man cook",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f373.png"
+  },
+  {
+    "emoji": "👨🏻‍🍳",
+    "name": "man cook: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f373.png"
+  },
+  {
+    "emoji": "👨🏼‍🍳",
+    "name": "man cook: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f373.png"
+  },
+  {
+    "emoji": "👨🏽‍🍳",
+    "name": "man cook: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f373.png"
+  },
+  {
+    "emoji": "👨🏾‍🍳",
+    "name": "man cook: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f373.png"
+  },
+  {
+    "emoji": "👨🏿‍🍳",
+    "name": "man cook: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f373.png"
+  },
+  {
+    "emoji": "👩‍🍳",
+    "name": "woman cook",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f373.png"
+  },
+  {
+    "emoji": "👩🏻‍🍳",
+    "name": "woman cook: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f373.png"
+  },
+  {
+    "emoji": "👩🏼‍🍳",
+    "name": "woman cook: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f373.png"
+  },
+  {
+    "emoji": "👩🏽‍🍳",
+    "name": "woman cook: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f373.png"
+  },
+  {
+    "emoji": "👩🏾‍🍳",
+    "name": "woman cook: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f373.png"
+  },
+  {
+    "emoji": "👩🏿‍🍳",
+    "name": "woman cook: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f373.png"
+  },
+  {
+    "emoji": "🧑‍🔧",
+    "name": "mechanic",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f527.png"
+  },
+  {
+    "emoji": "🧑🏻‍🔧",
+    "name": "mechanic: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f527.png"
+  },
+  {
+    "emoji": "🧑🏼‍🔧",
+    "name": "mechanic: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f527.png"
+  },
+  {
+    "emoji": "🧑🏽‍🔧",
+    "name": "mechanic: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f527.png"
+  },
+  {
+    "emoji": "🧑🏾‍🔧",
+    "name": "mechanic: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f527.png"
+  },
+  {
+    "emoji": "🧑🏿‍🔧",
+    "name": "mechanic: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f527.png"
+  },
+  {
+    "emoji": "👨‍🔧",
+    "name": "man mechanic",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f527.png"
+  },
+  {
+    "emoji": "👨🏻‍🔧",
+    "name": "man mechanic: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f527.png"
+  },
+  {
+    "emoji": "👨🏼‍🔧",
+    "name": "man mechanic: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f527.png"
+  },
+  {
+    "emoji": "👨🏽‍🔧",
+    "name": "man mechanic: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f527.png"
+  },
+  {
+    "emoji": "👨🏾‍🔧",
+    "name": "man mechanic: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f527.png"
+  },
+  {
+    "emoji": "👨🏿‍🔧",
+    "name": "man mechanic: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f527.png"
+  },
+  {
+    "emoji": "👩‍🔧",
+    "name": "woman mechanic",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f527.png"
+  },
+  {
+    "emoji": "👩🏻‍🔧",
+    "name": "woman mechanic: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f527.png"
+  },
+  {
+    "emoji": "👩🏼‍🔧",
+    "name": "woman mechanic: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f527.png"
+  },
+  {
+    "emoji": "👩🏽‍🔧",
+    "name": "woman mechanic: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f527.png"
+  },
+  {
+    "emoji": "👩🏾‍🔧",
+    "name": "woman mechanic: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f527.png"
+  },
+  {
+    "emoji": "👩🏿‍🔧",
+    "name": "woman mechanic: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f527.png"
+  },
+  {
+    "emoji": "🧑‍🏭",
+    "name": "factory worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f3ed.png"
+  },
+  {
+    "emoji": "🧑🏻‍🏭",
+    "name": "factory worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f3ed.png"
+  },
+  {
+    "emoji": "🧑🏼‍🏭",
+    "name": "factory worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f3ed.png"
+  },
+  {
+    "emoji": "🧑🏽‍🏭",
+    "name": "factory worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f3ed.png"
+  },
+  {
+    "emoji": "🧑🏾‍🏭",
+    "name": "factory worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f3ed.png"
+  },
+  {
+    "emoji": "🧑🏿‍🏭",
+    "name": "factory worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👨‍🏭",
+    "name": "man factory worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👨🏻‍🏭",
+    "name": "man factory worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👨🏼‍🏭",
+    "name": "man factory worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👨🏽‍🏭",
+    "name": "man factory worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👨🏾‍🏭",
+    "name": "man factory worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👨🏿‍🏭",
+    "name": "man factory worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👩‍🏭",
+    "name": "woman factory worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👩🏻‍🏭",
+    "name": "woman factory worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👩🏼‍🏭",
+    "name": "woman factory worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👩🏽‍🏭",
+    "name": "woman factory worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👩🏾‍🏭",
+    "name": "woman factory worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f3ed.png"
+  },
+  {
+    "emoji": "👩🏿‍🏭",
+    "name": "woman factory worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f3ed.png"
+  },
+  {
+    "emoji": "🧑‍💼",
+    "name": "office worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f4bc.png"
+  },
+  {
+    "emoji": "🧑🏻‍💼",
+    "name": "office worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f4bc.png"
+  },
+  {
+    "emoji": "🧑🏼‍💼",
+    "name": "office worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f4bc.png"
+  },
+  {
+    "emoji": "🧑🏽‍💼",
+    "name": "office worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f4bc.png"
+  },
+  {
+    "emoji": "🧑🏾‍💼",
+    "name": "office worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f4bc.png"
+  },
+  {
+    "emoji": "🧑🏿‍💼",
+    "name": "office worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👨‍💼",
+    "name": "man office worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👨🏻‍💼",
+    "name": "man office worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👨🏼‍💼",
+    "name": "man office worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👨🏽‍💼",
+    "name": "man office worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👨🏾‍💼",
+    "name": "man office worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👨🏿‍💼",
+    "name": "man office worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👩‍💼",
+    "name": "woman office worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👩🏻‍💼",
+    "name": "woman office worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👩🏼‍💼",
+    "name": "woman office worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👩🏽‍💼",
+    "name": "woman office worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👩🏾‍💼",
+    "name": "woman office worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f4bc.png"
+  },
+  {
+    "emoji": "👩🏿‍💼",
+    "name": "woman office worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f4bc.png"
+  },
+  {
+    "emoji": "🧑‍🔬",
+    "name": "scientist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f52c.png"
+  },
+  {
+    "emoji": "🧑🏻‍🔬",
+    "name": "scientist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f52c.png"
+  },
+  {
+    "emoji": "🧑🏼‍🔬",
+    "name": "scientist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f52c.png"
+  },
+  {
+    "emoji": "🧑🏽‍🔬",
+    "name": "scientist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f52c.png"
+  },
+  {
+    "emoji": "🧑🏾‍🔬",
+    "name": "scientist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f52c.png"
+  },
+  {
+    "emoji": "🧑🏿‍🔬",
+    "name": "scientist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f52c.png"
+  },
+  {
+    "emoji": "👨‍🔬",
+    "name": "man scientist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f52c.png"
+  },
+  {
+    "emoji": "👨🏻‍🔬",
+    "name": "man scientist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f52c.png"
+  },
+  {
+    "emoji": "👨🏼‍🔬",
+    "name": "man scientist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f52c.png"
+  },
+  {
+    "emoji": "👨🏽‍🔬",
+    "name": "man scientist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f52c.png"
+  },
+  {
+    "emoji": "👨🏾‍🔬",
+    "name": "man scientist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f52c.png"
+  },
+  {
+    "emoji": "👨🏿‍🔬",
+    "name": "man scientist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f52c.png"
+  },
+  {
+    "emoji": "👩‍🔬",
+    "name": "woman scientist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f52c.png"
+  },
+  {
+    "emoji": "👩🏻‍🔬",
+    "name": "woman scientist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f52c.png"
+  },
+  {
+    "emoji": "👩🏼‍🔬",
+    "name": "woman scientist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f52c.png"
+  },
+  {
+    "emoji": "👩🏽‍🔬",
+    "name": "woman scientist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f52c.png"
+  },
+  {
+    "emoji": "👩🏾‍🔬",
+    "name": "woman scientist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f52c.png"
+  },
+  {
+    "emoji": "👩🏿‍🔬",
+    "name": "woman scientist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f52c.png"
+  },
+  {
+    "emoji": "🧑‍💻",
+    "name": "technologist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f4bb.png"
+  },
+  {
+    "emoji": "🧑🏻‍💻",
+    "name": "technologist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f4bb.png"
+  },
+  {
+    "emoji": "🧑🏼‍💻",
+    "name": "technologist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f4bb.png"
+  },
+  {
+    "emoji": "🧑🏽‍💻",
+    "name": "technologist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f4bb.png"
+  },
+  {
+    "emoji": "🧑🏾‍💻",
+    "name": "technologist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f4bb.png"
+  },
+  {
+    "emoji": "🧑🏿‍💻",
+    "name": "technologist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👨‍💻",
+    "name": "man technologist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👨🏻‍💻",
+    "name": "man technologist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👨🏼‍💻",
+    "name": "man technologist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👨🏽‍💻",
+    "name": "man technologist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👨🏾‍💻",
+    "name": "man technologist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👨🏿‍💻",
+    "name": "man technologist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👩‍💻",
+    "name": "woman technologist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👩🏻‍💻",
+    "name": "woman technologist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👩🏼‍💻",
+    "name": "woman technologist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👩🏽‍💻",
+    "name": "woman technologist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👩🏾‍💻",
+    "name": "woman technologist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f4bb.png"
+  },
+  {
+    "emoji": "👩🏿‍💻",
+    "name": "woman technologist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f4bb.png"
+  },
+  {
+    "emoji": "🧑‍🎤",
+    "name": "singer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f3a4.png"
+  },
+  {
+    "emoji": "🧑🏻‍🎤",
+    "name": "singer: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f3a4.png"
+  },
+  {
+    "emoji": "🧑🏼‍🎤",
+    "name": "singer: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f3a4.png"
+  },
+  {
+    "emoji": "🧑🏽‍🎤",
+    "name": "singer: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f3a4.png"
+  },
+  {
+    "emoji": "🧑🏾‍🎤",
+    "name": "singer: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f3a4.png"
+  },
+  {
+    "emoji": "🧑🏿‍🎤",
+    "name": "singer: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👨‍🎤",
+    "name": "man singer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👨🏻‍🎤",
+    "name": "man singer: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👨🏼‍🎤",
+    "name": "man singer: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👨🏽‍🎤",
+    "name": "man singer: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👨🏾‍🎤",
+    "name": "man singer: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👨🏿‍🎤",
+    "name": "man singer: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👩‍🎤",
+    "name": "woman singer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👩🏻‍🎤",
+    "name": "woman singer: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👩🏼‍🎤",
+    "name": "woman singer: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👩🏽‍🎤",
+    "name": "woman singer: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👩🏾‍🎤",
+    "name": "woman singer: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f3a4.png"
+  },
+  {
+    "emoji": "👩🏿‍🎤",
+    "name": "woman singer: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f3a4.png"
+  },
+  {
+    "emoji": "🧑‍🎨",
+    "name": "artist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f3a8.png"
+  },
+  {
+    "emoji": "🧑🏻‍🎨",
+    "name": "artist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f3a8.png"
+  },
+  {
+    "emoji": "🧑🏼‍🎨",
+    "name": "artist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f3a8.png"
+  },
+  {
+    "emoji": "🧑🏽‍🎨",
+    "name": "artist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f3a8.png"
+  },
+  {
+    "emoji": "🧑🏾‍🎨",
+    "name": "artist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f3a8.png"
+  },
+  {
+    "emoji": "🧑🏿‍🎨",
+    "name": "artist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👨‍🎨",
+    "name": "man artist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👨🏻‍🎨",
+    "name": "man artist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👨🏼‍🎨",
+    "name": "man artist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👨🏽‍🎨",
+    "name": "man artist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👨🏾‍🎨",
+    "name": "man artist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👨🏿‍🎨",
+    "name": "man artist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👩‍🎨",
+    "name": "woman artist",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👩🏻‍🎨",
+    "name": "woman artist: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👩🏼‍🎨",
+    "name": "woman artist: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👩🏽‍🎨",
+    "name": "woman artist: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👩🏾‍🎨",
+    "name": "woman artist: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f3a8.png"
+  },
+  {
+    "emoji": "👩🏿‍🎨",
+    "name": "woman artist: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f3a8.png"
+  },
+  {
+    "emoji": "🧑‍✈️",
+    "name": "pilot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏻‍✈️",
+    "name": "pilot: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏼‍✈️",
+    "name": "pilot: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏽‍✈️",
+    "name": "pilot: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏾‍✈️",
+    "name": "pilot: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏿‍✈️",
+    "name": "pilot: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👨‍✈️",
+    "name": "man pilot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👨🏻‍✈️",
+    "name": "man pilot: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👨🏼‍✈️",
+    "name": "man pilot: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👨🏽‍✈️",
+    "name": "man pilot: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👨🏾‍✈️",
+    "name": "man pilot: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👨🏿‍✈️",
+    "name": "man pilot: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👩‍✈️",
+    "name": "woman pilot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👩🏻‍✈️",
+    "name": "woman pilot: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👩🏼‍✈️",
+    "name": "woman pilot: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👩🏽‍✈️",
+    "name": "woman pilot: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👩🏾‍✈️",
+    "name": "woman pilot: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "👩🏿‍✈️",
+    "name": "woman pilot: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2708-fe0f.png"
+  },
+  {
+    "emoji": "🧑‍🚀",
+    "name": "astronaut",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f680.png"
+  },
+  {
+    "emoji": "🧑🏻‍🚀",
+    "name": "astronaut: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f680.png"
+  },
+  {
+    "emoji": "🧑🏼‍🚀",
+    "name": "astronaut: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f680.png"
+  },
+  {
+    "emoji": "🧑🏽‍🚀",
+    "name": "astronaut: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f680.png"
+  },
+  {
+    "emoji": "🧑🏾‍🚀",
+    "name": "astronaut: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f680.png"
+  },
+  {
+    "emoji": "🧑🏿‍🚀",
+    "name": "astronaut: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f680.png"
+  },
+  {
+    "emoji": "👨‍🚀",
+    "name": "man astronaut",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f680.png"
+  },
+  {
+    "emoji": "👨🏻‍🚀",
+    "name": "man astronaut: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f680.png"
+  },
+  {
+    "emoji": "👨🏼‍🚀",
+    "name": "man astronaut: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f680.png"
+  },
+  {
+    "emoji": "👨🏽‍🚀",
+    "name": "man astronaut: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f680.png"
+  },
+  {
+    "emoji": "👨🏾‍🚀",
+    "name": "man astronaut: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f680.png"
+  },
+  {
+    "emoji": "👨🏿‍🚀",
+    "name": "man astronaut: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f680.png"
+  },
+  {
+    "emoji": "👩‍🚀",
+    "name": "woman astronaut",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f680.png"
+  },
+  {
+    "emoji": "👩🏻‍🚀",
+    "name": "woman astronaut: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f680.png"
+  },
+  {
+    "emoji": "👩🏼‍🚀",
+    "name": "woman astronaut: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f680.png"
+  },
+  {
+    "emoji": "👩🏽‍🚀",
+    "name": "woman astronaut: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f680.png"
+  },
+  {
+    "emoji": "👩🏾‍🚀",
+    "name": "woman astronaut: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f680.png"
+  },
+  {
+    "emoji": "👩🏿‍🚀",
+    "name": "woman astronaut: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f680.png"
+  },
+  {
+    "emoji": "🧑‍🚒",
+    "name": "firefighter",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f692.png"
+  },
+  {
+    "emoji": "🧑🏻‍🚒",
+    "name": "firefighter: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f692.png"
+  },
+  {
+    "emoji": "🧑🏼‍🚒",
+    "name": "firefighter: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f692.png"
+  },
+  {
+    "emoji": "🧑🏽‍🚒",
+    "name": "firefighter: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f692.png"
+  },
+  {
+    "emoji": "🧑🏾‍🚒",
+    "name": "firefighter: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f692.png"
+  },
+  {
+    "emoji": "🧑🏿‍🚒",
+    "name": "firefighter: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f692.png"
+  },
+  {
+    "emoji": "👨‍🚒",
+    "name": "man firefighter",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f692.png"
+  },
+  {
+    "emoji": "👨🏻‍🚒",
+    "name": "man firefighter: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f692.png"
+  },
+  {
+    "emoji": "👨🏼‍🚒",
+    "name": "man firefighter: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f692.png"
+  },
+  {
+    "emoji": "👨🏽‍🚒",
+    "name": "man firefighter: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f692.png"
+  },
+  {
+    "emoji": "👨🏾‍🚒",
+    "name": "man firefighter: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f692.png"
+  },
+  {
+    "emoji": "👨🏿‍🚒",
+    "name": "man firefighter: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f692.png"
+  },
+  {
+    "emoji": "👩‍🚒",
+    "name": "woman firefighter",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f692.png"
+  },
+  {
+    "emoji": "👩🏻‍🚒",
+    "name": "woman firefighter: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f692.png"
+  },
+  {
+    "emoji": "👩🏼‍🚒",
+    "name": "woman firefighter: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f692.png"
+  },
+  {
+    "emoji": "👩🏽‍🚒",
+    "name": "woman firefighter: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f692.png"
+  },
+  {
+    "emoji": "👩🏾‍🚒",
+    "name": "woman firefighter: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f692.png"
+  },
+  {
+    "emoji": "👩🏿‍🚒",
+    "name": "woman firefighter: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f692.png"
+  },
+  {
+    "emoji": "👮",
+    "name": "police officer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e.png"
+  },
+  {
+    "emoji": "👮🏻",
+    "name": "police officer: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fb.png"
+  },
+  {
+    "emoji": "👮🏼",
+    "name": "police officer: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fc.png"
+  },
+  {
+    "emoji": "👮🏽",
+    "name": "police officer: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fd.png"
+  },
+  {
+    "emoji": "👮🏾",
+    "name": "police officer: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fe.png"
+  },
+  {
+    "emoji": "👮🏿",
+    "name": "police officer: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3ff.png"
+  },
+  {
+    "emoji": "👮‍♂️",
+    "name": "man police officer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👮🏻‍♂️",
+    "name": "man police officer: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👮🏼‍♂️",
+    "name": "man police officer: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👮🏽‍♂️",
+    "name": "man police officer: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👮🏾‍♂️",
+    "name": "man police officer: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👮🏿‍♂️",
+    "name": "man police officer: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👮‍♀️",
+    "name": "woman police officer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👮🏻‍♀️",
+    "name": "woman police officer: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👮🏼‍♀️",
+    "name": "woman police officer: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👮🏽‍♀️",
+    "name": "woman police officer: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👮🏾‍♀️",
+    "name": "woman police officer: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👮🏿‍♀️",
+    "name": "woman police officer: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46e-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🕵️",
+    "name": "detective",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏻",
+    "name": "detective: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fb.png"
+  },
+  {
+    "emoji": "🕵🏼",
+    "name": "detective: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fc.png"
+  },
+  {
+    "emoji": "🕵🏽",
+    "name": "detective: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fd.png"
+  },
+  {
+    "emoji": "🕵🏾",
+    "name": "detective: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fe.png"
+  },
+  {
+    "emoji": "🕵🏿",
+    "name": "detective: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3ff.png"
+  },
+  {
+    "emoji": "🕵️‍♂️",
+    "name": "man detective",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-fe0f-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏻‍♂️",
+    "name": "man detective: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏼‍♂️",
+    "name": "man detective: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏽‍♂️",
+    "name": "man detective: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏾‍♂️",
+    "name": "man detective: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏿‍♂️",
+    "name": "man detective: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🕵️‍♀️",
+    "name": "woman detective",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-fe0f-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏻‍♀️",
+    "name": "woman detective: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏼‍♀️",
+    "name": "woman detective: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏽‍♀️",
+    "name": "woman detective: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏾‍♀️",
+    "name": "woman detective: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🕵🏿‍♀️",
+    "name": "woman detective: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f575-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💂",
+    "name": "guard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482.png"
+  },
+  {
+    "emoji": "💂🏻",
+    "name": "guard: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fb.png"
+  },
+  {
+    "emoji": "💂🏼",
+    "name": "guard: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fc.png"
+  },
+  {
+    "emoji": "💂🏽",
+    "name": "guard: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fd.png"
+  },
+  {
+    "emoji": "💂🏾",
+    "name": "guard: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fe.png"
+  },
+  {
+    "emoji": "💂🏿",
+    "name": "guard: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3ff.png"
+  },
+  {
+    "emoji": "💂‍♂️",
+    "name": "man guard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💂🏻‍♂️",
+    "name": "man guard: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💂🏼‍♂️",
+    "name": "man guard: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💂🏽‍♂️",
+    "name": "man guard: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💂🏾‍♂️",
+    "name": "man guard: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💂🏿‍♂️",
+    "name": "man guard: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💂‍♀️",
+    "name": "woman guard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💂🏻‍♀️",
+    "name": "woman guard: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💂🏼‍♀️",
+    "name": "woman guard: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💂🏽‍♀️",
+    "name": "woman guard: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💂🏾‍♀️",
+    "name": "woman guard: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💂🏿‍♀️",
+    "name": "woman guard: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f482-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🥷",
+    "name": "ninja",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f977.png"
+  },
+  {
+    "emoji": "🥷🏻",
+    "name": "ninja: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f977-1f3fb.png"
+  },
+  {
+    "emoji": "🥷🏼",
+    "name": "ninja: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f977-1f3fc.png"
+  },
+  {
+    "emoji": "🥷🏽",
+    "name": "ninja: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f977-1f3fd.png"
+  },
+  {
+    "emoji": "🥷🏾",
+    "name": "ninja: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f977-1f3fe.png"
+  },
+  {
+    "emoji": "🥷🏿",
+    "name": "ninja: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f977-1f3ff.png"
+  },
+  {
+    "emoji": "👷",
+    "name": "construction worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477.png"
+  },
+  {
+    "emoji": "👷🏻",
+    "name": "construction worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fb.png"
+  },
+  {
+    "emoji": "👷🏼",
+    "name": "construction worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fc.png"
+  },
+  {
+    "emoji": "👷🏽",
+    "name": "construction worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fd.png"
+  },
+  {
+    "emoji": "👷🏾",
+    "name": "construction worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fe.png"
+  },
+  {
+    "emoji": "👷🏿",
+    "name": "construction worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3ff.png"
+  },
+  {
+    "emoji": "👷‍♂️",
+    "name": "man construction worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👷🏻‍♂️",
+    "name": "man construction worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👷🏼‍♂️",
+    "name": "man construction worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👷🏽‍♂️",
+    "name": "man construction worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👷🏾‍♂️",
+    "name": "man construction worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👷🏿‍♂️",
+    "name": "man construction worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👷‍♀️",
+    "name": "woman construction worker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👷🏻‍♀️",
+    "name": "woman construction worker: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👷🏼‍♀️",
+    "name": "woman construction worker: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👷🏽‍♀️",
+    "name": "woman construction worker: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👷🏾‍♀️",
+    "name": "woman construction worker: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👷🏿‍♀️",
+    "name": "woman construction worker: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f477-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🫅",
+    "name": "person with crown",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac5.png"
+  },
+  {
+    "emoji": "🫅🏻",
+    "name": "person with crown: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac5-1f3fb.png"
+  },
+  {
+    "emoji": "🫅🏼",
+    "name": "person with crown: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac5-1f3fc.png"
+  },
+  {
+    "emoji": "🫅🏽",
+    "name": "person with crown: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac5-1f3fd.png"
+  },
+  {
+    "emoji": "🫅🏾",
+    "name": "person with crown: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac5-1f3fe.png"
+  },
+  {
+    "emoji": "🫅🏿",
+    "name": "person with crown: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac5-1f3ff.png"
+  },
+  {
+    "emoji": "🤴",
+    "name": "prince",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f934.png"
+  },
+  {
+    "emoji": "🤴🏻",
+    "name": "prince: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f934-1f3fb.png"
+  },
+  {
+    "emoji": "🤴🏼",
+    "name": "prince: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f934-1f3fc.png"
+  },
+  {
+    "emoji": "🤴🏽",
+    "name": "prince: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f934-1f3fd.png"
+  },
+  {
+    "emoji": "🤴🏾",
+    "name": "prince: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f934-1f3fe.png"
+  },
+  {
+    "emoji": "🤴🏿",
+    "name": "prince: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f934-1f3ff.png"
+  },
+  {
+    "emoji": "👸",
+    "name": "princess",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f478.png"
+  },
+  {
+    "emoji": "👸🏻",
+    "name": "princess: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f478-1f3fb.png"
+  },
+  {
+    "emoji": "👸🏼",
+    "name": "princess: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f478-1f3fc.png"
+  },
+  {
+    "emoji": "👸🏽",
+    "name": "princess: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f478-1f3fd.png"
+  },
+  {
+    "emoji": "👸🏾",
+    "name": "princess: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f478-1f3fe.png"
+  },
+  {
+    "emoji": "👸🏿",
+    "name": "princess: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f478-1f3ff.png"
+  },
+  {
+    "emoji": "👳",
+    "name": "person wearing turban",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473.png"
+  },
+  {
+    "emoji": "👳🏻",
+    "name": "person wearing turban: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fb.png"
+  },
+  {
+    "emoji": "👳🏼",
+    "name": "person wearing turban: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fc.png"
+  },
+  {
+    "emoji": "👳🏽",
+    "name": "person wearing turban: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fd.png"
+  },
+  {
+    "emoji": "👳🏾",
+    "name": "person wearing turban: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fe.png"
+  },
+  {
+    "emoji": "👳🏿",
+    "name": "person wearing turban: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3ff.png"
+  },
+  {
+    "emoji": "👳‍♂️",
+    "name": "man wearing turban",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👳🏻‍♂️",
+    "name": "man wearing turban: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👳🏼‍♂️",
+    "name": "man wearing turban: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👳🏽‍♂️",
+    "name": "man wearing turban: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👳🏾‍♂️",
+    "name": "man wearing turban: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👳🏿‍♂️",
+    "name": "man wearing turban: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👳‍♀️",
+    "name": "woman wearing turban",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👳🏻‍♀️",
+    "name": "woman wearing turban: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👳🏼‍♀️",
+    "name": "woman wearing turban: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👳🏽‍♀️",
+    "name": "woman wearing turban: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👳🏾‍♀️",
+    "name": "woman wearing turban: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👳🏿‍♀️",
+    "name": "woman wearing turban: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f473-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👲",
+    "name": "person with skullcap",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f472.png"
+  },
+  {
+    "emoji": "👲🏻",
+    "name": "person with skullcap: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f472-1f3fb.png"
+  },
+  {
+    "emoji": "👲🏼",
+    "name": "person with skullcap: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f472-1f3fc.png"
+  },
+  {
+    "emoji": "👲🏽",
+    "name": "person with skullcap: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f472-1f3fd.png"
+  },
+  {
+    "emoji": "👲🏾",
+    "name": "person with skullcap: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f472-1f3fe.png"
+  },
+  {
+    "emoji": "👲🏿",
+    "name": "person with skullcap: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f472-1f3ff.png"
+  },
+  {
+    "emoji": "🧕",
+    "name": "woman with headscarf",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d5.png"
+  },
+  {
+    "emoji": "🧕🏻",
+    "name": "woman with headscarf: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d5-1f3fb.png"
+  },
+  {
+    "emoji": "🧕🏼",
+    "name": "woman with headscarf: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d5-1f3fc.png"
+  },
+  {
+    "emoji": "🧕🏽",
+    "name": "woman with headscarf: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d5-1f3fd.png"
+  },
+  {
+    "emoji": "🧕🏾",
+    "name": "woman with headscarf: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d5-1f3fe.png"
+  },
+  {
+    "emoji": "🧕🏿",
+    "name": "woman with headscarf: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d5-1f3ff.png"
+  },
+  {
+    "emoji": "🤵",
+    "name": "person in tuxedo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935.png"
+  },
+  {
+    "emoji": "🤵🏻",
+    "name": "person in tuxedo: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fb.png"
+  },
+  {
+    "emoji": "🤵🏼",
+    "name": "person in tuxedo: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fc.png"
+  },
+  {
+    "emoji": "🤵🏽",
+    "name": "person in tuxedo: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fd.png"
+  },
+  {
+    "emoji": "🤵🏾",
+    "name": "person in tuxedo: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fe.png"
+  },
+  {
+    "emoji": "🤵🏿",
+    "name": "person in tuxedo: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3ff.png"
+  },
+  {
+    "emoji": "🤵‍♂️",
+    "name": "man in tuxedo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤵🏻‍♂️",
+    "name": "man in tuxedo: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤵🏼‍♂️",
+    "name": "man in tuxedo: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤵🏽‍♂️",
+    "name": "man in tuxedo: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤵🏾‍♂️",
+    "name": "man in tuxedo: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤵🏿‍♂️",
+    "name": "man in tuxedo: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤵‍♀️",
+    "name": "woman in tuxedo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤵🏻‍♀️",
+    "name": "woman in tuxedo: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤵🏼‍♀️",
+    "name": "woman in tuxedo: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤵🏽‍♀️",
+    "name": "woman in tuxedo: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤵🏾‍♀️",
+    "name": "woman in tuxedo: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤵🏿‍♀️",
+    "name": "woman in tuxedo: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f935-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👰",
+    "name": "person with veil",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470.png"
+  },
+  {
+    "emoji": "👰🏻",
+    "name": "person with veil: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fb.png"
+  },
+  {
+    "emoji": "👰🏼",
+    "name": "person with veil: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fc.png"
+  },
+  {
+    "emoji": "👰🏽",
+    "name": "person with veil: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fd.png"
+  },
+  {
+    "emoji": "👰🏾",
+    "name": "person with veil: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fe.png"
+  },
+  {
+    "emoji": "👰🏿",
+    "name": "person with veil: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3ff.png"
+  },
+  {
+    "emoji": "👰‍♂️",
+    "name": "man with veil",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👰🏻‍♂️",
+    "name": "man with veil: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👰🏼‍♂️",
+    "name": "man with veil: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👰🏽‍♂️",
+    "name": "man with veil: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👰🏾‍♂️",
+    "name": "man with veil: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👰🏿‍♂️",
+    "name": "man with veil: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👰‍♀️",
+    "name": "woman with veil",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👰🏻‍♀️",
+    "name": "woman with veil: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👰🏼‍♀️",
+    "name": "woman with veil: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👰🏽‍♀️",
+    "name": "woman with veil: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👰🏾‍♀️",
+    "name": "woman with veil: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "👰🏿‍♀️",
+    "name": "woman with veil: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f470-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤰",
+    "name": "pregnant woman",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f930.png"
+  },
+  {
+    "emoji": "🤰🏻",
+    "name": "pregnant woman: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f930-1f3fb.png"
+  },
+  {
+    "emoji": "🤰🏼",
+    "name": "pregnant woman: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f930-1f3fc.png"
+  },
+  {
+    "emoji": "🤰🏽",
+    "name": "pregnant woman: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f930-1f3fd.png"
+  },
+  {
+    "emoji": "🤰🏾",
+    "name": "pregnant woman: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f930-1f3fe.png"
+  },
+  {
+    "emoji": "🤰🏿",
+    "name": "pregnant woman: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f930-1f3ff.png"
+  },
+  {
+    "emoji": "🫃",
+    "name": "pregnant man",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac3.png"
+  },
+  {
+    "emoji": "🫃🏻",
+    "name": "pregnant man: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac3-1f3fb.png"
+  },
+  {
+    "emoji": "🫃🏼",
+    "name": "pregnant man: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac3-1f3fc.png"
+  },
+  {
+    "emoji": "🫃🏽",
+    "name": "pregnant man: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac3-1f3fd.png"
+  },
+  {
+    "emoji": "🫃🏾",
+    "name": "pregnant man: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac3-1f3fe.png"
+  },
+  {
+    "emoji": "🫃🏿",
+    "name": "pregnant man: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac3-1f3ff.png"
+  },
+  {
+    "emoji": "🫄",
+    "name": "pregnant person",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac4.png"
+  },
+  {
+    "emoji": "🫄🏻",
+    "name": "pregnant person: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac4-1f3fb.png"
+  },
+  {
+    "emoji": "🫄🏼",
+    "name": "pregnant person: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac4-1f3fc.png"
+  },
+  {
+    "emoji": "🫄🏽",
+    "name": "pregnant person: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac4-1f3fd.png"
+  },
+  {
+    "emoji": "🫄🏾",
+    "name": "pregnant person: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac4-1f3fe.png"
+  },
+  {
+    "emoji": "🫄🏿",
+    "name": "pregnant person: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac4-1f3ff.png"
+  },
+  {
+    "emoji": "🤱",
+    "name": "breast-feeding",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f931.png"
+  },
+  {
+    "emoji": "🤱🏻",
+    "name": "breast-feeding: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f931-1f3fb.png"
+  },
+  {
+    "emoji": "🤱🏼",
+    "name": "breast-feeding: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f931-1f3fc.png"
+  },
+  {
+    "emoji": "🤱🏽",
+    "name": "breast-feeding: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f931-1f3fd.png"
+  },
+  {
+    "emoji": "🤱🏾",
+    "name": "breast-feeding: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f931-1f3fe.png"
+  },
+  {
+    "emoji": "🤱🏿",
+    "name": "breast-feeding: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f931-1f3ff.png"
+  },
+  {
+    "emoji": "👩‍🍼",
+    "name": "woman feeding baby",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f37c.png"
+  },
+  {
+    "emoji": "👩🏻‍🍼",
+    "name": "woman feeding baby: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f37c.png"
+  },
+  {
+    "emoji": "👩🏼‍🍼",
+    "name": "woman feeding baby: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f37c.png"
+  },
+  {
+    "emoji": "👩🏽‍🍼",
+    "name": "woman feeding baby: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f37c.png"
+  },
+  {
+    "emoji": "👩🏾‍🍼",
+    "name": "woman feeding baby: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f37c.png"
+  },
+  {
+    "emoji": "👩🏿‍🍼",
+    "name": "woman feeding baby: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f37c.png"
+  },
+  {
+    "emoji": "👨‍🍼",
+    "name": "man feeding baby",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f37c.png"
+  },
+  {
+    "emoji": "👨🏻‍🍼",
+    "name": "man feeding baby: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f37c.png"
+  },
+  {
+    "emoji": "👨🏼‍🍼",
+    "name": "man feeding baby: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f37c.png"
+  },
+  {
+    "emoji": "👨🏽‍🍼",
+    "name": "man feeding baby: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f37c.png"
+  },
+  {
+    "emoji": "👨🏾‍🍼",
+    "name": "man feeding baby: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f37c.png"
+  },
+  {
+    "emoji": "👨🏿‍🍼",
+    "name": "man feeding baby: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f37c.png"
+  },
+  {
+    "emoji": "🧑‍🍼",
+    "name": "person feeding baby",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f37c.png"
+  },
+  {
+    "emoji": "🧑🏻‍🍼",
+    "name": "person feeding baby: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f37c.png"
+  },
+  {
+    "emoji": "🧑🏼‍🍼",
+    "name": "person feeding baby: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f37c.png"
+  },
+  {
+    "emoji": "🧑🏽‍🍼",
+    "name": "person feeding baby: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f37c.png"
+  },
+  {
+    "emoji": "🧑🏾‍🍼",
+    "name": "person feeding baby: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f37c.png"
+  },
+  {
+    "emoji": "🧑🏿‍🍼",
+    "name": "person feeding baby: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f37c.png"
+  },
+  {
+    "emoji": "👼",
+    "name": "baby angel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47c.png"
+  },
+  {
+    "emoji": "👼🏻",
+    "name": "baby angel: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47c-1f3fb.png"
+  },
+  {
+    "emoji": "👼🏼",
+    "name": "baby angel: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47c-1f3fc.png"
+  },
+  {
+    "emoji": "👼🏽",
+    "name": "baby angel: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47c-1f3fd.png"
+  },
+  {
+    "emoji": "👼🏾",
+    "name": "baby angel: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47c-1f3fe.png"
+  },
+  {
+    "emoji": "👼🏿",
+    "name": "baby angel: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f47c-1f3ff.png"
+  },
+  {
+    "emoji": "🎅",
+    "name": "Santa Claus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f385.png"
+  },
+  {
+    "emoji": "🎅🏻",
+    "name": "Santa Claus: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f385-1f3fb.png"
+  },
+  {
+    "emoji": "🎅🏼",
+    "name": "Santa Claus: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f385-1f3fc.png"
+  },
+  {
+    "emoji": "🎅🏽",
+    "name": "Santa Claus: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f385-1f3fd.png"
+  },
+  {
+    "emoji": "🎅🏾",
+    "name": "Santa Claus: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f385-1f3fe.png"
+  },
+  {
+    "emoji": "🎅🏿",
+    "name": "Santa Claus: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f385-1f3ff.png"
+  },
+  {
+    "emoji": "🤶",
+    "name": "Mrs. Claus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f936.png"
+  },
+  {
+    "emoji": "🤶🏻",
+    "name": "Mrs. Claus: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f936-1f3fb.png"
+  },
+  {
+    "emoji": "🤶🏼",
+    "name": "Mrs. Claus: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f936-1f3fc.png"
+  },
+  {
+    "emoji": "🤶🏽",
+    "name": "Mrs. Claus: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f936-1f3fd.png"
+  },
+  {
+    "emoji": "🤶🏾",
+    "name": "Mrs. Claus: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f936-1f3fe.png"
+  },
+  {
+    "emoji": "🤶🏿",
+    "name": "Mrs. Claus: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f936-1f3ff.png"
+  },
+  {
+    "emoji": "🧑‍🎄",
+    "name": "mx claus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f384.png"
+  },
+  {
+    "emoji": "🧑🏻‍🎄",
+    "name": "mx claus: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f384.png"
+  },
+  {
+    "emoji": "🧑🏼‍🎄",
+    "name": "mx claus: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f384.png"
+  },
+  {
+    "emoji": "🧑🏽‍🎄",
+    "name": "mx claus: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f384.png"
+  },
+  {
+    "emoji": "🧑🏾‍🎄",
+    "name": "mx claus: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f384.png"
+  },
+  {
+    "emoji": "🧑🏿‍🎄",
+    "name": "mx claus: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f384.png"
+  },
+  {
+    "emoji": "🦸",
+    "name": "superhero",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8.png"
+  },
+  {
+    "emoji": "🦸🏻",
+    "name": "superhero: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fb.png"
+  },
+  {
+    "emoji": "🦸🏼",
+    "name": "superhero: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fc.png"
+  },
+  {
+    "emoji": "🦸🏽",
+    "name": "superhero: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fd.png"
+  },
+  {
+    "emoji": "🦸🏾",
+    "name": "superhero: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fe.png"
+  },
+  {
+    "emoji": "🦸🏿",
+    "name": "superhero: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3ff.png"
+  },
+  {
+    "emoji": "🦸‍♂️",
+    "name": "man superhero",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦸🏻‍♂️",
+    "name": "man superhero: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦸🏼‍♂️",
+    "name": "man superhero: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦸🏽‍♂️",
+    "name": "man superhero: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦸🏾‍♂️",
+    "name": "man superhero: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦸🏿‍♂️",
+    "name": "man superhero: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦸‍♀️",
+    "name": "woman superhero",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦸🏻‍♀️",
+    "name": "woman superhero: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦸🏼‍♀️",
+    "name": "woman superhero: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦸🏽‍♀️",
+    "name": "woman superhero: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦸🏾‍♀️",
+    "name": "woman superhero: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦸🏿‍♀️",
+    "name": "woman superhero: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b8-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦹",
+    "name": "supervillain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9.png"
+  },
+  {
+    "emoji": "🦹🏻",
+    "name": "supervillain: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fb.png"
+  },
+  {
+    "emoji": "🦹🏼",
+    "name": "supervillain: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fc.png"
+  },
+  {
+    "emoji": "🦹🏽",
+    "name": "supervillain: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fd.png"
+  },
+  {
+    "emoji": "🦹🏾",
+    "name": "supervillain: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fe.png"
+  },
+  {
+    "emoji": "🦹🏿",
+    "name": "supervillain: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3ff.png"
+  },
+  {
+    "emoji": "🦹‍♂️",
+    "name": "man supervillain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦹🏻‍♂️",
+    "name": "man supervillain: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦹🏼‍♂️",
+    "name": "man supervillain: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦹🏽‍♂️",
+    "name": "man supervillain: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦹🏾‍♂️",
+    "name": "man supervillain: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦹🏿‍♂️",
+    "name": "man supervillain: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🦹‍♀️",
+    "name": "woman supervillain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦹🏻‍♀️",
+    "name": "woman supervillain: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦹🏼‍♀️",
+    "name": "woman supervillain: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦹🏽‍♀️",
+    "name": "woman supervillain: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦹🏾‍♀️",
+    "name": "woman supervillain: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🦹🏿‍♀️",
+    "name": "woman supervillain: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9b9-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧙",
+    "name": "mage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9.png"
+  },
+  {
+    "emoji": "🧙🏻",
+    "name": "mage: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fb.png"
+  },
+  {
+    "emoji": "🧙🏼",
+    "name": "mage: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fc.png"
+  },
+  {
+    "emoji": "🧙🏽",
+    "name": "mage: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fd.png"
+  },
+  {
+    "emoji": "🧙🏾",
+    "name": "mage: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fe.png"
+  },
+  {
+    "emoji": "🧙🏿",
+    "name": "mage: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3ff.png"
+  },
+  {
+    "emoji": "🧙‍♂️",
+    "name": "man mage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧙🏻‍♂️",
+    "name": "man mage: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧙🏼‍♂️",
+    "name": "man mage: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧙🏽‍♂️",
+    "name": "man mage: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧙🏾‍♂️",
+    "name": "man mage: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧙🏿‍♂️",
+    "name": "man mage: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧙‍♀️",
+    "name": "woman mage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧙🏻‍♀️",
+    "name": "woman mage: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧙🏼‍♀️",
+    "name": "woman mage: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧙🏽‍♀️",
+    "name": "woman mage: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧙🏾‍♀️",
+    "name": "woman mage: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧙🏿‍♀️",
+    "name": "woman mage: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d9-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧚",
+    "name": "fairy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da.png"
+  },
+  {
+    "emoji": "🧚🏻",
+    "name": "fairy: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fb.png"
+  },
+  {
+    "emoji": "🧚🏼",
+    "name": "fairy: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fc.png"
+  },
+  {
+    "emoji": "🧚🏽",
+    "name": "fairy: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fd.png"
+  },
+  {
+    "emoji": "🧚🏾",
+    "name": "fairy: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fe.png"
+  },
+  {
+    "emoji": "🧚🏿",
+    "name": "fairy: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3ff.png"
+  },
+  {
+    "emoji": "🧚‍♂️",
+    "name": "man fairy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧚🏻‍♂️",
+    "name": "man fairy: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧚🏼‍♂️",
+    "name": "man fairy: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧚🏽‍♂️",
+    "name": "man fairy: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧚🏾‍♂️",
+    "name": "man fairy: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧚🏿‍♂️",
+    "name": "man fairy: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧚‍♀️",
+    "name": "woman fairy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧚🏻‍♀️",
+    "name": "woman fairy: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧚🏼‍♀️",
+    "name": "woman fairy: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧚🏽‍♀️",
+    "name": "woman fairy: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧚🏾‍♀️",
+    "name": "woman fairy: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧚🏿‍♀️",
+    "name": "woman fairy: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9da-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧛",
+    "name": "vampire",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db.png"
+  },
+  {
+    "emoji": "🧛🏻",
+    "name": "vampire: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fb.png"
+  },
+  {
+    "emoji": "🧛🏼",
+    "name": "vampire: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fc.png"
+  },
+  {
+    "emoji": "🧛🏽",
+    "name": "vampire: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fd.png"
+  },
+  {
+    "emoji": "🧛🏾",
+    "name": "vampire: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fe.png"
+  },
+  {
+    "emoji": "🧛🏿",
+    "name": "vampire: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3ff.png"
+  },
+  {
+    "emoji": "🧛‍♂️",
+    "name": "man vampire",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧛🏻‍♂️",
+    "name": "man vampire: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧛🏼‍♂️",
+    "name": "man vampire: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧛🏽‍♂️",
+    "name": "man vampire: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧛🏾‍♂️",
+    "name": "man vampire: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧛🏿‍♂️",
+    "name": "man vampire: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧛‍♀️",
+    "name": "woman vampire",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧛🏻‍♀️",
+    "name": "woman vampire: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧛🏼‍♀️",
+    "name": "woman vampire: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧛🏽‍♀️",
+    "name": "woman vampire: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧛🏾‍♀️",
+    "name": "woman vampire: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧛🏿‍♀️",
+    "name": "woman vampire: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9db-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧜",
+    "name": "merperson",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc.png"
+  },
+  {
+    "emoji": "🧜🏻",
+    "name": "merperson: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fb.png"
+  },
+  {
+    "emoji": "🧜🏼",
+    "name": "merperson: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fc.png"
+  },
+  {
+    "emoji": "🧜🏽",
+    "name": "merperson: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fd.png"
+  },
+  {
+    "emoji": "🧜🏾",
+    "name": "merperson: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fe.png"
+  },
+  {
+    "emoji": "🧜🏿",
+    "name": "merperson: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3ff.png"
+  },
+  {
+    "emoji": "🧜‍♂️",
+    "name": "merman",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧜🏻‍♂️",
+    "name": "merman: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧜🏼‍♂️",
+    "name": "merman: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧜🏽‍♂️",
+    "name": "merman: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧜🏾‍♂️",
+    "name": "merman: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧜🏿‍♂️",
+    "name": "merman: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧜‍♀️",
+    "name": "mermaid",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧜🏻‍♀️",
+    "name": "mermaid: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧜🏼‍♀️",
+    "name": "mermaid: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧜🏽‍♀️",
+    "name": "mermaid: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧜🏾‍♀️",
+    "name": "mermaid: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧜🏿‍♀️",
+    "name": "mermaid: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dc-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧝",
+    "name": "elf",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd.png"
+  },
+  {
+    "emoji": "🧝🏻",
+    "name": "elf: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fb.png"
+  },
+  {
+    "emoji": "🧝🏼",
+    "name": "elf: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fc.png"
+  },
+  {
+    "emoji": "🧝🏽",
+    "name": "elf: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fd.png"
+  },
+  {
+    "emoji": "🧝🏾",
+    "name": "elf: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fe.png"
+  },
+  {
+    "emoji": "🧝🏿",
+    "name": "elf: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3ff.png"
+  },
+  {
+    "emoji": "🧝‍♂️",
+    "name": "man elf",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧝🏻‍♂️",
+    "name": "man elf: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧝🏼‍♂️",
+    "name": "man elf: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧝🏽‍♂️",
+    "name": "man elf: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧝🏾‍♂️",
+    "name": "man elf: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧝🏿‍♂️",
+    "name": "man elf: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧝‍♀️",
+    "name": "woman elf",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧝🏻‍♀️",
+    "name": "woman elf: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧝🏼‍♀️",
+    "name": "woman elf: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧝🏽‍♀️",
+    "name": "woman elf: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧝🏾‍♀️",
+    "name": "woman elf: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧝🏿‍♀️",
+    "name": "woman elf: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9dd-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧞",
+    "name": "genie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9de.png"
+  },
+  {
+    "emoji": "🧞‍♂️",
+    "name": "man genie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9de-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧞‍♀️",
+    "name": "woman genie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9de-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧟",
+    "name": "zombie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9df.png"
+  },
+  {
+    "emoji": "🧟‍♂️",
+    "name": "man zombie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9df-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧟‍♀️",
+    "name": "woman zombie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9df-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧌",
+    "name": "troll",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cc.png"
+  },
+  {
+    "emoji": "💆",
+    "name": "person getting massage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486.png"
+  },
+  {
+    "emoji": "💆🏻",
+    "name": "person getting massage: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fb.png"
+  },
+  {
+    "emoji": "💆🏼",
+    "name": "person getting massage: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fc.png"
+  },
+  {
+    "emoji": "💆🏽",
+    "name": "person getting massage: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fd.png"
+  },
+  {
+    "emoji": "💆🏾",
+    "name": "person getting massage: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fe.png"
+  },
+  {
+    "emoji": "💆🏿",
+    "name": "person getting massage: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3ff.png"
+  },
+  {
+    "emoji": "💆‍♂️",
+    "name": "man getting massage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💆🏻‍♂️",
+    "name": "man getting massage: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💆🏼‍♂️",
+    "name": "man getting massage: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💆🏽‍♂️",
+    "name": "man getting massage: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💆🏾‍♂️",
+    "name": "man getting massage: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💆🏿‍♂️",
+    "name": "man getting massage: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💆‍♀️",
+    "name": "woman getting massage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💆🏻‍♀️",
+    "name": "woman getting massage: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💆🏼‍♀️",
+    "name": "woman getting massage: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💆🏽‍♀️",
+    "name": "woman getting massage: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💆🏾‍♀️",
+    "name": "woman getting massage: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💆🏿‍♀️",
+    "name": "woman getting massage: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f486-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💇",
+    "name": "person getting haircut",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487.png"
+  },
+  {
+    "emoji": "💇🏻",
+    "name": "person getting haircut: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fb.png"
+  },
+  {
+    "emoji": "💇🏼",
+    "name": "person getting haircut: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fc.png"
+  },
+  {
+    "emoji": "💇🏽",
+    "name": "person getting haircut: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fd.png"
+  },
+  {
+    "emoji": "💇🏾",
+    "name": "person getting haircut: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fe.png"
+  },
+  {
+    "emoji": "💇🏿",
+    "name": "person getting haircut: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3ff.png"
+  },
+  {
+    "emoji": "💇‍♂️",
+    "name": "man getting haircut",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💇🏻‍♂️",
+    "name": "man getting haircut: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💇🏼‍♂️",
+    "name": "man getting haircut: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💇🏽‍♂️",
+    "name": "man getting haircut: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💇🏾‍♂️",
+    "name": "man getting haircut: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💇🏿‍♂️",
+    "name": "man getting haircut: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "💇‍♀️",
+    "name": "woman getting haircut",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💇🏻‍♀️",
+    "name": "woman getting haircut: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💇🏼‍♀️",
+    "name": "woman getting haircut: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💇🏽‍♀️",
+    "name": "woman getting haircut: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💇🏾‍♀️",
+    "name": "woman getting haircut: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "💇🏿‍♀️",
+    "name": "woman getting haircut: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f487-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚶",
+    "name": "person walking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6.png"
+  },
+  {
+    "emoji": "🚶🏻",
+    "name": "person walking: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fb.png"
+  },
+  {
+    "emoji": "🚶🏼",
+    "name": "person walking: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fc.png"
+  },
+  {
+    "emoji": "🚶🏽",
+    "name": "person walking: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fd.png"
+  },
+  {
+    "emoji": "🚶🏾",
+    "name": "person walking: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fe.png"
+  },
+  {
+    "emoji": "🚶🏿",
+    "name": "person walking: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3ff.png"
+  },
+  {
+    "emoji": "🚶‍♂️",
+    "name": "man walking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏻‍♂️",
+    "name": "man walking: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏼‍♂️",
+    "name": "man walking: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏽‍♂️",
+    "name": "man walking: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏾‍♂️",
+    "name": "man walking: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏿‍♂️",
+    "name": "man walking: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚶‍♀️",
+    "name": "woman walking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏻‍♀️",
+    "name": "woman walking: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏼‍♀️",
+    "name": "woman walking: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏽‍♀️",
+    "name": "woman walking: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏾‍♀️",
+    "name": "woman walking: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏿‍♀️",
+    "name": "woman walking: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚶‍➡️",
+    "name": "person walking facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏻‍➡️",
+    "name": "person walking facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fb-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏼‍➡️",
+    "name": "person walking facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏽‍➡️",
+    "name": "person walking facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏾‍➡️",
+    "name": "person walking facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fe-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏿‍➡️",
+    "name": "person walking facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3ff-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶‍♀️‍➡️",
+    "name": "woman walking facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏻‍♀️‍➡️",
+    "name": "woman walking facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fb-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏼‍♀️‍➡️",
+    "name": "woman walking facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fc-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏽‍♀️‍➡️",
+    "name": "woman walking facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fd-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏾‍♀️‍➡️",
+    "name": "woman walking facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fe-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏿‍♀️‍➡️",
+    "name": "woman walking facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3ff-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶‍♂️‍➡️",
+    "name": "man walking facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏻‍♂️‍➡️",
+    "name": "man walking facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fb-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏼‍♂️‍➡️",
+    "name": "man walking facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fc-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏽‍♂️‍➡️",
+    "name": "man walking facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fd-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏾‍♂️‍➡️",
+    "name": "man walking facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3fe-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🚶🏿‍♂️‍➡️",
+    "name": "man walking facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b6-1f3ff-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧍",
+    "name": "person standing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd.png"
+  },
+  {
+    "emoji": "🧍🏻",
+    "name": "person standing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fb.png"
+  },
+  {
+    "emoji": "🧍🏼",
+    "name": "person standing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fc.png"
+  },
+  {
+    "emoji": "🧍🏽",
+    "name": "person standing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fd.png"
+  },
+  {
+    "emoji": "🧍🏾",
+    "name": "person standing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fe.png"
+  },
+  {
+    "emoji": "🧍🏿",
+    "name": "person standing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3ff.png"
+  },
+  {
+    "emoji": "🧍‍♂️",
+    "name": "man standing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧍🏻‍♂️",
+    "name": "man standing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧍🏼‍♂️",
+    "name": "man standing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧍🏽‍♂️",
+    "name": "man standing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧍🏾‍♂️",
+    "name": "man standing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧍🏿‍♂️",
+    "name": "man standing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧍‍♀️",
+    "name": "woman standing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧍🏻‍♀️",
+    "name": "woman standing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧍🏼‍♀️",
+    "name": "woman standing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧍🏽‍♀️",
+    "name": "woman standing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧍🏾‍♀️",
+    "name": "woman standing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧍🏿‍♀️",
+    "name": "woman standing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cd-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧎",
+    "name": "person kneeling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce.png"
+  },
+  {
+    "emoji": "🧎🏻",
+    "name": "person kneeling: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fb.png"
+  },
+  {
+    "emoji": "🧎🏼",
+    "name": "person kneeling: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fc.png"
+  },
+  {
+    "emoji": "🧎🏽",
+    "name": "person kneeling: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fd.png"
+  },
+  {
+    "emoji": "🧎🏾",
+    "name": "person kneeling: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fe.png"
+  },
+  {
+    "emoji": "🧎🏿",
+    "name": "person kneeling: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3ff.png"
+  },
+  {
+    "emoji": "🧎‍♂️",
+    "name": "man kneeling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏻‍♂️",
+    "name": "man kneeling: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏼‍♂️",
+    "name": "man kneeling: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏽‍♂️",
+    "name": "man kneeling: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏾‍♂️",
+    "name": "man kneeling: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏿‍♂️",
+    "name": "man kneeling: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧎‍♀️",
+    "name": "woman kneeling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏻‍♀️",
+    "name": "woman kneeling: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏼‍♀️",
+    "name": "woman kneeling: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏽‍♀️",
+    "name": "woman kneeling: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏾‍♀️",
+    "name": "woman kneeling: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏿‍♀️",
+    "name": "woman kneeling: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧎‍➡️",
+    "name": "person kneeling facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏻‍➡️",
+    "name": "person kneeling facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fb-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏼‍➡️",
+    "name": "person kneeling facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏽‍➡️",
+    "name": "person kneeling facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏾‍➡️",
+    "name": "person kneeling facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fe-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏿‍➡️",
+    "name": "person kneeling facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3ff-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎‍♀️‍➡️",
+    "name": "woman kneeling facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏻‍♀️‍➡️",
+    "name": "woman kneeling facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fb-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏼‍♀️‍➡️",
+    "name": "woman kneeling facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fc-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏽‍♀️‍➡️",
+    "name": "woman kneeling facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fd-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏾‍♀️‍➡️",
+    "name": "woman kneeling facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fe-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏿‍♀️‍➡️",
+    "name": "woman kneeling facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3ff-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎‍♂️‍➡️",
+    "name": "man kneeling facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏻‍♂️‍➡️",
+    "name": "man kneeling facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fb-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏼‍♂️‍➡️",
+    "name": "man kneeling facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fc-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏽‍♂️‍➡️",
+    "name": "man kneeling facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fd-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏾‍♂️‍➡️",
+    "name": "man kneeling facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3fe-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧎🏿‍♂️‍➡️",
+    "name": "man kneeling facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ce-1f3ff-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑‍🦯",
+    "name": "person with white cane",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9af.png"
+  },
+  {
+    "emoji": "🧑🏻‍🦯",
+    "name": "person with white cane: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f9af.png"
+  },
+  {
+    "emoji": "🧑🏼‍🦯",
+    "name": "person with white cane: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f9af.png"
+  },
+  {
+    "emoji": "🧑🏽‍🦯",
+    "name": "person with white cane: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f9af.png"
+  },
+  {
+    "emoji": "🧑🏾‍🦯",
+    "name": "person with white cane: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f9af.png"
+  },
+  {
+    "emoji": "🧑🏿‍🦯",
+    "name": "person with white cane: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f9af.png"
+  },
+  {
+    "emoji": "🧑‍🦯‍➡️",
+    "name": "person with white cane facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏻‍🦯‍➡️",
+    "name": "person with white cane facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏼‍🦯‍➡️",
+    "name": "person with white cane facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏽‍🦯‍➡️",
+    "name": "person with white cane facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏾‍🦯‍➡️",
+    "name": "person with white cane facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏿‍🦯‍➡️",
+    "name": "person with white cane facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨‍🦯",
+    "name": "man with white cane",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f9af.png"
+  },
+  {
+    "emoji": "👨🏻‍🦯",
+    "name": "man with white cane: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f9af.png"
+  },
+  {
+    "emoji": "👨🏼‍🦯",
+    "name": "man with white cane: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f9af.png"
+  },
+  {
+    "emoji": "👨🏽‍🦯",
+    "name": "man with white cane: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f9af.png"
+  },
+  {
+    "emoji": "👨🏾‍🦯",
+    "name": "man with white cane: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f9af.png"
+  },
+  {
+    "emoji": "👨🏿‍🦯",
+    "name": "man with white cane: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f9af.png"
+  },
+  {
+    "emoji": "👨‍🦯‍➡️",
+    "name": "man with white cane facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏻‍🦯‍➡️",
+    "name": "man with white cane facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏼‍🦯‍➡️",
+    "name": "man with white cane facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏽‍🦯‍➡️",
+    "name": "man with white cane facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏾‍🦯‍➡️",
+    "name": "man with white cane facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏿‍🦯‍➡️",
+    "name": "man with white cane facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩‍🦯",
+    "name": "woman with white cane",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f9af.png"
+  },
+  {
+    "emoji": "👩🏻‍🦯",
+    "name": "woman with white cane: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f9af.png"
+  },
+  {
+    "emoji": "👩🏼‍🦯",
+    "name": "woman with white cane: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f9af.png"
+  },
+  {
+    "emoji": "👩🏽‍🦯",
+    "name": "woman with white cane: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f9af.png"
+  },
+  {
+    "emoji": "👩🏾‍🦯",
+    "name": "woman with white cane: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f9af.png"
+  },
+  {
+    "emoji": "👩🏿‍🦯",
+    "name": "woman with white cane: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f9af.png"
+  },
+  {
+    "emoji": "👩‍🦯‍➡️",
+    "name": "woman with white cane facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏻‍🦯‍➡️",
+    "name": "woman with white cane facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏼‍🦯‍➡️",
+    "name": "woman with white cane facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏽‍🦯‍➡️",
+    "name": "woman with white cane facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏾‍🦯‍➡️",
+    "name": "woman with white cane facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏿‍🦯‍➡️",
+    "name": "woman with white cane facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f9af-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑‍🦼",
+    "name": "person in motorized wheelchair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9bc.png"
+  },
+  {
+    "emoji": "🧑🏻‍🦼",
+    "name": "person in motorized wheelchair: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f9bc.png"
+  },
+  {
+    "emoji": "🧑🏼‍🦼",
+    "name": "person in motorized wheelchair: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f9bc.png"
+  },
+  {
+    "emoji": "🧑🏽‍🦼",
+    "name": "person in motorized wheelchair: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f9bc.png"
+  },
+  {
+    "emoji": "🧑🏾‍🦼",
+    "name": "person in motorized wheelchair: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f9bc.png"
+  },
+  {
+    "emoji": "🧑🏿‍🦼",
+    "name": "person in motorized wheelchair: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f9bc.png"
+  },
+  {
+    "emoji": "🧑‍🦼‍➡️",
+    "name": "person in motorized wheelchair facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏻‍🦼‍➡️",
+    "name": "person in motorized wheelchair facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏼‍🦼‍➡️",
+    "name": "person in motorized wheelchair facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏽‍🦼‍➡️",
+    "name": "person in motorized wheelchair facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏾‍🦼‍➡️",
+    "name": "person in motorized wheelchair facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏿‍🦼‍➡️",
+    "name": "person in motorized wheelchair facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨‍🦼",
+    "name": "man in motorized wheelchair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👨🏻‍🦼",
+    "name": "man in motorized wheelchair: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👨🏼‍🦼",
+    "name": "man in motorized wheelchair: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👨🏽‍🦼",
+    "name": "man in motorized wheelchair: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👨🏾‍🦼",
+    "name": "man in motorized wheelchair: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👨🏿‍🦼",
+    "name": "man in motorized wheelchair: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👨‍🦼‍➡️",
+    "name": "man in motorized wheelchair facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏻‍🦼‍➡️",
+    "name": "man in motorized wheelchair facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏼‍🦼‍➡️",
+    "name": "man in motorized wheelchair facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏽‍🦼‍➡️",
+    "name": "man in motorized wheelchair facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏾‍🦼‍➡️",
+    "name": "man in motorized wheelchair facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏿‍🦼‍➡️",
+    "name": "man in motorized wheelchair facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩‍🦼",
+    "name": "woman in motorized wheelchair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👩🏻‍🦼",
+    "name": "woman in motorized wheelchair: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👩🏼‍🦼",
+    "name": "woman in motorized wheelchair: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👩🏽‍🦼",
+    "name": "woman in motorized wheelchair: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👩🏾‍🦼",
+    "name": "woman in motorized wheelchair: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👩🏿‍🦼",
+    "name": "woman in motorized wheelchair: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f9bc.png"
+  },
+  {
+    "emoji": "👩‍🦼‍➡️",
+    "name": "woman in motorized wheelchair facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏻‍🦼‍➡️",
+    "name": "woman in motorized wheelchair facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏼‍🦼‍➡️",
+    "name": "woman in motorized wheelchair facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏽‍🦼‍➡️",
+    "name": "woman in motorized wheelchair facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏾‍🦼‍➡️",
+    "name": "woman in motorized wheelchair facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏿‍🦼‍➡️",
+    "name": "woman in motorized wheelchair facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f9bc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑‍🦽",
+    "name": "person in manual wheelchair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9bd.png"
+  },
+  {
+    "emoji": "🧑🏻‍🦽",
+    "name": "person in manual wheelchair: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f9bd.png"
+  },
+  {
+    "emoji": "🧑🏼‍🦽",
+    "name": "person in manual wheelchair: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f9bd.png"
+  },
+  {
+    "emoji": "🧑🏽‍🦽",
+    "name": "person in manual wheelchair: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f9bd.png"
+  },
+  {
+    "emoji": "🧑🏾‍🦽",
+    "name": "person in manual wheelchair: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f9bd.png"
+  },
+  {
+    "emoji": "🧑🏿‍🦽",
+    "name": "person in manual wheelchair: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f9bd.png"
+  },
+  {
+    "emoji": "🧑‍🦽‍➡️",
+    "name": "person in manual wheelchair facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏻‍🦽‍➡️",
+    "name": "person in manual wheelchair facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏼‍🦽‍➡️",
+    "name": "person in manual wheelchair facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏽‍🦽‍➡️",
+    "name": "person in manual wheelchair facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏾‍🦽‍➡️",
+    "name": "person in manual wheelchair facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🧑🏿‍🦽‍➡️",
+    "name": "person in manual wheelchair facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨‍🦽",
+    "name": "man in manual wheelchair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👨🏻‍🦽",
+    "name": "man in manual wheelchair: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👨🏼‍🦽",
+    "name": "man in manual wheelchair: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👨🏽‍🦽",
+    "name": "man in manual wheelchair: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👨🏾‍🦽",
+    "name": "man in manual wheelchair: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👨🏿‍🦽",
+    "name": "man in manual wheelchair: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👨‍🦽‍➡️",
+    "name": "man in manual wheelchair facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏻‍🦽‍➡️",
+    "name": "man in manual wheelchair facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏼‍🦽‍➡️",
+    "name": "man in manual wheelchair facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏽‍🦽‍➡️",
+    "name": "man in manual wheelchair facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏾‍🦽‍➡️",
+    "name": "man in manual wheelchair facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👨🏿‍🦽‍➡️",
+    "name": "man in manual wheelchair facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩‍🦽",
+    "name": "woman in manual wheelchair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👩🏻‍🦽",
+    "name": "woman in manual wheelchair: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👩🏼‍🦽",
+    "name": "woman in manual wheelchair: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👩🏽‍🦽",
+    "name": "woman in manual wheelchair: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👩🏾‍🦽",
+    "name": "woman in manual wheelchair: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👩🏿‍🦽",
+    "name": "woman in manual wheelchair: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f9bd.png"
+  },
+  {
+    "emoji": "👩‍🦽‍➡️",
+    "name": "woman in manual wheelchair facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏻‍🦽‍➡️",
+    "name": "woman in manual wheelchair facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏼‍🦽‍➡️",
+    "name": "woman in manual wheelchair facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏽‍🦽‍➡️",
+    "name": "woman in manual wheelchair facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏾‍🦽‍➡️",
+    "name": "woman in manual wheelchair facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "👩🏿‍🦽‍➡️",
+    "name": "woman in manual wheelchair facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f9bd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃",
+    "name": "person running",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3.png"
+  },
+  {
+    "emoji": "🏃🏻",
+    "name": "person running: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fb.png"
+  },
+  {
+    "emoji": "🏃🏼",
+    "name": "person running: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fc.png"
+  },
+  {
+    "emoji": "🏃🏽",
+    "name": "person running: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fd.png"
+  },
+  {
+    "emoji": "🏃🏾",
+    "name": "person running: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fe.png"
+  },
+  {
+    "emoji": "🏃🏿",
+    "name": "person running: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3ff.png"
+  },
+  {
+    "emoji": "🏃‍♂️",
+    "name": "man running",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏻‍♂️",
+    "name": "man running: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏼‍♂️",
+    "name": "man running: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏽‍♂️",
+    "name": "man running: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏾‍♂️",
+    "name": "man running: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏿‍♂️",
+    "name": "man running: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏃‍♀️",
+    "name": "woman running",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏻‍♀️",
+    "name": "woman running: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏼‍♀️",
+    "name": "woman running: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏽‍♀️",
+    "name": "woman running: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏾‍♀️",
+    "name": "woman running: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏿‍♀️",
+    "name": "woman running: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏃‍➡️",
+    "name": "person running facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏻‍➡️",
+    "name": "person running facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fb-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏼‍➡️",
+    "name": "person running facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fc-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏽‍➡️",
+    "name": "person running facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fd-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏾‍➡️",
+    "name": "person running facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fe-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏿‍➡️",
+    "name": "person running facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3ff-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃‍♀️‍➡️",
+    "name": "woman running facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏻‍♀️‍➡️",
+    "name": "woman running facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fb-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏼‍♀️‍➡️",
+    "name": "woman running facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fc-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏽‍♀️‍➡️",
+    "name": "woman running facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fd-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏾‍♀️‍➡️",
+    "name": "woman running facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fe-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏿‍♀️‍➡️",
+    "name": "woman running facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3ff-200d-2640-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃‍♂️‍➡️",
+    "name": "man running facing right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏻‍♂️‍➡️",
+    "name": "man running facing right: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fb-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏼‍♂️‍➡️",
+    "name": "man running facing right: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fc-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏽‍♂️‍➡️",
+    "name": "man running facing right: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fd-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏾‍♂️‍➡️",
+    "name": "man running facing right: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3fe-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "🏃🏿‍♂️‍➡️",
+    "name": "man running facing right: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c3-1f3ff-200d-2642-fe0f-200d-27a1-fe0f.png"
+  },
+  {
+    "emoji": "💃",
+    "name": "woman dancing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f483.png"
+  },
+  {
+    "emoji": "💃🏻",
+    "name": "woman dancing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f483-1f3fb.png"
+  },
+  {
+    "emoji": "💃🏼",
+    "name": "woman dancing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f483-1f3fc.png"
+  },
+  {
+    "emoji": "💃🏽",
+    "name": "woman dancing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f483-1f3fd.png"
+  },
+  {
+    "emoji": "💃🏾",
+    "name": "woman dancing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f483-1f3fe.png"
+  },
+  {
+    "emoji": "💃🏿",
+    "name": "woman dancing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f483-1f3ff.png"
+  },
+  {
+    "emoji": "🕺",
+    "name": "man dancing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f57a.png"
+  },
+  {
+    "emoji": "🕺🏻",
+    "name": "man dancing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f57a-1f3fb.png"
+  },
+  {
+    "emoji": "🕺🏼",
+    "name": "man dancing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f57a-1f3fc.png"
+  },
+  {
+    "emoji": "🕺🏽",
+    "name": "man dancing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f57a-1f3fd.png"
+  },
+  {
+    "emoji": "🕺🏾",
+    "name": "man dancing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f57a-1f3fe.png"
+  },
+  {
+    "emoji": "🕺🏿",
+    "name": "man dancing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f57a-1f3ff.png"
+  },
+  {
+    "emoji": "🕴️",
+    "name": "person in suit levitating",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f574-fe0f.png"
+  },
+  {
+    "emoji": "🕴🏻",
+    "name": "person in suit levitating: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f574-1f3fb.png"
+  },
+  {
+    "emoji": "🕴🏼",
+    "name": "person in suit levitating: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f574-1f3fc.png"
+  },
+  {
+    "emoji": "🕴🏽",
+    "name": "person in suit levitating: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f574-1f3fd.png"
+  },
+  {
+    "emoji": "🕴🏾",
+    "name": "person in suit levitating: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f574-1f3fe.png"
+  },
+  {
+    "emoji": "🕴🏿",
+    "name": "person in suit levitating: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f574-1f3ff.png"
+  },
+  {
+    "emoji": "👯",
+    "name": "people with bunny ears",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46f.png"
+  },
+  {
+    "emoji": "👯‍♂️",
+    "name": "men with bunny ears",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46f-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "👯‍♀️",
+    "name": "women with bunny ears",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46f-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧖",
+    "name": "person in steamy room",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6.png"
+  },
+  {
+    "emoji": "🧖🏻",
+    "name": "person in steamy room: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fb.png"
+  },
+  {
+    "emoji": "🧖🏼",
+    "name": "person in steamy room: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fc.png"
+  },
+  {
+    "emoji": "🧖🏽",
+    "name": "person in steamy room: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fd.png"
+  },
+  {
+    "emoji": "🧖🏾",
+    "name": "person in steamy room: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fe.png"
+  },
+  {
+    "emoji": "🧖🏿",
+    "name": "person in steamy room: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3ff.png"
+  },
+  {
+    "emoji": "🧖‍♂️",
+    "name": "man in steamy room",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧖🏻‍♂️",
+    "name": "man in steamy room: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧖🏼‍♂️",
+    "name": "man in steamy room: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧖🏽‍♂️",
+    "name": "man in steamy room: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧖🏾‍♂️",
+    "name": "man in steamy room: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧖🏿‍♂️",
+    "name": "man in steamy room: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧖‍♀️",
+    "name": "woman in steamy room",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧖🏻‍♀️",
+    "name": "woman in steamy room: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧖🏼‍♀️",
+    "name": "woman in steamy room: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧖🏽‍♀️",
+    "name": "woman in steamy room: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧖🏾‍♀️",
+    "name": "woman in steamy room: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧖🏿‍♀️",
+    "name": "woman in steamy room: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d6-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧗",
+    "name": "person climbing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7.png"
+  },
+  {
+    "emoji": "🧗🏻",
+    "name": "person climbing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fb.png"
+  },
+  {
+    "emoji": "🧗🏼",
+    "name": "person climbing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fc.png"
+  },
+  {
+    "emoji": "🧗🏽",
+    "name": "person climbing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fd.png"
+  },
+  {
+    "emoji": "🧗🏾",
+    "name": "person climbing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fe.png"
+  },
+  {
+    "emoji": "🧗🏿",
+    "name": "person climbing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3ff.png"
+  },
+  {
+    "emoji": "🧗‍♂️",
+    "name": "man climbing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧗🏻‍♂️",
+    "name": "man climbing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧗🏼‍♂️",
+    "name": "man climbing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧗🏽‍♂️",
+    "name": "man climbing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧗🏾‍♂️",
+    "name": "man climbing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧗🏿‍♂️",
+    "name": "man climbing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧗‍♀️",
+    "name": "woman climbing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧗🏻‍♀️",
+    "name": "woman climbing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧗🏼‍♀️",
+    "name": "woman climbing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧗🏽‍♀️",
+    "name": "woman climbing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧗🏾‍♀️",
+    "name": "woman climbing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧗🏿‍♀️",
+    "name": "woman climbing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d7-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤺",
+    "name": "person fencing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93a.png"
+  },
+  {
+    "emoji": "🏇",
+    "name": "horse racing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c7.png"
+  },
+  {
+    "emoji": "🏇🏻",
+    "name": "horse racing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c7-1f3fb.png"
+  },
+  {
+    "emoji": "🏇🏼",
+    "name": "horse racing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c7-1f3fc.png"
+  },
+  {
+    "emoji": "🏇🏽",
+    "name": "horse racing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c7-1f3fd.png"
+  },
+  {
+    "emoji": "🏇🏾",
+    "name": "horse racing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c7-1f3fe.png"
+  },
+  {
+    "emoji": "🏇🏿",
+    "name": "horse racing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c7-1f3ff.png"
+  },
+  {
+    "emoji": "⛷️",
+    "name": "skier",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f7-fe0f.png"
+  },
+  {
+    "emoji": "🏂",
+    "name": "snowboarder",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c2.png"
+  },
+  {
+    "emoji": "🏂🏻",
+    "name": "snowboarder: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c2-1f3fb.png"
+  },
+  {
+    "emoji": "🏂🏼",
+    "name": "snowboarder: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c2-1f3fc.png"
+  },
+  {
+    "emoji": "🏂🏽",
+    "name": "snowboarder: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c2-1f3fd.png"
+  },
+  {
+    "emoji": "🏂🏾",
+    "name": "snowboarder: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c2-1f3fe.png"
+  },
+  {
+    "emoji": "🏂🏿",
+    "name": "snowboarder: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c2-1f3ff.png"
+  },
+  {
+    "emoji": "🏌️",
+    "name": "person golfing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏻",
+    "name": "person golfing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fb.png"
+  },
+  {
+    "emoji": "🏌🏼",
+    "name": "person golfing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fc.png"
+  },
+  {
+    "emoji": "🏌🏽",
+    "name": "person golfing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fd.png"
+  },
+  {
+    "emoji": "🏌🏾",
+    "name": "person golfing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fe.png"
+  },
+  {
+    "emoji": "🏌🏿",
+    "name": "person golfing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3ff.png"
+  },
+  {
+    "emoji": "🏌️‍♂️",
+    "name": "man golfing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-fe0f-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏻‍♂️",
+    "name": "man golfing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏼‍♂️",
+    "name": "man golfing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏽‍♂️",
+    "name": "man golfing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏾‍♂️",
+    "name": "man golfing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏿‍♂️",
+    "name": "man golfing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏌️‍♀️",
+    "name": "woman golfing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-fe0f-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏻‍♀️",
+    "name": "woman golfing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏼‍♀️",
+    "name": "woman golfing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏽‍♀️",
+    "name": "woman golfing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏾‍♀️",
+    "name": "woman golfing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏌🏿‍♀️",
+    "name": "woman golfing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cc-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏄",
+    "name": "person surfing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4.png"
+  },
+  {
+    "emoji": "🏄🏻",
+    "name": "person surfing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fb.png"
+  },
+  {
+    "emoji": "🏄🏼",
+    "name": "person surfing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fc.png"
+  },
+  {
+    "emoji": "🏄🏽",
+    "name": "person surfing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fd.png"
+  },
+  {
+    "emoji": "🏄🏾",
+    "name": "person surfing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fe.png"
+  },
+  {
+    "emoji": "🏄🏿",
+    "name": "person surfing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3ff.png"
+  },
+  {
+    "emoji": "🏄‍♂️",
+    "name": "man surfing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏄🏻‍♂️",
+    "name": "man surfing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏄🏼‍♂️",
+    "name": "man surfing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏄🏽‍♂️",
+    "name": "man surfing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏄🏾‍♂️",
+    "name": "man surfing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏄🏿‍♂️",
+    "name": "man surfing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏄‍♀️",
+    "name": "woman surfing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏄🏻‍♀️",
+    "name": "woman surfing: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏄🏼‍♀️",
+    "name": "woman surfing: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏄🏽‍♀️",
+    "name": "woman surfing: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏄🏾‍♀️",
+    "name": "woman surfing: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏄🏿‍♀️",
+    "name": "woman surfing: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c4-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚣",
+    "name": "person rowing boat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3.png"
+  },
+  {
+    "emoji": "🚣🏻",
+    "name": "person rowing boat: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fb.png"
+  },
+  {
+    "emoji": "🚣🏼",
+    "name": "person rowing boat: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fc.png"
+  },
+  {
+    "emoji": "🚣🏽",
+    "name": "person rowing boat: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fd.png"
+  },
+  {
+    "emoji": "🚣🏾",
+    "name": "person rowing boat: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fe.png"
+  },
+  {
+    "emoji": "🚣🏿",
+    "name": "person rowing boat: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3ff.png"
+  },
+  {
+    "emoji": "🚣‍♂️",
+    "name": "man rowing boat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚣🏻‍♂️",
+    "name": "man rowing boat: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚣🏼‍♂️",
+    "name": "man rowing boat: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚣🏽‍♂️",
+    "name": "man rowing boat: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚣🏾‍♂️",
+    "name": "man rowing boat: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚣🏿‍♂️",
+    "name": "man rowing boat: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚣‍♀️",
+    "name": "woman rowing boat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚣🏻‍♀️",
+    "name": "woman rowing boat: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚣🏼‍♀️",
+    "name": "woman rowing boat: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚣🏽‍♀️",
+    "name": "woman rowing boat: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚣🏾‍♀️",
+    "name": "woman rowing boat: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚣🏿‍♀️",
+    "name": "woman rowing boat: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a3-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏊",
+    "name": "person swimming",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca.png"
+  },
+  {
+    "emoji": "🏊🏻",
+    "name": "person swimming: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fb.png"
+  },
+  {
+    "emoji": "🏊🏼",
+    "name": "person swimming: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fc.png"
+  },
+  {
+    "emoji": "🏊🏽",
+    "name": "person swimming: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fd.png"
+  },
+  {
+    "emoji": "🏊🏾",
+    "name": "person swimming: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fe.png"
+  },
+  {
+    "emoji": "🏊🏿",
+    "name": "person swimming: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3ff.png"
+  },
+  {
+    "emoji": "🏊‍♂️",
+    "name": "man swimming",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏊🏻‍♂️",
+    "name": "man swimming: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏊🏼‍♂️",
+    "name": "man swimming: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏊🏽‍♂️",
+    "name": "man swimming: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏊🏾‍♂️",
+    "name": "man swimming: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏊🏿‍♂️",
+    "name": "man swimming: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏊‍♀️",
+    "name": "woman swimming",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏊🏻‍♀️",
+    "name": "woman swimming: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏊🏼‍♀️",
+    "name": "woman swimming: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏊🏽‍♀️",
+    "name": "woman swimming: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏊🏾‍♀️",
+    "name": "woman swimming: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏊🏿‍♀️",
+    "name": "woman swimming: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ca-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "⛹️",
+    "name": "person bouncing ball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏻",
+    "name": "person bouncing ball: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fb.png"
+  },
+  {
+    "emoji": "⛹🏼",
+    "name": "person bouncing ball: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fc.png"
+  },
+  {
+    "emoji": "⛹🏽",
+    "name": "person bouncing ball: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fd.png"
+  },
+  {
+    "emoji": "⛹🏾",
+    "name": "person bouncing ball: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fe.png"
+  },
+  {
+    "emoji": "⛹🏿",
+    "name": "person bouncing ball: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3ff.png"
+  },
+  {
+    "emoji": "⛹️‍♂️",
+    "name": "man bouncing ball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-fe0f-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏻‍♂️",
+    "name": "man bouncing ball: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏼‍♂️",
+    "name": "man bouncing ball: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏽‍♂️",
+    "name": "man bouncing ball: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏾‍♂️",
+    "name": "man bouncing ball: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏿‍♂️",
+    "name": "man bouncing ball: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "⛹️‍♀️",
+    "name": "woman bouncing ball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-fe0f-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏻‍♀️",
+    "name": "woman bouncing ball: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏼‍♀️",
+    "name": "woman bouncing ball: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏽‍♀️",
+    "name": "woman bouncing ball: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏾‍♀️",
+    "name": "woman bouncing ball: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "⛹🏿‍♀️",
+    "name": "woman bouncing ball: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f9-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏋️",
+    "name": "person lifting weights",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏻",
+    "name": "person lifting weights: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fb.png"
+  },
+  {
+    "emoji": "🏋🏼",
+    "name": "person lifting weights: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fc.png"
+  },
+  {
+    "emoji": "🏋🏽",
+    "name": "person lifting weights: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fd.png"
+  },
+  {
+    "emoji": "🏋🏾",
+    "name": "person lifting weights: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fe.png"
+  },
+  {
+    "emoji": "🏋🏿",
+    "name": "person lifting weights: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3ff.png"
+  },
+  {
+    "emoji": "🏋️‍♂️",
+    "name": "man lifting weights",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-fe0f-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏻‍♂️",
+    "name": "man lifting weights: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏼‍♂️",
+    "name": "man lifting weights: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏽‍♂️",
+    "name": "man lifting weights: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏾‍♂️",
+    "name": "man lifting weights: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏿‍♂️",
+    "name": "man lifting weights: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🏋️‍♀️",
+    "name": "woman lifting weights",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-fe0f-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏻‍♀️",
+    "name": "woman lifting weights: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏼‍♀️",
+    "name": "woman lifting weights: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏽‍♀️",
+    "name": "woman lifting weights: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏾‍♀️",
+    "name": "woman lifting weights: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🏋🏿‍♀️",
+    "name": "woman lifting weights: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cb-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚴",
+    "name": "person biking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4.png"
+  },
+  {
+    "emoji": "🚴🏻",
+    "name": "person biking: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fb.png"
+  },
+  {
+    "emoji": "🚴🏼",
+    "name": "person biking: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fc.png"
+  },
+  {
+    "emoji": "🚴🏽",
+    "name": "person biking: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fd.png"
+  },
+  {
+    "emoji": "🚴🏾",
+    "name": "person biking: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fe.png"
+  },
+  {
+    "emoji": "🚴🏿",
+    "name": "person biking: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3ff.png"
+  },
+  {
+    "emoji": "🚴‍♂️",
+    "name": "man biking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚴🏻‍♂️",
+    "name": "man biking: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚴🏼‍♂️",
+    "name": "man biking: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚴🏽‍♂️",
+    "name": "man biking: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚴🏾‍♂️",
+    "name": "man biking: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚴🏿‍♂️",
+    "name": "man biking: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚴‍♀️",
+    "name": "woman biking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚴🏻‍♀️",
+    "name": "woman biking: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚴🏼‍♀️",
+    "name": "woman biking: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚴🏽‍♀️",
+    "name": "woman biking: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚴🏾‍♀️",
+    "name": "woman biking: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚴🏿‍♀️",
+    "name": "woman biking: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b4-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚵",
+    "name": "person mountain biking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5.png"
+  },
+  {
+    "emoji": "🚵🏻",
+    "name": "person mountain biking: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fb.png"
+  },
+  {
+    "emoji": "🚵🏼",
+    "name": "person mountain biking: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fc.png"
+  },
+  {
+    "emoji": "🚵🏽",
+    "name": "person mountain biking: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fd.png"
+  },
+  {
+    "emoji": "🚵🏾",
+    "name": "person mountain biking: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fe.png"
+  },
+  {
+    "emoji": "🚵🏿",
+    "name": "person mountain biking: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3ff.png"
+  },
+  {
+    "emoji": "🚵‍♂️",
+    "name": "man mountain biking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚵🏻‍♂️",
+    "name": "man mountain biking: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚵🏼‍♂️",
+    "name": "man mountain biking: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚵🏽‍♂️",
+    "name": "man mountain biking: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚵🏾‍♂️",
+    "name": "man mountain biking: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚵🏿‍♂️",
+    "name": "man mountain biking: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🚵‍♀️",
+    "name": "woman mountain biking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚵🏻‍♀️",
+    "name": "woman mountain biking: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚵🏼‍♀️",
+    "name": "woman mountain biking: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚵🏽‍♀️",
+    "name": "woman mountain biking: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚵🏾‍♀️",
+    "name": "woman mountain biking: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🚵🏿‍♀️",
+    "name": "woman mountain biking: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b5-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤸",
+    "name": "person cartwheeling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938.png"
+  },
+  {
+    "emoji": "🤸🏻",
+    "name": "person cartwheeling: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fb.png"
+  },
+  {
+    "emoji": "🤸🏼",
+    "name": "person cartwheeling: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fc.png"
+  },
+  {
+    "emoji": "🤸🏽",
+    "name": "person cartwheeling: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fd.png"
+  },
+  {
+    "emoji": "🤸🏾",
+    "name": "person cartwheeling: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fe.png"
+  },
+  {
+    "emoji": "🤸🏿",
+    "name": "person cartwheeling: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3ff.png"
+  },
+  {
+    "emoji": "🤸‍♂️",
+    "name": "man cartwheeling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤸🏻‍♂️",
+    "name": "man cartwheeling: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤸🏼‍♂️",
+    "name": "man cartwheeling: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤸🏽‍♂️",
+    "name": "man cartwheeling: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤸🏾‍♂️",
+    "name": "man cartwheeling: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤸🏿‍♂️",
+    "name": "man cartwheeling: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤸‍♀️",
+    "name": "woman cartwheeling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤸🏻‍♀️",
+    "name": "woman cartwheeling: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤸🏼‍♀️",
+    "name": "woman cartwheeling: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤸🏽‍♀️",
+    "name": "woman cartwheeling: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤸🏾‍♀️",
+    "name": "woman cartwheeling: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤸🏿‍♀️",
+    "name": "woman cartwheeling: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f938-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤼",
+    "name": "people wrestling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93c.png"
+  },
+  {
+    "emoji": "🤼‍♂️",
+    "name": "men wrestling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93c-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤼‍♀️",
+    "name": "women wrestling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93c-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤽",
+    "name": "person playing water polo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d.png"
+  },
+  {
+    "emoji": "🤽🏻",
+    "name": "person playing water polo: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fb.png"
+  },
+  {
+    "emoji": "🤽🏼",
+    "name": "person playing water polo: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fc.png"
+  },
+  {
+    "emoji": "🤽🏽",
+    "name": "person playing water polo: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fd.png"
+  },
+  {
+    "emoji": "🤽🏾",
+    "name": "person playing water polo: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fe.png"
+  },
+  {
+    "emoji": "🤽🏿",
+    "name": "person playing water polo: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3ff.png"
+  },
+  {
+    "emoji": "🤽‍♂️",
+    "name": "man playing water polo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤽🏻‍♂️",
+    "name": "man playing water polo: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤽🏼‍♂️",
+    "name": "man playing water polo: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤽🏽‍♂️",
+    "name": "man playing water polo: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤽🏾‍♂️",
+    "name": "man playing water polo: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤽🏿‍♂️",
+    "name": "man playing water polo: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤽‍♀️",
+    "name": "woman playing water polo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤽🏻‍♀️",
+    "name": "woman playing water polo: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤽🏼‍♀️",
+    "name": "woman playing water polo: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤽🏽‍♀️",
+    "name": "woman playing water polo: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤽🏾‍♀️",
+    "name": "woman playing water polo: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤽🏿‍♀️",
+    "name": "woman playing water polo: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93d-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤾",
+    "name": "person playing handball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e.png"
+  },
+  {
+    "emoji": "🤾🏻",
+    "name": "person playing handball: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fb.png"
+  },
+  {
+    "emoji": "🤾🏼",
+    "name": "person playing handball: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fc.png"
+  },
+  {
+    "emoji": "🤾🏽",
+    "name": "person playing handball: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fd.png"
+  },
+  {
+    "emoji": "🤾🏾",
+    "name": "person playing handball: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fe.png"
+  },
+  {
+    "emoji": "🤾🏿",
+    "name": "person playing handball: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3ff.png"
+  },
+  {
+    "emoji": "🤾‍♂️",
+    "name": "man playing handball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤾🏻‍♂️",
+    "name": "man playing handball: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤾🏼‍♂️",
+    "name": "man playing handball: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤾🏽‍♂️",
+    "name": "man playing handball: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤾🏾‍♂️",
+    "name": "man playing handball: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤾🏿‍♂️",
+    "name": "man playing handball: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤾‍♀️",
+    "name": "woman playing handball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤾🏻‍♀️",
+    "name": "woman playing handball: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤾🏼‍♀️",
+    "name": "woman playing handball: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤾🏽‍♀️",
+    "name": "woman playing handball: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤾🏾‍♀️",
+    "name": "woman playing handball: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤾🏿‍♀️",
+    "name": "woman playing handball: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93e-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤹",
+    "name": "person juggling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939.png"
+  },
+  {
+    "emoji": "🤹🏻",
+    "name": "person juggling: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fb.png"
+  },
+  {
+    "emoji": "🤹🏼",
+    "name": "person juggling: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fc.png"
+  },
+  {
+    "emoji": "🤹🏽",
+    "name": "person juggling: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fd.png"
+  },
+  {
+    "emoji": "🤹🏾",
+    "name": "person juggling: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fe.png"
+  },
+  {
+    "emoji": "🤹🏿",
+    "name": "person juggling: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3ff.png"
+  },
+  {
+    "emoji": "🤹‍♂️",
+    "name": "man juggling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤹🏻‍♂️",
+    "name": "man juggling: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤹🏼‍♂️",
+    "name": "man juggling: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤹🏽‍♂️",
+    "name": "man juggling: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤹🏾‍♂️",
+    "name": "man juggling: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤹🏿‍♂️",
+    "name": "man juggling: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🤹‍♀️",
+    "name": "woman juggling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤹🏻‍♀️",
+    "name": "woman juggling: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤹🏼‍♀️",
+    "name": "woman juggling: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤹🏽‍♀️",
+    "name": "woman juggling: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤹🏾‍♀️",
+    "name": "woman juggling: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🤹🏿‍♀️",
+    "name": "woman juggling: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f939-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧘",
+    "name": "person in lotus position",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8.png"
+  },
+  {
+    "emoji": "🧘🏻",
+    "name": "person in lotus position: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fb.png"
+  },
+  {
+    "emoji": "🧘🏼",
+    "name": "person in lotus position: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fc.png"
+  },
+  {
+    "emoji": "🧘🏽",
+    "name": "person in lotus position: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fd.png"
+  },
+  {
+    "emoji": "🧘🏾",
+    "name": "person in lotus position: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fe.png"
+  },
+  {
+    "emoji": "🧘🏿",
+    "name": "person in lotus position: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3ff.png"
+  },
+  {
+    "emoji": "🧘‍♂️",
+    "name": "man in lotus position",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧘🏻‍♂️",
+    "name": "man in lotus position: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fb-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧘🏼‍♂️",
+    "name": "man in lotus position: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fc-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧘🏽‍♂️",
+    "name": "man in lotus position: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fd-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧘🏾‍♂️",
+    "name": "man in lotus position: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fe-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧘🏿‍♂️",
+    "name": "man in lotus position: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3ff-200d-2642-fe0f.png"
+  },
+  {
+    "emoji": "🧘‍♀️",
+    "name": "woman in lotus position",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧘🏻‍♀️",
+    "name": "woman in lotus position: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fb-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧘🏼‍♀️",
+    "name": "woman in lotus position: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fc-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧘🏽‍♀️",
+    "name": "woman in lotus position: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fd-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧘🏾‍♀️",
+    "name": "woman in lotus position: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3fe-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🧘🏿‍♀️",
+    "name": "woman in lotus position: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d8-1f3ff-200d-2640-fe0f.png"
+  },
+  {
+    "emoji": "🛀",
+    "name": "person taking bath",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c0.png"
+  },
+  {
+    "emoji": "🛀🏻",
+    "name": "person taking bath: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c0-1f3fb.png"
+  },
+  {
+    "emoji": "🛀🏼",
+    "name": "person taking bath: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c0-1f3fc.png"
+  },
+  {
+    "emoji": "🛀🏽",
+    "name": "person taking bath: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c0-1f3fd.png"
+  },
+  {
+    "emoji": "🛀🏾",
+    "name": "person taking bath: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c0-1f3fe.png"
+  },
+  {
+    "emoji": "🛀🏿",
+    "name": "person taking bath: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c0-1f3ff.png"
+  },
+  {
+    "emoji": "🛌",
+    "name": "person in bed",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6cc.png"
+  },
+  {
+    "emoji": "🛌🏻",
+    "name": "person in bed: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6cc-1f3fb.png"
+  },
+  {
+    "emoji": "🛌🏼",
+    "name": "person in bed: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6cc-1f3fc.png"
+  },
+  {
+    "emoji": "🛌🏽",
+    "name": "person in bed: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6cc-1f3fd.png"
+  },
+  {
+    "emoji": "🛌🏾",
+    "name": "person in bed: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6cc-1f3fe.png"
+  },
+  {
+    "emoji": "🛌🏿",
+    "name": "person in bed: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6cc-1f3ff.png"
+  },
+  {
+    "emoji": "🧑‍🤝‍🧑",
+    "name": "people holding hands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f91d-200d-1f9d1.png"
+  },
+  {
+    "emoji": "🧑🏻‍🤝‍🧑🏻",
+    "name": "people holding hands: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f91d-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏻‍🤝‍🧑🏼",
+    "name": "people holding hands: light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f91d-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏻‍🤝‍🧑🏽",
+    "name": "people holding hands: light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f91d-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏻‍🤝‍🧑🏾",
+    "name": "people holding hands: light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f91d-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏻‍🤝‍🧑🏿",
+    "name": "people holding hands: light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-1f91d-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏼‍🤝‍🧑🏻",
+    "name": "people holding hands: medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f91d-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏼‍🤝‍🧑🏼",
+    "name": "people holding hands: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f91d-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏼‍🤝‍🧑🏽",
+    "name": "people holding hands: medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f91d-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏼‍🤝‍🧑🏾",
+    "name": "people holding hands: medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f91d-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏼‍🤝‍🧑🏿",
+    "name": "people holding hands: medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-1f91d-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏽‍🤝‍🧑🏻",
+    "name": "people holding hands: medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f91d-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏽‍🤝‍🧑🏼",
+    "name": "people holding hands: medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f91d-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏽‍🤝‍🧑🏽",
+    "name": "people holding hands: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f91d-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏽‍🤝‍🧑🏾",
+    "name": "people holding hands: medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f91d-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏽‍🤝‍🧑🏿",
+    "name": "people holding hands: medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-1f91d-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏾‍🤝‍🧑🏻",
+    "name": "people holding hands: medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f91d-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏾‍🤝‍🧑🏼",
+    "name": "people holding hands: medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f91d-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏾‍🤝‍🧑🏽",
+    "name": "people holding hands: medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f91d-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏾‍🤝‍🧑🏾",
+    "name": "people holding hands: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f91d-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏾‍🤝‍🧑🏿",
+    "name": "people holding hands: medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-1f91d-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏿‍🤝‍🧑🏻",
+    "name": "people holding hands: dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f91d-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏿‍🤝‍🧑🏼",
+    "name": "people holding hands: dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f91d-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏿‍🤝‍🧑🏽",
+    "name": "people holding hands: dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f91d-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏿‍🤝‍🧑🏾",
+    "name": "people holding hands: dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f91d-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏿‍🤝‍🧑🏿",
+    "name": "people holding hands: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-1f91d-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "👭",
+    "name": "women holding hands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46d.png"
+  },
+  {
+    "emoji": "👭🏻",
+    "name": "women holding hands: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46d-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏻‍🤝‍👩🏼",
+    "name": "women holding hands: light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f91d-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏻‍🤝‍👩🏽",
+    "name": "women holding hands: light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f91d-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏻‍🤝‍👩🏾",
+    "name": "women holding hands: light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f91d-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏻‍🤝‍👩🏿",
+    "name": "women holding hands: light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f91d-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏼‍🤝‍👩🏻",
+    "name": "women holding hands: medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f91d-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👭🏼",
+    "name": "women holding hands: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46d-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏼‍🤝‍👩🏽",
+    "name": "women holding hands: medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f91d-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏼‍🤝‍👩🏾",
+    "name": "women holding hands: medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f91d-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏼‍🤝‍👩🏿",
+    "name": "women holding hands: medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f91d-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏽‍🤝‍👩🏻",
+    "name": "women holding hands: medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f91d-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏽‍🤝‍👩🏼",
+    "name": "women holding hands: medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f91d-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👭🏽",
+    "name": "women holding hands: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46d-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏽‍🤝‍👩🏾",
+    "name": "women holding hands: medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f91d-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏽‍🤝‍👩🏿",
+    "name": "women holding hands: medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f91d-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏾‍🤝‍👩🏻",
+    "name": "women holding hands: medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f91d-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏾‍🤝‍👩🏼",
+    "name": "women holding hands: medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f91d-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏾‍🤝‍👩🏽",
+    "name": "women holding hands: medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f91d-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👭🏾",
+    "name": "women holding hands: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46d-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏾‍🤝‍👩🏿",
+    "name": "women holding hands: medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f91d-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏿‍🤝‍👩🏻",
+    "name": "women holding hands: dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f91d-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏿‍🤝‍👩🏼",
+    "name": "women holding hands: dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f91d-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏿‍🤝‍👩🏽",
+    "name": "women holding hands: dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f91d-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏿‍🤝‍👩🏾",
+    "name": "women holding hands: dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f91d-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👭🏿",
+    "name": "women holding hands: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46d-1f3ff.png"
+  },
+  {
+    "emoji": "👫",
+    "name": "woman and man holding hands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46b.png"
+  },
+  {
+    "emoji": "👫🏻",
+    "name": "woman and man holding hands: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46b-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏻‍🤝‍👨🏼",
+    "name": "woman and man holding hands: light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f91d-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏻‍🤝‍👨🏽",
+    "name": "woman and man holding hands: light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f91d-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏻‍🤝‍👨🏾",
+    "name": "woman and man holding hands: light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f91d-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏻‍🤝‍👨🏿",
+    "name": "woman and man holding hands: light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-1f91d-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏼‍🤝‍👨🏻",
+    "name": "woman and man holding hands: medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f91d-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👫🏼",
+    "name": "woman and man holding hands: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46b-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏼‍🤝‍👨🏽",
+    "name": "woman and man holding hands: medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f91d-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏼‍🤝‍👨🏾",
+    "name": "woman and man holding hands: medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f91d-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏼‍🤝‍👨🏿",
+    "name": "woman and man holding hands: medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-1f91d-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏽‍🤝‍👨🏻",
+    "name": "woman and man holding hands: medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f91d-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏽‍🤝‍👨🏼",
+    "name": "woman and man holding hands: medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f91d-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👫🏽",
+    "name": "woman and man holding hands: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46b-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏽‍🤝‍👨🏾",
+    "name": "woman and man holding hands: medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f91d-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏽‍🤝‍👨🏿",
+    "name": "woman and man holding hands: medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-1f91d-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏾‍🤝‍👨🏻",
+    "name": "woman and man holding hands: medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f91d-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏾‍🤝‍👨🏼",
+    "name": "woman and man holding hands: medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f91d-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏾‍🤝‍👨🏽",
+    "name": "woman and man holding hands: medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f91d-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👫🏾",
+    "name": "woman and man holding hands: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46b-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏾‍🤝‍👨🏿",
+    "name": "woman and man holding hands: medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-1f91d-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏿‍🤝‍👨🏻",
+    "name": "woman and man holding hands: dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f91d-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏿‍🤝‍👨🏼",
+    "name": "woman and man holding hands: dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f91d-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏿‍🤝‍👨🏽",
+    "name": "woman and man holding hands: dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f91d-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏿‍🤝‍👨🏾",
+    "name": "woman and man holding hands: dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-1f91d-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👫🏿",
+    "name": "woman and man holding hands: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46b-1f3ff.png"
+  },
+  {
+    "emoji": "👬",
+    "name": "men holding hands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46c.png"
+  },
+  {
+    "emoji": "👬🏻",
+    "name": "men holding hands: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46c-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏻‍🤝‍👨🏼",
+    "name": "men holding hands: light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f91d-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏻‍🤝‍👨🏽",
+    "name": "men holding hands: light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f91d-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏻‍🤝‍👨🏾",
+    "name": "men holding hands: light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f91d-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏻‍🤝‍👨🏿",
+    "name": "men holding hands: light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-1f91d-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏼‍🤝‍👨🏻",
+    "name": "men holding hands: medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f91d-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👬🏼",
+    "name": "men holding hands: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46c-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏼‍🤝‍👨🏽",
+    "name": "men holding hands: medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f91d-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏼‍🤝‍👨🏾",
+    "name": "men holding hands: medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f91d-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏼‍🤝‍👨🏿",
+    "name": "men holding hands: medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-1f91d-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏽‍🤝‍👨🏻",
+    "name": "men holding hands: medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f91d-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏽‍🤝‍👨🏼",
+    "name": "men holding hands: medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f91d-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👬🏽",
+    "name": "men holding hands: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46c-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏽‍🤝‍👨🏾",
+    "name": "men holding hands: medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f91d-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏽‍🤝‍👨🏿",
+    "name": "men holding hands: medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-1f91d-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏾‍🤝‍👨🏻",
+    "name": "men holding hands: medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f91d-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏾‍🤝‍👨🏼",
+    "name": "men holding hands: medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f91d-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏾‍🤝‍👨🏽",
+    "name": "men holding hands: medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f91d-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👬🏾",
+    "name": "men holding hands: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46c-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏾‍🤝‍👨🏿",
+    "name": "men holding hands: medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-1f91d-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏿‍🤝‍👨🏻",
+    "name": "men holding hands: dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f91d-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏿‍🤝‍👨🏼",
+    "name": "men holding hands: dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f91d-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏿‍🤝‍👨🏽",
+    "name": "men holding hands: dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f91d-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏿‍🤝‍👨🏾",
+    "name": "men holding hands: dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-1f91d-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👬🏿",
+    "name": "men holding hands: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46c-1f3ff.png"
+  },
+  {
+    "emoji": "💏",
+    "name": "kiss",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48f.png"
+  },
+  {
+    "emoji": "💏🏻",
+    "name": "kiss: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48f-1f3fb.png"
+  },
+  {
+    "emoji": "💏🏼",
+    "name": "kiss: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48f-1f3fc.png"
+  },
+  {
+    "emoji": "💏🏽",
+    "name": "kiss: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48f-1f3fd.png"
+  },
+  {
+    "emoji": "💏🏾",
+    "name": "kiss: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48f-1f3fe.png"
+  },
+  {
+    "emoji": "💏🏿",
+    "name": "kiss: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48f-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏻‍❤️‍💋‍🧑🏼",
+    "name": "kiss: person, person, light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏻‍❤️‍💋‍🧑🏽",
+    "name": "kiss: person, person, light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏻‍❤️‍💋‍🧑🏾",
+    "name": "kiss: person, person, light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏻‍❤️‍💋‍🧑🏿",
+    "name": "kiss: person, person, light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏼‍❤️‍💋‍🧑🏻",
+    "name": "kiss: person, person, medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏼‍❤️‍💋‍🧑🏽",
+    "name": "kiss: person, person, medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏼‍❤️‍💋‍🧑🏾",
+    "name": "kiss: person, person, medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏼‍❤️‍💋‍🧑🏿",
+    "name": "kiss: person, person, medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏽‍❤️‍💋‍🧑🏻",
+    "name": "kiss: person, person, medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏽‍❤️‍💋‍🧑🏼",
+    "name": "kiss: person, person, medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏽‍❤️‍💋‍🧑🏾",
+    "name": "kiss: person, person, medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏽‍❤️‍💋‍🧑🏿",
+    "name": "kiss: person, person, medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏾‍❤️‍💋‍🧑🏻",
+    "name": "kiss: person, person, medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏾‍❤️‍💋‍🧑🏼",
+    "name": "kiss: person, person, medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏾‍❤️‍💋‍🧑🏽",
+    "name": "kiss: person, person, medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏾‍❤️‍💋‍🧑🏿",
+    "name": "kiss: person, person, medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏿‍❤️‍💋‍🧑🏻",
+    "name": "kiss: person, person, dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏿‍❤️‍💋‍🧑🏼",
+    "name": "kiss: person, person, dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏿‍❤️‍💋‍🧑🏽",
+    "name": "kiss: person, person, dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏿‍❤️‍💋‍🧑🏾",
+    "name": "kiss: person, person, dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "👩‍❤️‍💋‍👨",
+    "name": "kiss: woman, man",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-2764-fe0f-200d-1f48b-200d-1f468.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍💋‍👨🏻",
+    "name": "kiss: woman, man, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍💋‍👨🏼",
+    "name": "kiss: woman, man, light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍💋‍👨🏽",
+    "name": "kiss: woman, man, light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍💋‍👨🏾",
+    "name": "kiss: woman, man, light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍💋‍👨🏿",
+    "name": "kiss: woman, man, light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍💋‍👨🏻",
+    "name": "kiss: woman, man, medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍💋‍👨🏼",
+    "name": "kiss: woman, man, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍💋‍👨🏽",
+    "name": "kiss: woman, man, medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍💋‍👨🏾",
+    "name": "kiss: woman, man, medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍💋‍👨🏿",
+    "name": "kiss: woman, man, medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍💋‍👨🏻",
+    "name": "kiss: woman, man, medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍💋‍👨🏼",
+    "name": "kiss: woman, man, medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍💋‍👨🏽",
+    "name": "kiss: woman, man, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍💋‍👨🏾",
+    "name": "kiss: woman, man, medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍💋‍👨🏿",
+    "name": "kiss: woman, man, medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍💋‍👨🏻",
+    "name": "kiss: woman, man, medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍💋‍👨🏼",
+    "name": "kiss: woman, man, medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍💋‍👨🏽",
+    "name": "kiss: woman, man, medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍💋‍👨🏾",
+    "name": "kiss: woman, man, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍💋‍👨🏿",
+    "name": "kiss: woman, man, medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍💋‍👨🏻",
+    "name": "kiss: woman, man, dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍💋‍👨🏼",
+    "name": "kiss: woman, man, dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍💋‍👨🏽",
+    "name": "kiss: woman, man, dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍💋‍👨🏾",
+    "name": "kiss: woman, man, dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍💋‍👨🏿",
+    "name": "kiss: woman, man, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨‍❤️‍💋‍👨",
+    "name": "kiss: man, man",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-2764-fe0f-200d-1f48b-200d-1f468.png"
+  },
+  {
+    "emoji": "👨🏻‍❤️‍💋‍👨🏻",
+    "name": "kiss: man, man, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏻‍❤️‍💋‍👨🏼",
+    "name": "kiss: man, man, light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏻‍❤️‍💋‍👨🏽",
+    "name": "kiss: man, man, light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏻‍❤️‍💋‍👨🏾",
+    "name": "kiss: man, man, light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏻‍❤️‍💋‍👨🏿",
+    "name": "kiss: man, man, light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏼‍❤️‍💋‍👨🏻",
+    "name": "kiss: man, man, medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏼‍❤️‍💋‍👨🏼",
+    "name": "kiss: man, man, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏼‍❤️‍💋‍👨🏽",
+    "name": "kiss: man, man, medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏼‍❤️‍💋‍👨🏾",
+    "name": "kiss: man, man, medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏼‍❤️‍💋‍👨🏿",
+    "name": "kiss: man, man, medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏽‍❤️‍💋‍👨🏻",
+    "name": "kiss: man, man, medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏽‍❤️‍💋‍👨🏼",
+    "name": "kiss: man, man, medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏽‍❤️‍💋‍👨🏽",
+    "name": "kiss: man, man, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏽‍❤️‍💋‍👨🏾",
+    "name": "kiss: man, man, medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏽‍❤️‍💋‍👨🏿",
+    "name": "kiss: man, man, medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏾‍❤️‍💋‍👨🏻",
+    "name": "kiss: man, man, medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏾‍❤️‍💋‍👨🏼",
+    "name": "kiss: man, man, medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏾‍❤️‍💋‍👨🏽",
+    "name": "kiss: man, man, medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏾‍❤️‍💋‍👨🏾",
+    "name": "kiss: man, man, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏾‍❤️‍💋‍👨🏿",
+    "name": "kiss: man, man, medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏿‍❤️‍💋‍👨🏻",
+    "name": "kiss: man, man, dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏿‍❤️‍💋‍👨🏼",
+    "name": "kiss: man, man, dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏿‍❤️‍💋‍👨🏽",
+    "name": "kiss: man, man, dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏿‍❤️‍💋‍👨🏾",
+    "name": "kiss: man, man, dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏿‍❤️‍💋‍👨🏿",
+    "name": "kiss: man, man, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩‍❤️‍💋‍👩",
+    "name": "kiss: woman, woman",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-2764-fe0f-200d-1f48b-200d-1f469.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍💋‍👩🏻",
+    "name": "kiss: woman, woman, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍💋‍👩🏼",
+    "name": "kiss: woman, woman, light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍💋‍👩🏽",
+    "name": "kiss: woman, woman, light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍💋‍👩🏾",
+    "name": "kiss: woman, woman, light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍💋‍👩🏿",
+    "name": "kiss: woman, woman, light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍💋‍👩🏻",
+    "name": "kiss: woman, woman, medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍💋‍👩🏼",
+    "name": "kiss: woman, woman, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍💋‍👩🏽",
+    "name": "kiss: woman, woman, medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍💋‍👩🏾",
+    "name": "kiss: woman, woman, medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍💋‍👩🏿",
+    "name": "kiss: woman, woman, medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍💋‍👩🏻",
+    "name": "kiss: woman, woman, medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍💋‍👩🏼",
+    "name": "kiss: woman, woman, medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍💋‍👩🏽",
+    "name": "kiss: woman, woman, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍💋‍👩🏾",
+    "name": "kiss: woman, woman, medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍💋‍👩🏿",
+    "name": "kiss: woman, woman, medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍💋‍👩🏻",
+    "name": "kiss: woman, woman, medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍💋‍👩🏼",
+    "name": "kiss: woman, woman, medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍💋‍👩🏽",
+    "name": "kiss: woman, woman, medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍💋‍👩🏾",
+    "name": "kiss: woman, woman, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍💋‍👩🏿",
+    "name": "kiss: woman, woman, medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍💋‍👩🏻",
+    "name": "kiss: woman, woman, dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍💋‍👩🏼",
+    "name": "kiss: woman, woman, dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍💋‍👩🏽",
+    "name": "kiss: woman, woman, dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍💋‍👩🏾",
+    "name": "kiss: woman, woman, dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍💋‍👩🏿",
+    "name": "kiss: woman, woman, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f48b-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "💑",
+    "name": "couple with heart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f491.png"
+  },
+  {
+    "emoji": "💑🏻",
+    "name": "couple with heart: light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f491-1f3fb.png"
+  },
+  {
+    "emoji": "💑🏼",
+    "name": "couple with heart: medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f491-1f3fc.png"
+  },
+  {
+    "emoji": "💑🏽",
+    "name": "couple with heart: medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f491-1f3fd.png"
+  },
+  {
+    "emoji": "💑🏾",
+    "name": "couple with heart: medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f491-1f3fe.png"
+  },
+  {
+    "emoji": "💑🏿",
+    "name": "couple with heart: dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f491-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏻‍❤️‍🧑🏼",
+    "name": "couple with heart: person, person, light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2764-fe0f-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏻‍❤️‍🧑🏽",
+    "name": "couple with heart: person, person, light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2764-fe0f-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏻‍❤️‍🧑🏾",
+    "name": "couple with heart: person, person, light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2764-fe0f-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏻‍❤️‍🧑🏿",
+    "name": "couple with heart: person, person, light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fb-200d-2764-fe0f-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏼‍❤️‍🧑🏻",
+    "name": "couple with heart: person, person, medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2764-fe0f-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏼‍❤️‍🧑🏽",
+    "name": "couple with heart: person, person, medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2764-fe0f-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏼‍❤️‍🧑🏾",
+    "name": "couple with heart: person, person, medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2764-fe0f-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏼‍❤️‍🧑🏿",
+    "name": "couple with heart: person, person, medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fc-200d-2764-fe0f-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏽‍❤️‍🧑🏻",
+    "name": "couple with heart: person, person, medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2764-fe0f-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏽‍❤️‍🧑🏼",
+    "name": "couple with heart: person, person, medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2764-fe0f-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏽‍❤️‍🧑🏾",
+    "name": "couple with heart: person, person, medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2764-fe0f-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "🧑🏽‍❤️‍🧑🏿",
+    "name": "couple with heart: person, person, medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fd-200d-2764-fe0f-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏾‍❤️‍🧑🏻",
+    "name": "couple with heart: person, person, medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2764-fe0f-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏾‍❤️‍🧑🏼",
+    "name": "couple with heart: person, person, medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2764-fe0f-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏾‍❤️‍🧑🏽",
+    "name": "couple with heart: person, person, medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2764-fe0f-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏾‍❤️‍🧑🏿",
+    "name": "couple with heart: person, person, medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3fe-200d-2764-fe0f-200d-1f9d1-1f3ff.png"
+  },
+  {
+    "emoji": "🧑🏿‍❤️‍🧑🏻",
+    "name": "couple with heart: person, person, dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2764-fe0f-200d-1f9d1-1f3fb.png"
+  },
+  {
+    "emoji": "🧑🏿‍❤️‍🧑🏼",
+    "name": "couple with heart: person, person, dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2764-fe0f-200d-1f9d1-1f3fc.png"
+  },
+  {
+    "emoji": "🧑🏿‍❤️‍🧑🏽",
+    "name": "couple with heart: person, person, dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2764-fe0f-200d-1f9d1-1f3fd.png"
+  },
+  {
+    "emoji": "🧑🏿‍❤️‍🧑🏾",
+    "name": "couple with heart: person, person, dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-1f3ff-200d-2764-fe0f-200d-1f9d1-1f3fe.png"
+  },
+  {
+    "emoji": "👩‍❤️‍👨",
+    "name": "couple with heart: woman, man",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-2764-fe0f-200d-1f468.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍👨🏻",
+    "name": "couple with heart: woman, man, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍👨🏼",
+    "name": "couple with heart: woman, man, light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍👨🏽",
+    "name": "couple with heart: woman, man, light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍👨🏾",
+    "name": "couple with heart: woman, man, light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍👨🏿",
+    "name": "couple with heart: woman, man, light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍👨🏻",
+    "name": "couple with heart: woman, man, medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍👨🏼",
+    "name": "couple with heart: woman, man, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍👨🏽",
+    "name": "couple with heart: woman, man, medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍👨🏾",
+    "name": "couple with heart: woman, man, medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍👨🏿",
+    "name": "couple with heart: woman, man, medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍👨🏻",
+    "name": "couple with heart: woman, man, medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍👨🏼",
+    "name": "couple with heart: woman, man, medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍👨🏽",
+    "name": "couple with heart: woman, man, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍👨🏾",
+    "name": "couple with heart: woman, man, medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍👨🏿",
+    "name": "couple with heart: woman, man, medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍👨🏻",
+    "name": "couple with heart: woman, man, medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍👨🏼",
+    "name": "couple with heart: woman, man, medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍👨🏽",
+    "name": "couple with heart: woman, man, medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍👨🏾",
+    "name": "couple with heart: woman, man, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍👨🏿",
+    "name": "couple with heart: woman, man, medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍👨🏻",
+    "name": "couple with heart: woman, man, dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍👨🏼",
+    "name": "couple with heart: woman, man, dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍👨🏽",
+    "name": "couple with heart: woman, man, dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍👨🏾",
+    "name": "couple with heart: woman, man, dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍👨🏿",
+    "name": "couple with heart: woman, man, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨‍❤️‍👨",
+    "name": "couple with heart: man, man",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-2764-fe0f-200d-1f468.png"
+  },
+  {
+    "emoji": "👨🏻‍❤️‍👨🏻",
+    "name": "couple with heart: man, man, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2764-fe0f-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏻‍❤️‍👨🏼",
+    "name": "couple with heart: man, man, light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2764-fe0f-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏻‍❤️‍👨🏽",
+    "name": "couple with heart: man, man, light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2764-fe0f-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏻‍❤️‍👨🏾",
+    "name": "couple with heart: man, man, light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2764-fe0f-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏻‍❤️‍👨🏿",
+    "name": "couple with heart: man, man, light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fb-200d-2764-fe0f-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏼‍❤️‍👨🏻",
+    "name": "couple with heart: man, man, medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2764-fe0f-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏼‍❤️‍👨🏼",
+    "name": "couple with heart: man, man, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2764-fe0f-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏼‍❤️‍👨🏽",
+    "name": "couple with heart: man, man, medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2764-fe0f-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏼‍❤️‍👨🏾",
+    "name": "couple with heart: man, man, medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2764-fe0f-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏼‍❤️‍👨🏿",
+    "name": "couple with heart: man, man, medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fc-200d-2764-fe0f-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏽‍❤️‍👨🏻",
+    "name": "couple with heart: man, man, medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2764-fe0f-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏽‍❤️‍👨🏼",
+    "name": "couple with heart: man, man, medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2764-fe0f-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏽‍❤️‍👨🏽",
+    "name": "couple with heart: man, man, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2764-fe0f-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏽‍❤️‍👨🏾",
+    "name": "couple with heart: man, man, medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2764-fe0f-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏽‍❤️‍👨🏿",
+    "name": "couple with heart: man, man, medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fd-200d-2764-fe0f-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏾‍❤️‍👨🏻",
+    "name": "couple with heart: man, man, medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2764-fe0f-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏾‍❤️‍👨🏼",
+    "name": "couple with heart: man, man, medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2764-fe0f-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏾‍❤️‍👨🏽",
+    "name": "couple with heart: man, man, medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2764-fe0f-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏾‍❤️‍👨🏾",
+    "name": "couple with heart: man, man, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2764-fe0f-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏾‍❤️‍👨🏿",
+    "name": "couple with heart: man, man, medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3fe-200d-2764-fe0f-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👨🏿‍❤️‍👨🏻",
+    "name": "couple with heart: man, man, dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2764-fe0f-200d-1f468-1f3fb.png"
+  },
+  {
+    "emoji": "👨🏿‍❤️‍👨🏼",
+    "name": "couple with heart: man, man, dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2764-fe0f-200d-1f468-1f3fc.png"
+  },
+  {
+    "emoji": "👨🏿‍❤️‍👨🏽",
+    "name": "couple with heart: man, man, dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2764-fe0f-200d-1f468-1f3fd.png"
+  },
+  {
+    "emoji": "👨🏿‍❤️‍👨🏾",
+    "name": "couple with heart: man, man, dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2764-fe0f-200d-1f468-1f3fe.png"
+  },
+  {
+    "emoji": "👨🏿‍❤️‍👨🏿",
+    "name": "couple with heart: man, man, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-1f3ff-200d-2764-fe0f-200d-1f468-1f3ff.png"
+  },
+  {
+    "emoji": "👩‍❤️‍👩",
+    "name": "couple with heart: woman, woman",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-2764-fe0f-200d-1f469.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍👩🏻",
+    "name": "couple with heart: woman, woman, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍👩🏼",
+    "name": "couple with heart: woman, woman, light skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍👩🏽",
+    "name": "couple with heart: woman, woman, light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍👩🏾",
+    "name": "couple with heart: woman, woman, light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏻‍❤️‍👩🏿",
+    "name": "couple with heart: woman, woman, light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fb-200d-2764-fe0f-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍👩🏻",
+    "name": "couple with heart: woman, woman, medium-light skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍👩🏼",
+    "name": "couple with heart: woman, woman, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍👩🏽",
+    "name": "couple with heart: woman, woman, medium-light skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍👩🏾",
+    "name": "couple with heart: woman, woman, medium-light skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏼‍❤️‍👩🏿",
+    "name": "couple with heart: woman, woman, medium-light skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fc-200d-2764-fe0f-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍👩🏻",
+    "name": "couple with heart: woman, woman, medium skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍👩🏼",
+    "name": "couple with heart: woman, woman, medium skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍👩🏽",
+    "name": "couple with heart: woman, woman, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍👩🏾",
+    "name": "couple with heart: woman, woman, medium skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏽‍❤️‍👩🏿",
+    "name": "couple with heart: woman, woman, medium skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fd-200d-2764-fe0f-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍👩🏻",
+    "name": "couple with heart: woman, woman, medium-dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍👩🏼",
+    "name": "couple with heart: woman, woman, medium-dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍👩🏽",
+    "name": "couple with heart: woman, woman, medium-dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍👩🏾",
+    "name": "couple with heart: woman, woman, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏾‍❤️‍👩🏿",
+    "name": "couple with heart: woman, woman, medium-dark skin tone, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3fe-200d-2764-fe0f-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍👩🏻",
+    "name": "couple with heart: woman, woman, dark skin tone, light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f469-1f3fb.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍👩🏼",
+    "name": "couple with heart: woman, woman, dark skin tone, medium-light skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f469-1f3fc.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍👩🏽",
+    "name": "couple with heart: woman, woman, dark skin tone, medium skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f469-1f3fd.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍👩🏾",
+    "name": "couple with heart: woman, woman, dark skin tone, medium-dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f469-1f3fe.png"
+  },
+  {
+    "emoji": "👩🏿‍❤️‍👩🏿",
+    "name": "couple with heart: woman, woman, dark skin tone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-1f3ff-200d-2764-fe0f-200d-1f469-1f3ff.png"
+  },
+  {
+    "emoji": "👨‍👩‍👦",
+    "name": "family: man, woman, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f469-200d-1f466.png"
+  },
+  {
+    "emoji": "👨‍👩‍👧",
+    "name": "family: man, woman, girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f469-200d-1f467.png"
+  },
+  {
+    "emoji": "👨‍👩‍👧‍👦",
+    "name": "family: man, woman, girl, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f469-200d-1f467-200d-1f466.png"
+  },
+  {
+    "emoji": "👨‍👩‍👦‍👦",
+    "name": "family: man, woman, boy, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f469-200d-1f466-200d-1f466.png"
+  },
+  {
+    "emoji": "👨‍👩‍👧‍👧",
+    "name": "family: man, woman, girl, girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f469-200d-1f467-200d-1f467.png"
+  },
+  {
+    "emoji": "👨‍👨‍👦",
+    "name": "family: man, man, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f468-200d-1f466.png"
+  },
+  {
+    "emoji": "👨‍👨‍👧",
+    "name": "family: man, man, girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f468-200d-1f467.png"
+  },
+  {
+    "emoji": "👨‍👨‍👧‍👦",
+    "name": "family: man, man, girl, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f468-200d-1f467-200d-1f466.png"
+  },
+  {
+    "emoji": "👨‍👨‍👦‍👦",
+    "name": "family: man, man, boy, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f468-200d-1f466-200d-1f466.png"
+  },
+  {
+    "emoji": "👨‍👨‍👧‍👧",
+    "name": "family: man, man, girl, girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f468-200d-1f467-200d-1f467.png"
+  },
+  {
+    "emoji": "👩‍👩‍👦",
+    "name": "family: woman, woman, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f469-200d-1f466.png"
+  },
+  {
+    "emoji": "👩‍👩‍👧",
+    "name": "family: woman, woman, girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f469-200d-1f467.png"
+  },
+  {
+    "emoji": "👩‍👩‍👧‍👦",
+    "name": "family: woman, woman, girl, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f469-200d-1f467-200d-1f466.png"
+  },
+  {
+    "emoji": "👩‍👩‍👦‍👦",
+    "name": "family: woman, woman, boy, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f469-200d-1f466-200d-1f466.png"
+  },
+  {
+    "emoji": "👩‍👩‍👧‍👧",
+    "name": "family: woman, woman, girl, girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f469-200d-1f467-200d-1f467.png"
+  },
+  {
+    "emoji": "👨‍👦",
+    "name": "family: man, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f466.png"
+  },
+  {
+    "emoji": "👨‍👦‍👦",
+    "name": "family: man, boy, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f466-200d-1f466.png"
+  },
+  {
+    "emoji": "👨‍👧",
+    "name": "family: man, girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f467.png"
+  },
+  {
+    "emoji": "👨‍👧‍👦",
+    "name": "family: man, girl, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f467-200d-1f466.png"
+  },
+  {
+    "emoji": "👨‍👧‍👧",
+    "name": "family: man, girl, girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f468-200d-1f467-200d-1f467.png"
+  },
+  {
+    "emoji": "👩‍👦",
+    "name": "family: woman, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f466.png"
+  },
+  {
+    "emoji": "👩‍👦‍👦",
+    "name": "family: woman, boy, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f466-200d-1f466.png"
+  },
+  {
+    "emoji": "👩‍👧",
+    "name": "family: woman, girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f467.png"
+  },
+  {
+    "emoji": "👩‍👧‍👦",
+    "name": "family: woman, girl, boy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f467-200d-1f466.png"
+  },
+  {
+    "emoji": "👩‍👧‍👧",
+    "name": "family: woman, girl, girl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f469-200d-1f467-200d-1f467.png"
+  },
+  {
+    "emoji": "🗣️",
+    "name": "speaking head",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5e3-fe0f.png"
+  },
+  {
+    "emoji": "👤",
+    "name": "bust in silhouette",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f464.png"
+  },
+  {
+    "emoji": "👥",
+    "name": "busts in silhouette",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f465.png"
+  },
+  {
+    "emoji": "🫂",
+    "name": "people hugging",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fac2.png"
+  },
+  {
+    "emoji": "👪",
+    "name": "family",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f46a.png"
+  },
+  {
+    "emoji": "🧑‍🧑‍🧒",
+    "name": "family: adult, adult, child",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9d1-200d-1f9d2.png"
+  },
+  {
+    "emoji": "🧑‍🧑‍🧒‍🧒",
+    "name": "family: adult, adult, child, child",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9d1-200d-1f9d2-200d-1f9d2.png"
+  },
+  {
+    "emoji": "🧑‍🧒",
+    "name": "family: adult, child",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9d2.png"
+  },
+  {
+    "emoji": "🧑‍🧒‍🧒",
+    "name": "family: adult, child, child",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9d1-200d-1f9d2-200d-1f9d2.png"
+  },
+  {
+    "emoji": "👣",
+    "name": "footprints",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f463.png"
+  },
+  {
+    "emoji": "🐵",
+    "name": "monkey face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f435.png"
+  },
+  {
+    "emoji": "🐒",
+    "name": "monkey",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f412.png"
+  },
+  {
+    "emoji": "🦍",
+    "name": "gorilla",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f98d.png"
+  },
+  {
+    "emoji": "🦧",
+    "name": "orangutan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9a7.png"
+  },
+  {
+    "emoji": "🐶",
+    "name": "dog face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f436.png"
+  },
+  {
+    "emoji": "🐕",
+    "name": "dog",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f415.png"
+  },
+  {
+    "emoji": "🦮",
+    "name": "guide dog",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ae.png"
+  },
+  {
+    "emoji": "🐕‍🦺",
+    "name": "service dog",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f415-200d-1f9ba.png"
+  },
+  {
+    "emoji": "🐩",
+    "name": "poodle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f429.png"
+  },
+  {
+    "emoji": "🐺",
+    "name": "wolf",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f43a.png"
+  },
+  {
+    "emoji": "🦊",
+    "name": "fox",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f98a.png"
+  },
+  {
+    "emoji": "🦝",
+    "name": "raccoon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f99d.png"
+  },
+  {
+    "emoji": "🐱",
+    "name": "cat face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f431.png"
+  },
+  {
+    "emoji": "🐈",
+    "name": "cat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f408.png"
+  },
+  {
+    "emoji": "🐈‍⬛",
+    "name": "black cat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f408-200d-2b1b.png"
+  },
+  {
+    "emoji": "🦁",
+    "name": "lion",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f981.png"
+  },
+  {
+    "emoji": "🐯",
+    "name": "tiger face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f42f.png"
+  },
+  {
+    "emoji": "🐅",
+    "name": "tiger",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f405.png"
+  },
+  {
+    "emoji": "🐆",
+    "name": "leopard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f406.png"
+  },
+  {
+    "emoji": "🐴",
+    "name": "horse face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f434.png"
+  },
+  {
+    "emoji": "🫎",
+    "name": "moose",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1face.png"
+  },
+  {
+    "emoji": "🫏",
+    "name": "donkey",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1facf.png"
+  },
+  {
+    "emoji": "🐎",
+    "name": "horse",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f40e.png"
+  },
+  {
+    "emoji": "🦄",
+    "name": "unicorn",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f984.png"
+  },
+  {
+    "emoji": "🦓",
+    "name": "zebra",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f993.png"
+  },
+  {
+    "emoji": "🦌",
+    "name": "deer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f98c.png"
+  },
+  {
+    "emoji": "🦬",
+    "name": "bison",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ac.png"
+  },
+  {
+    "emoji": "🐮",
+    "name": "cow face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f42e.png"
+  },
+  {
+    "emoji": "🐂",
+    "name": "ox",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f402.png"
+  },
+  {
+    "emoji": "🐃",
+    "name": "water buffalo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f403.png"
+  },
+  {
+    "emoji": "🐄",
+    "name": "cow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f404.png"
+  },
+  {
+    "emoji": "🐷",
+    "name": "pig face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f437.png"
+  },
+  {
+    "emoji": "🐖",
+    "name": "pig",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f416.png"
+  },
+  {
+    "emoji": "🐗",
+    "name": "boar",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f417.png"
+  },
+  {
+    "emoji": "🐽",
+    "name": "pig nose",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f43d.png"
+  },
+  {
+    "emoji": "🐏",
+    "name": "ram",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f40f.png"
+  },
+  {
+    "emoji": "🐑",
+    "name": "ewe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f411.png"
+  },
+  {
+    "emoji": "🐐",
+    "name": "goat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f410.png"
+  },
+  {
+    "emoji": "🐪",
+    "name": "camel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f42a.png"
+  },
+  {
+    "emoji": "🐫",
+    "name": "two-hump camel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f42b.png"
+  },
+  {
+    "emoji": "🦙",
+    "name": "llama",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f999.png"
+  },
+  {
+    "emoji": "🦒",
+    "name": "giraffe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f992.png"
+  },
+  {
+    "emoji": "🐘",
+    "name": "elephant",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f418.png"
+  },
+  {
+    "emoji": "🦣",
+    "name": "mammoth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9a3.png"
+  },
+  {
+    "emoji": "🦏",
+    "name": "rhinoceros",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f98f.png"
+  },
+  {
+    "emoji": "🦛",
+    "name": "hippopotamus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f99b.png"
+  },
+  {
+    "emoji": "🐭",
+    "name": "mouse face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f42d.png"
+  },
+  {
+    "emoji": "🐁",
+    "name": "mouse",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f401.png"
+  },
+  {
+    "emoji": "🐀",
+    "name": "rat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f400.png"
+  },
+  {
+    "emoji": "🐹",
+    "name": "hamster",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f439.png"
+  },
+  {
+    "emoji": "🐰",
+    "name": "rabbit face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f430.png"
+  },
+  {
+    "emoji": "🐇",
+    "name": "rabbit",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f407.png"
+  },
+  {
+    "emoji": "🐿️",
+    "name": "chipmunk",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f43f-fe0f.png"
+  },
+  {
+    "emoji": "🦫",
+    "name": "beaver",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ab.png"
+  },
+  {
+    "emoji": "🦔",
+    "name": "hedgehog",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f994.png"
+  },
+  {
+    "emoji": "🦇",
+    "name": "bat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f987.png"
+  },
+  {
+    "emoji": "🐻",
+    "name": "bear",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f43b.png"
+  },
+  {
+    "emoji": "🐻‍❄️",
+    "name": "polar bear",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f43b-200d-2744-fe0f.png"
+  },
+  {
+    "emoji": "🐨",
+    "name": "koala",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f428.png"
+  },
+  {
+    "emoji": "🐼",
+    "name": "panda",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f43c.png"
+  },
+  {
+    "emoji": "🦥",
+    "name": "sloth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9a5.png"
+  },
+  {
+    "emoji": "🦦",
+    "name": "otter",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9a6.png"
+  },
+  {
+    "emoji": "🦨",
+    "name": "skunk",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9a8.png"
+  },
+  {
+    "emoji": "🦘",
+    "name": "kangaroo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f998.png"
+  },
+  {
+    "emoji": "🦡",
+    "name": "badger",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9a1.png"
+  },
+  {
+    "emoji": "🐾",
+    "name": "paw prints",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f43e.png"
+  },
+  {
+    "emoji": "🦃",
+    "name": "turkey",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f983.png"
+  },
+  {
+    "emoji": "🐔",
+    "name": "chicken",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f414.png"
+  },
+  {
+    "emoji": "🐓",
+    "name": "rooster",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f413.png"
+  },
+  {
+    "emoji": "🐣",
+    "name": "hatching chick",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f423.png"
+  },
+  {
+    "emoji": "🐤",
+    "name": "baby chick",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f424.png"
+  },
+  {
+    "emoji": "🐥",
+    "name": "front-facing baby chick",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f425.png"
+  },
+  {
+    "emoji": "🐦",
+    "name": "bird",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f426.png"
+  },
+  {
+    "emoji": "🐧",
+    "name": "penguin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f427.png"
+  },
+  {
+    "emoji": "🕊️",
+    "name": "dove",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f54a-fe0f.png"
+  },
+  {
+    "emoji": "🦅",
+    "name": "eagle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f985.png"
+  },
+  {
+    "emoji": "🦆",
+    "name": "duck",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f986.png"
+  },
+  {
+    "emoji": "🦢",
+    "name": "swan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9a2.png"
+  },
+  {
+    "emoji": "🦉",
+    "name": "owl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f989.png"
+  },
+  {
+    "emoji": "🦤",
+    "name": "dodo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9a4.png"
+  },
+  {
+    "emoji": "🪶",
+    "name": "feather",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fab6.png"
+  },
+  {
+    "emoji": "🦩",
+    "name": "flamingo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9a9.png"
+  },
+  {
+    "emoji": "🦚",
+    "name": "peacock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f99a.png"
+  },
+  {
+    "emoji": "🦜",
+    "name": "parrot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f99c.png"
+  },
+  {
+    "emoji": "🪽",
+    "name": "wing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fabd.png"
+  },
+  {
+    "emoji": "🐦‍⬛",
+    "name": "black bird",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f426-200d-2b1b.png"
+  },
+  {
+    "emoji": "🪿",
+    "name": "goose",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fabf.png"
+  },
+  {
+    "emoji": "🐦‍🔥",
+    "name": "phoenix",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f426-200d-1f525.png"
+  },
+  {
+    "emoji": "🐸",
+    "name": "frog",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f438.png"
+  },
+  {
+    "emoji": "🐊",
+    "name": "crocodile",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f40a.png"
+  },
+  {
+    "emoji": "🐢",
+    "name": "turtle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f422.png"
+  },
+  {
+    "emoji": "🦎",
+    "name": "lizard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f98e.png"
+  },
+  {
+    "emoji": "🐍",
+    "name": "snake",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f40d.png"
+  },
+  {
+    "emoji": "🐲",
+    "name": "dragon face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f432.png"
+  },
+  {
+    "emoji": "🐉",
+    "name": "dragon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f409.png"
+  },
+  {
+    "emoji": "🦕",
+    "name": "sauropod",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f995.png"
+  },
+  {
+    "emoji": "🦖",
+    "name": "T-Rex",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f996.png"
+  },
+  {
+    "emoji": "🐳",
+    "name": "spouting whale",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f433.png"
+  },
+  {
+    "emoji": "🐋",
+    "name": "whale",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f40b.png"
+  },
+  {
+    "emoji": "🐬",
+    "name": "dolphin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f42c.png"
+  },
+  {
+    "emoji": "🦭",
+    "name": "seal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ad.png"
+  },
+  {
+    "emoji": "🐟",
+    "name": "fish",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f41f.png"
+  },
+  {
+    "emoji": "🐠",
+    "name": "tropical fish",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f420.png"
+  },
+  {
+    "emoji": "🐡",
+    "name": "blowfish",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f421.png"
+  },
+  {
+    "emoji": "🦈",
+    "name": "shark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f988.png"
+  },
+  {
+    "emoji": "🐙",
+    "name": "octopus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f419.png"
+  },
+  {
+    "emoji": "🐚",
+    "name": "spiral shell",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f41a.png"
+  },
+  {
+    "emoji": "🪸",
+    "name": "coral",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fab8.png"
+  },
+  {
+    "emoji": "🪼",
+    "name": "jellyfish",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fabc.png"
+  },
+  {
+    "emoji": "🐌",
+    "name": "snail",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f40c.png"
+  },
+  {
+    "emoji": "🦋",
+    "name": "butterfly",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f98b.png"
+  },
+  {
+    "emoji": "🐛",
+    "name": "bug",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f41b.png"
+  },
+  {
+    "emoji": "🐜",
+    "name": "ant",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f41c.png"
+  },
+  {
+    "emoji": "🐝",
+    "name": "honeybee",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f41d.png"
+  },
+  {
+    "emoji": "🪲",
+    "name": "beetle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fab2.png"
+  },
+  {
+    "emoji": "🐞",
+    "name": "lady beetle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f41e.png"
+  },
+  {
+    "emoji": "🦗",
+    "name": "cricket",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f997.png"
+  },
+  {
+    "emoji": "🪳",
+    "name": "cockroach",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fab3.png"
+  },
+  {
+    "emoji": "🕷️",
+    "name": "spider",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f577-fe0f.png"
+  },
+  {
+    "emoji": "🕸️",
+    "name": "spider web",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f578-fe0f.png"
+  },
+  {
+    "emoji": "🦂",
+    "name": "scorpion",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f982.png"
+  },
+  {
+    "emoji": "🦟",
+    "name": "mosquito",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f99f.png"
+  },
+  {
+    "emoji": "🪰",
+    "name": "fly",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fab0.png"
+  },
+  {
+    "emoji": "🪱",
+    "name": "worm",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fab1.png"
+  },
+  {
+    "emoji": "🦠",
+    "name": "microbe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9a0.png"
+  },
+  {
+    "emoji": "💐",
+    "name": "bouquet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f490.png"
+  },
+  {
+    "emoji": "🌸",
+    "name": "cherry blossom",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f338.png"
+  },
+  {
+    "emoji": "💮",
+    "name": "white flower",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ae.png"
+  },
+  {
+    "emoji": "🪷",
+    "name": "lotus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fab7.png"
+  },
+  {
+    "emoji": "🏵️",
+    "name": "rosette",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f5-fe0f.png"
+  },
+  {
+    "emoji": "🌹",
+    "name": "rose",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f339.png"
+  },
+  {
+    "emoji": "🥀",
+    "name": "wilted flower",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f940.png"
+  },
+  {
+    "emoji": "🌺",
+    "name": "hibiscus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f33a.png"
+  },
+  {
+    "emoji": "🌻",
+    "name": "sunflower",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f33b.png"
+  },
+  {
+    "emoji": "🌼",
+    "name": "blossom",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f33c.png"
+  },
+  {
+    "emoji": "🌷",
+    "name": "tulip",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f337.png"
+  },
+  {
+    "emoji": "🪻",
+    "name": "hyacinth",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fabb.png"
+  },
+  {
+    "emoji": "🌱",
+    "name": "seedling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f331.png"
+  },
+  {
+    "emoji": "🪴",
+    "name": "potted plant",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fab4.png"
+  },
+  {
+    "emoji": "🌲",
+    "name": "evergreen tree",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f332.png"
+  },
+  {
+    "emoji": "🌳",
+    "name": "deciduous tree",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f333.png"
+  },
+  {
+    "emoji": "🌴",
+    "name": "palm tree",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f334.png"
+  },
+  {
+    "emoji": "🌵",
+    "name": "cactus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f335.png"
+  },
+  {
+    "emoji": "🌾",
+    "name": "sheaf of rice",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f33e.png"
+  },
+  {
+    "emoji": "🌿",
+    "name": "herb",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f33f.png"
+  },
+  {
+    "emoji": "☘️",
+    "name": "shamrock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2618-fe0f.png"
+  },
+  {
+    "emoji": "🍀",
+    "name": "four leaf clover",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f340.png"
+  },
+  {
+    "emoji": "🍁",
+    "name": "maple leaf",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f341.png"
+  },
+  {
+    "emoji": "🍂",
+    "name": "fallen leaf",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f342.png"
+  },
+  {
+    "emoji": "🍃",
+    "name": "leaf fluttering in wind",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f343.png"
+  },
+  {
+    "emoji": "🪹",
+    "name": "empty nest",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fab9.png"
+  },
+  {
+    "emoji": "🪺",
+    "name": "nest with eggs",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faba.png"
+  },
+  {
+    "emoji": "🍄",
+    "name": "mushroom",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f344.png"
+  },
+  {
+    "emoji": "🍇",
+    "name": "grapes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f347.png"
+  },
+  {
+    "emoji": "🍈",
+    "name": "melon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f348.png"
+  },
+  {
+    "emoji": "🍉",
+    "name": "watermelon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f349.png"
+  },
+  {
+    "emoji": "🍊",
+    "name": "tangerine",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f34a.png"
+  },
+  {
+    "emoji": "🍋",
+    "name": "lemon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f34b.png"
+  },
+  {
+    "emoji": "🍋‍🟩",
+    "name": "lime",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f34b-200d-1f7e9.png"
+  },
+  {
+    "emoji": "🍌",
+    "name": "banana",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f34c.png"
+  },
+  {
+    "emoji": "🍍",
+    "name": "pineapple",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f34d.png"
+  },
+  {
+    "emoji": "🥭",
+    "name": "mango",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f96d.png"
+  },
+  {
+    "emoji": "🍎",
+    "name": "red apple",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f34e.png"
+  },
+  {
+    "emoji": "🍏",
+    "name": "green apple",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f34f.png"
+  },
+  {
+    "emoji": "🍐",
+    "name": "pear",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f350.png"
+  },
+  {
+    "emoji": "🍑",
+    "name": "peach",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f351.png"
+  },
+  {
+    "emoji": "🍒",
+    "name": "cherries",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f352.png"
+  },
+  {
+    "emoji": "🍓",
+    "name": "strawberry",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f353.png"
+  },
+  {
+    "emoji": "🫐",
+    "name": "blueberries",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fad0.png"
+  },
+  {
+    "emoji": "🥝",
+    "name": "kiwi fruit",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f95d.png"
+  },
+  {
+    "emoji": "🍅",
+    "name": "tomato",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f345.png"
+  },
+  {
+    "emoji": "🫒",
+    "name": "olive",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fad2.png"
+  },
+  {
+    "emoji": "🥥",
+    "name": "coconut",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f965.png"
+  },
+  {
+    "emoji": "🥑",
+    "name": "avocado",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f951.png"
+  },
+  {
+    "emoji": "🍆",
+    "name": "eggplant",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f346.png"
+  },
+  {
+    "emoji": "🥔",
+    "name": "potato",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f954.png"
+  },
+  {
+    "emoji": "🥕",
+    "name": "carrot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f955.png"
+  },
+  {
+    "emoji": "🌽",
+    "name": "ear of corn",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f33d.png"
+  },
+  {
+    "emoji": "🌶️",
+    "name": "hot pepper",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f336-fe0f.png"
+  },
+  {
+    "emoji": "🫑",
+    "name": "bell pepper",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fad1.png"
+  },
+  {
+    "emoji": "🥒",
+    "name": "cucumber",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f952.png"
+  },
+  {
+    "emoji": "🥬",
+    "name": "leafy green",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f96c.png"
+  },
+  {
+    "emoji": "🥦",
+    "name": "broccoli",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f966.png"
+  },
+  {
+    "emoji": "🧄",
+    "name": "garlic",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9c4.png"
+  },
+  {
+    "emoji": "🧅",
+    "name": "onion",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9c5.png"
+  },
+  {
+    "emoji": "🥜",
+    "name": "peanuts",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f95c.png"
+  },
+  {
+    "emoji": "🫘",
+    "name": "beans",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fad8.png"
+  },
+  {
+    "emoji": "🌰",
+    "name": "chestnut",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f330.png"
+  },
+  {
+    "emoji": "🫚",
+    "name": "ginger root",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fada.png"
+  },
+  {
+    "emoji": "🫛",
+    "name": "pea pod",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fadb.png"
+  },
+  {
+    "emoji": "🍄‍🟫",
+    "name": "brown mushroom",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f344-200d-1f7eb.png"
+  },
+  {
+    "emoji": "🍞",
+    "name": "bread",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f35e.png"
+  },
+  {
+    "emoji": "🥐",
+    "name": "croissant",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f950.png"
+  },
+  {
+    "emoji": "🥖",
+    "name": "baguette bread",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f956.png"
+  },
+  {
+    "emoji": "🫓",
+    "name": "flatbread",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fad3.png"
+  },
+  {
+    "emoji": "🥨",
+    "name": "pretzel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f968.png"
+  },
+  {
+    "emoji": "🥯",
+    "name": "bagel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f96f.png"
+  },
+  {
+    "emoji": "🥞",
+    "name": "pancakes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f95e.png"
+  },
+  {
+    "emoji": "🧇",
+    "name": "waffle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9c7.png"
+  },
+  {
+    "emoji": "🧀",
+    "name": "cheese wedge",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9c0.png"
+  },
+  {
+    "emoji": "🍖",
+    "name": "meat on bone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f356.png"
+  },
+  {
+    "emoji": "🍗",
+    "name": "poultry leg",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f357.png"
+  },
+  {
+    "emoji": "🥩",
+    "name": "cut of meat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f969.png"
+  },
+  {
+    "emoji": "🥓",
+    "name": "bacon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f953.png"
+  },
+  {
+    "emoji": "🍔",
+    "name": "hamburger",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f354.png"
+  },
+  {
+    "emoji": "🍟",
+    "name": "french fries",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f35f.png"
+  },
+  {
+    "emoji": "🍕",
+    "name": "pizza",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f355.png"
+  },
+  {
+    "emoji": "🌭",
+    "name": "hot dog",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f32d.png"
+  },
+  {
+    "emoji": "🥪",
+    "name": "sandwich",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f96a.png"
+  },
+  {
+    "emoji": "🌮",
+    "name": "taco",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f32e.png"
+  },
+  {
+    "emoji": "🌯",
+    "name": "burrito",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f32f.png"
+  },
+  {
+    "emoji": "🫔",
+    "name": "tamale",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fad4.png"
+  },
+  {
+    "emoji": "🥙",
+    "name": "stuffed flatbread",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f959.png"
+  },
+  {
+    "emoji": "🧆",
+    "name": "falafel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9c6.png"
+  },
+  {
+    "emoji": "🥚",
+    "name": "egg",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f95a.png"
+  },
+  {
+    "emoji": "🍳",
+    "name": "cooking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f373.png"
+  },
+  {
+    "emoji": "🥘",
+    "name": "shallow pan of food",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f958.png"
+  },
+  {
+    "emoji": "🍲",
+    "name": "pot of food",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f372.png"
+  },
+  {
+    "emoji": "🫕",
+    "name": "fondue",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fad5.png"
+  },
+  {
+    "emoji": "🥣",
+    "name": "bowl with spoon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f963.png"
+  },
+  {
+    "emoji": "🥗",
+    "name": "green salad",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f957.png"
+  },
+  {
+    "emoji": "🍿",
+    "name": "popcorn",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f37f.png"
+  },
+  {
+    "emoji": "🧈",
+    "name": "butter",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9c8.png"
+  },
+  {
+    "emoji": "🧂",
+    "name": "salt",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9c2.png"
+  },
+  {
+    "emoji": "🥫",
+    "name": "canned food",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f96b.png"
+  },
+  {
+    "emoji": "🍱",
+    "name": "bento box",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f371.png"
+  },
+  {
+    "emoji": "🍘",
+    "name": "rice cracker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f358.png"
+  },
+  {
+    "emoji": "🍙",
+    "name": "rice ball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f359.png"
+  },
+  {
+    "emoji": "🍚",
+    "name": "cooked rice",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f35a.png"
+  },
+  {
+    "emoji": "🍛",
+    "name": "curry rice",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f35b.png"
+  },
+  {
+    "emoji": "🍜",
+    "name": "steaming bowl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f35c.png"
+  },
+  {
+    "emoji": "🍝",
+    "name": "spaghetti",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f35d.png"
+  },
+  {
+    "emoji": "🍠",
+    "name": "roasted sweet potato",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f360.png"
+  },
+  {
+    "emoji": "🍢",
+    "name": "oden",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f362.png"
+  },
+  {
+    "emoji": "🍣",
+    "name": "sushi",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f363.png"
+  },
+  {
+    "emoji": "🍤",
+    "name": "fried shrimp",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f364.png"
+  },
+  {
+    "emoji": "🍥",
+    "name": "fish cake with swirl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f365.png"
+  },
+  {
+    "emoji": "🥮",
+    "name": "moon cake",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f96e.png"
+  },
+  {
+    "emoji": "🍡",
+    "name": "dango",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f361.png"
+  },
+  {
+    "emoji": "🥟",
+    "name": "dumpling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f95f.png"
+  },
+  {
+    "emoji": "🥠",
+    "name": "fortune cookie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f960.png"
+  },
+  {
+    "emoji": "🥡",
+    "name": "takeout box",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f961.png"
+  },
+  {
+    "emoji": "🦀",
+    "name": "crab",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f980.png"
+  },
+  {
+    "emoji": "🦞",
+    "name": "lobster",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f99e.png"
+  },
+  {
+    "emoji": "🦐",
+    "name": "shrimp",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f990.png"
+  },
+  {
+    "emoji": "🦑",
+    "name": "squid",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f991.png"
+  },
+  {
+    "emoji": "🦪",
+    "name": "oyster",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9aa.png"
+  },
+  {
+    "emoji": "🍦",
+    "name": "soft ice cream",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f366.png"
+  },
+  {
+    "emoji": "🍧",
+    "name": "shaved ice",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f367.png"
+  },
+  {
+    "emoji": "🍨",
+    "name": "ice cream",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f368.png"
+  },
+  {
+    "emoji": "🍩",
+    "name": "doughnut",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f369.png"
+  },
+  {
+    "emoji": "🍪",
+    "name": "cookie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f36a.png"
+  },
+  {
+    "emoji": "🎂",
+    "name": "birthday cake",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f382.png"
+  },
+  {
+    "emoji": "🍰",
+    "name": "shortcake",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f370.png"
+  },
+  {
+    "emoji": "🧁",
+    "name": "cupcake",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9c1.png"
+  },
+  {
+    "emoji": "🥧",
+    "name": "pie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f967.png"
+  },
+  {
+    "emoji": "🍫",
+    "name": "chocolate bar",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f36b.png"
+  },
+  {
+    "emoji": "🍬",
+    "name": "candy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f36c.png"
+  },
+  {
+    "emoji": "🍭",
+    "name": "lollipop",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f36d.png"
+  },
+  {
+    "emoji": "🍮",
+    "name": "custard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f36e.png"
+  },
+  {
+    "emoji": "🍯",
+    "name": "honey pot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f36f.png"
+  },
+  {
+    "emoji": "🍼",
+    "name": "baby bottle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f37c.png"
+  },
+  {
+    "emoji": "🥛",
+    "name": "glass of milk",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f95b.png"
+  },
+  {
+    "emoji": "☕",
+    "name": "hot beverage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2615.png"
+  },
+  {
+    "emoji": "🫖",
+    "name": "teapot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fad6.png"
+  },
+  {
+    "emoji": "🍵",
+    "name": "teacup without handle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f375.png"
+  },
+  {
+    "emoji": "🍶",
+    "name": "sake",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f376.png"
+  },
+  {
+    "emoji": "🍾",
+    "name": "bottle with popping cork",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f37e.png"
+  },
+  {
+    "emoji": "🍷",
+    "name": "wine glass",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f377.png"
+  },
+  {
+    "emoji": "🍸",
+    "name": "cocktail glass",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f378.png"
+  },
+  {
+    "emoji": "🍹",
+    "name": "tropical drink",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f379.png"
+  },
+  {
+    "emoji": "🍺",
+    "name": "beer mug",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f37a.png"
+  },
+  {
+    "emoji": "🍻",
+    "name": "clinking beer mugs",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f37b.png"
+  },
+  {
+    "emoji": "🥂",
+    "name": "clinking glasses",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f942.png"
+  },
+  {
+    "emoji": "🥃",
+    "name": "tumbler glass",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f943.png"
+  },
+  {
+    "emoji": "🫗",
+    "name": "pouring liquid",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fad7.png"
+  },
+  {
+    "emoji": "🥤",
+    "name": "cup with straw",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f964.png"
+  },
+  {
+    "emoji": "🧋",
+    "name": "bubble tea",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9cb.png"
+  },
+  {
+    "emoji": "🧃",
+    "name": "beverage box",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9c3.png"
+  },
+  {
+    "emoji": "🧉",
+    "name": "mate",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9c9.png"
+  },
+  {
+    "emoji": "🧊",
+    "name": "ice",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ca.png"
+  },
+  {
+    "emoji": "🥢",
+    "name": "chopsticks",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f962.png"
+  },
+  {
+    "emoji": "🍽️",
+    "name": "fork and knife with plate",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f37d-fe0f.png"
+  },
+  {
+    "emoji": "🍴",
+    "name": "fork and knife",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f374.png"
+  },
+  {
+    "emoji": "🥄",
+    "name": "spoon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f944.png"
+  },
+  {
+    "emoji": "🔪",
+    "name": "kitchen knife",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f52a.png"
+  },
+  {
+    "emoji": "🫙",
+    "name": "jar",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fad9.png"
+  },
+  {
+    "emoji": "🏺",
+    "name": "amphora",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3fa.png"
+  },
+  {
+    "emoji": "🌍",
+    "name": "globe showing Europe-Africa",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f30d.png"
+  },
+  {
+    "emoji": "🌎",
+    "name": "globe showing Americas",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f30e.png"
+  },
+  {
+    "emoji": "🌏",
+    "name": "globe showing Asia-Australia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f30f.png"
+  },
+  {
+    "emoji": "🌐",
+    "name": "globe with meridians",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f310.png"
+  },
+  {
+    "emoji": "🗺️",
+    "name": "world map",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5fa-fe0f.png"
+  },
+  {
+    "emoji": "🗾",
+    "name": "map of Japan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5fe.png"
+  },
+  {
+    "emoji": "🧭",
+    "name": "compass",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ed.png"
+  },
+  {
+    "emoji": "🏔️",
+    "name": "snow-capped mountain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3d4-fe0f.png"
+  },
+  {
+    "emoji": "⛰️",
+    "name": "mountain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f0-fe0f.png"
+  },
+  {
+    "emoji": "🌋",
+    "name": "volcano",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f30b.png"
+  },
+  {
+    "emoji": "🗻",
+    "name": "mount fuji",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5fb.png"
+  },
+  {
+    "emoji": "🏕️",
+    "name": "camping",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3d5-fe0f.png"
+  },
+  {
+    "emoji": "🏖️",
+    "name": "beach with umbrella",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3d6-fe0f.png"
+  },
+  {
+    "emoji": "🏜️",
+    "name": "desert",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3dc-fe0f.png"
+  },
+  {
+    "emoji": "🏝️",
+    "name": "desert island",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3dd-fe0f.png"
+  },
+  {
+    "emoji": "🏞️",
+    "name": "national park",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3de-fe0f.png"
+  },
+  {
+    "emoji": "🏟️",
+    "name": "stadium",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3df-fe0f.png"
+  },
+  {
+    "emoji": "🏛️",
+    "name": "classical building",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3db-fe0f.png"
+  },
+  {
+    "emoji": "🏗️",
+    "name": "building construction",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3d7-fe0f.png"
+  },
+  {
+    "emoji": "🧱",
+    "name": "brick",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9f1.png"
+  },
+  {
+    "emoji": "🪨",
+    "name": "rock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faa8.png"
+  },
+  {
+    "emoji": "🪵",
+    "name": "wood",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fab5.png"
+  },
+  {
+    "emoji": "🛖",
+    "name": "hut",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6d6.png"
+  },
+  {
+    "emoji": "🏘️",
+    "name": "houses",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3d8-fe0f.png"
+  },
+  {
+    "emoji": "🏚️",
+    "name": "derelict house",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3da-fe0f.png"
+  },
+  {
+    "emoji": "🏠",
+    "name": "house",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3e0.png"
+  },
+  {
+    "emoji": "🏡",
+    "name": "house with garden",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3e1.png"
+  },
+  {
+    "emoji": "🏢",
+    "name": "office building",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3e2.png"
+  },
+  {
+    "emoji": "🏣",
+    "name": "Japanese post office",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3e3.png"
+  },
+  {
+    "emoji": "🏤",
+    "name": "post office",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3e4.png"
+  },
+  {
+    "emoji": "🏥",
+    "name": "hospital",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3e5.png"
+  },
+  {
+    "emoji": "🏦",
+    "name": "bank",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3e6.png"
+  },
+  {
+    "emoji": "🏨",
+    "name": "hotel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3e8.png"
+  },
+  {
+    "emoji": "🏩",
+    "name": "love hotel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3e9.png"
+  },
+  {
+    "emoji": "🏪",
+    "name": "convenience store",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ea.png"
+  },
+  {
+    "emoji": "🏫",
+    "name": "school",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3eb.png"
+  },
+  {
+    "emoji": "🏬",
+    "name": "department store",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ec.png"
+  },
+  {
+    "emoji": "🏭",
+    "name": "factory",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ed.png"
+  },
+  {
+    "emoji": "🏯",
+    "name": "Japanese castle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ef.png"
+  },
+  {
+    "emoji": "🏰",
+    "name": "castle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f0.png"
+  },
+  {
+    "emoji": "💒",
+    "name": "wedding",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f492.png"
+  },
+  {
+    "emoji": "🗼",
+    "name": "Tokyo tower",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5fc.png"
+  },
+  {
+    "emoji": "🗽",
+    "name": "Statue of Liberty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5fd.png"
+  },
+  {
+    "emoji": "⛪",
+    "name": "church",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26ea.png"
+  },
+  {
+    "emoji": "🕌",
+    "name": "mosque",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f54c.png"
+  },
+  {
+    "emoji": "🛕",
+    "name": "hindu temple",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6d5.png"
+  },
+  {
+    "emoji": "🕍",
+    "name": "synagogue",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f54d.png"
+  },
+  {
+    "emoji": "⛩️",
+    "name": "shinto shrine",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26e9-fe0f.png"
+  },
+  {
+    "emoji": "🕋",
+    "name": "kaaba",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f54b.png"
+  },
+  {
+    "emoji": "⛲",
+    "name": "fountain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f2.png"
+  },
+  {
+    "emoji": "⛺",
+    "name": "tent",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26fa.png"
+  },
+  {
+    "emoji": "🌁",
+    "name": "foggy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f301.png"
+  },
+  {
+    "emoji": "🌃",
+    "name": "night with stars",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f303.png"
+  },
+  {
+    "emoji": "🏙️",
+    "name": "cityscape",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3d9-fe0f.png"
+  },
+  {
+    "emoji": "🌄",
+    "name": "sunrise over mountains",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f304.png"
+  },
+  {
+    "emoji": "🌅",
+    "name": "sunrise",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f305.png"
+  },
+  {
+    "emoji": "🌆",
+    "name": "cityscape at dusk",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f306.png"
+  },
+  {
+    "emoji": "🌇",
+    "name": "sunset",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f307.png"
+  },
+  {
+    "emoji": "🌉",
+    "name": "bridge at night",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f309.png"
+  },
+  {
+    "emoji": "♨️",
+    "name": "hot springs",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2668-fe0f.png"
+  },
+  {
+    "emoji": "🎠",
+    "name": "carousel horse",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3a0.png"
+  },
+  {
+    "emoji": "🛝",
+    "name": "playground slide",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6dd.png"
+  },
+  {
+    "emoji": "🎡",
+    "name": "ferris wheel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3a1.png"
+  },
+  {
+    "emoji": "🎢",
+    "name": "roller coaster",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3a2.png"
+  },
+  {
+    "emoji": "💈",
+    "name": "barber pole",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f488.png"
+  },
+  {
+    "emoji": "🎪",
+    "name": "circus tent",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3aa.png"
+  },
+  {
+    "emoji": "🚂",
+    "name": "locomotive",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f682.png"
+  },
+  {
+    "emoji": "🚃",
+    "name": "railway car",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f683.png"
+  },
+  {
+    "emoji": "🚄",
+    "name": "high-speed train",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f684.png"
+  },
+  {
+    "emoji": "🚅",
+    "name": "bullet train",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f685.png"
+  },
+  {
+    "emoji": "🚆",
+    "name": "train",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f686.png"
+  },
+  {
+    "emoji": "🚇",
+    "name": "metro",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f687.png"
+  },
+  {
+    "emoji": "🚈",
+    "name": "light rail",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f688.png"
+  },
+  {
+    "emoji": "🚉",
+    "name": "station",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f689.png"
+  },
+  {
+    "emoji": "🚊",
+    "name": "tram",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f68a.png"
+  },
+  {
+    "emoji": "🚝",
+    "name": "monorail",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f69d.png"
+  },
+  {
+    "emoji": "🚞",
+    "name": "mountain railway",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f69e.png"
+  },
+  {
+    "emoji": "🚋",
+    "name": "tram car",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f68b.png"
+  },
+  {
+    "emoji": "🚌",
+    "name": "bus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f68c.png"
+  },
+  {
+    "emoji": "🚍",
+    "name": "oncoming bus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f68d.png"
+  },
+  {
+    "emoji": "🚎",
+    "name": "trolleybus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f68e.png"
+  },
+  {
+    "emoji": "🚐",
+    "name": "minibus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f690.png"
+  },
+  {
+    "emoji": "🚑",
+    "name": "ambulance",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f691.png"
+  },
+  {
+    "emoji": "🚒",
+    "name": "fire engine",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f692.png"
+  },
+  {
+    "emoji": "🚓",
+    "name": "police car",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f693.png"
+  },
+  {
+    "emoji": "🚔",
+    "name": "oncoming police car",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f694.png"
+  },
+  {
+    "emoji": "🚕",
+    "name": "taxi",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f695.png"
+  },
+  {
+    "emoji": "🚖",
+    "name": "oncoming taxi",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f696.png"
+  },
+  {
+    "emoji": "🚗",
+    "name": "automobile",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f697.png"
+  },
+  {
+    "emoji": "🚘",
+    "name": "oncoming automobile",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f698.png"
+  },
+  {
+    "emoji": "🚙",
+    "name": "sport utility vehicle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f699.png"
+  },
+  {
+    "emoji": "🛻",
+    "name": "pickup truck",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6fb.png"
+  },
+  {
+    "emoji": "🚚",
+    "name": "delivery truck",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f69a.png"
+  },
+  {
+    "emoji": "🚛",
+    "name": "articulated lorry",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f69b.png"
+  },
+  {
+    "emoji": "🚜",
+    "name": "tractor",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f69c.png"
+  },
+  {
+    "emoji": "🏎️",
+    "name": "racing car",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ce-fe0f.png"
+  },
+  {
+    "emoji": "🏍️",
+    "name": "motorcycle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cd-fe0f.png"
+  },
+  {
+    "emoji": "🛵",
+    "name": "motor scooter",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6f5.png"
+  },
+  {
+    "emoji": "🦽",
+    "name": "manual wheelchair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9bd.png"
+  },
+  {
+    "emoji": "🦼",
+    "name": "motorized wheelchair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9bc.png"
+  },
+  {
+    "emoji": "🛺",
+    "name": "auto rickshaw",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6fa.png"
+  },
+  {
+    "emoji": "🚲",
+    "name": "bicycle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b2.png"
+  },
+  {
+    "emoji": "🛴",
+    "name": "kick scooter",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6f4.png"
+  },
+  {
+    "emoji": "🛹",
+    "name": "skateboard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6f9.png"
+  },
+  {
+    "emoji": "🛼",
+    "name": "roller skate",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6fc.png"
+  },
+  {
+    "emoji": "🚏",
+    "name": "bus stop",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f68f.png"
+  },
+  {
+    "emoji": "🛣️",
+    "name": "motorway",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6e3-fe0f.png"
+  },
+  {
+    "emoji": "🛤️",
+    "name": "railway track",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6e4-fe0f.png"
+  },
+  {
+    "emoji": "🛢️",
+    "name": "oil drum",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6e2-fe0f.png"
+  },
+  {
+    "emoji": "⛽",
+    "name": "fuel pump",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26fd.png"
+  },
+  {
+    "emoji": "🛞",
+    "name": "wheel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6de.png"
+  },
+  {
+    "emoji": "🚨",
+    "name": "police car light",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a8.png"
+  },
+  {
+    "emoji": "🚥",
+    "name": "horizontal traffic light",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a5.png"
+  },
+  {
+    "emoji": "🚦",
+    "name": "vertical traffic light",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a6.png"
+  },
+  {
+    "emoji": "🛑",
+    "name": "stop sign",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6d1.png"
+  },
+  {
+    "emoji": "🚧",
+    "name": "construction",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a7.png"
+  },
+  {
+    "emoji": "⚓",
+    "name": "anchor",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2693.png"
+  },
+  {
+    "emoji": "🛟",
+    "name": "ring buoy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6df.png"
+  },
+  {
+    "emoji": "⛵",
+    "name": "sailboat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f5.png"
+  },
+  {
+    "emoji": "🛶",
+    "name": "canoe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6f6.png"
+  },
+  {
+    "emoji": "🚤",
+    "name": "speedboat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a4.png"
+  },
+  {
+    "emoji": "🛳️",
+    "name": "passenger ship",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6f3-fe0f.png"
+  },
+  {
+    "emoji": "⛴️",
+    "name": "ferry",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f4-fe0f.png"
+  },
+  {
+    "emoji": "🛥️",
+    "name": "motor boat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6e5-fe0f.png"
+  },
+  {
+    "emoji": "🚢",
+    "name": "ship",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a2.png"
+  },
+  {
+    "emoji": "✈️",
+    "name": "airplane",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2708-fe0f.png"
+  },
+  {
+    "emoji": "🛩️",
+    "name": "small airplane",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6e9-fe0f.png"
+  },
+  {
+    "emoji": "🛫",
+    "name": "airplane departure",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6eb.png"
+  },
+  {
+    "emoji": "🛬",
+    "name": "airplane arrival",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6ec.png"
+  },
+  {
+    "emoji": "🪂",
+    "name": "parachute",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa82.png"
+  },
+  {
+    "emoji": "💺",
+    "name": "seat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ba.png"
+  },
+  {
+    "emoji": "🚁",
+    "name": "helicopter",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f681.png"
+  },
+  {
+    "emoji": "🚟",
+    "name": "suspension railway",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f69f.png"
+  },
+  {
+    "emoji": "🚠",
+    "name": "mountain cableway",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a0.png"
+  },
+  {
+    "emoji": "🚡",
+    "name": "aerial tramway",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a1.png"
+  },
+  {
+    "emoji": "🛰️",
+    "name": "satellite",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6f0-fe0f.png"
+  },
+  {
+    "emoji": "🚀",
+    "name": "rocket",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f680.png"
+  },
+  {
+    "emoji": "🛸",
+    "name": "flying saucer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6f8.png"
+  },
+  {
+    "emoji": "🛎️",
+    "name": "bellhop bell",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6ce-fe0f.png"
+  },
+  {
+    "emoji": "🧳",
+    "name": "luggage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9f3.png"
+  },
+  {
+    "emoji": "⌛",
+    "name": "hourglass done",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/231b.png"
+  },
+  {
+    "emoji": "⏳",
+    "name": "hourglass not done",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23f3.png"
+  },
+  {
+    "emoji": "⌚",
+    "name": "watch",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/231a.png"
+  },
+  {
+    "emoji": "⏰",
+    "name": "alarm clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23f0.png"
+  },
+  {
+    "emoji": "⏱️",
+    "name": "stopwatch",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23f1-fe0f.png"
+  },
+  {
+    "emoji": "⏲️",
+    "name": "timer clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23f2-fe0f.png"
+  },
+  {
+    "emoji": "🕰️",
+    "name": "mantelpiece clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f570-fe0f.png"
+  },
+  {
+    "emoji": "🕛",
+    "name": "twelve o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f55b.png"
+  },
+  {
+    "emoji": "🕧",
+    "name": "twelve-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f567.png"
+  },
+  {
+    "emoji": "🕐",
+    "name": "one o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f550.png"
+  },
+  {
+    "emoji": "🕜",
+    "name": "one-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f55c.png"
+  },
+  {
+    "emoji": "🕑",
+    "name": "two o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f551.png"
+  },
+  {
+    "emoji": "🕝",
+    "name": "two-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f55d.png"
+  },
+  {
+    "emoji": "🕒",
+    "name": "three o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f552.png"
+  },
+  {
+    "emoji": "🕞",
+    "name": "three-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f55e.png"
+  },
+  {
+    "emoji": "🕓",
+    "name": "four o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f553.png"
+  },
+  {
+    "emoji": "🕟",
+    "name": "four-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f55f.png"
+  },
+  {
+    "emoji": "🕔",
+    "name": "five o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f554.png"
+  },
+  {
+    "emoji": "🕠",
+    "name": "five-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f560.png"
+  },
+  {
+    "emoji": "🕕",
+    "name": "six o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f555.png"
+  },
+  {
+    "emoji": "🕡",
+    "name": "six-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f561.png"
+  },
+  {
+    "emoji": "🕖",
+    "name": "seven o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f556.png"
+  },
+  {
+    "emoji": "🕢",
+    "name": "seven-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f562.png"
+  },
+  {
+    "emoji": "🕗",
+    "name": "eight o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f557.png"
+  },
+  {
+    "emoji": "🕣",
+    "name": "eight-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f563.png"
+  },
+  {
+    "emoji": "🕘",
+    "name": "nine o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f558.png"
+  },
+  {
+    "emoji": "🕤",
+    "name": "nine-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f564.png"
+  },
+  {
+    "emoji": "🕙",
+    "name": "ten o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f559.png"
+  },
+  {
+    "emoji": "🕥",
+    "name": "ten-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f565.png"
+  },
+  {
+    "emoji": "🕚",
+    "name": "eleven o’clock",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f55a.png"
+  },
+  {
+    "emoji": "🕦",
+    "name": "eleven-thirty",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f566.png"
+  },
+  {
+    "emoji": "🌑",
+    "name": "new moon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f311.png"
+  },
+  {
+    "emoji": "🌒",
+    "name": "waxing crescent moon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f312.png"
+  },
+  {
+    "emoji": "🌓",
+    "name": "first quarter moon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f313.png"
+  },
+  {
+    "emoji": "🌔",
+    "name": "waxing gibbous moon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f314.png"
+  },
+  {
+    "emoji": "🌕",
+    "name": "full moon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f315.png"
+  },
+  {
+    "emoji": "🌖",
+    "name": "waning gibbous moon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f316.png"
+  },
+  {
+    "emoji": "🌗",
+    "name": "last quarter moon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f317.png"
+  },
+  {
+    "emoji": "🌘",
+    "name": "waning crescent moon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f318.png"
+  },
+  {
+    "emoji": "🌙",
+    "name": "crescent moon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f319.png"
+  },
+  {
+    "emoji": "🌚",
+    "name": "new moon face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f31a.png"
+  },
+  {
+    "emoji": "🌛",
+    "name": "first quarter moon face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f31b.png"
+  },
+  {
+    "emoji": "🌜",
+    "name": "last quarter moon face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f31c.png"
+  },
+  {
+    "emoji": "🌡️",
+    "name": "thermometer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f321-fe0f.png"
+  },
+  {
+    "emoji": "☀️",
+    "name": "sun",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2600-fe0f.png"
+  },
+  {
+    "emoji": "🌝",
+    "name": "full moon face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f31d.png"
+  },
+  {
+    "emoji": "🌞",
+    "name": "sun with face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f31e.png"
+  },
+  {
+    "emoji": "🪐",
+    "name": "ringed planet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa90.png"
+  },
+  {
+    "emoji": "⭐",
+    "name": "star",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2b50.png"
+  },
+  {
+    "emoji": "🌟",
+    "name": "glowing star",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f31f.png"
+  },
+  {
+    "emoji": "🌠",
+    "name": "shooting star",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f320.png"
+  },
+  {
+    "emoji": "🌌",
+    "name": "milky way",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f30c.png"
+  },
+  {
+    "emoji": "☁️",
+    "name": "cloud",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2601-fe0f.png"
+  },
+  {
+    "emoji": "⛅",
+    "name": "sun behind cloud",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26c5.png"
+  },
+  {
+    "emoji": "⛈️",
+    "name": "cloud with lightning and rain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26c8-fe0f.png"
+  },
+  {
+    "emoji": "🌤️",
+    "name": "sun behind small cloud",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f324-fe0f.png"
+  },
+  {
+    "emoji": "🌥️",
+    "name": "sun behind large cloud",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f325-fe0f.png"
+  },
+  {
+    "emoji": "🌦️",
+    "name": "sun behind rain cloud",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f326-fe0f.png"
+  },
+  {
+    "emoji": "🌧️",
+    "name": "cloud with rain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f327-fe0f.png"
+  },
+  {
+    "emoji": "🌨️",
+    "name": "cloud with snow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f328-fe0f.png"
+  },
+  {
+    "emoji": "🌩️",
+    "name": "cloud with lightning",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f329-fe0f.png"
+  },
+  {
+    "emoji": "🌪️",
+    "name": "tornado",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f32a-fe0f.png"
+  },
+  {
+    "emoji": "🌫️",
+    "name": "fog",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f32b-fe0f.png"
+  },
+  {
+    "emoji": "🌬️",
+    "name": "wind face",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f32c-fe0f.png"
+  },
+  {
+    "emoji": "🌀",
+    "name": "cyclone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f300.png"
+  },
+  {
+    "emoji": "🌈",
+    "name": "rainbow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f308.png"
+  },
+  {
+    "emoji": "🌂",
+    "name": "closed umbrella",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f302.png"
+  },
+  {
+    "emoji": "☂️",
+    "name": "umbrella",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2602-fe0f.png"
+  },
+  {
+    "emoji": "☔",
+    "name": "umbrella with rain drops",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2614.png"
+  },
+  {
+    "emoji": "⛱️",
+    "name": "umbrella on ground",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f1-fe0f.png"
+  },
+  {
+    "emoji": "⚡",
+    "name": "high voltage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26a1.png"
+  },
+  {
+    "emoji": "❄️",
+    "name": "snowflake",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2744-fe0f.png"
+  },
+  {
+    "emoji": "☃️",
+    "name": "snowman",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2603-fe0f.png"
+  },
+  {
+    "emoji": "⛄",
+    "name": "snowman without snow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26c4.png"
+  },
+  {
+    "emoji": "☄️",
+    "name": "comet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2604-fe0f.png"
+  },
+  {
+    "emoji": "🔥",
+    "name": "fire",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f525.png"
+  },
+  {
+    "emoji": "💧",
+    "name": "droplet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4a7.png"
+  },
+  {
+    "emoji": "🌊",
+    "name": "water wave",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f30a.png"
+  },
+  {
+    "emoji": "🎃",
+    "name": "jack-o-lantern",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f383.png"
+  },
+  {
+    "emoji": "🎄",
+    "name": "Christmas tree",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f384.png"
+  },
+  {
+    "emoji": "🎆",
+    "name": "fireworks",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f386.png"
+  },
+  {
+    "emoji": "🎇",
+    "name": "sparkler",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f387.png"
+  },
+  {
+    "emoji": "🧨",
+    "name": "firecracker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9e8.png"
+  },
+  {
+    "emoji": "✨",
+    "name": "sparkles",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2728.png"
+  },
+  {
+    "emoji": "🎈",
+    "name": "balloon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f388.png"
+  },
+  {
+    "emoji": "🎉",
+    "name": "party popper",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f389.png"
+  },
+  {
+    "emoji": "🎊",
+    "name": "confetti ball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f38a.png"
+  },
+  {
+    "emoji": "🎋",
+    "name": "tanabata tree",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f38b.png"
+  },
+  {
+    "emoji": "🎍",
+    "name": "pine decoration",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f38d.png"
+  },
+  {
+    "emoji": "🎎",
+    "name": "Japanese dolls",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f38e.png"
+  },
+  {
+    "emoji": "🎏",
+    "name": "carp streamer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f38f.png"
+  },
+  {
+    "emoji": "🎐",
+    "name": "wind chime",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f390.png"
+  },
+  {
+    "emoji": "🎑",
+    "name": "moon viewing ceremony",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f391.png"
+  },
+  {
+    "emoji": "🧧",
+    "name": "red envelope",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9e7.png"
+  },
+  {
+    "emoji": "🎀",
+    "name": "ribbon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f380.png"
+  },
+  {
+    "emoji": "🎁",
+    "name": "wrapped gift",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f381.png"
+  },
+  {
+    "emoji": "🎗️",
+    "name": "reminder ribbon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f397-fe0f.png"
+  },
+  {
+    "emoji": "🎟️",
+    "name": "admission tickets",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f39f-fe0f.png"
+  },
+  {
+    "emoji": "🎫",
+    "name": "ticket",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ab.png"
+  },
+  {
+    "emoji": "🎖️",
+    "name": "military medal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f396-fe0f.png"
+  },
+  {
+    "emoji": "🏆",
+    "name": "trophy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c6.png"
+  },
+  {
+    "emoji": "🏅",
+    "name": "sports medal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c5.png"
+  },
+  {
+    "emoji": "🥇",
+    "name": "1st place medal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f947.png"
+  },
+  {
+    "emoji": "🥈",
+    "name": "2nd place medal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f948.png"
+  },
+  {
+    "emoji": "🥉",
+    "name": "3rd place medal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f949.png"
+  },
+  {
+    "emoji": "⚽",
+    "name": "soccer ball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26bd.png"
+  },
+  {
+    "emoji": "⚾",
+    "name": "baseball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26be.png"
+  },
+  {
+    "emoji": "🥎",
+    "name": "softball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f94e.png"
+  },
+  {
+    "emoji": "🏀",
+    "name": "basketball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c0.png"
+  },
+  {
+    "emoji": "🏐",
+    "name": "volleyball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3d0.png"
+  },
+  {
+    "emoji": "🏈",
+    "name": "american football",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c8.png"
+  },
+  {
+    "emoji": "🏉",
+    "name": "rugby football",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c9.png"
+  },
+  {
+    "emoji": "🎾",
+    "name": "tennis",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3be.png"
+  },
+  {
+    "emoji": "🥏",
+    "name": "flying disc",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f94f.png"
+  },
+  {
+    "emoji": "🎳",
+    "name": "bowling",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3b3.png"
+  },
+  {
+    "emoji": "🏏",
+    "name": "cricket game",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3cf.png"
+  },
+  {
+    "emoji": "🏑",
+    "name": "field hockey",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3d1.png"
+  },
+  {
+    "emoji": "🏒",
+    "name": "ice hockey",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3d2.png"
+  },
+  {
+    "emoji": "🥍",
+    "name": "lacrosse",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f94d.png"
+  },
+  {
+    "emoji": "🏓",
+    "name": "ping pong",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3d3.png"
+  },
+  {
+    "emoji": "🏸",
+    "name": "badminton",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f8.png"
+  },
+  {
+    "emoji": "🥊",
+    "name": "boxing glove",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f94a.png"
+  },
+  {
+    "emoji": "🥋",
+    "name": "martial arts uniform",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f94b.png"
+  },
+  {
+    "emoji": "🥅",
+    "name": "goal net",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f945.png"
+  },
+  {
+    "emoji": "⛳",
+    "name": "flag in hole",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f3.png"
+  },
+  {
+    "emoji": "⛸️",
+    "name": "ice skate",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26f8-fe0f.png"
+  },
+  {
+    "emoji": "🎣",
+    "name": "fishing pole",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3a3.png"
+  },
+  {
+    "emoji": "🤿",
+    "name": "diving mask",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f93f.png"
+  },
+  {
+    "emoji": "🎽",
+    "name": "running shirt",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3bd.png"
+  },
+  {
+    "emoji": "🎿",
+    "name": "skis",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3bf.png"
+  },
+  {
+    "emoji": "🛷",
+    "name": "sled",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6f7.png"
+  },
+  {
+    "emoji": "🥌",
+    "name": "curling stone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f94c.png"
+  },
+  {
+    "emoji": "🎯",
+    "name": "bullseye",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3af.png"
+  },
+  {
+    "emoji": "🪀",
+    "name": "yo-yo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa80.png"
+  },
+  {
+    "emoji": "🪁",
+    "name": "kite",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa81.png"
+  },
+  {
+    "emoji": "🔫",
+    "name": "water pistol",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f52b.png"
+  },
+  {
+    "emoji": "🎱",
+    "name": "pool 8 ball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3b1.png"
+  },
+  {
+    "emoji": "🔮",
+    "name": "crystal ball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f52e.png"
+  },
+  {
+    "emoji": "🪄",
+    "name": "magic wand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa84.png"
+  },
+  {
+    "emoji": "🎮",
+    "name": "video game",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ae.png"
+  },
+  {
+    "emoji": "🕹️",
+    "name": "joystick",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f579-fe0f.png"
+  },
+  {
+    "emoji": "🎰",
+    "name": "slot machine",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3b0.png"
+  },
+  {
+    "emoji": "🎲",
+    "name": "game die",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3b2.png"
+  },
+  {
+    "emoji": "🧩",
+    "name": "puzzle piece",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9e9.png"
+  },
+  {
+    "emoji": "🧸",
+    "name": "teddy bear",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9f8.png"
+  },
+  {
+    "emoji": "🪅",
+    "name": "piñata",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa85.png"
+  },
+  {
+    "emoji": "🪩",
+    "name": "mirror ball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faa9.png"
+  },
+  {
+    "emoji": "🪆",
+    "name": "nesting dolls",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa86.png"
+  },
+  {
+    "emoji": "♠️",
+    "name": "spade suit",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2660-fe0f.png"
+  },
+  {
+    "emoji": "♥️",
+    "name": "heart suit",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2665-fe0f.png"
+  },
+  {
+    "emoji": "♦️",
+    "name": "diamond suit",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2666-fe0f.png"
+  },
+  {
+    "emoji": "♣️",
+    "name": "club suit",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2663-fe0f.png"
+  },
+  {
+    "emoji": "♟️",
+    "name": "chess pawn",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/265f-fe0f.png"
+  },
+  {
+    "emoji": "🃏",
+    "name": "joker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f0cf.png"
+  },
+  {
+    "emoji": "🀄",
+    "name": "mahjong red dragon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f004.png"
+  },
+  {
+    "emoji": "🎴",
+    "name": "flower playing cards",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3b4.png"
+  },
+  {
+    "emoji": "🎭",
+    "name": "performing arts",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ad.png"
+  },
+  {
+    "emoji": "🖼️",
+    "name": "framed picture",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5bc-fe0f.png"
+  },
+  {
+    "emoji": "🎨",
+    "name": "artist palette",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3a8.png"
+  },
+  {
+    "emoji": "🧵",
+    "name": "thread",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9f5.png"
+  },
+  {
+    "emoji": "🪡",
+    "name": "sewing needle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faa1.png"
+  },
+  {
+    "emoji": "🧶",
+    "name": "yarn",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9f6.png"
+  },
+  {
+    "emoji": "🪢",
+    "name": "knot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faa2.png"
+  },
+  {
+    "emoji": "👓",
+    "name": "glasses",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f453.png"
+  },
+  {
+    "emoji": "🕶️",
+    "name": "sunglasses",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f576-fe0f.png"
+  },
+  {
+    "emoji": "🥽",
+    "name": "goggles",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f97d.png"
+  },
+  {
+    "emoji": "🥼",
+    "name": "lab coat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f97c.png"
+  },
+  {
+    "emoji": "🦺",
+    "name": "safety vest",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ba.png"
+  },
+  {
+    "emoji": "👔",
+    "name": "necktie",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f454.png"
+  },
+  {
+    "emoji": "👕",
+    "name": "t-shirt",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f455.png"
+  },
+  {
+    "emoji": "👖",
+    "name": "jeans",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f456.png"
+  },
+  {
+    "emoji": "🧣",
+    "name": "scarf",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9e3.png"
+  },
+  {
+    "emoji": "🧤",
+    "name": "gloves",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9e4.png"
+  },
+  {
+    "emoji": "🧥",
+    "name": "coat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9e5.png"
+  },
+  {
+    "emoji": "🧦",
+    "name": "socks",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9e6.png"
+  },
+  {
+    "emoji": "👗",
+    "name": "dress",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f457.png"
+  },
+  {
+    "emoji": "👘",
+    "name": "kimono",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f458.png"
+  },
+  {
+    "emoji": "🥻",
+    "name": "sari",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f97b.png"
+  },
+  {
+    "emoji": "🩱",
+    "name": "one-piece swimsuit",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa71.png"
+  },
+  {
+    "emoji": "🩲",
+    "name": "briefs",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa72.png"
+  },
+  {
+    "emoji": "🩳",
+    "name": "shorts",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa73.png"
+  },
+  {
+    "emoji": "👙",
+    "name": "bikini",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f459.png"
+  },
+  {
+    "emoji": "👚",
+    "name": "woman’s clothes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f45a.png"
+  },
+  {
+    "emoji": "🪭",
+    "name": "folding hand fan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faad.png"
+  },
+  {
+    "emoji": "👛",
+    "name": "purse",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f45b.png"
+  },
+  {
+    "emoji": "👜",
+    "name": "handbag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f45c.png"
+  },
+  {
+    "emoji": "👝",
+    "name": "clutch bag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f45d.png"
+  },
+  {
+    "emoji": "🛍️",
+    "name": "shopping bags",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6cd-fe0f.png"
+  },
+  {
+    "emoji": "🎒",
+    "name": "backpack",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f392.png"
+  },
+  {
+    "emoji": "🩴",
+    "name": "thong sandal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa74.png"
+  },
+  {
+    "emoji": "👞",
+    "name": "man’s shoe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f45e.png"
+  },
+  {
+    "emoji": "👟",
+    "name": "running shoe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f45f.png"
+  },
+  {
+    "emoji": "🥾",
+    "name": "hiking boot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f97e.png"
+  },
+  {
+    "emoji": "🥿",
+    "name": "flat shoe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f97f.png"
+  },
+  {
+    "emoji": "👠",
+    "name": "high-heeled shoe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f460.png"
+  },
+  {
+    "emoji": "👡",
+    "name": "woman’s sandal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f461.png"
+  },
+  {
+    "emoji": "🩰",
+    "name": "ballet shoes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa70.png"
+  },
+  {
+    "emoji": "👢",
+    "name": "woman’s boot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f462.png"
+  },
+  {
+    "emoji": "🪮",
+    "name": "hair pick",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faae.png"
+  },
+  {
+    "emoji": "👑",
+    "name": "crown",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f451.png"
+  },
+  {
+    "emoji": "👒",
+    "name": "woman’s hat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f452.png"
+  },
+  {
+    "emoji": "🎩",
+    "name": "top hat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3a9.png"
+  },
+  {
+    "emoji": "🎓",
+    "name": "graduation cap",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f393.png"
+  },
+  {
+    "emoji": "🧢",
+    "name": "billed cap",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9e2.png"
+  },
+  {
+    "emoji": "🪖",
+    "name": "military helmet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa96.png"
+  },
+  {
+    "emoji": "⛑️",
+    "name": "rescue worker’s helmet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26d1-fe0f.png"
+  },
+  {
+    "emoji": "📿",
+    "name": "prayer beads",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ff.png"
+  },
+  {
+    "emoji": "💄",
+    "name": "lipstick",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f484.png"
+  },
+  {
+    "emoji": "💍",
+    "name": "ring",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48d.png"
+  },
+  {
+    "emoji": "💎",
+    "name": "gem stone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48e.png"
+  },
+  {
+    "emoji": "🔇",
+    "name": "muted speaker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f507.png"
+  },
+  {
+    "emoji": "🔈",
+    "name": "speaker low volume",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f508.png"
+  },
+  {
+    "emoji": "🔉",
+    "name": "speaker medium volume",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f509.png"
+  },
+  {
+    "emoji": "🔊",
+    "name": "speaker high volume",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f50a.png"
+  },
+  {
+    "emoji": "📢",
+    "name": "loudspeaker",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4e2.png"
+  },
+  {
+    "emoji": "📣",
+    "name": "megaphone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4e3.png"
+  },
+  {
+    "emoji": "📯",
+    "name": "postal horn",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ef.png"
+  },
+  {
+    "emoji": "🔔",
+    "name": "bell",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f514.png"
+  },
+  {
+    "emoji": "🔕",
+    "name": "bell with slash",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f515.png"
+  },
+  {
+    "emoji": "🎼",
+    "name": "musical score",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3bc.png"
+  },
+  {
+    "emoji": "🎵",
+    "name": "musical note",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3b5.png"
+  },
+  {
+    "emoji": "🎶",
+    "name": "musical notes",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3b6.png"
+  },
+  {
+    "emoji": "🎙️",
+    "name": "studio microphone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f399-fe0f.png"
+  },
+  {
+    "emoji": "🎚️",
+    "name": "level slider",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f39a-fe0f.png"
+  },
+  {
+    "emoji": "🎛️",
+    "name": "control knobs",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f39b-fe0f.png"
+  },
+  {
+    "emoji": "🎤",
+    "name": "microphone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3a4.png"
+  },
+  {
+    "emoji": "🎧",
+    "name": "headphone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3a7.png"
+  },
+  {
+    "emoji": "📻",
+    "name": "radio",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4fb.png"
+  },
+  {
+    "emoji": "🎷",
+    "name": "saxophone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3b7.png"
+  },
+  {
+    "emoji": "🪗",
+    "name": "accordion",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa97.png"
+  },
+  {
+    "emoji": "🎸",
+    "name": "guitar",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3b8.png"
+  },
+  {
+    "emoji": "🎹",
+    "name": "musical keyboard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3b9.png"
+  },
+  {
+    "emoji": "🎺",
+    "name": "trumpet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ba.png"
+  },
+  {
+    "emoji": "🎻",
+    "name": "violin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3bb.png"
+  },
+  {
+    "emoji": "🪕",
+    "name": "banjo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa95.png"
+  },
+  {
+    "emoji": "🥁",
+    "name": "drum",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f941.png"
+  },
+  {
+    "emoji": "🪘",
+    "name": "long drum",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa98.png"
+  },
+  {
+    "emoji": "🪇",
+    "name": "maracas",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa87.png"
+  },
+  {
+    "emoji": "🪈",
+    "name": "flute",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa88.png"
+  },
+  {
+    "emoji": "📱",
+    "name": "mobile phone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4f1.png"
+  },
+  {
+    "emoji": "📲",
+    "name": "mobile phone with arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4f2.png"
+  },
+  {
+    "emoji": "☎️",
+    "name": "telephone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/260e-fe0f.png"
+  },
+  {
+    "emoji": "📞",
+    "name": "telephone receiver",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4de.png"
+  },
+  {
+    "emoji": "📟",
+    "name": "pager",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4df.png"
+  },
+  {
+    "emoji": "📠",
+    "name": "fax machine",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4e0.png"
+  },
+  {
+    "emoji": "🔋",
+    "name": "battery",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f50b.png"
+  },
+  {
+    "emoji": "🪫",
+    "name": "low battery",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faab.png"
+  },
+  {
+    "emoji": "🔌",
+    "name": "electric plug",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f50c.png"
+  },
+  {
+    "emoji": "💻",
+    "name": "laptop",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4bb.png"
+  },
+  {
+    "emoji": "🖥️",
+    "name": "desktop computer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5a5-fe0f.png"
+  },
+  {
+    "emoji": "🖨️",
+    "name": "printer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5a8-fe0f.png"
+  },
+  {
+    "emoji": "⌨️",
+    "name": "keyboard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2328-fe0f.png"
+  },
+  {
+    "emoji": "🖱️",
+    "name": "computer mouse",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5b1-fe0f.png"
+  },
+  {
+    "emoji": "🖲️",
+    "name": "trackball",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5b2-fe0f.png"
+  },
+  {
+    "emoji": "💽",
+    "name": "computer disk",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4bd.png"
+  },
+  {
+    "emoji": "💾",
+    "name": "floppy disk",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4be.png"
+  },
+  {
+    "emoji": "💿",
+    "name": "optical disk",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4bf.png"
+  },
+  {
+    "emoji": "📀",
+    "name": "dvd",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4c0.png"
+  },
+  {
+    "emoji": "🧮",
+    "name": "abacus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ee.png"
+  },
+  {
+    "emoji": "🎥",
+    "name": "movie camera",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3a5.png"
+  },
+  {
+    "emoji": "🎞️",
+    "name": "film frames",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f39e-fe0f.png"
+  },
+  {
+    "emoji": "📽️",
+    "name": "film projector",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4fd-fe0f.png"
+  },
+  {
+    "emoji": "🎬",
+    "name": "clapper board",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ac.png"
+  },
+  {
+    "emoji": "📺",
+    "name": "television",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4fa.png"
+  },
+  {
+    "emoji": "📷",
+    "name": "camera",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4f7.png"
+  },
+  {
+    "emoji": "📸",
+    "name": "camera with flash",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4f8.png"
+  },
+  {
+    "emoji": "📹",
+    "name": "video camera",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4f9.png"
+  },
+  {
+    "emoji": "📼",
+    "name": "videocassette",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4fc.png"
+  },
+  {
+    "emoji": "🔍",
+    "name": "magnifying glass tilted left",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f50d.png"
+  },
+  {
+    "emoji": "🔎",
+    "name": "magnifying glass tilted right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f50e.png"
+  },
+  {
+    "emoji": "🕯️",
+    "name": "candle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f56f-fe0f.png"
+  },
+  {
+    "emoji": "💡",
+    "name": "light bulb",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4a1.png"
+  },
+  {
+    "emoji": "🔦",
+    "name": "flashlight",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f526.png"
+  },
+  {
+    "emoji": "🏮",
+    "name": "red paper lantern",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3ee.png"
+  },
+  {
+    "emoji": "🪔",
+    "name": "diya lamp",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa94.png"
+  },
+  {
+    "emoji": "📔",
+    "name": "notebook with decorative cover",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4d4.png"
+  },
+  {
+    "emoji": "📕",
+    "name": "closed book",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4d5.png"
+  },
+  {
+    "emoji": "📖",
+    "name": "open book",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4d6.png"
+  },
+  {
+    "emoji": "📗",
+    "name": "green book",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4d7.png"
+  },
+  {
+    "emoji": "📘",
+    "name": "blue book",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4d8.png"
+  },
+  {
+    "emoji": "📙",
+    "name": "orange book",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4d9.png"
+  },
+  {
+    "emoji": "📚",
+    "name": "books",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4da.png"
+  },
+  {
+    "emoji": "📓",
+    "name": "notebook",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4d3.png"
+  },
+  {
+    "emoji": "📒",
+    "name": "ledger",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4d2.png"
+  },
+  {
+    "emoji": "📃",
+    "name": "page with curl",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4c3.png"
+  },
+  {
+    "emoji": "📜",
+    "name": "scroll",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4dc.png"
+  },
+  {
+    "emoji": "📄",
+    "name": "page facing up",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4c4.png"
+  },
+  {
+    "emoji": "📰",
+    "name": "newspaper",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4f0.png"
+  },
+  {
+    "emoji": "🗞️",
+    "name": "rolled-up newspaper",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5de-fe0f.png"
+  },
+  {
+    "emoji": "📑",
+    "name": "bookmark tabs",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4d1.png"
+  },
+  {
+    "emoji": "🔖",
+    "name": "bookmark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f516.png"
+  },
+  {
+    "emoji": "🏷️",
+    "name": "label",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f7-fe0f.png"
+  },
+  {
+    "emoji": "💰",
+    "name": "money bag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4b0.png"
+  },
+  {
+    "emoji": "🪙",
+    "name": "coin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa99.png"
+  },
+  {
+    "emoji": "💴",
+    "name": "yen banknote",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4b4.png"
+  },
+  {
+    "emoji": "💵",
+    "name": "dollar banknote",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4b5.png"
+  },
+  {
+    "emoji": "💶",
+    "name": "euro banknote",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4b6.png"
+  },
+  {
+    "emoji": "💷",
+    "name": "pound banknote",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4b7.png"
+  },
+  {
+    "emoji": "💸",
+    "name": "money with wings",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4b8.png"
+  },
+  {
+    "emoji": "💳",
+    "name": "credit card",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4b3.png"
+  },
+  {
+    "emoji": "🧾",
+    "name": "receipt",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9fe.png"
+  },
+  {
+    "emoji": "💹",
+    "name": "chart increasing with yen",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4b9.png"
+  },
+  {
+    "emoji": "✉️",
+    "name": "envelope",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2709-fe0f.png"
+  },
+  {
+    "emoji": "📧",
+    "name": "e-mail",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4e7.png"
+  },
+  {
+    "emoji": "📨",
+    "name": "incoming envelope",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4e8.png"
+  },
+  {
+    "emoji": "📩",
+    "name": "envelope with arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4e9.png"
+  },
+  {
+    "emoji": "📤",
+    "name": "outbox tray",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4e4.png"
+  },
+  {
+    "emoji": "📥",
+    "name": "inbox tray",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4e5.png"
+  },
+  {
+    "emoji": "📦",
+    "name": "package",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4e6.png"
+  },
+  {
+    "emoji": "📫",
+    "name": "closed mailbox with raised flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4eb.png"
+  },
+  {
+    "emoji": "📪",
+    "name": "closed mailbox with lowered flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ea.png"
+  },
+  {
+    "emoji": "📬",
+    "name": "open mailbox with raised flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ec.png"
+  },
+  {
+    "emoji": "📭",
+    "name": "open mailbox with lowered flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ed.png"
+  },
+  {
+    "emoji": "📮",
+    "name": "postbox",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ee.png"
+  },
+  {
+    "emoji": "🗳️",
+    "name": "ballot box with ballot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5f3-fe0f.png"
+  },
+  {
+    "emoji": "✏️",
+    "name": "pencil",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/270f-fe0f.png"
+  },
+  {
+    "emoji": "✒️",
+    "name": "black nib",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2712-fe0f.png"
+  },
+  {
+    "emoji": "🖋️",
+    "name": "fountain pen",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f58b-fe0f.png"
+  },
+  {
+    "emoji": "🖊️",
+    "name": "pen",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f58a-fe0f.png"
+  },
+  {
+    "emoji": "🖌️",
+    "name": "paintbrush",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f58c-fe0f.png"
+  },
+  {
+    "emoji": "🖍️",
+    "name": "crayon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f58d-fe0f.png"
+  },
+  {
+    "emoji": "📝",
+    "name": "memo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4dd.png"
+  },
+  {
+    "emoji": "💼",
+    "name": "briefcase",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4bc.png"
+  },
+  {
+    "emoji": "📁",
+    "name": "file folder",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4c1.png"
+  },
+  {
+    "emoji": "📂",
+    "name": "open file folder",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4c2.png"
+  },
+  {
+    "emoji": "🗂️",
+    "name": "card index dividers",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5c2-fe0f.png"
+  },
+  {
+    "emoji": "📅",
+    "name": "calendar",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4c5.png"
+  },
+  {
+    "emoji": "📆",
+    "name": "tear-off calendar",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4c6.png"
+  },
+  {
+    "emoji": "🗒️",
+    "name": "spiral notepad",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5d2-fe0f.png"
+  },
+  {
+    "emoji": "🗓️",
+    "name": "spiral calendar",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5d3-fe0f.png"
+  },
+  {
+    "emoji": "📇",
+    "name": "card index",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4c7.png"
+  },
+  {
+    "emoji": "📈",
+    "name": "chart increasing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4c8.png"
+  },
+  {
+    "emoji": "📉",
+    "name": "chart decreasing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4c9.png"
+  },
+  {
+    "emoji": "📊",
+    "name": "bar chart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ca.png"
+  },
+  {
+    "emoji": "📋",
+    "name": "clipboard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4cb.png"
+  },
+  {
+    "emoji": "📌",
+    "name": "pushpin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4cc.png"
+  },
+  {
+    "emoji": "📍",
+    "name": "round pushpin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4cd.png"
+  },
+  {
+    "emoji": "📎",
+    "name": "paperclip",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4ce.png"
+  },
+  {
+    "emoji": "🖇️",
+    "name": "linked paperclips",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f587-fe0f.png"
+  },
+  {
+    "emoji": "📏",
+    "name": "straight ruler",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4cf.png"
+  },
+  {
+    "emoji": "📐",
+    "name": "triangular ruler",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4d0.png"
+  },
+  {
+    "emoji": "✂️",
+    "name": "scissors",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2702-fe0f.png"
+  },
+  {
+    "emoji": "🗃️",
+    "name": "card file box",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5c3-fe0f.png"
+  },
+  {
+    "emoji": "🗄️",
+    "name": "file cabinet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5c4-fe0f.png"
+  },
+  {
+    "emoji": "🗑️",
+    "name": "wastebasket",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5d1-fe0f.png"
+  },
+  {
+    "emoji": "🔒",
+    "name": "locked",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f512.png"
+  },
+  {
+    "emoji": "🔓",
+    "name": "unlocked",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f513.png"
+  },
+  {
+    "emoji": "🔏",
+    "name": "locked with pen",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f50f.png"
+  },
+  {
+    "emoji": "🔐",
+    "name": "locked with key",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f510.png"
+  },
+  {
+    "emoji": "🔑",
+    "name": "key",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f511.png"
+  },
+  {
+    "emoji": "🗝️",
+    "name": "old key",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5dd-fe0f.png"
+  },
+  {
+    "emoji": "🔨",
+    "name": "hammer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f528.png"
+  },
+  {
+    "emoji": "🪓",
+    "name": "axe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa93.png"
+  },
+  {
+    "emoji": "⛏️",
+    "name": "pick",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26cf-fe0f.png"
+  },
+  {
+    "emoji": "⚒️",
+    "name": "hammer and pick",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2692-fe0f.png"
+  },
+  {
+    "emoji": "🛠️",
+    "name": "hammer and wrench",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6e0-fe0f.png"
+  },
+  {
+    "emoji": "🗡️",
+    "name": "dagger",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5e1-fe0f.png"
+  },
+  {
+    "emoji": "⚔️",
+    "name": "crossed swords",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2694-fe0f.png"
+  },
+  {
+    "emoji": "💣",
+    "name": "bomb",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4a3.png"
+  },
+  {
+    "emoji": "🪃",
+    "name": "boomerang",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa83.png"
+  },
+  {
+    "emoji": "🏹",
+    "name": "bow and arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f9.png"
+  },
+  {
+    "emoji": "🛡️",
+    "name": "shield",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6e1-fe0f.png"
+  },
+  {
+    "emoji": "🪚",
+    "name": "carpentry saw",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa9a.png"
+  },
+  {
+    "emoji": "🔧",
+    "name": "wrench",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f527.png"
+  },
+  {
+    "emoji": "🪛",
+    "name": "screwdriver",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa9b.png"
+  },
+  {
+    "emoji": "🔩",
+    "name": "nut and bolt",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f529.png"
+  },
+  {
+    "emoji": "⚙️",
+    "name": "gear",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2699-fe0f.png"
+  },
+  {
+    "emoji": "🗜️",
+    "name": "clamp",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5dc-fe0f.png"
+  },
+  {
+    "emoji": "⚖️",
+    "name": "balance scale",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2696-fe0f.png"
+  },
+  {
+    "emoji": "🦯",
+    "name": "white cane",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9af.png"
+  },
+  {
+    "emoji": "🔗",
+    "name": "link",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f517.png"
+  },
+  {
+    "emoji": "⛓️‍💥",
+    "name": "broken chain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26d3-fe0f-200d-1f4a5.png"
+  },
+  {
+    "emoji": "⛓️",
+    "name": "chains",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26d3-fe0f.png"
+  },
+  {
+    "emoji": "🪝",
+    "name": "hook",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa9d.png"
+  },
+  {
+    "emoji": "🧰",
+    "name": "toolbox",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9f0.png"
+  },
+  {
+    "emoji": "🧲",
+    "name": "magnet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9f2.png"
+  },
+  {
+    "emoji": "🪜",
+    "name": "ladder",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa9c.png"
+  },
+  {
+    "emoji": "⚗️",
+    "name": "alembic",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2697-fe0f.png"
+  },
+  {
+    "emoji": "🧪",
+    "name": "test tube",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ea.png"
+  },
+  {
+    "emoji": "🧫",
+    "name": "petri dish",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9eb.png"
+  },
+  {
+    "emoji": "🧬",
+    "name": "dna",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ec.png"
+  },
+  {
+    "emoji": "🔬",
+    "name": "microscope",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f52c.png"
+  },
+  {
+    "emoji": "🔭",
+    "name": "telescope",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f52d.png"
+  },
+  {
+    "emoji": "📡",
+    "name": "satellite antenna",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4e1.png"
+  },
+  {
+    "emoji": "💉",
+    "name": "syringe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f489.png"
+  },
+  {
+    "emoji": "🩸",
+    "name": "drop of blood",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa78.png"
+  },
+  {
+    "emoji": "💊",
+    "name": "pill",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f48a.png"
+  },
+  {
+    "emoji": "🩹",
+    "name": "adhesive bandage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa79.png"
+  },
+  {
+    "emoji": "🩼",
+    "name": "crutch",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa7c.png"
+  },
+  {
+    "emoji": "🩺",
+    "name": "stethoscope",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa7a.png"
+  },
+  {
+    "emoji": "🩻",
+    "name": "x-ray",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa7b.png"
+  },
+  {
+    "emoji": "🚪",
+    "name": "door",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6aa.png"
+  },
+  {
+    "emoji": "🛗",
+    "name": "elevator",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6d7.png"
+  },
+  {
+    "emoji": "🪞",
+    "name": "mirror",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa9e.png"
+  },
+  {
+    "emoji": "🪟",
+    "name": "window",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa9f.png"
+  },
+  {
+    "emoji": "🛏️",
+    "name": "bed",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6cf-fe0f.png"
+  },
+  {
+    "emoji": "🛋️",
+    "name": "couch and lamp",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6cb-fe0f.png"
+  },
+  {
+    "emoji": "🪑",
+    "name": "chair",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa91.png"
+  },
+  {
+    "emoji": "🚽",
+    "name": "toilet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6bd.png"
+  },
+  {
+    "emoji": "🪠",
+    "name": "plunger",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faa0.png"
+  },
+  {
+    "emoji": "🚿",
+    "name": "shower",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6bf.png"
+  },
+  {
+    "emoji": "🛁",
+    "name": "bathtub",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c1.png"
+  },
+  {
+    "emoji": "🪤",
+    "name": "mouse trap",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faa4.png"
+  },
+  {
+    "emoji": "🪒",
+    "name": "razor",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fa92.png"
+  },
+  {
+    "emoji": "🧴",
+    "name": "lotion bottle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9f4.png"
+  },
+  {
+    "emoji": "🧷",
+    "name": "safety pin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9f7.png"
+  },
+  {
+    "emoji": "🧹",
+    "name": "broom",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9f9.png"
+  },
+  {
+    "emoji": "🧺",
+    "name": "basket",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9fa.png"
+  },
+  {
+    "emoji": "🧻",
+    "name": "roll of paper",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9fb.png"
+  },
+  {
+    "emoji": "🪣",
+    "name": "bucket",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faa3.png"
+  },
+  {
+    "emoji": "🧼",
+    "name": "soap",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9fc.png"
+  },
+  {
+    "emoji": "🫧",
+    "name": "bubbles",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1fae7.png"
+  },
+  {
+    "emoji": "🪥",
+    "name": "toothbrush",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faa5.png"
+  },
+  {
+    "emoji": "🧽",
+    "name": "sponge",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9fd.png"
+  },
+  {
+    "emoji": "🧯",
+    "name": "fire extinguisher",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ef.png"
+  },
+  {
+    "emoji": "🛒",
+    "name": "shopping cart",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6d2.png"
+  },
+  {
+    "emoji": "🚬",
+    "name": "cigarette",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6ac.png"
+  },
+  {
+    "emoji": "⚰️",
+    "name": "coffin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26b0-fe0f.png"
+  },
+  {
+    "emoji": "🪦",
+    "name": "headstone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faa6.png"
+  },
+  {
+    "emoji": "⚱️",
+    "name": "funeral urn",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26b1-fe0f.png"
+  },
+  {
+    "emoji": "🧿",
+    "name": "nazar amulet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f9ff.png"
+  },
+  {
+    "emoji": "🪬",
+    "name": "hamsa",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faac.png"
+  },
+  {
+    "emoji": "🗿",
+    "name": "moai",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f5ff.png"
+  },
+  {
+    "emoji": "🪧",
+    "name": "placard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faa7.png"
+  },
+  {
+    "emoji": "🪪",
+    "name": "identification card",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faaa.png"
+  },
+  {
+    "emoji": "🏧",
+    "name": "ATM sign",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3e7.png"
+  },
+  {
+    "emoji": "🚮",
+    "name": "litter in bin sign",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6ae.png"
+  },
+  {
+    "emoji": "🚰",
+    "name": "potable water",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b0.png"
+  },
+  {
+    "emoji": "♿",
+    "name": "wheelchair symbol",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/267f.png"
+  },
+  {
+    "emoji": "🚹",
+    "name": "men’s room",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b9.png"
+  },
+  {
+    "emoji": "🚺",
+    "name": "women’s room",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6ba.png"
+  },
+  {
+    "emoji": "🚻",
+    "name": "restroom",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6bb.png"
+  },
+  {
+    "emoji": "🚼",
+    "name": "baby symbol",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6bc.png"
+  },
+  {
+    "emoji": "🚾",
+    "name": "water closet",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6be.png"
+  },
+  {
+    "emoji": "🛂",
+    "name": "passport control",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c2.png"
+  },
+  {
+    "emoji": "🛃",
+    "name": "customs",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c3.png"
+  },
+  {
+    "emoji": "🛄",
+    "name": "baggage claim",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c4.png"
+  },
+  {
+    "emoji": "🛅",
+    "name": "left luggage",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6c5.png"
+  },
+  {
+    "emoji": "⚠️",
+    "name": "warning",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26a0-fe0f.png"
+  },
+  {
+    "emoji": "🚸",
+    "name": "children crossing",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b8.png"
+  },
+  {
+    "emoji": "⛔",
+    "name": "no entry",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26d4.png"
+  },
+  {
+    "emoji": "🚫",
+    "name": "prohibited",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6ab.png"
+  },
+  {
+    "emoji": "🚳",
+    "name": "no bicycles",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b3.png"
+  },
+  {
+    "emoji": "🚭",
+    "name": "no smoking",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6ad.png"
+  },
+  {
+    "emoji": "🚯",
+    "name": "no littering",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6af.png"
+  },
+  {
+    "emoji": "🚱",
+    "name": "non-potable water",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b1.png"
+  },
+  {
+    "emoji": "🚷",
+    "name": "no pedestrians",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6b7.png"
+  },
+  {
+    "emoji": "📵",
+    "name": "no mobile phones",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4f5.png"
+  },
+  {
+    "emoji": "🔞",
+    "name": "no one under eighteen",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f51e.png"
+  },
+  {
+    "emoji": "☢️",
+    "name": "radioactive",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2622-fe0f.png"
+  },
+  {
+    "emoji": "☣️",
+    "name": "biohazard",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2623-fe0f.png"
+  },
+  {
+    "emoji": "⬆️",
+    "name": "up arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2b06-fe0f.png"
+  },
+  {
+    "emoji": "↗️",
+    "name": "up-right arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2197-fe0f.png"
+  },
+  {
+    "emoji": "➡️",
+    "name": "right arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/27a1-fe0f.png"
+  },
+  {
+    "emoji": "↘️",
+    "name": "down-right arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2198-fe0f.png"
+  },
+  {
+    "emoji": "⬇️",
+    "name": "down arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2b07-fe0f.png"
+  },
+  {
+    "emoji": "↙️",
+    "name": "down-left arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2199-fe0f.png"
+  },
+  {
+    "emoji": "⬅️",
+    "name": "left arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2b05-fe0f.png"
+  },
+  {
+    "emoji": "↖️",
+    "name": "up-left arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2196-fe0f.png"
+  },
+  {
+    "emoji": "↕️",
+    "name": "up-down arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2195-fe0f.png"
+  },
+  {
+    "emoji": "↔️",
+    "name": "left-right arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2194-fe0f.png"
+  },
+  {
+    "emoji": "↩️",
+    "name": "right arrow curving left",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/21a9-fe0f.png"
+  },
+  {
+    "emoji": "↪️",
+    "name": "left arrow curving right",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/21aa-fe0f.png"
+  },
+  {
+    "emoji": "⤴️",
+    "name": "right arrow curving up",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2934-fe0f.png"
+  },
+  {
+    "emoji": "⤵️",
+    "name": "right arrow curving down",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2935-fe0f.png"
+  },
+  {
+    "emoji": "🔃",
+    "name": "clockwise vertical arrows",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f503.png"
+  },
+  {
+    "emoji": "🔄",
+    "name": "counterclockwise arrows button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f504.png"
+  },
+  {
+    "emoji": "🔙",
+    "name": "BACK arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f519.png"
+  },
+  {
+    "emoji": "🔚",
+    "name": "END arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f51a.png"
+  },
+  {
+    "emoji": "🔛",
+    "name": "ON! arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f51b.png"
+  },
+  {
+    "emoji": "🔜",
+    "name": "SOON arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f51c.png"
+  },
+  {
+    "emoji": "🔝",
+    "name": "TOP arrow",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f51d.png"
+  },
+  {
+    "emoji": "🛐",
+    "name": "place of worship",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6d0.png"
+  },
+  {
+    "emoji": "⚛️",
+    "name": "atom symbol",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/269b-fe0f.png"
+  },
+  {
+    "emoji": "🕉️",
+    "name": "om",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f549-fe0f.png"
+  },
+  {
+    "emoji": "✡️",
+    "name": "star of David",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2721-fe0f.png"
+  },
+  {
+    "emoji": "☸️",
+    "name": "wheel of dharma",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2638-fe0f.png"
+  },
+  {
+    "emoji": "☯️",
+    "name": "yin yang",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/262f-fe0f.png"
+  },
+  {
+    "emoji": "✝️",
+    "name": "latin cross",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/271d-fe0f.png"
+  },
+  {
+    "emoji": "☦️",
+    "name": "orthodox cross",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2626-fe0f.png"
+  },
+  {
+    "emoji": "☪️",
+    "name": "star and crescent",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/262a-fe0f.png"
+  },
+  {
+    "emoji": "☮️",
+    "name": "peace symbol",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/262e-fe0f.png"
+  },
+  {
+    "emoji": "🕎",
+    "name": "menorah",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f54e.png"
+  },
+  {
+    "emoji": "🔯",
+    "name": "dotted six-pointed star",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f52f.png"
+  },
+  {
+    "emoji": "🪯",
+    "name": "khanda",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1faaf.png"
+  },
+  {
+    "emoji": "♈",
+    "name": "Aries",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2648.png"
+  },
+  {
+    "emoji": "♉",
+    "name": "Taurus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2649.png"
+  },
+  {
+    "emoji": "♊",
+    "name": "Gemini",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/264a.png"
+  },
+  {
+    "emoji": "♋",
+    "name": "Cancer",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/264b.png"
+  },
+  {
+    "emoji": "♌",
+    "name": "Leo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/264c.png"
+  },
+  {
+    "emoji": "♍",
+    "name": "Virgo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/264d.png"
+  },
+  {
+    "emoji": "♎",
+    "name": "Libra",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/264e.png"
+  },
+  {
+    "emoji": "♏",
+    "name": "Scorpio",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/264f.png"
+  },
+  {
+    "emoji": "♐",
+    "name": "Sagittarius",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2650.png"
+  },
+  {
+    "emoji": "♑",
+    "name": "Capricorn",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2651.png"
+  },
+  {
+    "emoji": "♒",
+    "name": "Aquarius",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2652.png"
+  },
+  {
+    "emoji": "♓",
+    "name": "Pisces",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2653.png"
+  },
+  {
+    "emoji": "⛎",
+    "name": "Ophiuchus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26ce.png"
+  },
+  {
+    "emoji": "🔀",
+    "name": "shuffle tracks button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f500.png"
+  },
+  {
+    "emoji": "🔁",
+    "name": "repeat button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f501.png"
+  },
+  {
+    "emoji": "🔂",
+    "name": "repeat single button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f502.png"
+  },
+  {
+    "emoji": "▶️",
+    "name": "play button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/25b6-fe0f.png"
+  },
+  {
+    "emoji": "⏩",
+    "name": "fast-forward button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23e9.png"
+  },
+  {
+    "emoji": "⏭️",
+    "name": "next track button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23ed-fe0f.png"
+  },
+  {
+    "emoji": "⏯️",
+    "name": "play or pause button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23ef-fe0f.png"
+  },
+  {
+    "emoji": "◀️",
+    "name": "reverse button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/25c0-fe0f.png"
+  },
+  {
+    "emoji": "⏪",
+    "name": "fast reverse button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23ea.png"
+  },
+  {
+    "emoji": "⏮️",
+    "name": "last track button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23ee-fe0f.png"
+  },
+  {
+    "emoji": "🔼",
+    "name": "upwards button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f53c.png"
+  },
+  {
+    "emoji": "⏫",
+    "name": "fast up button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23eb.png"
+  },
+  {
+    "emoji": "🔽",
+    "name": "downwards button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f53d.png"
+  },
+  {
+    "emoji": "⏬",
+    "name": "fast down button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23ec.png"
+  },
+  {
+    "emoji": "⏸️",
+    "name": "pause button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23f8-fe0f.png"
+  },
+  {
+    "emoji": "⏹️",
+    "name": "stop button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23f9-fe0f.png"
+  },
+  {
+    "emoji": "⏺️",
+    "name": "record button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23fa-fe0f.png"
+  },
+  {
+    "emoji": "⏏️",
+    "name": "eject button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23cf-fe0f.png"
+  },
+  {
+    "emoji": "🎦",
+    "name": "cinema",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3a6.png"
+  },
+  {
+    "emoji": "🔅",
+    "name": "dim button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f505.png"
+  },
+  {
+    "emoji": "🔆",
+    "name": "bright button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f506.png"
+  },
+  {
+    "emoji": "📶",
+    "name": "antenna bars",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4f6.png"
+  },
+  {
+    "emoji": "🛜",
+    "name": "wireless",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6dc.png"
+  },
+  {
+    "emoji": "📳",
+    "name": "vibration mode",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4f3.png"
+  },
+  {
+    "emoji": "📴",
+    "name": "mobile phone off",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4f4.png"
+  },
+  {
+    "emoji": "♀️",
+    "name": "female sign",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2640-fe0f.png"
+  },
+  {
+    "emoji": "♂️",
+    "name": "male sign",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2642-fe0f.png"
+  },
+  {
+    "emoji": "⚧️",
+    "name": "transgender symbol",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26a7-fe0f.png"
+  },
+  {
+    "emoji": "✖️",
+    "name": "multiply",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2716-fe0f.png"
+  },
+  {
+    "emoji": "➕",
+    "name": "plus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2795.png"
+  },
+  {
+    "emoji": "➖",
+    "name": "minus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2796.png"
+  },
+  {
+    "emoji": "➗",
+    "name": "divide",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2797.png"
+  },
+  {
+    "emoji": "🟰",
+    "name": "heavy equals sign",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7f0.png"
+  },
+  {
+    "emoji": "♾️",
+    "name": "infinity",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/267e-fe0f.png"
+  },
+  {
+    "emoji": "‼️",
+    "name": "double exclamation mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/203c-fe0f.png"
+  },
+  {
+    "emoji": "⁉️",
+    "name": "exclamation question mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2049-fe0f.png"
+  },
+  {
+    "emoji": "❓",
+    "name": "red question mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2753.png"
+  },
+  {
+    "emoji": "❔",
+    "name": "white question mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2754.png"
+  },
+  {
+    "emoji": "❕",
+    "name": "white exclamation mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2755.png"
+  },
+  {
+    "emoji": "❗",
+    "name": "red exclamation mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2757.png"
+  },
+  {
+    "emoji": "〰️",
+    "name": "wavy dash",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/3030-fe0f.png"
+  },
+  {
+    "emoji": "💱",
+    "name": "currency exchange",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4b1.png"
+  },
+  {
+    "emoji": "💲",
+    "name": "heavy dollar sign",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4b2.png"
+  },
+  {
+    "emoji": "⚕️",
+    "name": "medical symbol",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2695-fe0f.png"
+  },
+  {
+    "emoji": "♻️",
+    "name": "recycling symbol",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/267b-fe0f.png"
+  },
+  {
+    "emoji": "⚜️",
+    "name": "fleur-de-lis",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/269c-fe0f.png"
+  },
+  {
+    "emoji": "🔱",
+    "name": "trident emblem",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f531.png"
+  },
+  {
+    "emoji": "📛",
+    "name": "name badge",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4db.png"
+  },
+  {
+    "emoji": "🔰",
+    "name": "Japanese symbol for beginner",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f530.png"
+  },
+  {
+    "emoji": "⭕",
+    "name": "hollow red circle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2b55.png"
+  },
+  {
+    "emoji": "✅",
+    "name": "check mark button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2705.png"
+  },
+  {
+    "emoji": "☑️",
+    "name": "check box with check",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2611-fe0f.png"
+  },
+  {
+    "emoji": "✔️",
+    "name": "check mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2714-fe0f.png"
+  },
+  {
+    "emoji": "❌",
+    "name": "cross mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/274c.png"
+  },
+  {
+    "emoji": "❎",
+    "name": "cross mark button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/274e.png"
+  },
+  {
+    "emoji": "➰",
+    "name": "curly loop",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/27b0.png"
+  },
+  {
+    "emoji": "➿",
+    "name": "double curly loop",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/27bf.png"
+  },
+  {
+    "emoji": "〽️",
+    "name": "part alternation mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/303d-fe0f.png"
+  },
+  {
+    "emoji": "✳️",
+    "name": "eight-spoked asterisk",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2733-fe0f.png"
+  },
+  {
+    "emoji": "✴️",
+    "name": "eight-pointed star",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2734-fe0f.png"
+  },
+  {
+    "emoji": "❇️",
+    "name": "sparkle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2747-fe0f.png"
+  },
+  {
+    "emoji": "©️",
+    "name": "copyright",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/a9-fe0f.png"
+  },
+  {
+    "emoji": "®️",
+    "name": "registered",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/ae-fe0f.png"
+  },
+  {
+    "emoji": "™️",
+    "name": "trade mark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2122-fe0f.png"
+  },
+  {
+    "emoji": "#️⃣",
+    "name": "keycap: #",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/23-fe0f-20e3.png"
+  },
+  {
+    "emoji": "*️⃣",
+    "name": "keycap: *",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2a-fe0f-20e3.png"
+  },
+  {
+    "emoji": "0️⃣",
+    "name": "keycap: 0",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/30-fe0f-20e3.png"
+  },
+  {
+    "emoji": "1️⃣",
+    "name": "keycap: 1",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/31-fe0f-20e3.png"
+  },
+  {
+    "emoji": "2️⃣",
+    "name": "keycap: 2",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/32-fe0f-20e3.png"
+  },
+  {
+    "emoji": "3️⃣",
+    "name": "keycap: 3",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/33-fe0f-20e3.png"
+  },
+  {
+    "emoji": "4️⃣",
+    "name": "keycap: 4",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/34-fe0f-20e3.png"
+  },
+  {
+    "emoji": "5️⃣",
+    "name": "keycap: 5",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/35-fe0f-20e3.png"
+  },
+  {
+    "emoji": "6️⃣",
+    "name": "keycap: 6",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/36-fe0f-20e3.png"
+  },
+  {
+    "emoji": "7️⃣",
+    "name": "keycap: 7",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/37-fe0f-20e3.png"
+  },
+  {
+    "emoji": "8️⃣",
+    "name": "keycap: 8",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/38-fe0f-20e3.png"
+  },
+  {
+    "emoji": "9️⃣",
+    "name": "keycap: 9",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/39-fe0f-20e3.png"
+  },
+  {
+    "emoji": "🔟",
+    "name": "keycap: 10",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f51f.png"
+  },
+  {
+    "emoji": "🔠",
+    "name": "input latin uppercase",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f520.png"
+  },
+  {
+    "emoji": "🔡",
+    "name": "input latin lowercase",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f521.png"
+  },
+  {
+    "emoji": "🔢",
+    "name": "input numbers",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f522.png"
+  },
+  {
+    "emoji": "🔣",
+    "name": "input symbols",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f523.png"
+  },
+  {
+    "emoji": "🔤",
+    "name": "input latin letters",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f524.png"
+  },
+  {
+    "emoji": "🅰️",
+    "name": "A button (blood type)",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f170-fe0f.png"
+  },
+  {
+    "emoji": "🆎",
+    "name": "AB button (blood type)",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f18e.png"
+  },
+  {
+    "emoji": "🅱️",
+    "name": "B button (blood type)",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f171-fe0f.png"
+  },
+  {
+    "emoji": "🆑",
+    "name": "CL button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f191.png"
+  },
+  {
+    "emoji": "🆒",
+    "name": "COOL button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f192.png"
+  },
+  {
+    "emoji": "🆓",
+    "name": "FREE button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f193.png"
+  },
+  {
+    "emoji": "ℹ️",
+    "name": "information",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2139-fe0f.png"
+  },
+  {
+    "emoji": "🆔",
+    "name": "ID button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f194.png"
+  },
+  {
+    "emoji": "Ⓜ️",
+    "name": "circled M",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/24c2-fe0f.png"
+  },
+  {
+    "emoji": "🆕",
+    "name": "NEW button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f195.png"
+  },
+  {
+    "emoji": "🆖",
+    "name": "NG button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f196.png"
+  },
+  {
+    "emoji": "🅾️",
+    "name": "O button (blood type)",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f17e-fe0f.png"
+  },
+  {
+    "emoji": "🆗",
+    "name": "OK button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f197.png"
+  },
+  {
+    "emoji": "🅿️",
+    "name": "P button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f17f-fe0f.png"
+  },
+  {
+    "emoji": "🆘",
+    "name": "SOS button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f198.png"
+  },
+  {
+    "emoji": "🆙",
+    "name": "UP! button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f199.png"
+  },
+  {
+    "emoji": "🆚",
+    "name": "VS button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f19a.png"
+  },
+  {
+    "emoji": "🈁",
+    "name": "Japanese “here” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f201.png"
+  },
+  {
+    "emoji": "🈂️",
+    "name": "Japanese “service charge” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f202-fe0f.png"
+  },
+  {
+    "emoji": "🈷️",
+    "name": "Japanese “monthly amount” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f237-fe0f.png"
+  },
+  {
+    "emoji": "🈶",
+    "name": "Japanese “not free of charge” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f236.png"
+  },
+  {
+    "emoji": "🈯",
+    "name": "Japanese “reserved” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f22f.png"
+  },
+  {
+    "emoji": "🉐",
+    "name": "Japanese “bargain” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f250.png"
+  },
+  {
+    "emoji": "🈹",
+    "name": "Japanese “discount” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f239.png"
+  },
+  {
+    "emoji": "🈚",
+    "name": "Japanese “free of charge” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f21a.png"
+  },
+  {
+    "emoji": "🈲",
+    "name": "Japanese “prohibited” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f232.png"
+  },
+  {
+    "emoji": "🉑",
+    "name": "Japanese “acceptable” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f251.png"
+  },
+  {
+    "emoji": "🈸",
+    "name": "Japanese “application” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f238.png"
+  },
+  {
+    "emoji": "🈴",
+    "name": "Japanese “passing grade” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f234.png"
+  },
+  {
+    "emoji": "🈳",
+    "name": "Japanese “vacancy” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f233.png"
+  },
+  {
+    "emoji": "㊗️",
+    "name": "Japanese “congratulations” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/3297-fe0f.png"
+  },
+  {
+    "emoji": "㊙️",
+    "name": "Japanese “secret” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/3299-fe0f.png"
+  },
+  {
+    "emoji": "🈺",
+    "name": "Japanese “open for business” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f23a.png"
+  },
+  {
+    "emoji": "🈵",
+    "name": "Japanese “no vacancy” button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f235.png"
+  },
+  {
+    "emoji": "🔴",
+    "name": "red circle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f534.png"
+  },
+  {
+    "emoji": "🟠",
+    "name": "orange circle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7e0.png"
+  },
+  {
+    "emoji": "🟡",
+    "name": "yellow circle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7e1.png"
+  },
+  {
+    "emoji": "🟢",
+    "name": "green circle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7e2.png"
+  },
+  {
+    "emoji": "🔵",
+    "name": "blue circle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f535.png"
+  },
+  {
+    "emoji": "🟣",
+    "name": "purple circle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7e3.png"
+  },
+  {
+    "emoji": "🟤",
+    "name": "brown circle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7e4.png"
+  },
+  {
+    "emoji": "⚫",
+    "name": "black circle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26ab.png"
+  },
+  {
+    "emoji": "⚪",
+    "name": "white circle",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/26aa.png"
+  },
+  {
+    "emoji": "🟥",
+    "name": "red square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7e5.png"
+  },
+  {
+    "emoji": "🟧",
+    "name": "orange square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7e7.png"
+  },
+  {
+    "emoji": "🟨",
+    "name": "yellow square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7e8.png"
+  },
+  {
+    "emoji": "🟩",
+    "name": "green square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7e9.png"
+  },
+  {
+    "emoji": "🟦",
+    "name": "blue square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7e6.png"
+  },
+  {
+    "emoji": "🟪",
+    "name": "purple square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7ea.png"
+  },
+  {
+    "emoji": "🟫",
+    "name": "brown square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f7eb.png"
+  },
+  {
+    "emoji": "⬛",
+    "name": "black large square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2b1b.png"
+  },
+  {
+    "emoji": "⬜",
+    "name": "white large square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/2b1c.png"
+  },
+  {
+    "emoji": "◼️",
+    "name": "black medium square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/25fc-fe0f.png"
+  },
+  {
+    "emoji": "◻️",
+    "name": "white medium square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/25fb-fe0f.png"
+  },
+  {
+    "emoji": "◾",
+    "name": "black medium-small square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/25fe.png"
+  },
+  {
+    "emoji": "◽",
+    "name": "white medium-small square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/25fd.png"
+  },
+  {
+    "emoji": "▪️",
+    "name": "black small square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/25aa-fe0f.png"
+  },
+  {
+    "emoji": "▫️",
+    "name": "white small square",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/25ab-fe0f.png"
+  },
+  {
+    "emoji": "🔶",
+    "name": "large orange diamond",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f536.png"
+  },
+  {
+    "emoji": "🔷",
+    "name": "large blue diamond",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f537.png"
+  },
+  {
+    "emoji": "🔸",
+    "name": "small orange diamond",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f538.png"
+  },
+  {
+    "emoji": "🔹",
+    "name": "small blue diamond",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f539.png"
+  },
+  {
+    "emoji": "🔺",
+    "name": "red triangle pointed up",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f53a.png"
+  },
+  {
+    "emoji": "🔻",
+    "name": "red triangle pointed down",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f53b.png"
+  },
+  {
+    "emoji": "💠",
+    "name": "diamond with a dot",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f4a0.png"
+  },
+  {
+    "emoji": "🔘",
+    "name": "radio button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f518.png"
+  },
+  {
+    "emoji": "🔳",
+    "name": "white square button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f533.png"
+  },
+  {
+    "emoji": "🔲",
+    "name": "black square button",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f532.png"
+  },
+  {
+    "emoji": "🏁",
+    "name": "chequered flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3c1.png"
+  },
+  {
+    "emoji": "🚩",
+    "name": "triangular flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f6a9.png"
+  },
+  {
+    "emoji": "🎌",
+    "name": "crossed flags",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f38c.png"
+  },
+  {
+    "emoji": "🏴",
+    "name": "black flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f4.png"
+  },
+  {
+    "emoji": "🏳️",
+    "name": "white flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f3-fe0f.png"
+  },
+  {
+    "emoji": "🏳️‍🌈",
+    "name": "rainbow flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f3-fe0f-200d-1f308.png"
+  },
+  {
+    "emoji": "🏳️‍⚧️",
+    "name": "transgender flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f3-fe0f-200d-26a7-fe0f.png"
+  },
+  {
+    "emoji": "🏴‍☠️",
+    "name": "pirate flag",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f4-200d-2620-fe0f.png"
+  },
+  {
+    "emoji": "🇦🇨",
+    "name": "flag: Ascension Island",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1e8.png"
+  },
+  {
+    "emoji": "🇦🇩",
+    "name": "flag: Andorra",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1e9.png"
+  },
+  {
+    "emoji": "🇦🇪",
+    "name": "flag: United Arab Emirates",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1ea.png"
+  },
+  {
+    "emoji": "🇦🇫",
+    "name": "flag: Afghanistan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1eb.png"
+  },
+  {
+    "emoji": "🇦🇬",
+    "name": "flag: Antigua & Barbuda",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1ec.png"
+  },
+  {
+    "emoji": "🇦🇮",
+    "name": "flag: Anguilla",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1ee.png"
+  },
+  {
+    "emoji": "🇦🇱",
+    "name": "flag: Albania",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1f1.png"
+  },
+  {
+    "emoji": "🇦🇲",
+    "name": "flag: Armenia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1f2.png"
+  },
+  {
+    "emoji": "🇦🇴",
+    "name": "flag: Angola",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1f4.png"
+  },
+  {
+    "emoji": "🇦🇶",
+    "name": "flag: Antarctica",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1f6.png"
+  },
+  {
+    "emoji": "🇦🇷",
+    "name": "flag: Argentina",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1f7.png"
+  },
+  {
+    "emoji": "🇦🇸",
+    "name": "flag: American Samoa",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1f8.png"
+  },
+  {
+    "emoji": "🇦🇹",
+    "name": "flag: Austria",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1f9.png"
+  },
+  {
+    "emoji": "🇦🇺",
+    "name": "flag: Australia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1fa.png"
+  },
+  {
+    "emoji": "🇦🇼",
+    "name": "flag: Aruba",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1fc.png"
+  },
+  {
+    "emoji": "🇦🇽",
+    "name": "flag: Åland Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1fd.png"
+  },
+  {
+    "emoji": "🇦🇿",
+    "name": "flag: Azerbaijan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e6-1f1ff.png"
+  },
+  {
+    "emoji": "🇧🇦",
+    "name": "flag: Bosnia & Herzegovina",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1e6.png"
+  },
+  {
+    "emoji": "🇧🇧",
+    "name": "flag: Barbados",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1e7.png"
+  },
+  {
+    "emoji": "🇧🇩",
+    "name": "flag: Bangladesh",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1e9.png"
+  },
+  {
+    "emoji": "🇧🇪",
+    "name": "flag: Belgium",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1ea.png"
+  },
+  {
+    "emoji": "🇧🇫",
+    "name": "flag: Burkina Faso",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1eb.png"
+  },
+  {
+    "emoji": "🇧🇬",
+    "name": "flag: Bulgaria",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1ec.png"
+  },
+  {
+    "emoji": "🇧🇭",
+    "name": "flag: Bahrain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1ed.png"
+  },
+  {
+    "emoji": "🇧🇮",
+    "name": "flag: Burundi",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1ee.png"
+  },
+  {
+    "emoji": "🇧🇯",
+    "name": "flag: Benin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1ef.png"
+  },
+  {
+    "emoji": "🇧🇱",
+    "name": "flag: St. Barthélemy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1f1.png"
+  },
+  {
+    "emoji": "🇧🇲",
+    "name": "flag: Bermuda",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1f2.png"
+  },
+  {
+    "emoji": "🇧🇳",
+    "name": "flag: Brunei",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1f3.png"
+  },
+  {
+    "emoji": "🇧🇴",
+    "name": "flag: Bolivia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1f4.png"
+  },
+  {
+    "emoji": "🇧🇶",
+    "name": "flag: Caribbean Netherlands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1f6.png"
+  },
+  {
+    "emoji": "🇧🇷",
+    "name": "flag: Brazil",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1f7.png"
+  },
+  {
+    "emoji": "🇧🇸",
+    "name": "flag: Bahamas",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1f8.png"
+  },
+  {
+    "emoji": "🇧🇹",
+    "name": "flag: Bhutan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1f9.png"
+  },
+  {
+    "emoji": "🇧🇻",
+    "name": "flag: Bouvet Island",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1fb.png"
+  },
+  {
+    "emoji": "🇧🇼",
+    "name": "flag: Botswana",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1fc.png"
+  },
+  {
+    "emoji": "🇧🇾",
+    "name": "flag: Belarus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1fe.png"
+  },
+  {
+    "emoji": "🇧🇿",
+    "name": "flag: Belize",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e7-1f1ff.png"
+  },
+  {
+    "emoji": "🇨🇦",
+    "name": "flag: Canada",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1e6.png"
+  },
+  {
+    "emoji": "🇨🇨",
+    "name": "flag: Cocos (Keeling) Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1e8.png"
+  },
+  {
+    "emoji": "🇨🇩",
+    "name": "flag: Congo - Kinshasa",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1e9.png"
+  },
+  {
+    "emoji": "🇨🇫",
+    "name": "flag: Central African Republic",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1eb.png"
+  },
+  {
+    "emoji": "🇨🇬",
+    "name": "flag: Congo - Brazzaville",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1ec.png"
+  },
+  {
+    "emoji": "🇨🇭",
+    "name": "flag: Switzerland",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1ed.png"
+  },
+  {
+    "emoji": "🇨🇮",
+    "name": "flag: Côte d’Ivoire",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1ee.png"
+  },
+  {
+    "emoji": "🇨🇰",
+    "name": "flag: Cook Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1f0.png"
+  },
+  {
+    "emoji": "🇨🇱",
+    "name": "flag: Chile",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1f1.png"
+  },
+  {
+    "emoji": "🇨🇲",
+    "name": "flag: Cameroon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1f2.png"
+  },
+  {
+    "emoji": "🇨🇳",
+    "name": "flag: China",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1f3.png"
+  },
+  {
+    "emoji": "🇨🇴",
+    "name": "flag: Colombia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1f4.png"
+  },
+  {
+    "emoji": "🇨🇵",
+    "name": "flag: Clipperton Island",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1f5.png"
+  },
+  {
+    "emoji": "🇨🇷",
+    "name": "flag: Costa Rica",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1f7.png"
+  },
+  {
+    "emoji": "🇨🇺",
+    "name": "flag: Cuba",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1fa.png"
+  },
+  {
+    "emoji": "🇨🇻",
+    "name": "flag: Cape Verde",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1fb.png"
+  },
+  {
+    "emoji": "🇨🇼",
+    "name": "flag: Curaçao",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1fc.png"
+  },
+  {
+    "emoji": "🇨🇽",
+    "name": "flag: Christmas Island",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1fd.png"
+  },
+  {
+    "emoji": "🇨🇾",
+    "name": "flag: Cyprus",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1fe.png"
+  },
+  {
+    "emoji": "🇨🇿",
+    "name": "flag: Czechia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e8-1f1ff.png"
+  },
+  {
+    "emoji": "🇩🇪",
+    "name": "flag: Germany",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e9-1f1ea.png"
+  },
+  {
+    "emoji": "🇩🇬",
+    "name": "flag: Diego Garcia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e9-1f1ec.png"
+  },
+  {
+    "emoji": "🇩🇯",
+    "name": "flag: Djibouti",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e9-1f1ef.png"
+  },
+  {
+    "emoji": "🇩🇰",
+    "name": "flag: Denmark",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e9-1f1f0.png"
+  },
+  {
+    "emoji": "🇩🇲",
+    "name": "flag: Dominica",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e9-1f1f2.png"
+  },
+  {
+    "emoji": "🇩🇴",
+    "name": "flag: Dominican Republic",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e9-1f1f4.png"
+  },
+  {
+    "emoji": "🇩🇿",
+    "name": "flag: Algeria",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1e9-1f1ff.png"
+  },
+  {
+    "emoji": "🇪🇦",
+    "name": "flag: Ceuta & Melilla",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ea-1f1e6.png"
+  },
+  {
+    "emoji": "🇪🇨",
+    "name": "flag: Ecuador",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ea-1f1e8.png"
+  },
+  {
+    "emoji": "🇪🇪",
+    "name": "flag: Estonia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ea-1f1ea.png"
+  },
+  {
+    "emoji": "🇪🇬",
+    "name": "flag: Egypt",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ea-1f1ec.png"
+  },
+  {
+    "emoji": "🇪🇭",
+    "name": "flag: Western Sahara",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ea-1f1ed.png"
+  },
+  {
+    "emoji": "🇪🇷",
+    "name": "flag: Eritrea",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ea-1f1f7.png"
+  },
+  {
+    "emoji": "🇪🇸",
+    "name": "flag: Spain",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ea-1f1f8.png"
+  },
+  {
+    "emoji": "🇪🇹",
+    "name": "flag: Ethiopia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ea-1f1f9.png"
+  },
+  {
+    "emoji": "🇪🇺",
+    "name": "flag: European Union",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ea-1f1fa.png"
+  },
+  {
+    "emoji": "🇫🇮",
+    "name": "flag: Finland",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1eb-1f1ee.png"
+  },
+  {
+    "emoji": "🇫🇯",
+    "name": "flag: Fiji",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1eb-1f1ef.png"
+  },
+  {
+    "emoji": "🇫🇰",
+    "name": "flag: Falkland Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1eb-1f1f0.png"
+  },
+  {
+    "emoji": "🇫🇲",
+    "name": "flag: Micronesia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1eb-1f1f2.png"
+  },
+  {
+    "emoji": "🇫🇴",
+    "name": "flag: Faroe Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1eb-1f1f4.png"
+  },
+  {
+    "emoji": "🇫🇷",
+    "name": "flag: France",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1eb-1f1f7.png"
+  },
+  {
+    "emoji": "🇬🇦",
+    "name": "flag: Gabon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1e6.png"
+  },
+  {
+    "emoji": "🇬🇧",
+    "name": "flag: United Kingdom",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1e7.png"
+  },
+  {
+    "emoji": "🇬🇩",
+    "name": "flag: Grenada",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1e9.png"
+  },
+  {
+    "emoji": "🇬🇪",
+    "name": "flag: Georgia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1ea.png"
+  },
+  {
+    "emoji": "🇬🇫",
+    "name": "flag: French Guiana",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1eb.png"
+  },
+  {
+    "emoji": "🇬🇬",
+    "name": "flag: Guernsey",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1ec.png"
+  },
+  {
+    "emoji": "🇬🇭",
+    "name": "flag: Ghana",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1ed.png"
+  },
+  {
+    "emoji": "🇬🇮",
+    "name": "flag: Gibraltar",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1ee.png"
+  },
+  {
+    "emoji": "🇬🇱",
+    "name": "flag: Greenland",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1f1.png"
+  },
+  {
+    "emoji": "🇬🇲",
+    "name": "flag: Gambia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1f2.png"
+  },
+  {
+    "emoji": "🇬🇳",
+    "name": "flag: Guinea",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1f3.png"
+  },
+  {
+    "emoji": "🇬🇵",
+    "name": "flag: Guadeloupe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1f5.png"
+  },
+  {
+    "emoji": "🇬🇶",
+    "name": "flag: Equatorial Guinea",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1f6.png"
+  },
+  {
+    "emoji": "🇬🇷",
+    "name": "flag: Greece",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1f7.png"
+  },
+  {
+    "emoji": "🇬🇸",
+    "name": "flag: South Georgia & South Sandwich Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1f8.png"
+  },
+  {
+    "emoji": "🇬🇹",
+    "name": "flag: Guatemala",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1f9.png"
+  },
+  {
+    "emoji": "🇬🇺",
+    "name": "flag: Guam",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1fa.png"
+  },
+  {
+    "emoji": "🇬🇼",
+    "name": "flag: Guinea-Bissau",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1fc.png"
+  },
+  {
+    "emoji": "🇬🇾",
+    "name": "flag: Guyana",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ec-1f1fe.png"
+  },
+  {
+    "emoji": "🇭🇰",
+    "name": "flag: Hong Kong SAR China",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ed-1f1f0.png"
+  },
+  {
+    "emoji": "🇭🇲",
+    "name": "flag: Heard & McDonald Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ed-1f1f2.png"
+  },
+  {
+    "emoji": "🇭🇳",
+    "name": "flag: Honduras",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ed-1f1f3.png"
+  },
+  {
+    "emoji": "🇭🇷",
+    "name": "flag: Croatia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ed-1f1f7.png"
+  },
+  {
+    "emoji": "🇭🇹",
+    "name": "flag: Haiti",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ed-1f1f9.png"
+  },
+  {
+    "emoji": "🇭🇺",
+    "name": "flag: Hungary",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ed-1f1fa.png"
+  },
+  {
+    "emoji": "🇮🇨",
+    "name": "flag: Canary Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1e8.png"
+  },
+  {
+    "emoji": "🇮🇩",
+    "name": "flag: Indonesia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1e9.png"
+  },
+  {
+    "emoji": "🇮🇪",
+    "name": "flag: Ireland",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1ea.png"
+  },
+  {
+    "emoji": "🇮🇱",
+    "name": "flag: Israel",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1f1.png"
+  },
+  {
+    "emoji": "🇮🇲",
+    "name": "flag: Isle of Man",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1f2.png"
+  },
+  {
+    "emoji": "🇮🇳",
+    "name": "flag: India",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1f3.png"
+  },
+  {
+    "emoji": "🇮🇴",
+    "name": "flag: British Indian Ocean Territory",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1f4.png"
+  },
+  {
+    "emoji": "🇮🇶",
+    "name": "flag: Iraq",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1f6.png"
+  },
+  {
+    "emoji": "🇮🇷",
+    "name": "flag: Iran",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1f7.png"
+  },
+  {
+    "emoji": "🇮🇸",
+    "name": "flag: Iceland",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1f8.png"
+  },
+  {
+    "emoji": "🇮🇹",
+    "name": "flag: Italy",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ee-1f1f9.png"
+  },
+  {
+    "emoji": "🇯🇪",
+    "name": "flag: Jersey",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ef-1f1ea.png"
+  },
+  {
+    "emoji": "🇯🇲",
+    "name": "flag: Jamaica",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ef-1f1f2.png"
+  },
+  {
+    "emoji": "🇯🇴",
+    "name": "flag: Jordan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ef-1f1f4.png"
+  },
+  {
+    "emoji": "🇯🇵",
+    "name": "flag: Japan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ef-1f1f5.png"
+  },
+  {
+    "emoji": "🇰🇪",
+    "name": "flag: Kenya",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1ea.png"
+  },
+  {
+    "emoji": "🇰🇬",
+    "name": "flag: Kyrgyzstan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1ec.png"
+  },
+  {
+    "emoji": "🇰🇭",
+    "name": "flag: Cambodia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1ed.png"
+  },
+  {
+    "emoji": "🇰🇮",
+    "name": "flag: Kiribati",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1ee.png"
+  },
+  {
+    "emoji": "🇰🇲",
+    "name": "flag: Comoros",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1f2.png"
+  },
+  {
+    "emoji": "🇰🇳",
+    "name": "flag: St. Kitts & Nevis",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1f3.png"
+  },
+  {
+    "emoji": "🇰🇵",
+    "name": "flag: North Korea",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1f5.png"
+  },
+  {
+    "emoji": "🇰🇷",
+    "name": "flag: South Korea",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1f7.png"
+  },
+  {
+    "emoji": "🇰🇼",
+    "name": "flag: Kuwait",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1fc.png"
+  },
+  {
+    "emoji": "🇰🇾",
+    "name": "flag: Cayman Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1fe.png"
+  },
+  {
+    "emoji": "🇰🇿",
+    "name": "flag: Kazakhstan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f0-1f1ff.png"
+  },
+  {
+    "emoji": "🇱🇦",
+    "name": "flag: Laos",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1e6.png"
+  },
+  {
+    "emoji": "🇱🇧",
+    "name": "flag: Lebanon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1e7.png"
+  },
+  {
+    "emoji": "🇱🇨",
+    "name": "flag: St. Lucia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1e8.png"
+  },
+  {
+    "emoji": "🇱🇮",
+    "name": "flag: Liechtenstein",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1ee.png"
+  },
+  {
+    "emoji": "🇱🇰",
+    "name": "flag: Sri Lanka",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1f0.png"
+  },
+  {
+    "emoji": "🇱🇷",
+    "name": "flag: Liberia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1f7.png"
+  },
+  {
+    "emoji": "🇱🇸",
+    "name": "flag: Lesotho",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1f8.png"
+  },
+  {
+    "emoji": "🇱🇹",
+    "name": "flag: Lithuania",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1f9.png"
+  },
+  {
+    "emoji": "🇱🇺",
+    "name": "flag: Luxembourg",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1fa.png"
+  },
+  {
+    "emoji": "🇱🇻",
+    "name": "flag: Latvia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1fb.png"
+  },
+  {
+    "emoji": "🇱🇾",
+    "name": "flag: Libya",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f1-1f1fe.png"
+  },
+  {
+    "emoji": "🇲🇦",
+    "name": "flag: Morocco",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1e6.png"
+  },
+  {
+    "emoji": "🇲🇨",
+    "name": "flag: Monaco",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1e8.png"
+  },
+  {
+    "emoji": "🇲🇩",
+    "name": "flag: Moldova",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1e9.png"
+  },
+  {
+    "emoji": "🇲🇪",
+    "name": "flag: Montenegro",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1ea.png"
+  },
+  {
+    "emoji": "🇲🇫",
+    "name": "flag: St. Martin",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1eb.png"
+  },
+  {
+    "emoji": "🇲🇬",
+    "name": "flag: Madagascar",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1ec.png"
+  },
+  {
+    "emoji": "🇲🇭",
+    "name": "flag: Marshall Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1ed.png"
+  },
+  {
+    "emoji": "🇲🇰",
+    "name": "flag: North Macedonia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1f0.png"
+  },
+  {
+    "emoji": "🇲🇱",
+    "name": "flag: Mali",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1f1.png"
+  },
+  {
+    "emoji": "🇲🇲",
+    "name": "flag: Myanmar (Burma)",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1f2.png"
+  },
+  {
+    "emoji": "🇲🇳",
+    "name": "flag: Mongolia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1f3.png"
+  },
+  {
+    "emoji": "🇲🇴",
+    "name": "flag: Macao SAR China",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1f4.png"
+  },
+  {
+    "emoji": "🇲🇵",
+    "name": "flag: Northern Mariana Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1f5.png"
+  },
+  {
+    "emoji": "🇲🇶",
+    "name": "flag: Martinique",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1f6.png"
+  },
+  {
+    "emoji": "🇲🇷",
+    "name": "flag: Mauritania",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1f7.png"
+  },
+  {
+    "emoji": "🇲🇸",
+    "name": "flag: Montserrat",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1f8.png"
+  },
+  {
+    "emoji": "🇲🇹",
+    "name": "flag: Malta",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1f9.png"
+  },
+  {
+    "emoji": "🇲🇺",
+    "name": "flag: Mauritius",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1fa.png"
+  },
+  {
+    "emoji": "🇲🇻",
+    "name": "flag: Maldives",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1fb.png"
+  },
+  {
+    "emoji": "🇲🇼",
+    "name": "flag: Malawi",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1fc.png"
+  },
+  {
+    "emoji": "🇲🇽",
+    "name": "flag: Mexico",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1fd.png"
+  },
+  {
+    "emoji": "🇲🇾",
+    "name": "flag: Malaysia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1fe.png"
+  },
+  {
+    "emoji": "🇲🇿",
+    "name": "flag: Mozambique",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f2-1f1ff.png"
+  },
+  {
+    "emoji": "🇳🇦",
+    "name": "flag: Namibia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1e6.png"
+  },
+  {
+    "emoji": "🇳🇨",
+    "name": "flag: New Caledonia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1e8.png"
+  },
+  {
+    "emoji": "🇳🇪",
+    "name": "flag: Niger",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1ea.png"
+  },
+  {
+    "emoji": "🇳🇫",
+    "name": "flag: Norfolk Island",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1eb.png"
+  },
+  {
+    "emoji": "🇳🇬",
+    "name": "flag: Nigeria",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1ec.png"
+  },
+  {
+    "emoji": "🇳🇮",
+    "name": "flag: Nicaragua",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1ee.png"
+  },
+  {
+    "emoji": "🇳🇱",
+    "name": "flag: Netherlands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1f1.png"
+  },
+  {
+    "emoji": "🇳🇴",
+    "name": "flag: Norway",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1f4.png"
+  },
+  {
+    "emoji": "🇳🇵",
+    "name": "flag: Nepal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1f5.png"
+  },
+  {
+    "emoji": "🇳🇷",
+    "name": "flag: Nauru",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1f7.png"
+  },
+  {
+    "emoji": "🇳🇺",
+    "name": "flag: Niue",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1fa.png"
+  },
+  {
+    "emoji": "🇳🇿",
+    "name": "flag: New Zealand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f3-1f1ff.png"
+  },
+  {
+    "emoji": "🇴🇲",
+    "name": "flag: Oman",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f4-1f1f2.png"
+  },
+  {
+    "emoji": "🇵🇦",
+    "name": "flag: Panama",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1e6.png"
+  },
+  {
+    "emoji": "🇵🇪",
+    "name": "flag: Peru",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1ea.png"
+  },
+  {
+    "emoji": "🇵🇫",
+    "name": "flag: French Polynesia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1eb.png"
+  },
+  {
+    "emoji": "🇵🇬",
+    "name": "flag: Papua New Guinea",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1ec.png"
+  },
+  {
+    "emoji": "🇵🇭",
+    "name": "flag: Philippines",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1ed.png"
+  },
+  {
+    "emoji": "🇵🇰",
+    "name": "flag: Pakistan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1f0.png"
+  },
+  {
+    "emoji": "🇵🇱",
+    "name": "flag: Poland",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1f1.png"
+  },
+  {
+    "emoji": "🇵🇲",
+    "name": "flag: St. Pierre & Miquelon",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1f2.png"
+  },
+  {
+    "emoji": "🇵🇳",
+    "name": "flag: Pitcairn Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1f3.png"
+  },
+  {
+    "emoji": "🇵🇷",
+    "name": "flag: Puerto Rico",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1f7.png"
+  },
+  {
+    "emoji": "🇵🇸",
+    "name": "flag: Palestinian Territories",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1f8.png"
+  },
+  {
+    "emoji": "🇵🇹",
+    "name": "flag: Portugal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1f9.png"
+  },
+  {
+    "emoji": "🇵🇼",
+    "name": "flag: Palau",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1fc.png"
+  },
+  {
+    "emoji": "🇵🇾",
+    "name": "flag: Paraguay",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f5-1f1fe.png"
+  },
+  {
+    "emoji": "🇶🇦",
+    "name": "flag: Qatar",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f6-1f1e6.png"
+  },
+  {
+    "emoji": "🇷🇪",
+    "name": "flag: Réunion",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f7-1f1ea.png"
+  },
+  {
+    "emoji": "🇷🇴",
+    "name": "flag: Romania",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f7-1f1f4.png"
+  },
+  {
+    "emoji": "🇷🇸",
+    "name": "flag: Serbia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f7-1f1f8.png"
+  },
+  {
+    "emoji": "🇷🇺",
+    "name": "flag: Russia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f7-1f1fa.png"
+  },
+  {
+    "emoji": "🇷🇼",
+    "name": "flag: Rwanda",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f7-1f1fc.png"
+  },
+  {
+    "emoji": "🇸🇦",
+    "name": "flag: Saudi Arabia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1e6.png"
+  },
+  {
+    "emoji": "🇸🇧",
+    "name": "flag: Solomon Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1e7.png"
+  },
+  {
+    "emoji": "🇸🇨",
+    "name": "flag: Seychelles",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1e8.png"
+  },
+  {
+    "emoji": "🇸🇩",
+    "name": "flag: Sudan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1e9.png"
+  },
+  {
+    "emoji": "🇸🇪",
+    "name": "flag: Sweden",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1ea.png"
+  },
+  {
+    "emoji": "🇸🇬",
+    "name": "flag: Singapore",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1ec.png"
+  },
+  {
+    "emoji": "🇸🇭",
+    "name": "flag: St. Helena",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1ed.png"
+  },
+  {
+    "emoji": "🇸🇮",
+    "name": "flag: Slovenia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1ee.png"
+  },
+  {
+    "emoji": "🇸🇯",
+    "name": "flag: Svalbard & Jan Mayen",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1ef.png"
+  },
+  {
+    "emoji": "🇸🇰",
+    "name": "flag: Slovakia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1f0.png"
+  },
+  {
+    "emoji": "🇸🇱",
+    "name": "flag: Sierra Leone",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1f1.png"
+  },
+  {
+    "emoji": "🇸🇲",
+    "name": "flag: San Marino",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1f2.png"
+  },
+  {
+    "emoji": "🇸🇳",
+    "name": "flag: Senegal",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1f3.png"
+  },
+  {
+    "emoji": "🇸🇴",
+    "name": "flag: Somalia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1f4.png"
+  },
+  {
+    "emoji": "🇸🇷",
+    "name": "flag: Suriname",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1f7.png"
+  },
+  {
+    "emoji": "🇸🇸",
+    "name": "flag: South Sudan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1f8.png"
+  },
+  {
+    "emoji": "🇸🇹",
+    "name": "flag: São Tomé & Príncipe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1f9.png"
+  },
+  {
+    "emoji": "🇸🇻",
+    "name": "flag: El Salvador",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1fb.png"
+  },
+  {
+    "emoji": "🇸🇽",
+    "name": "flag: Sint Maarten",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1fd.png"
+  },
+  {
+    "emoji": "🇸🇾",
+    "name": "flag: Syria",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1fe.png"
+  },
+  {
+    "emoji": "🇸🇿",
+    "name": "flag: Eswatini",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f8-1f1ff.png"
+  },
+  {
+    "emoji": "🇹🇦",
+    "name": "flag: Tristan da Cunha",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1e6.png"
+  },
+  {
+    "emoji": "🇹🇨",
+    "name": "flag: Turks & Caicos Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1e8.png"
+  },
+  {
+    "emoji": "🇹🇩",
+    "name": "flag: Chad",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1e9.png"
+  },
+  {
+    "emoji": "🇹🇫",
+    "name": "flag: French Southern Territories",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1eb.png"
+  },
+  {
+    "emoji": "🇹🇬",
+    "name": "flag: Togo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1ec.png"
+  },
+  {
+    "emoji": "🇹🇭",
+    "name": "flag: Thailand",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1ed.png"
+  },
+  {
+    "emoji": "🇹🇯",
+    "name": "flag: Tajikistan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1ef.png"
+  },
+  {
+    "emoji": "🇹🇰",
+    "name": "flag: Tokelau",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1f0.png"
+  },
+  {
+    "emoji": "🇹🇱",
+    "name": "flag: Timor-Leste",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1f1.png"
+  },
+  {
+    "emoji": "🇹🇲",
+    "name": "flag: Turkmenistan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1f2.png"
+  },
+  {
+    "emoji": "🇹🇳",
+    "name": "flag: Tunisia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1f3.png"
+  },
+  {
+    "emoji": "🇹🇴",
+    "name": "flag: Tonga",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1f4.png"
+  },
+  {
+    "emoji": "🇹🇷",
+    "name": "flag: Türkiye",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1f7.png"
+  },
+  {
+    "emoji": "🇹🇹",
+    "name": "flag: Trinidad & Tobago",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1f9.png"
+  },
+  {
+    "emoji": "🇹🇻",
+    "name": "flag: Tuvalu",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1fb.png"
+  },
+  {
+    "emoji": "🇹🇼",
+    "name": "flag: Taiwan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1fc.png"
+  },
+  {
+    "emoji": "🇹🇿",
+    "name": "flag: Tanzania",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1f9-1f1ff.png"
+  },
+  {
+    "emoji": "🇺🇦",
+    "name": "flag: Ukraine",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fa-1f1e6.png"
+  },
+  {
+    "emoji": "🇺🇬",
+    "name": "flag: Uganda",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fa-1f1ec.png"
+  },
+  {
+    "emoji": "🇺🇲",
+    "name": "flag: U.S. Outlying Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fa-1f1f2.png"
+  },
+  {
+    "emoji": "🇺🇳",
+    "name": "flag: United Nations",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fa-1f1f3.png"
+  },
+  {
+    "emoji": "🇺🇸",
+    "name": "flag: United States",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fa-1f1f8.png"
+  },
+  {
+    "emoji": "🇺🇾",
+    "name": "flag: Uruguay",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fa-1f1fe.png"
+  },
+  {
+    "emoji": "🇺🇿",
+    "name": "flag: Uzbekistan",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fa-1f1ff.png"
+  },
+  {
+    "emoji": "🇻🇦",
+    "name": "flag: Vatican City",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fb-1f1e6.png"
+  },
+  {
+    "emoji": "🇻🇨",
+    "name": "flag: St. Vincent & Grenadines",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fb-1f1e8.png"
+  },
+  {
+    "emoji": "🇻🇪",
+    "name": "flag: Venezuela",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fb-1f1ea.png"
+  },
+  {
+    "emoji": "🇻🇬",
+    "name": "flag: British Virgin Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fb-1f1ec.png"
+  },
+  {
+    "emoji": "🇻🇮",
+    "name": "flag: U.S. Virgin Islands",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fb-1f1ee.png"
+  },
+  {
+    "emoji": "🇻🇳",
+    "name": "flag: Vietnam",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fb-1f1f3.png"
+  },
+  {
+    "emoji": "🇻🇺",
+    "name": "flag: Vanuatu",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fb-1f1fa.png"
+  },
+  {
+    "emoji": "🇼🇫",
+    "name": "flag: Wallis & Futuna",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fc-1f1eb.png"
+  },
+  {
+    "emoji": "🇼🇸",
+    "name": "flag: Samoa",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fc-1f1f8.png"
+  },
+  {
+    "emoji": "🇽🇰",
+    "name": "flag: Kosovo",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fd-1f1f0.png"
+  },
+  {
+    "emoji": "🇾🇪",
+    "name": "flag: Yemen",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fe-1f1ea.png"
+  },
+  {
+    "emoji": "🇾🇹",
+    "name": "flag: Mayotte",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1fe-1f1f9.png"
+  },
+  {
+    "emoji": "🇿🇦",
+    "name": "flag: South Africa",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ff-1f1e6.png"
+  },
+  {
+    "emoji": "🇿🇲",
+    "name": "flag: Zambia",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ff-1f1f2.png"
+  },
+  {
+    "emoji": "🇿🇼",
+    "name": "flag: Zimbabwe",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f1ff-1f1fc.png"
+  },
+  {
+    "emoji": "🏴󠁧󠁢󠁥󠁮󠁧󠁿",
+    "name": "flag: England",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f4-e0067-e0062-e0065-e006e-e0067-e007f.png"
+  },
+  {
+    "emoji": "🏴󠁧󠁢󠁳󠁣󠁴󠁿",
+    "name": "flag: Scotland",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f4-e0067-e0062-e0073-e0063-e0074-e007f.png"
+  },
+  {
+    "emoji": "🏴󠁧󠁢󠁷󠁬󠁳󠁿",
+    "name": "flag: Wales",
+    "imageUrl": "https://cdn.jsdelivr.net/gh/jdecked/twemoji@v16.0.1/assets/72x72/1f3f4-e0067-e0062-e0077-e006c-e0073-e007f.png"
+  }
 ]

--- a/demibot/demibot/db/migrations/versions/0041_add_unicode_emojis_table.py
+++ b/demibot/demibot/db/migrations/versions/0041_add_unicode_emojis_table.py
@@ -1,7 +1,8 @@
 """add unicode emojis table"""
 
-from pathlib import Path
 import json
+import logging
+from pathlib import Path
 
 from alembic import op
 import sqlalchemy as sa
@@ -23,24 +24,28 @@ def upgrade() -> None:
     )
 
     data_path = Path(__file__).resolve().parents[2] / "data" / "unicode_emojis.json"
-    try:
-        with data_path.open("r", encoding="utf-8") as f:
+    with data_path.open("r", encoding="utf-8") as f:
+        try:
             data = json.load(f)
-        emoji_table = table(
-            "unicode_emojis",
-            column("emoji", sa.String),
-            column("name", sa.String),
-            column("image_url", sa.String),
-        )
-        op.bulk_insert(
-            emoji_table,
-            [
-                {"emoji": e.get("emoji"), "name": e.get("name"), "image_url": e.get("imageUrl")}
-                for e in data
-            ],
-        )
-    except Exception:
-        pass
+        except json.JSONDecodeError as exc:
+            logging.getLogger(__name__).exception(
+                "Failed to parse unicode emoji dataset at %s", data_path
+            )
+            raise exc
+
+    emoji_table = table(
+        "unicode_emojis",
+        column("emoji", sa.String),
+        column("name", sa.String),
+        column("image_url", sa.String),
+    )
+    op.bulk_insert(
+        emoji_table,
+        [
+            {"emoji": e.get("emoji"), "name": e.get("name"), "image_url": e.get("imageUrl")}
+            for e in data
+        ],
+    )
 
 
 def downgrade() -> None:

--- a/tests/test_unicode_emojis.py
+++ b/tests/test_unicode_emojis.py
@@ -1,7 +1,10 @@
+import json
 import sys
 from pathlib import Path
+
 import pytest
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy import insert
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 root = Path(__file__).resolve().parents[1] / 'demibot'
@@ -17,10 +20,22 @@ async def test_get_unicode_emojis():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+    dataset_path = root / "demibot" / "data" / "unicode_emojis.json"
+    payload = json.loads(dataset_path.read_text(encoding="utf-8"))
+    assert len(payload) > 1000
+
     Session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
     async with Session() as session:
-        session.add(UnicodeEmoji(emoji="😀", name="grinning face", image_url="url"))
+        emojis._unicode_cache = None
+        await session.execute(
+            insert(UnicodeEmoji),
+            [
+                {"emoji": item["emoji"], "name": item["name"], "image_url": item["imageUrl"]}
+                for item in payload
+            ],
+        )
         await session.commit()
         res = await emojis.get_unicode_emojis(session)
         assert isinstance(res, list)
-        assert any(e.get('emoji') == '😀' for e in res)
+        assert len(res) == len(payload)
+        assert any(e.get("emoji") == "📢" for e in res)


### PR DESCRIPTION
## Summary
- replace the unicode emoji seed data with the full Discord-supported Twemoji 16.0.1 set
- make the unicode emoji migration log and re-raise JSON parsing failures instead of swallowing them
- extend the unicode emoji route test to seed the expanded data and assert channel icons like 📢 are returned

## Testing
- pytest tests/test_unicode_emojis.py

------
https://chatgpt.com/codex/tasks/task_e_68dc819080088328b11f600cc33a2fe7