### PR TITLE
Ensure emoji font asset ships with plugin and warn when missing

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -46,11 +46,15 @@
     <None Include="Dock\**\*.*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup Condition="Exists('Emoji/NotoColorEmoji.ttf')">
-    <None Include="Emoji/NotoColorEmoji.ttf" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-  <ItemGroup Condition="!Exists('Emoji/NotoColorEmoji.ttf') and Exists('NotoColorEmoji.ttf')">
-    <None Include="NotoColorEmoji.ttf" CopyToOutputDirectory="PreserveNewest" />
+  <ItemGroup>
+    <None Include="Emoji/NotoColorEmoji.ttf" Condition="Exists('Emoji/NotoColorEmoji.ttf')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </None>
+    <None Include="NotoColorEmoji.ttf" Condition="!Exists('Emoji/NotoColorEmoji.ttf') and Exists('NotoColorEmoji.ttf')">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../DemiCat.UI/DemiCat.UI.csproj" />

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -377,10 +377,16 @@ public class Plugin : IDalamudPlugin
 
             if (fontPath == null)
             {
+                var paths = string.Join(", ", candidates);
+                const string message =
+                    "DemiCat could not find its emoji font. Channel icons will fall back to text until the font is restored.";
+
                 _services.Log.Info(
                     "Emoji font not found at any known path ({Paths}). Unicode emoji will use fallback glyphs.",
-                    string.Join(", ", candidates)
+                    paths
                 );
+
+                PluginServices.Instance?.ToastGui.ShowWarning(message);
                 return null;
             }
 


### PR DESCRIPTION
## Summary
- update the plugin project to always copy NotoColorEmoji.ttf into the build and publish output
- surface a toast warning when the emoji font asset is missing so users know icons will degrade

## Testing
- Not run (dotnet CLI is unavailable in the CI container)

------
https://chatgpt.com/codex/tasks/task_e_68dcaa7673188328ba1937ab2968c527