### PR TITLE
Add default sizes to dockable windows

### DIFF
--- a/DemiCatPlugin/DockableWindow.cs
+++ b/DemiCatPlugin/DockableWindow.cs
@@ -28,6 +28,7 @@ public abstract class DockableWindow
     protected virtual bool FadeEnabledByDefault => false;
     public virtual bool SupportsFade => _config.IsWindowFadeEnabled(FadePreferenceKey, FadeEnabledByDefault);
     protected virtual float BaseOpacity => 1f;
+    protected virtual Vector2? InitialSize => null;
 
     public bool IsOpen
     {
@@ -62,6 +63,14 @@ public abstract class DockableWindow
     {
         if (!IsOpen)
             return;
+
+        if (InitialSize is { } initialSize)
+        {
+            var sanitizedSize = new Vector2(
+                MathF.Max(initialSize.X, 1f),
+                MathF.Max(initialSize.Y, 1f));
+            ImGui.SetNextWindowSize(sanitizedSize, ImGuiCond.FirstUseEver);
+        }
 
         var open = IsOpen;
         var colorsPushed = 0;

--- a/DemiCatPlugin/DockableWindowHosts.cs
+++ b/DemiCatPlugin/DockableWindowHosts.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using Dalamud.Bindings.ImGui;
 
 namespace DemiCatPlugin;
@@ -16,6 +17,7 @@ public sealed class EventsDockableWindow : DockableWindow
     }
 
     protected override string? FadePreferenceKey => Config.FadePreferenceKeys.Events;
+    protected override Vector2? InitialSize => new(960f, 680f);
 
     protected override void OnOpened()
     {
@@ -54,6 +56,7 @@ public sealed class EventCreateDockableWindow : DockableWindow
     }
 
     protected override string? FadePreferenceKey => Config.FadePreferenceKeys.EventCreate;
+    protected override Vector2? InitialSize => new(980f, 720f);
 
     protected override void OnOpened()
     {
@@ -88,6 +91,7 @@ public sealed class TemplatesDockableWindow : DockableWindow
     }
 
     protected override string? FadePreferenceKey => Config.FadePreferenceKeys.Templates;
+    protected override Vector2? InitialSize => new(1040f, 720f);
 
     protected override void OnOpened()
     {
@@ -134,6 +138,7 @@ public sealed class NotePadDockableWindow : DockableWindow
     }
 
     protected override string? FadePreferenceKey => Config.FadePreferenceKeys.NotePad;
+    protected override Vector2? InitialSize => new(1100f, 720f);
 
     protected override void DrawContents()
     {
@@ -162,6 +167,7 @@ public sealed class RequestBoardDockableWindow : DockableWindow
     }
 
     protected override string? FadePreferenceKey => Config.FadePreferenceKeys.Requests;
+    protected override Vector2? InitialSize => new(940f, 680f);
 
     protected override void DrawContents()
     {
@@ -190,6 +196,7 @@ public sealed class SyncshellDockableWindow : DockableWindow
     }
 
     protected override string? FadePreferenceKey => Config.FadePreferenceKeys.Syncshell;
+    protected override Vector2? InitialSize => new(1100f, 740f);
 
     protected override void DrawContents()
     {
@@ -231,6 +238,7 @@ public class ChatDockableWindow : DockableWindow
     }
 
     protected override string? FadePreferenceKey => _fadePreferenceKey;
+    protected override Vector2? InitialSize => new(840f, 720f);
 
     protected override bool FadeEnabledByDefault => true;
 

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -25,6 +25,7 @@ public class SettingsWindow : IDisposable
     private readonly Func<Task> _startNetworking;
     private readonly DeveloperWindow _devWindow;
     private readonly IPluginLog _log;
+    private static readonly Vector2 DefaultWindowSize = new(960f, 720f);
 
     private string _apiKey = string.Empty;
     private string _apiBaseUrl = string.Empty;
@@ -76,6 +77,7 @@ public class SettingsWindow : IDisposable
     {
         if (IsOpen)
         {
+            ImGui.SetNextWindowSize(DefaultWindowSize, ImGuiCond.FirstUseEver);
             if (ImGui.Begin("DemiCat Settings", ref IsOpen))
             {
                 if (!_settingsLoaded)


### PR DESCRIPTION
## Summary
- add an overridable InitialSize to DockableWindow that applies a default size the first time a host opens
- assign layout-friendly initial sizes to each dockable host window so their content fits on first use
- apply the same first-use sizing pattern to the standalone settings window

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dca2b545e483288fd5ebb455ed14c3