### PR TITLE
Normalize NotePad page color deserialization

### DIFF
--- a/DemiCatPlugin/NotePadService.cs
+++ b/DemiCatPlugin/NotePadService.cs
@@ -995,12 +995,20 @@ public sealed class NotePadSection
 
 public sealed class NotePadPage
 {
+    private string _color = NotePadColorHelper.DefaultHexColor;
+
     public string Id { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
     public int Version { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }
-    public string? Color { get; set; }
+
+    [JsonConverter(typeof(NotePadColorJsonConverter))]
+    public string Color
+    {
+        get => _color;
+        set => _color = NotePadColorHelper.Normalize(value);
+    }
 }
 
 public sealed class NotePadListResponse


### PR DESCRIPTION
## Summary
- apply the NotePadColorJsonConverter to NotePadPage.Color
- normalize NotePadPage.Color values via NotePadColorHelper so numeric and string inputs deserialize correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc98bf495c8328b910529b5568f1e0