### PR TITLE
Escape backslash in collection name normalization

### DIFF
--- a/DemiCatPlugin/SyncShell/Resolver.cs
+++ b/DemiCatPlugin/SyncShell/Resolver.cs
@@ -783,7 +783,7 @@ public sealed class Resolver : IResolver
             name = name[..^4];
         }
 
-        name = name.Replace('\', '/');
+        name = name.Replace('\\', '/');
         var slashIndex = name.LastIndexOf('/');
         if (slashIndex >= 0)
         {


### PR DESCRIPTION
## Summary
- escape backslashes when normalizing collection names to ensure path separators are handled consistently

## Testing
- `dotnet build -c Release` *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc87d2258483288b92fd607137ca72