### PR TITLE
Fix texture loading and toast behavior for Dalamud v13

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -823,7 +823,7 @@ public class MainWindow : IDisposable
 
         try
         {
-            return provider.CreateFromFile(path);
+            return provider.GetFromFileAbsolute(path);
         }
         catch
         {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -386,7 +386,7 @@ public class Plugin : IDalamudPlugin
                     paths
                 );
 
-                PluginServices.Instance?.ToastGui.ShowWarning(message);
+                PluginServices.Instance?.ToastGui.ShowError(message);
                 return null;
             }
 


### PR DESCRIPTION
## Summary
- replace the deprecated texture loading helper with `GetFromFileAbsolute` so dock icons load under Dalamud v13
- swap the missing emoji font toast over to `ShowError` now that `ShowWarning` has been removed

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcace88a448328a1f9985719327b2c