### PR TITLE
Include dock icons in plugin build output

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -42,6 +42,10 @@
     <EmbeddedResource Include="icon.png" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="Dock\**\*.*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <ItemGroup Condition="Exists('Emoji/NotoColorEmoji.ttf')">
     <None Include="Emoji/NotoColorEmoji.ttf" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- copy the Dock PNG assets into the plugin output so the dock buttons have icons in packaged builds

## Testing
- ⚠️ `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dca53e5c508328b49cd28debab2ecf