### PR TITLE
Add per-window fade preferences and propagate appearance updates

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -19,6 +19,18 @@ public class Config : IPluginConfiguration
     public static readonly Vector4 DefaultSecondaryAccentColor = new(0.2f, 0.6f, 1f, 1f);
     public static readonly Vector4 DefaultDockBackgroundColor = new(0.11f, 0.11f, 0.12f, 0.9f);
 
+    public static class FadePreferenceKeys
+    {
+        public const string Events = "events";
+        public const string EventCreate = "create";
+        public const string Templates = "templates";
+        public const string NotePad = "notepad";
+        public const string Requests = "requests";
+        public const string Chat = "chat";
+        public const string OfficerChat = "officer";
+        public const string Syncshell = "syncshell";
+    }
+
     // Required by Dalamud
     public const float MinEmojiTileSize = 16f;
     public const float MaxEmojiTileSize = 64f;
@@ -27,7 +39,7 @@ public class Config : IPluginConfiguration
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
     public const string DefaultEmbedBorderGlyph = "⬛";
-    public const int CurrentVersion = 21;
+    public const int CurrentVersion = 22;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -84,6 +96,9 @@ public class Config : IPluginConfiguration
     public bool ChatFadeOutEnabled { get; set; } = false;
     public int ChatFadeOutDelaySeconds { get; set; } = 10;
     public float ChatFadeOutMinimumAlpha { get; set; } = 0.3f;
+
+    [JsonPropertyName("windowFadePreferences")]
+    public Dictionary<string, bool> WindowFadePreferences { get; set; } = new();
 
     [JsonPropertyName("dockVisible")]
     public bool DockVisible { get; set; } = true;
@@ -632,6 +647,14 @@ public class Config : IPluginConfiguration
             Version = 21;
             ExtensionData = null;
         }
+
+        if (Version < 22)
+        {
+            WindowFadePreferences ??= new Dictionary<string, bool>();
+
+            Version = 22;
+            ExtensionData = null;
+        }
     }
 
     public static uint GetDefaultEmbedColor(string? channelKind)
@@ -742,6 +765,41 @@ public class Config : IPluginConfiguration
         {
             DockAutoShow.Remove(id);
         }
+    }
+
+    public bool IsWindowFadeEnabled(string? id, bool defaultValue)
+    {
+        if (!ChatFadeOutEnabled)
+        {
+            return false;
+        }
+
+        if (WindowFadePreferences == null)
+        {
+            WindowFadePreferences = new Dictionary<string, bool>();
+        }
+
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return defaultValue;
+        }
+
+        return WindowFadePreferences.TryGetValue(id, out var enabled) ? enabled : defaultValue;
+    }
+
+    public void SetWindowFadePreference(string? id, bool enabled)
+    {
+        if (WindowFadePreferences == null)
+        {
+            WindowFadePreferences = new Dictionary<string, bool>();
+        }
+
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return;
+        }
+
+        WindowFadePreferences[id] = enabled;
     }
 
     internal static uint SanitizeRgb(uint value, uint fallback)

--- a/DemiCatPlugin/DockableWindow.cs
+++ b/DemiCatPlugin/DockableWindow.cs
@@ -24,7 +24,9 @@ public abstract class DockableWindow
 
     protected virtual ImGuiWindowFlags WindowFlags => ImGuiWindowFlags.NoCollapse;
     protected virtual bool UseThemedColors => true;
-    public virtual bool SupportsFade => false;
+    protected virtual string? FadePreferenceKey => null;
+    protected virtual bool FadeEnabledByDefault => false;
+    public virtual bool SupportsFade => _config.IsWindowFadeEnabled(FadePreferenceKey, FadeEnabledByDefault);
     protected virtual float BaseOpacity => 1f;
 
     public bool IsOpen

--- a/DemiCatPlugin/DockableWindowHosts.cs
+++ b/DemiCatPlugin/DockableWindowHosts.cs
@@ -15,6 +15,8 @@ public sealed class EventsDockableWindow : DockableWindow
         _isLinked = isLinked;
     }
 
+    protected override string? FadePreferenceKey => Config.FadePreferenceKeys.Events;
+
     protected override void OnOpened()
     {
         _ = _ui.StartNetworking();
@@ -51,6 +53,8 @@ public sealed class EventCreateDockableWindow : DockableWindow
         _isLinked = isLinked;
     }
 
+    protected override string? FadePreferenceKey => Config.FadePreferenceKeys.EventCreate;
+
     protected override void OnOpened()
     {
         _window.StartNetworking();
@@ -82,6 +86,8 @@ public sealed class TemplatesDockableWindow : DockableWindow
         _window = window;
         _isLinked = isLinked;
     }
+
+    protected override string? FadePreferenceKey => Config.FadePreferenceKeys.Templates;
 
     protected override void OnOpened()
     {
@@ -127,6 +133,8 @@ public sealed class NotePadDockableWindow : DockableWindow
         _window = window;
     }
 
+    protected override string? FadePreferenceKey => Config.FadePreferenceKeys.NotePad;
+
     protected override void DrawContents()
     {
         DrawHeaderWithSettingsButton();
@@ -152,6 +160,8 @@ public sealed class RequestBoardDockableWindow : DockableWindow
         _window = window;
         _isLinked = isLinked;
     }
+
+    protected override string? FadePreferenceKey => Config.FadePreferenceKeys.Requests;
 
     protected override void DrawContents()
     {
@@ -179,6 +189,8 @@ public sealed class SyncshellDockableWindow : DockableWindow
         _isLinked = isLinked;
     }
 
+    protected override string? FadePreferenceKey => Config.FadePreferenceKeys.Syncshell;
+
     protected override void DrawContents()
     {
         DrawHeaderWithSettingsButton();
@@ -199,6 +211,7 @@ public class ChatDockableWindow : DockableWindow
     private readonly Func<bool> _isLinked;
     private readonly Func<float> _opacityProvider;
     private readonly string _linkPrompt;
+    private readonly string _fadePreferenceKey;
 
     public ChatDockableWindow(
         Config config,
@@ -206,16 +219,20 @@ public class ChatDockableWindow : DockableWindow
         ChatWindow chatWindow,
         Func<bool> isLinked,
         Func<float> opacityProvider,
-        string linkPrompt)
+        string linkPrompt,
+        string fadePreferenceKey)
         : base(config, windowTitle)
     {
         _chatWindow = chatWindow;
         _isLinked = isLinked;
         _opacityProvider = opacityProvider;
         _linkPrompt = linkPrompt;
+        _fadePreferenceKey = fadePreferenceKey;
     }
 
-    public override bool SupportsFade => true;
+    protected override string? FadePreferenceKey => _fadePreferenceKey;
+
+    protected override bool FadeEnabledByDefault => true;
 
     protected override float BaseOpacity => Math.Clamp(_opacityProvider(), 0f, 1f);
 
@@ -270,7 +287,8 @@ public sealed class OfficerChatDockableWindow : ChatDockableWindow
             officerChat,
             isLinked,
             () => config.OfficerChatOpacity,
-            "Link DemiCat to use officer chat.")
+            "Link DemiCat to use officer chat.",
+            Config.FadePreferenceKeys.OfficerChat)
     {
         _officerChat = officerChat;
         _hasOfficerAccess = hasOfficerAccess;

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -164,7 +164,8 @@ public class MainWindow : IDisposable
                 _chat,
                 IsLinked,
                 opacityProvider,
-                linkPrompt);
+                linkPrompt,
+                Config.FadePreferenceKeys.Chat);
             _windowHosts.Add(_chatWindowHost);
         }
 

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -370,6 +370,7 @@ public class SettingsWindow : IDisposable
         {
             _config.FcChatOpacity = Math.Clamp(fcOpacity / 100f, 0f, 1f);
             SaveConfig();
+            MainWindow?.OnAppearanceSettingsChanged();
             MainWindow?.ResetFadeTimer();
         }
         ImGui.EndDisabled();
@@ -382,6 +383,7 @@ public class SettingsWindow : IDisposable
         {
             _config.OfficerChatOpacity = Math.Clamp(officerOpacity / 100f, 0f, 1f);
             SaveConfig();
+            MainWindow?.OnAppearanceSettingsChanged();
             MainWindow?.ResetFadeTimer();
         }
         ImGui.EndDisabled();
@@ -395,6 +397,7 @@ public class SettingsWindow : IDisposable
         {
             _config.ChatFadeOutEnabled = fadeOutEnabled;
             SaveConfig();
+            MainWindow?.OnAppearanceSettingsChanged();
             MainWindow?.ResetFadeTimer();
         }
 
@@ -417,6 +420,7 @@ public class SettingsWindow : IDisposable
                 {
                     _config.ChatFadeOutDelaySeconds = fadeDurations[i];
                     SaveConfig();
+                    MainWindow?.OnAppearanceSettingsChanged();
                     MainWindow?.ResetFadeTimer();
                     currentIndex = i;
                 }
@@ -431,6 +435,7 @@ public class SettingsWindow : IDisposable
         {
             _config.ChatFadeOutMinimumAlpha = Math.Clamp(fadeMinimumAlphaPercent / 100f, 0f, 1f);
             SaveConfig();
+            MainWindow?.OnAppearanceSettingsChanged();
             MainWindow?.ResetFadeTimer();
         }
 

--- a/tests/ChatDockableWindowLifecycleTests.cs
+++ b/tests/ChatDockableWindowLifecycleTests.cs
@@ -34,14 +34,13 @@ public class ChatDockableWindowLifecycleTests
             () => true,
             () => 1f,
             "Link DemiCat to use chat.",
-            () => { });
+            Config.FadePreferenceKeys.Chat);
 
         var officerDock = new OfficerChatDockableWindow(
             config,
             officerWindow,
             () => true,
-            () => true,
-            () => { });
+            () => true);
 
         chatWindow.StartNetworking();
         officerWindow.StartNetworking();

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -56,5 +56,29 @@ public class ConfigDefaultsTests
         Assert.Equal(cfg.DockBackgroundColor.W, cfg.DockBackgroundAlpha, 3);
         Assert.NotNull(cfg.DockAutoShow);
         Assert.Empty(cfg.DockAutoShow);
+        Assert.NotNull(cfg.WindowFadePreferences);
+        Assert.Empty(cfg.WindowFadePreferences);
+    }
+
+    [Fact]
+    public void WindowFadePreferences_DefaultsHonored()
+    {
+        var cfg = new Config();
+
+        Assert.False(cfg.IsWindowFadeEnabled(Config.FadePreferenceKeys.Chat, true));
+
+        cfg.ChatFadeOutEnabled = true;
+
+        Assert.True(cfg.IsWindowFadeEnabled(Config.FadePreferenceKeys.Chat, true));
+        Assert.False(cfg.IsWindowFadeEnabled(Config.FadePreferenceKeys.Events, false));
+
+        cfg.SetWindowFadePreference(Config.FadePreferenceKeys.Events, true);
+        Assert.True(cfg.IsWindowFadeEnabled(Config.FadePreferenceKeys.Events, false));
+
+        cfg.SetWindowFadePreference(Config.FadePreferenceKeys.Chat, false);
+        Assert.False(cfg.IsWindowFadeEnabled(Config.FadePreferenceKeys.Chat, true));
+
+        cfg.ChatFadeOutEnabled = false;
+        Assert.False(cfg.IsWindowFadeEnabled(Config.FadePreferenceKeys.Chat, true));
     }
 }


### PR DESCRIPTION
## Summary
- add window fade preference keys, persistence, and helpers to the plugin configuration
- wire DockableWindow and all dockable hosts to consult the new fade preferences
- ensure appearance settings changes, including fade controls, notify the main window immediately

## Testing
- unable to run `dotnet test` (dotnet CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dc9997dd5c8328906274a221b0dd50