### PR TITLE
Gracefully handle syncshell transfer budget load failures

### DIFF
--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -84,15 +84,21 @@ def create_app() -> FastAPI:
 
     @app.on_event("startup")
     async def _load_syncshell_transfer_budgets() -> None:
-        async with get_session() as db:
-            try:
-                await syncshell_module.load_transfer_budgets(db)
-            except Exception as exc:  # pragma: no cover - exercised in tests
-                logger.warning(
-                    "syncshell.transfer_budgets_load_failed",
-                    error=str(exc),
-                )
+        db = None
+        try:
+            async with get_session() as db_session:
+                db = db_session
+                await syncshell_module.load_transfer_budgets(db_session)
+        except Exception as exc:  # pragma: no cover - exercised in tests
+            logger.warning(
+                "syncshell.transfer_budgets_load_failed",
+                error=str(exc),
+            )
+
+            if db is not None:
                 await syncshell_module._transfer_budget_store.reset(db)
+            else:
+                await syncshell_module._transfer_budget_store.reset_cache()
 
     # Dynamically include routers from all modules in the routes package
     from . import routes as routes_pkg

--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -358,11 +358,14 @@ class _TransferBudgetStore:
         await db.flush()
 
     async def reset(self, db: AsyncSession) -> None:
+        await self.reset_cache()
+        await db.execute(delete(SyncshellTransferBudget))
+        await db.flush()
+
+    async def reset_cache(self) -> None:
         async with self._lock:
             self._cache.clear()
             self._loaded = False
-        await db.execute(delete(SyncshellTransferBudget))
-        await db.flush()
 
 
 _transfer_budget_store = _TransferBudgetStore()

--- a/tests/test_api_startup.py
+++ b/tests/test_api_startup.py
@@ -15,6 +15,14 @@ class _DummySessionContext:
         return None
 
 
+class _FailingSessionContext:
+    async def __aenter__(self) -> object:
+        raise RuntimeError("session failed")
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+        return None
+
+
 class _FakeLogger:
     def __init__(self) -> None:
         self.warnings: list[tuple[str, dict[str, object]]] = []
@@ -49,5 +57,33 @@ def test_startup_logs_warning_when_transfer_budget_load_fails(monkeypatch):
     assert "boom" in str(data["error"])
 
     reset_mock.assert_awaited_once()
+
+    asyncio.run(app.router.shutdown())
+
+
+def test_startup_handles_failing_session(monkeypatch):
+    fake_logger = _FakeLogger()
+    monkeypatch.setattr(api_module, "logger", fake_logger)
+
+    reset_cache_mock = AsyncMock()
+    monkeypatch.setattr(
+        syncshell_module._transfer_budget_store,
+        "reset_cache",
+        reset_cache_mock,
+    )
+
+    monkeypatch.setattr(api_module, "get_session", lambda: _FailingSessionContext())
+    monkeypatch.setattr(api_module.pkgutil, "iter_modules", lambda *args, **kwargs: [])
+
+    app = api_module.create_app()
+
+    asyncio.run(app.router.startup())
+
+    assert fake_logger.warnings
+    event, data = fake_logger.warnings[0]
+    assert event == "syncshell.transfer_budgets_load_failed"
+    assert "session failed" in str(data.get("error"))
+
+    reset_cache_mock.assert_awaited_once()
 
     asyncio.run(app.router.shutdown())


### PR DESCRIPTION
## Summary
- guard the syncshell transfer budget loading on startup and fall back to an empty cache if it fails
- add a cache-only reset helper on the transfer budget store
- extend the startup tests to cover failing database sessions

## Testing
- pytest tests/test_api_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68dc842385c88328b3bc4b687b409bee