### PR TITLE
Consolidate Penumbra directory overrides in settings

### DIFF
--- a/DemiCatPlugin/ImGuiDirectoryPickerHelper.cs
+++ b/DemiCatPlugin/ImGuiDirectoryPickerHelper.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.ImGuiFileDialog;
+
+namespace DemiCatPlugin;
+
+public static class ImGuiDirectoryPickerHelper
+{
+    public static void DrawDirectoryPicker(
+        string label,
+        string helpText,
+        Func<string?> getter,
+        Action<string?> setter,
+        FileDialogManager dialog,
+        string idSuffix,
+        Func<string?, string> normalizeDirectory,
+        Action<FileDialogManager, string, string?, Action<string?>> openFolderDialog)
+    {
+        var value = getter() ?? string.Empty;
+        if (ImGui.InputText(label, ref value, 260))
+        {
+            setter(value);
+        }
+
+        ImGui.SameLine();
+        if (ImGui.Button($"Browse##{idSuffix}"))
+        {
+            openFolderDialog(dialog, label, getter(), setter);
+        }
+
+        var current = getter();
+        if (!string.IsNullOrEmpty(normalizeDirectory(current)))
+        {
+            ImGui.SameLine();
+            if (ImGui.Button($"Clear##{idSuffix}"))
+            {
+                setter(string.Empty);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(helpText))
+        {
+            ImGui.TextDisabled(helpText);
+        }
+
+        current = normalizeDirectory(getter());
+        if (!string.IsNullOrEmpty(current) && !Directory.Exists(current))
+        {
+            ImGui.TextColored(new Vector4(1f, 0.6f, 0.6f, 1f), "Directory not found; automatic detection will be used instead.");
+        }
+
+        ImGui.Spacing();
+    }
+}

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -1193,73 +1193,32 @@ public class SettingsWindow : IDisposable
         ImGui.TextDisabled("Override the Penumbra folders used by SyncShell.");
         ImGui.Spacing();
 
-        DrawDirectoryPicker(
+        ImGuiDirectoryPickerHelper.DrawDirectoryPicker(
             "Penumbra Mods Directory",
             "Leave blank to use Penumbra's configured mods directory.",
             () => _penumbraModsDirectory,
             SetPenumbraModsDirectory,
             _penumbraModsDialog,
-            "PenumbraMods");
+            "PenumbraMods",
+            NormalizeDirectory,
+            OpenFolderDialog);
 
-        DrawDirectoryPicker(
+        ImGuiDirectoryPickerHelper.DrawDirectoryPicker(
             "Penumbra Config Directory",
             "Should contain default_mod.json. Leave blank to auto-detect.",
             () => _penumbraConfigDirectory,
             SetPenumbraConfigDirectory,
             _penumbraConfigDialog,
-            "PenumbraConfig");
-    }
-
-    private void DrawDirectoryPicker(
-        string label,
-        string helpText,
-        Func<string> getter,
-        Action<string> setter,
-        FileDialogManager dialog,
-        string idSuffix)
-    {
-        var value = getter() ?? string.Empty;
-        if (ImGui.InputText(label, ref value, 260))
-        {
-            setter(value);
-        }
-
-        ImGui.SameLine();
-        if (ImGui.Button($"Browse##{idSuffix}"))
-        {
-            OpenFolderDialog(dialog, label, getter(), setter);
-        }
-
-        var current = getter();
-        if (!string.IsNullOrEmpty(NormalizeDirectory(current)))
-        {
-            ImGui.SameLine();
-            if (ImGui.Button($"Clear##{idSuffix}"))
-            {
-                setter(string.Empty);
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(helpText))
-        {
-            ImGui.TextDisabled(helpText);
-        }
-
-        current = getter();
-        var normalized = NormalizeDirectory(current);
-        if (!string.IsNullOrEmpty(normalized) && !Directory.Exists(normalized))
-        {
-            ImGui.TextColored(new Vector4(1f, 0.6f, 0.6f, 1f), "Directory not found; automatic detection will be used instead.");
-        }
-
-        ImGui.Spacing();
+            "PenumbraConfig",
+            NormalizeDirectory,
+            OpenFolderDialog);
     }
 
     private void OpenFolderDialog(
         FileDialogManager dialog,
         string label,
         string? currentPath,
-        Action<string> setter)
+        Action<string?> setter)
     {
         var initial = NormalizeDirectory(currentPath);
         if (string.IsNullOrEmpty(initial) || !Directory.Exists(initial))

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -42,6 +42,7 @@ public class SettingsWindow : IDisposable
 
     private readonly FileDialogManager _penumbraModsDialog = new();
     private readonly FileDialogManager _penumbraConfigDialog = new();
+    private string _penumbraCollectionOverride = string.Empty;
 
     public bool IsOpen;
 
@@ -63,6 +64,7 @@ public class SettingsWindow : IDisposable
         _apiBaseUrl = config.ApiBaseUrl;
         _penumbraModsDirectory = config.PenumbraModsDirectory ?? string.Empty;
         _penumbraConfigDirectory = config.PenumbraConfigDirectory ?? string.Empty;
+        _penumbraCollectionOverride = config.PenumbraCollectionOverride ?? string.Empty;
         _devWindow = new DeveloperWindow(config, pluginInterface);
         _log = log;
         _isLinked = _tokenManager.State == LinkState.Linked;
@@ -96,6 +98,12 @@ public class SettingsWindow : IDisposable
                         ImGui.EndTabItem();
                     }
 
+                    if (ImGui.BeginTabItem("SyncShell Settings"))
+                    {
+                        DrawSyncshellTab();
+                        ImGui.EndTabItem();
+                    }
+
                     ImGui.EndTabBar();
                 }
 
@@ -112,9 +120,6 @@ public class SettingsWindow : IDisposable
 
     private void DrawGeneralTab()
     {
-        _penumbraModsDialog.Draw();
-        _penumbraConfigDialog.Draw();
-
         DrawConnectionIndicator(_isLinked);
         ImGui.Spacing();
 
@@ -179,41 +184,6 @@ public class SettingsWindow : IDisposable
             if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
                 ImGui.SetTooltip("Link DemiCat to enable chat and presence.");
         }
-
-        var syncEnabled = _config.FCSyncShell;
-        if (!linked)
-            ImGui.BeginDisabled();
-        if (ImGui.Checkbox("Enable FC SyncShell", ref syncEnabled))
-        {
-            _config.FCSyncShell = syncEnabled;
-            SaveConfig();
-            MainWindow?.UpdateSyncshell();
-            _ = Task.Run(PushSettings);
-        }
-        if (!linked)
-        {
-            ImGui.EndDisabled();
-            if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                ImGui.SetTooltip("Link DemiCat to enable SyncShell.");
-        }
-
-        var overlayVisible = _config.ShowSyncshellProgressOverlay;
-        var overlayDisabled = !_config.FCSyncShell;
-        if (overlayDisabled)
-            ImGui.BeginDisabled();
-        if (ImGui.Checkbox("Show Sync Progress Overlay", ref overlayVisible))
-        {
-            _config.ShowSyncshellProgressOverlay = overlayVisible;
-            SaveConfig();
-        }
-        if (overlayDisabled)
-        {
-            ImGui.EndDisabled();
-            if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-                ImGui.SetTooltip("Enable FC SyncShell to display transfer progress overlay.");
-        }
-
-        DrawPenumbraDirectorySettings();
 
         foreach (var kvp in _categoryToggles.ToList())
         {
@@ -281,6 +251,52 @@ public class SettingsWindow : IDisposable
 
             ImGui.TextColored(color, _syncStatus);
         }
+    }
+
+    private void DrawSyncshellTab()
+    {
+        _penumbraModsDialog.Draw();
+        _penumbraConfigDialog.Draw();
+
+        var linked = _isLinked;
+        ImGui.TextUnformatted("SyncShell Preferences");
+        ImGui.Spacing();
+
+        var syncEnabled = _config.FCSyncShell;
+        if (!linked)
+            ImGui.BeginDisabled();
+        if (ImGui.Checkbox("Enable FC SyncShell", ref syncEnabled))
+        {
+            _config.FCSyncShell = syncEnabled;
+            SaveConfig();
+            MainWindow?.UpdateSyncshell();
+            _ = Task.Run(PushSettings);
+        }
+        if (!linked)
+        {
+            ImGui.EndDisabled();
+            if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                ImGui.SetTooltip("Link DemiCat to enable SyncShell.");
+        }
+
+        var overlayVisible = _config.ShowSyncshellProgressOverlay;
+        var overlayDisabled = !_config.FCSyncShell;
+        if (overlayDisabled)
+            ImGui.BeginDisabled();
+        if (ImGui.Checkbox("Show Sync Progress Overlay", ref overlayVisible))
+        {
+            _config.ShowSyncshellProgressOverlay = overlayVisible;
+            SaveConfig();
+        }
+        if (overlayDisabled)
+        {
+            ImGui.EndDisabled();
+            if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+                ImGui.SetTooltip("Enable FC SyncShell to display transfer progress overlay.");
+        }
+
+        DrawPenumbraDirectorySettings();
+        DrawPenumbraCollectionSettings();
     }
 
     private void DrawAppearanceTab()
@@ -883,8 +899,10 @@ public class SettingsWindow : IDisposable
         _config.PenumbraChoices.Clear();
         _config.PenumbraModsDirectory = string.Empty;
         _config.PenumbraConfigDirectory = string.Empty;
+        _config.PenumbraCollectionOverride = string.Empty;
         _penumbraModsDirectory = string.Empty;
         _penumbraConfigDirectory = string.Empty;
+        _penumbraCollectionOverride = string.Empty;
         _config.NotePadLastSectionId = null;
         _config.NotePadLastPageId = null;
 
@@ -1214,6 +1232,46 @@ public class SettingsWindow : IDisposable
             OpenFolderDialog);
     }
 
+    private void DrawPenumbraCollectionSettings()
+    {
+        ImGui.Separator();
+        ImGui.TextUnformatted("Penumbra Collection");
+        ImGui.TextDisabled("Choose the collection used when syncing.");
+        ImGui.Spacing();
+
+        var collection = _penumbraCollectionOverride;
+        if (ImGui.InputText("Active collection override", ref collection, 260))
+        {
+            SetPenumbraCollectionOverride(collection);
+        }
+
+        var suggestions = EnumeratePenumbraCollectionSuggestions();
+        var preview = GetCollectionPreview(_penumbraCollectionOverride, suggestions);
+        if (suggestions.Count > 0 && ImGui.BeginCombo("##syncshell-collection", preview))
+        {
+            foreach (var option in suggestions)
+            {
+                var selected = string.Equals(_penumbraCollectionOverride, option.Identifier, StringComparison.OrdinalIgnoreCase);
+                if (ImGui.Selectable(option.Display, selected))
+                {
+                    SetPenumbraCollectionOverride(option.Identifier);
+                    collection = _penumbraCollectionOverride;
+                }
+
+                if (selected)
+                {
+                    ImGui.SetItemDefaultFocus();
+                }
+            }
+
+            ImGui.EndCombo();
+        }
+
+        ImGui.TextDisabled(suggestions.Count > 0
+            ? "Select from detected collections or enter a custom value (e.g. default)."
+            : "Enter the collection name or file (e.g. default or default_mod.json).");
+    }
+
     private void OpenFolderDialog(
         FileDialogManager dialog,
         string label,
@@ -1262,6 +1320,7 @@ public class SettingsWindow : IDisposable
         _penumbraModsDirectory = normalized;
         _config.PenumbraModsDirectory = normalized;
         SaveConfig();
+        SyncshellWindow.Instance?.OnPenumbraOverridesChanged();
     }
 
     private void SetPenumbraConfigDirectory(string? path)
@@ -1275,10 +1334,126 @@ public class SettingsWindow : IDisposable
         _penumbraConfigDirectory = normalized;
         _config.PenumbraConfigDirectory = normalized;
         SaveConfig();
+        SyncshellWindow.Instance?.OnPenumbraOverridesChanged();
+    }
+
+    private void SetPenumbraCollectionOverride(string? value)
+    {
+        var normalized = string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+        if (string.Equals(_penumbraCollectionOverride, normalized, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _penumbraCollectionOverride = normalized;
+        _config.PenumbraCollectionOverride = normalized;
+        SaveConfig();
+        SyncshellWindow.Instance?.OnPenumbraOverridesChanged();
     }
 
     private static string NormalizeDirectory(string? value)
         => string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+
+    private List<CollectionOption> EnumeratePenumbraCollectionSuggestions()
+    {
+        var results = new List<CollectionOption>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var baseDir = NormalizeDirectory(_config.PenumbraConfigDirectory);
+        if (string.IsNullOrEmpty(baseDir) || !Directory.Exists(baseDir))
+        {
+            return results;
+        }
+
+        string Describe(string identifier, string relative)
+            => string.IsNullOrEmpty(relative) ? identifier : $"{identifier} ({relative})";
+
+        void AddSuggestion(string filePath)
+        {
+            if (!File.Exists(filePath))
+            {
+                return;
+            }
+
+            string relative;
+            try
+            {
+                relative = Path.GetRelativePath(baseDir, filePath);
+            }
+            catch
+            {
+                relative = Path.GetFileName(filePath) ?? filePath;
+            }
+
+            var identifier = Path.GetFileNameWithoutExtension(filePath);
+            if (string.IsNullOrEmpty(identifier))
+            {
+                return;
+            }
+
+            if (identifier.EndsWith("_mod", StringComparison.OrdinalIgnoreCase))
+            {
+                var trimmed = identifier[..^4];
+                if (seen.Add(trimmed))
+                {
+                    results.Add(new CollectionOption(trimmed, Describe(trimmed, relative)));
+                }
+            }
+
+            if (seen.Add(identifier))
+            {
+                results.Add(new CollectionOption(identifier, Describe(identifier, relative)));
+            }
+        }
+
+        try
+        {
+            foreach (var file in Directory.EnumerateFiles(baseDir, "*_mod.json", SearchOption.TopDirectoryOnly))
+            {
+                AddSuggestion(file);
+            }
+
+            foreach (var file in Directory.EnumerateFiles(baseDir, "*.json", SearchOption.TopDirectoryOnly))
+            {
+                AddSuggestion(file);
+            }
+
+            var collectionsDir = Path.Combine(baseDir, "collections");
+            if (Directory.Exists(collectionsDir))
+            {
+                foreach (var file in Directory.EnumerateFiles(collectionsDir, "*.json", SearchOption.TopDirectoryOnly))
+                {
+                    AddSuggestion(file);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance?.Log?.Debug(ex, "Failed to enumerate Penumbra collections in {Directory}", baseDir);
+        }
+
+        results.Sort((a, b) => string.Compare(a.Identifier, b.Identifier, StringComparison.OrdinalIgnoreCase));
+        return results;
+    }
+
+    private static string GetCollectionPreview(string? currentValue, IReadOnlyList<CollectionOption> options)
+    {
+        if (string.IsNullOrWhiteSpace(currentValue))
+        {
+            return "Auto-detect (default)";
+        }
+
+        foreach (var option in options)
+        {
+            if (string.Equals(option.Identifier, currentValue, StringComparison.OrdinalIgnoreCase))
+            {
+                return option.Display;
+            }
+        }
+
+        return currentValue;
+    }
+
+    private sealed record CollectionOption(string Identifier, string Display);
 
     private void ClearCachedData()
     {

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -89,8 +89,6 @@ public class SyncshellWindow : IDisposable
     private bool _membershipPanelRatiosDirty;
     private float _syncSettingsHeight = DefaultSyncSettingsHeight;
     private bool _syncSettingsHeightDirty;
-    private string _penumbraCollectionOverride = string.Empty;
-
     private bool _autoSyncAllUsers;
     private bool _manualSyncAllUsers;
     private bool _manualSyncCustom;
@@ -228,7 +226,6 @@ public class SyncshellWindow : IDisposable
         _autoSyncAllUsers = _config.SyncshellAutoSyncAllUsers;
         _manualSyncAllUsers = _config.SyncshellManualSyncAllUsers;
         _manualSyncCustom = _config.SyncshellManualSyncCustom;
-        _penumbraCollectionOverride = _config.PenumbraCollectionOverride ?? string.Empty;
         EnforceSyncPreferenceInvariant(saveIfChanged: true);
 
         _syncClient.UpdatePenumbraOverrides(PenumbraResolveOptions.FromConfig(_config));
@@ -246,6 +243,12 @@ public class SyncshellWindow : IDisposable
         _tokenManager.RegisterWatcher(HandleTokenLinked, HandleTokenUnlinked);
 
         RequestMembershipRefresh();
+    }
+
+    public void OnPenumbraOverridesChanged()
+    {
+        PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
+        _syncClient.UpdatePenumbraOverrides(PenumbraResolveOptions.FromConfig(_config));
     }
 
     public void Draw()
@@ -414,12 +417,6 @@ public class SyncshellWindow : IDisposable
         {
             SetSyncPaused(!_syncPaused);
         }
-                ImGui.EndTabItem();
-            }
-
-            if (ImGui.BeginTabItem("Locations"))
-            {
-                DrawLocationsTab();
                 ImGui.EndTabItem();
             }
 
@@ -597,194 +594,6 @@ public class SyncshellWindow : IDisposable
         }
     }
 
-    private void DrawLocationsTab()
-    {
-        ImGui.TextUnformatted("Penumbra Locations");
-        ImGui.TextDisabled("Choose the collection used when syncing.");
-        ImGui.Spacing();
-
-        ImGui.TextDisabled("Configure Penumbra directories in DemiCat Settings under General > Penumbra Directories.");
-        ImGui.Spacing();
-
-        var collection = _penumbraCollectionOverride ?? string.Empty;
-        if (ImGui.InputText("Active collection override", ref collection, 260))
-        {
-            SetPenumbraCollectionOverride(collection);
-        }
-
-        var suggestions = EnumerateCollectionSuggestions();
-        var preview = GetCollectionPreview(_penumbraCollectionOverride, suggestions);
-        if (suggestions.Count > 0 && ImGui.BeginCombo("##syncshell-collection", preview))
-        {
-            foreach (var option in suggestions)
-            {
-                var selected = string.Equals(_penumbraCollectionOverride, option.Identifier, StringComparison.OrdinalIgnoreCase);
-                if (ImGui.Selectable(option.Display, selected))
-                {
-                    SetPenumbraCollectionOverride(option.Identifier);
-                    collection = _penumbraCollectionOverride;
-                }
-
-                if (selected)
-                {
-                    ImGui.SetItemDefaultFocus();
-                }
-            }
-
-            ImGui.EndCombo();
-        }
-
-        ImGui.TextDisabled(suggestions.Count > 0
-            ? "Select from detected collections or enter a custom value (e.g. default)."
-            : "Enter the collection name or file (e.g. default or default_mod.json).");
-    }
-
-    private void SetPenumbraModsDirectory(string? path)
-    {
-        var normalized = NormalizeDirectory(path);
-        if (string.Equals(_config.PenumbraModsDirectory, normalized, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        _config.PenumbraModsDirectory = normalized;
-        PersistPenumbraOverrides();
-    }
-
-    private void SetPenumbraConfigDirectory(string? path)
-    {
-        var normalized = NormalizeDirectory(path);
-        if (string.Equals(_config.PenumbraConfigDirectory, normalized, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        _config.PenumbraConfigDirectory = normalized;
-        PersistPenumbraOverrides();
-    }
-
-    private void SetPenumbraCollectionOverride(string? value)
-    {
-        var normalized = string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
-        if (string.Equals(_penumbraCollectionOverride, normalized, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        _penumbraCollectionOverride = normalized;
-        _config.PenumbraCollectionOverride = normalized;
-        PersistPenumbraOverrides();
-    }
-
-    private void PersistPenumbraOverrides()
-    {
-        PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
-        _syncClient.UpdatePenumbraOverrides(PenumbraResolveOptions.FromConfig(_config));
-    }
-
-    private static string NormalizeDirectory(string? value)
-        => string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
-
-    private string GetCollectionPreview(string? currentValue, IReadOnlyList<CollectionOption> options)
-    {
-        if (string.IsNullOrWhiteSpace(currentValue))
-        {
-            return "Auto-detect (default)";
-        }
-
-        foreach (var option in options)
-        {
-            if (string.Equals(option.Identifier, currentValue, StringComparison.OrdinalIgnoreCase))
-            {
-                return option.Display;
-            }
-        }
-
-        return currentValue;
-    }
-
-    private List<CollectionOption> EnumerateCollectionSuggestions()
-    {
-        var results = new List<CollectionOption>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var baseDir = NormalizeDirectory(_config.PenumbraConfigDirectory);
-        if (string.IsNullOrEmpty(baseDir) || !Directory.Exists(baseDir))
-        {
-            return results;
-        }
-
-        string Describe(string identifier, string relative)
-            => string.IsNullOrEmpty(relative) ? identifier : $"{identifier} ({relative})";
-
-        void AddSuggestion(string filePath)
-        {
-            if (!File.Exists(filePath))
-            {
-                return;
-            }
-
-            string relative;
-            try
-            {
-                relative = Path.GetRelativePath(baseDir, filePath);
-            }
-            catch
-            {
-                relative = Path.GetFileName(filePath) ?? filePath;
-            }
-
-            var identifier = Path.GetFileNameWithoutExtension(filePath);
-            if (string.IsNullOrEmpty(identifier))
-            {
-                return;
-            }
-
-            if (identifier.EndsWith("_mod", StringComparison.OrdinalIgnoreCase))
-            {
-                var trimmed = identifier[..^4];
-                if (seen.Add(trimmed))
-                {
-                    results.Add(new CollectionOption(trimmed, Describe(trimmed, relative)));
-                }
-            }
-
-            if (seen.Add(identifier))
-            {
-                results.Add(new CollectionOption(identifier, Describe(identifier, relative)));
-            }
-        }
-
-        try
-        {
-            foreach (var file in Directory.EnumerateFiles(baseDir, "*_mod.json", SearchOption.TopDirectoryOnly))
-            {
-                AddSuggestion(file);
-            }
-
-            foreach (var file in Directory.EnumerateFiles(baseDir, "*.json", SearchOption.TopDirectoryOnly))
-            {
-                AddSuggestion(file);
-            }
-
-            var collectionsDir = Path.Combine(baseDir, "collections");
-            if (Directory.Exists(collectionsDir))
-            {
-                foreach (var file in Directory.EnumerateFiles(collectionsDir, "*.json", SearchOption.TopDirectoryOnly))
-                {
-                    AddSuggestion(file);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            PluginServices.Instance?.Log?.Debug(ex, "Failed to enumerate Penumbra collections in {Directory}", baseDir);
-        }
-
-        results.Sort((a, b) => string.Compare(a.Identifier, b.Identifier, StringComparison.OrdinalIgnoreCase));
-        return results;
-    }
-
-    private sealed record CollectionOption(string Identifier, string Display);
 
     private void DrawMembershipSplitter(int index, float splitterHeight, float totalPanelHeight)
     {

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -15,7 +15,6 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
-using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Services;
 using DemiCatPlugin.SyncShell;
@@ -90,8 +89,6 @@ public class SyncshellWindow : IDisposable
     private bool _membershipPanelRatiosDirty;
     private float _syncSettingsHeight = DefaultSyncSettingsHeight;
     private bool _syncSettingsHeightDirty;
-    private readonly FileDialogManager _penumbraModsDialog = new();
-    private readonly FileDialogManager _penumbraConfigDialog = new();
     private string _penumbraCollectionOverride = string.Empty;
 
     private bool _autoSyncAllUsers;
@@ -254,8 +251,6 @@ public class SyncshellWindow : IDisposable
     public void Draw()
     {
         PumpClientEvents();
-        _penumbraModsDialog.Draw();
-        _penumbraConfigDialog.Draw();
 
         if (!_config.FCSyncShell)
         {
@@ -605,24 +600,11 @@ public class SyncshellWindow : IDisposable
     private void DrawLocationsTab()
     {
         ImGui.TextUnformatted("Penumbra Locations");
-        ImGui.TextDisabled("Choose the directories and collection used when syncing.");
+        ImGui.TextDisabled("Choose the collection used when syncing.");
         ImGui.Spacing();
 
-        DrawDirectoryPicker(
-            "Penumbra Mods Directory",
-            "Leave blank to use Penumbra's configured mods directory.",
-            () => _config.PenumbraModsDirectory ?? string.Empty,
-            SetPenumbraModsDirectory,
-            _penumbraModsDialog,
-            "SyncshellMods");
-
-        DrawDirectoryPicker(
-            "Penumbra Config Directory",
-            "Should contain default_mod.json. Leave blank to auto-detect.",
-            () => _config.PenumbraConfigDirectory ?? string.Empty,
-            SetPenumbraConfigDirectory,
-            _penumbraConfigDialog,
-            "SyncshellConfig");
+        ImGui.TextDisabled("Configure Penumbra directories in DemiCat Settings under General > Penumbra Directories.");
+        ImGui.Spacing();
 
         var collection = _penumbraCollectionOverride ?? string.Empty;
         if (ImGui.InputText("Active collection override", ref collection, 260))
@@ -655,87 +637,6 @@ public class SyncshellWindow : IDisposable
         ImGui.TextDisabled(suggestions.Count > 0
             ? "Select from detected collections or enter a custom value (e.g. default)."
             : "Enter the collection name or file (e.g. default or default_mod.json).");
-    }
-
-    private void DrawDirectoryPicker(
-        string label,
-        string helpText,
-        Func<string> getter,
-        Action<string?> setter,
-        FileDialogManager dialog,
-        string idSuffix)
-    {
-        var value = getter() ?? string.Empty;
-        if (ImGui.InputText(label, ref value, 260))
-        {
-            setter(value);
-        }
-
-        ImGui.SameLine();
-        if (ImGui.Button($"Browse##{idSuffix}"))
-        {
-            OpenFolderDialog(dialog, label, getter(), setter);
-        }
-
-        var current = getter();
-        if (!string.IsNullOrEmpty(NormalizeDirectory(current)))
-        {
-            ImGui.SameLine();
-            if (ImGui.Button($"Clear##{idSuffix}"))
-            {
-                setter(string.Empty);
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(helpText))
-        {
-            ImGui.TextDisabled(helpText);
-        }
-
-        current = NormalizeDirectory(getter());
-        if (!string.IsNullOrEmpty(current) && !Directory.Exists(current))
-        {
-            ImGui.TextColored(new Vector4(1f, 0.6f, 0.6f, 1f), "Directory not found; automatic detection will be used instead.");
-        }
-
-        ImGui.Spacing();
-    }
-
-    private void OpenFolderDialog(
-        FileDialogManager dialog,
-        string label,
-        string? currentPath,
-        Action<string?> setter)
-    {
-        var initial = NormalizeDirectory(currentPath);
-        if (string.IsNullOrEmpty(initial) || !Directory.Exists(initial))
-        {
-            initial = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-        }
-
-        if (string.IsNullOrEmpty(initial) || !Directory.Exists(initial))
-        {
-            initial = Environment.CurrentDirectory;
-        }
-
-        dialog.OpenFolderDialog($"Select {label}", (success, selected) =>
-        {
-            if (!success || string.IsNullOrWhiteSpace(selected))
-            {
-                return;
-            }
-
-            var normalized = NormalizeDirectory(selected);
-            var framework = PluginServices.Instance?.Framework;
-            if (framework != null)
-            {
-                _ = framework.RunOnTick(() => setter(normalized));
-            }
-            else
-            {
-                setter(normalized);
-            }
-        }, initial);
     }
 
     private void SetPenumbraModsDirectory(string? path)


### PR DESCRIPTION
## Summary
- add a shared ImGui helper for directory picker controls
- switch the settings window to the shared helper for Penumbra overrides
- remove the duplicate Penumbra directory UI from the Syncshell window and point users to the settings window

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9b65e30c8328bf327d6b5ca74bfa