### PR TITLE
Round feature window corners and stabilize button widths

### DIFF
--- a/DemiCat.UI/ButtonSizeHelper.cs
+++ b/DemiCat.UI/ButtonSizeHelper.cs
@@ -14,4 +14,15 @@ public static class ButtonSizeHelper
         var width = label.Length * 8 + 24;
         return Math.Min(width, Max);
     }
+
+    public static float ResolveWidth(int? explicitWidth, string label)
+    {
+        if (explicitWidth.HasValue && explicitWidth.Value > 0)
+        {
+            return Math.Min(explicitWidth.Value, Max);
+        }
+
+        var computed = ComputeWidth(label);
+        return Math.Max(1, computed);
+    }
 }

--- a/DemiCatPlugin/DockableWindow.cs
+++ b/DemiCatPlugin/DockableWindow.cs
@@ -29,6 +29,7 @@ public abstract class DockableWindow
     public virtual bool SupportsFade => _config.IsWindowFadeEnabled(FadePreferenceKey, FadeEnabledByDefault);
     protected virtual float BaseOpacity => 1f;
     protected virtual Vector2? InitialSize => null;
+    protected virtual float WindowCornerRadius => 14f;
 
     public bool IsOpen
     {
@@ -80,6 +81,7 @@ public abstract class DockableWindow
             colorsPushed = PushWindowThemeColors();
         }
 
+        var pushedCornerRadius = TryPushWindowCornerRadius();
         var pushedAlpha = TryPushWindowOpacityOverride(ComputeEffectiveOpacity());
 
         if (ImGui.Begin(WindowTitle, ref open, WindowFlags))
@@ -97,6 +99,11 @@ public abstract class DockableWindow
         ImGui.End();
 
         if (pushedAlpha)
+        {
+            ImGui.PopStyleVar();
+        }
+
+        if (pushedCornerRadius)
         {
             ImGui.PopStyleVar();
         }
@@ -149,6 +156,19 @@ public abstract class DockableWindow
 
     private static float Lerp(float a, float b, float t)
         => a + (b - a) * t;
+
+    private bool TryPushWindowCornerRadius()
+    {
+        var radius = MathF.Max(WindowCornerRadius, 0f);
+        if (radius <= 0f)
+        {
+            return false;
+        }
+
+        var scale = ImGui.GetIO().FontGlobalScale;
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, radius * MathF.Max(scale, 0.01f));
+        return true;
+    }
 
     private static bool TryPushWindowOpacityOverride(float alpha)
     {

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures;
 using DiscordHelper;
+using DemiCat.UI;
 using DemiCatPlugin.Emoji;
 
 namespace DemiCatPlugin;
@@ -162,8 +163,8 @@ public static class EmbedPreviewRenderer
                         ImGui.PushStyleColor(ImGuiCol.ButtonActive, Lighten(color, 1.2f));
                     }
 
-                    var w = button.Width ?? -1;
-                    if (ImGui.Button($"{button.Label}##{id}{dto.Id}", new Vector2(w, 0)))
+                    var width = ButtonSizeHelper.ResolveWidth(button.Width, button.Label);
+                    if (ImGui.Button($"{button.Label}##{id}{dto.Id}", new Vector2(width, 0)))
                     {
                         if (!string.IsNullOrEmpty(button.Url))
                         {

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures;
 using DiscordHelper;
+using DemiCat.UI;
 using DemiCatPlugin.Emoji;
 
 namespace DemiCatPlugin;
@@ -113,8 +114,8 @@ public static class EmbedRenderer
                         ImGui.PushStyleColor(ImGuiCol.ButtonActive, Lighten(color, 1.2f));
                     }
 
-                    var w = button.Width ?? -1;
-                    if (ImGui.Button($"{button.Label}##{id}{dto.Id}", new Vector2(w, 0)))
+                    var width = ButtonSizeHelper.ResolveWidth(button.Width, button.Label);
+                    if (ImGui.Button($"{button.Label}##{id}{dto.Id}", new Vector2(width, 0)))
                     {
                         if (!string.IsNullOrEmpty(button.Url))
                         {

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -13,6 +13,7 @@ using Dalamud.Bindings.ImGui;
 using StbImageSharp;
 using System.Diagnostics;
 using System.Linq;
+using DemiCat.UI;
 using DemiCatPlugin.Emoji;
 
 namespace DemiCatPlugin;
@@ -516,8 +517,8 @@ public class EventView : IDisposable
                         ImGui.PushStyleColor(ImGuiCol.ButtonActive, EmbedPreviewRenderer.Lighten(color, 1.2f));
                     }
 
-                    var w = button.Width ?? -1;
-                    if (ImGui.Button($"{button.Label}##{id}{_dto.Id}", new Vector2(w, 0)))
+                    var width = ButtonSizeHelper.ResolveWidth(button.Width, button.Label);
+                    if (ImGui.Button($"{button.Label}##{id}{_dto.Id}", new Vector2(width, 0)))
                     {
                         if (!string.IsNullOrEmpty(button.Url))
                         {
@@ -538,15 +539,18 @@ public class EventView : IDisposable
         }
         else if (IsApolloEvent(_dto))
         {
-            if (ImGui.Button($"Yes##rsvpYes{_dto.Id}", new Vector2(-1, 0)))
+            var yesSize = new Vector2(ButtonSizeHelper.ResolveWidth(null, "Yes"), 0f);
+            if (ImGui.Button($"Yes##rsvpYes{_dto.Id}", yesSize))
             {
                 _ = SendInteraction("rsvp:yes");
             }
-            if (ImGui.Button($"Maybe##rsvpMaybe{_dto.Id}", new Vector2(-1, 0)))
+            var maybeSize = new Vector2(ButtonSizeHelper.ResolveWidth(null, "Maybe"), 0f);
+            if (ImGui.Button($"Maybe##rsvpMaybe{_dto.Id}", maybeSize))
             {
                 _ = SendInteraction("rsvp:maybe");
             }
-            if (ImGui.Button($"No##rsvpNo{_dto.Id}", new Vector2(-1, 0)))
+            var noSize = new Vector2(ButtonSizeHelper.ResolveWidth(null, "No"), 0f);
+            if (ImGui.Button($"No##rsvpNo{_dto.Id}", noSize))
             {
                 _ = SendInteraction("rsvp:no");
             }


### PR DESCRIPTION
## Summary
- round dockable feature windows so their corners match the dock styling
- give Discord-style buttons fixed widths derived from their labels or explicit settings
- add a helper to resolve button widths that is shared across embed renderers and event views

## Testing
- ⚠️ `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dca79beee08328a6bd1d9bcb68056e