### PR TITLE
Ensure SyncShell picks up Penumbra override changes immediately

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -1320,7 +1320,7 @@ public class SettingsWindow : IDisposable
         _penumbraModsDirectory = normalized;
         _config.PenumbraModsDirectory = normalized;
         SaveConfig();
-        SyncshellWindow.Instance?.OnPenumbraOverridesChanged();
+        SyncshellWindow.NotifyPenumbraOverridesChanged(_config);
     }
 
     private void SetPenumbraConfigDirectory(string? path)
@@ -1334,7 +1334,7 @@ public class SettingsWindow : IDisposable
         _penumbraConfigDirectory = normalized;
         _config.PenumbraConfigDirectory = normalized;
         SaveConfig();
-        SyncshellWindow.Instance?.OnPenumbraOverridesChanged();
+        SyncshellWindow.NotifyPenumbraOverridesChanged(_config);
     }
 
     private void SetPenumbraCollectionOverride(string? value)
@@ -1348,7 +1348,7 @@ public class SettingsWindow : IDisposable
         _penumbraCollectionOverride = normalized;
         _config.PenumbraCollectionOverride = normalized;
         SaveConfig();
-        SyncshellWindow.Instance?.OnPenumbraOverridesChanged();
+        SyncshellWindow.NotifyPenumbraOverridesChanged(_config);
     }
 
     private static string NormalizeDirectory(string? value)

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -28,6 +28,9 @@ public class SyncshellWindow : IDisposable
 {
     public static SyncshellWindow? Instance { get; private set; }
 
+    private static readonly object PenumbraOverrideLock = new();
+    private static PenumbraResolveOptions? _pendingPenumbraOverrides;
+
     private static readonly TimeSpan DefaultPairingLifetime = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan PairingRefreshSkew = TimeSpan.FromSeconds(15);
     private static readonly string[] PairingLifetimeProperties = { "expiresIn", "expires_in", "ttl" };
@@ -230,14 +233,25 @@ public class SyncshellWindow : IDisposable
 
         _syncClient.UpdatePenumbraOverrides(PenumbraResolveOptions.FromConfig(_config));
 
+        PenumbraResolveOptions? pendingOverrides;
+        lock (PenumbraOverrideLock)
+        {
+            pendingOverrides = _pendingPenumbraOverrides;
+            _pendingPenumbraOverrides = null;
+            Instance = this;
+        }
+
+        if (pendingOverrides != null)
+        {
+            _syncClient.UpdatePenumbraOverrides(pendingOverrides);
+        }
+
         _assetsFile = Path.Combine(configDir, "assets.json");
         _installedFile = Path.Combine(configDir, "installed.json");
         _bundlesFile = Path.Combine(configDir, "bundles.json");
         LoadCaches();
 
         _ = TrimCacheAsync();
-
-        Instance = this;
 
         SubscribeToStateChanges();
         _tokenManager.RegisterWatcher(HandleTokenLinked, HandleTokenUnlinked);
@@ -249,6 +263,21 @@ public class SyncshellWindow : IDisposable
     {
         PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
         _syncClient.UpdatePenumbraOverrides(PenumbraResolveOptions.FromConfig(_config));
+    }
+
+    public static void NotifyPenumbraOverridesChanged(Config config)
+    {
+        var overrides = PenumbraResolveOptions.FromConfig(config);
+        lock (PenumbraOverrideLock)
+        {
+            if (Instance != null)
+            {
+                Instance._syncClient.UpdatePenumbraOverrides(overrides);
+                return;
+            }
+
+            _pendingPenumbraOverrides = overrides;
+        }
     }
 
     public void Draw()
@@ -4744,8 +4773,11 @@ public class SyncshellWindow : IDisposable
         _manifestPushLock.Dispose();
         _pairingLock.Dispose();
         _bundleFetchLock.Dispose();
-        if (Instance == this)
-            Instance = null;
+        lock (PenumbraOverrideLock)
+        {
+            if (Instance == this)
+                Instance = null;
+        }
     }
 
     private static string FormatSize(long size)


### PR DESCRIPTION
## Summary
- route Penumbra override setters through a SyncshellWindow notifier so the running client is refreshed
- track pending Penumbra overrides to apply them when SyncShell starts later
- update disposal to clear the SyncShell instance under the new lock

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dca381e3cc8328bfb20f269b9a13e4