### PR TITLE
Add requests channel configuration

### DIFF
--- a/DemiCatPlugin/ChannelKind.cs
+++ b/DemiCatPlugin/ChannelKind.cs
@@ -4,6 +4,7 @@ public static class ChannelKind
 {
     public const string Chat = "chat";
     public const string Event = "event";
+    public const string Requests = "requests";
     public const string FcChat = "fc_chat";
     public const string OfficerChat = "officer_chat";
     public const string OfficerVisible = "officer_visible";

--- a/DemiCatPlugin/ChannelSelectionService.cs
+++ b/DemiCatPlugin/ChannelSelectionService.cs
@@ -7,6 +7,7 @@ public class ChannelSelectionService
 {
     private const string EventSelectionPrefix = "Event:";
     private static readonly string NormalizedEventKind = ChannelKeyHelper.NormalizeKind(ChannelKind.Event);
+    private static readonly string NormalizedRequestsKind = ChannelKeyHelper.NormalizeKind(ChannelKind.Requests);
     private static readonly string NormalizedFcKind = ChannelKeyHelper.NormalizeKind(ChannelKind.FcChat);
     private static readonly string NormalizedOfficerKind = ChannelKeyHelper.NormalizeKind(ChannelKind.OfficerChat);
     private static readonly string NormalizedChatKind = ChannelKeyHelper.NormalizeKind(ChannelKind.Chat);
@@ -58,6 +59,11 @@ public class ChannelSelectionService
         if (normalizedKind == NormalizedEventKind)
         {
             return _config.EventChannelId ?? string.Empty;
+        }
+
+        if (normalizedKind == NormalizedRequestsKind)
+        {
+            return _config.RequestsChannelId ?? string.Empty;
         }
 
         if (normalizedKind == NormalizedFcKind)
@@ -131,6 +137,9 @@ public class ChannelSelectionService
             {
                 case ChannelKind.Event:
                     _config.EventChannelId = id;
+                    break;
+                case ChannelKind.Requests:
+                    _config.RequestsChannelId = id;
                     break;
                 case ChannelKind.FcChat:
                     _config.FcChannelId = id;

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -82,6 +82,7 @@ public class Config : IPluginConfiguration
     public Dictionary<string, long> RestChatCursors { get; set; } = new();
     public Dictionary<string, string> ChannelSelections { get; set; } = new();
     public string EventChannelId { get; set; } = string.Empty;
+    public string RequestsChannelId { get; set; } = string.Empty;
     public string FcChannelId { get; set; } = string.Empty;
     public string FcChannelName { get; set; } = string.Empty;
     public string OfficerChannelId { get; set; } = string.Empty;
@@ -350,6 +351,7 @@ public class Config : IPluginConfiguration
 
             EnsureSelection(ChannelKind.Chat, ChatChannelId);
             EnsureSelection(ChannelKind.Event, EventChannelId);
+            EnsureSelection(ChannelKind.Requests, RequestsChannelId);
             EnsureSelection(ChannelKind.FcChat, FcChannelId);
             EnsureSelection(ChannelKind.OfficerChat, OfficerChannelId);
 
@@ -366,6 +368,8 @@ public class Config : IPluginConfiguration
                     var kinds = new List<string>();
                     if (!string.IsNullOrEmpty(EventChannelId) && channelId == EventChannelId)
                         kinds.Add(ChannelKind.Event);
+                    if (!string.IsNullOrEmpty(RequestsChannelId) && channelId == RequestsChannelId)
+                        kinds.Add(ChannelKind.Requests);
                     if (!string.IsNullOrEmpty(FcChannelId) && channelId == FcChannelId)
                         kinds.Add(ChannelKind.FcChat);
                     if (!string.IsNullOrEmpty(OfficerChannelId) && channelId == OfficerChannelId)

--- a/DemiCatPlugin/GuildRolesResponseDto.cs
+++ b/DemiCatPlugin/GuildRolesResponseDto.cs
@@ -10,5 +10,8 @@ internal sealed class GuildRolesResponseDto
 
     [JsonPropertyName("mention_role_ids")]
     public List<string> MentionRoleIds { get; set; } = new();
+
+    [JsonPropertyName("requests_channel_id")]
+    public string? RequestsChannelId { get; set; }
 }
 

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -588,6 +588,7 @@ public class Plugin : IDalamudPlugin
         {
             ChannelKind.Chat,
             ChannelKind.Event,
+            ChannelKind.Requests,
             ChannelKind.FcChat,
             ChannelKind.OfficerChat
         };

--- a/DemiCatPlugin/RoleCache.cs
+++ b/DemiCatPlugin/RoleCache.cs
@@ -68,6 +68,7 @@ internal static class RoleCache
                 ?? new GuildRolesResponseDto();
             var roles = payload.Roles ?? new List<RoleDto>();
             var mentionRoleIds = payload.MentionRoleIds ?? new List<string>();
+            var requestsChannelId = payload.RequestsChannelId;
 
             _roles = roles;
             _lastErrorMessage = null;
@@ -76,6 +77,7 @@ internal static class RoleCache
             {
                 config.GuildRoles = roles;
                 config.MentionRoleIds = mentionRoleIds;
+                config.RequestsChannelId = requestsChannelId ?? string.Empty;
                 PluginServices.Instance!.PluginInterface.SavePluginConfig(config);
             });
         }

--- a/demibot/demibot/db/migrations/versions/0056_add_requests_channel_kind.py
+++ b/demibot/demibot/db/migrations/versions/0056_add_requests_channel_kind.py
@@ -1,0 +1,83 @@
+"""add requests channel kind
+
+Revision ID: 0056_add_requests_channel_kind
+Revises: 0055_add_syncshell_transfer_budgets
+Create Date: 2024-03-11
+"""
+
+from alembic import op
+
+
+revision = "0056_add_requests_channel_kind"
+down_revision = "0055_add_syncshell_transfer_budgets"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == "postgresql":
+        op.execute("ALTER TYPE channelkind ADD VALUE IF NOT EXISTS 'requests'")
+    elif dialect == "mysql":
+        op.execute(
+            """
+            ALTER TABLE guild_channels
+            MODIFY COLUMN kind ENUM(
+                'chat',
+                'event',
+                'requests',
+                'fc_chat',
+                'officer_chat',
+                'officer_visible'
+            ) NOT NULL
+            """
+        )
+    else:
+        # SQLite stores enums as plain TEXT so no migration is required.
+        return
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    op.execute("DELETE FROM guild_channels WHERE kind = 'requests'")
+
+    if dialect == "postgresql":
+        op.execute(
+            """
+            CREATE TYPE channelkind_old AS ENUM(
+                'chat',
+                'event',
+                'fc_chat',
+                'officer_chat',
+                'officer_visible'
+            )
+            """
+        )
+        op.execute(
+            """
+            ALTER TABLE guild_channels
+            ALTER COLUMN kind TYPE channelkind_old
+            USING kind::text::channelkind_old
+            """
+        )
+        op.execute("DROP TYPE channelkind")
+        op.execute("ALTER TYPE channelkind_old RENAME TO channelkind")
+    elif dialect == "mysql":
+        op.execute(
+            """
+            ALTER TABLE guild_channels
+            MODIFY COLUMN kind ENUM(
+                'chat',
+                'event',
+                'fc_chat',
+                'officer_chat',
+                'officer_visible'
+            ) NOT NULL
+            """
+        )
+    else:
+        return

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -63,6 +63,7 @@ class InstallStatus(str, Enum):
 class ChannelKind(str, Enum):
     CHAT = "chat"
     EVENT = "event"
+    REQUESTS = "requests"
     FC_CHAT = "fc_chat"
     OFFICER_CHAT = "officer_chat"
     OFFICER_VISIBLE = "officer_visible"

--- a/demibot/demibot/discordbot/cogs/admin.py
+++ b/demibot/demibot/discordbot/cogs/admin.py
@@ -395,6 +395,7 @@ class ConfigWizard(discord.ui.View):
         self.success_message = success_message
         self.step = 0
         self.event_channel_ids: list[int] = []
+        self.requests_channel_id: int | None = None
         self.fc_chat_channel_ids: list[int] = []
         self.officer_chat_channel_ids: list[int] = []
         self.officer_role_ids: list[int] = []
@@ -423,6 +424,39 @@ class ConfigWizard(discord.ui.View):
         )
         self.finish_button.callback = self.on_finish
 
+    def _channel_selected_ids(self, step: int) -> list[int]:
+        if step == 0:
+            return list(self.event_channel_ids)
+        if step == 1:
+            return [self.requests_channel_id] if self.requests_channel_id is not None else []
+        if step == 2:
+            return list(self.fc_chat_channel_ids)
+        if step == 3:
+            return list(self.officer_chat_channel_ids)
+        return []
+
+    def _toggle_channel_selection(self, step: int, channel_id: int) -> None:
+        if step == 0:
+            if channel_id in self.event_channel_ids:
+                self.event_channel_ids.remove(channel_id)
+            else:
+                self.event_channel_ids.append(channel_id)
+        elif step == 1:
+            if self.requests_channel_id == channel_id:
+                self.requests_channel_id = None
+            else:
+                self.requests_channel_id = channel_id
+        elif step == 2:
+            if channel_id in self.fc_chat_channel_ids:
+                self.fc_chat_channel_ids.remove(channel_id)
+            else:
+                self.fc_chat_channel_ids.append(channel_id)
+        elif step == 3:
+            if channel_id in self.officer_chat_channel_ids:
+                self.officer_chat_channel_ids.remove(channel_id)
+            else:
+                self.officer_chat_channel_ids.append(channel_id)
+
     async def render(
         self,
         inter: discord.Interaction,
@@ -433,29 +467,23 @@ class ConfigWizard(discord.ui.View):
         self.clear_items()
         step_descriptions = [
             "Select the event channels to be used in the plugin",
+            "Select the requests channel to be used in the plugin",
             "Select the FC chat channels to be used in the plugin",
             "Select the officer chat channels to be used in the plugin",
             "Select the roles that should be treated as officers",
             "Select the roles that can be mentioned",
         ]
+        total_steps = len(step_descriptions)
         embed = discord.Embed(
             title=self.title,
-            description=f"Step {self.step + 1} / 5\n{step_descriptions[self.step]}",
+            description=f"Step {self.step + 1} / {total_steps}\n{step_descriptions[self.step]}",
         )
-        if self.step in (0, 1, 2):
-            selected_map = {
-                0: self.event_channel_ids,
-                1: self.fc_chat_channel_ids,
-                2: self.officer_chat_channel_ids,
-            }
-            selected = selected_map[self.step]
+        channel_step_count = 4
+        if self.step < channel_step_count:
+            selected_ids = self._channel_selected_ids(self.step)
             used_ids: set[int] = set()
-            if self.step > 0:
-                used_ids.update(self.event_channel_ids)
-            if self.step > 1:
-                used_ids.update(self.fc_chat_channel_ids)
-            if self.step > 2:
-                used_ids.update(self.officer_chat_channel_ids)
+            for previous_step in range(self.step):
+                used_ids.update(self._channel_selected_ids(previous_step))
             channels = [ch for ch in self.channels if ch.id not in used_ids]
             max_page = max((len(channels) - 1) // self.page_size, 0)
             self.channel_page = min(self.channel_page, max_page)
@@ -464,16 +492,13 @@ class ConfigWizard(discord.ui.View):
             for ch in channels[start:end]:
                 style = (
                     discord.ButtonStyle.primary
-                    if ch.id in selected
+                    if ch.id in selected_ids
                     else discord.ButtonStyle.secondary
                 )
                 button = discord.ui.Button(label=ch.name, style=style)
 
                 async def channel_cb(i: discord.Interaction, cid=ch.id) -> None:
-                    if cid in selected:
-                        selected.remove(cid)
-                    else:
-                        selected.append(cid)
+                    self._toggle_channel_selection(self.step, cid)
                     await self.render(i)
 
                 button.callback = channel_cb
@@ -482,8 +507,8 @@ class ConfigWizard(discord.ui.View):
                 self.add_item(self.page_prev_button)
             if end < len(channels):
                 self.add_item(self.page_next_button)
-            self.next_button.disabled = len(selected) == 0
-        elif self.step == 3:
+            self.next_button.disabled = len(selected_ids) == 0
+        elif self.step == channel_step_count:
             officer_select = discord.ui.RoleSelect(
                 placeholder="Select officer roles",
                 min_values=1,
@@ -501,6 +526,7 @@ class ConfigWizard(discord.ui.View):
 
             officer_select.callback = officer_cb
             self.add_item(officer_select)
+            self.next_button.disabled = len(self.officer_role_ids) == 0
         else:
             mention_select = discord.ui.RoleSelect(
                 placeholder="Select mentionable roles",
@@ -521,7 +547,7 @@ class ConfigWizard(discord.ui.View):
             self.add_item(mention_select)
         if self.step > 0:
             self.add_item(self.back_button)
-        if self.step < 4:
+        if self.step < total_steps - 1:
             self.add_item(self.next_button)
         else:
             self.finish_button.disabled = len(self.mention_role_ids) == 0
@@ -546,17 +572,22 @@ class ConfigWizard(discord.ui.View):
                 "Select at least one event channel", ephemeral=True
             )
             return
-        if self.step == 1 and not self.fc_chat_channel_ids:
+        if self.step == 1 and self.requests_channel_id is None:
+            await interaction.response.send_message(
+                "Select a requests channel", ephemeral=True
+            )
+            return
+        if self.step == 2 and not self.fc_chat_channel_ids:
             await interaction.response.send_message(
                 "Select at least one FC chat channel", ephemeral=True
             )
             return
-        if self.step == 2 and not self.officer_chat_channel_ids:
+        if self.step == 3 and not self.officer_chat_channel_ids:
             await interaction.response.send_message(
                 "Select at least one officer chat channel", ephemeral=True
             )
             return
-        if self.step == 3 and not self.officer_role_ids:
+        if self.step == 4 and not self.officer_role_ids:
             await interaction.response.send_message(
                 "Select at least one officer role", ephemeral=True
             )
@@ -578,6 +609,7 @@ class ConfigWizard(discord.ui.View):
         if not all(
             [
                 self.event_channel_ids,
+                [self.requests_channel_id] if self.requests_channel_id else [],
                 self.fc_chat_channel_ids,
                 self.officer_chat_channel_ids,
                 self.officer_role_ids,
@@ -588,11 +620,21 @@ class ConfigWizard(discord.ui.View):
                 "All selections are required", ephemeral=True
             )
             return
-        if (
-            set(self.event_channel_ids) & set(self.fc_chat_channel_ids)
-            or set(self.event_channel_ids) & set(self.officer_chat_channel_ids)
-            or set(self.fc_chat_channel_ids) & set(self.officer_chat_channel_ids)
-        ):
+        channel_sets = [
+            set(self.event_channel_ids),
+            {self.requests_channel_id} if self.requests_channel_id else set(),
+            set(self.fc_chat_channel_ids),
+            set(self.officer_chat_channel_ids),
+        ]
+        duplicate = False
+        for idx, current in enumerate(channel_sets):
+            for other in channel_sets[idx + 1 :]:
+                if current & other:
+                    duplicate = True
+                    break
+            if duplicate:
+                break
+        if duplicate:
             await interaction.response.send_message(
                 "Each channel may only be selected once", ephemeral=True
             )
@@ -675,6 +717,8 @@ class ConfigWizard(discord.ui.View):
                 desired_channel_map: dict[int, ChannelKind] = {}
                 for cid in self.event_channel_ids:
                     desired_channel_map[cid] = ChannelKind.EVENT
+                if self.requests_channel_id is not None:
+                    desired_channel_map[self.requests_channel_id] = ChannelKind.REQUESTS
                 for cid in self.fc_chat_channel_ids:
                     desired_channel_map[cid] = ChannelKind.FC_CHAT
                 for cid in self.officer_chat_channel_ids:
@@ -688,6 +732,7 @@ class ConfigWizard(discord.ui.View):
                 duplicate_channels: list[GuildChannel] = []
                 replaceable_kinds = {
                     ChannelKind.EVENT,
+                    ChannelKind.REQUESTS,
                     ChannelKind.FC_CHAT,
                     ChannelKind.OFFICER_CHAT,
                 }
@@ -750,6 +795,7 @@ class ConfigWizard(discord.ui.View):
         summary = (
             f"{self.success_message}\n"
             f"Event channels: {', '.join(f'<#{c}>' for c in self.event_channel_ids)}\n"
+            f"Requests channel: <#{self.requests_channel_id}>\n"
             f"FC chat channels: {', '.join(f'<#{c}>' for c in self.fc_chat_channel_ids)}\n"
             f"Officer chat channels: {', '.join(f'<#{c}>' for c in self.officer_chat_channel_ids)}\n"
             f"Officer roles: {', '.join(f'<@&{r}>' for r in self.officer_role_ids)}\n"

--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -182,6 +182,7 @@ async def get_channels(
     # Allow fetching a single channel kind for plugin convenience
     single_kinds = {
         ChannelKind.EVENT.value: ChannelKind.EVENT,
+        ChannelKind.REQUESTS.value: ChannelKind.REQUESTS,
         ChannelKind.FC_CHAT.value: ChannelKind.FC_CHAT,
         ChannelKind.OFFICER_CHAT.value: ChannelKind.OFFICER_CHAT,
     }

--- a/demibot/demibot/http/routes/guild_roles.py
+++ b/demibot/demibot/http/routes/guild_roles.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..deps import RequestContext, api_key_auth, get_db
 from ._messages_common import _role_set
 from ..discord_client import discord_client
-from ...db.models import GuildConfig, Role
+from ...db.models import GuildConfig, GuildChannel, Role, ChannelKind
 from ...discordbot.utils import is_premium_subscriber_role
 
 router = APIRouter(prefix="/api")
@@ -27,6 +27,16 @@ async def get_guild_roles(
         if rid
     ]
 
+    requests_channel_id_row = await db.scalar(
+        select(GuildChannel.channel_id).where(
+            GuildChannel.guild_id == ctx.guild.id,
+            GuildChannel.kind == ChannelKind.REQUESTS,
+        )
+    )
+    requests_channel_id = (
+        str(requests_channel_id_row) if requests_channel_id_row is not None else None
+    )
+
     mention_ids: set[int] | None = None
     roles = _role_set(ctx)
     if "officer" not in roles:
@@ -40,6 +50,7 @@ async def get_guild_roles(
             return {
                 "roles": [],
                 "mention_role_ids": mention_role_ids,
+                "requests_channel_id": requests_channel_id,
             }
 
     stmt = select(Role).where(Role.guild_id == ctx.guild.id)
@@ -60,8 +71,9 @@ async def get_guild_roles(
                 },
             }
             for role in rows
-        ],
+            ],
             "mention_role_ids": mention_role_ids,
+            "requests_channel_id": requests_channel_id,
         }
 
     if discord_client:
@@ -100,9 +112,11 @@ async def get_guild_roles(
             return {
                 "roles": roles_out,
                 "mention_role_ids": mention_role_ids,
+                "requests_channel_id": requests_channel_id,
             }
     return {
         "roles": [],
         "mention_role_ids": mention_role_ids,
+        "requests_channel_id": requests_channel_id,
     }
 

--- a/demibot/demibot/http/routes/requests.py
+++ b/demibot/demibot/http/routes/requests.py
@@ -16,7 +16,16 @@ from ..deps import RequestContext, api_key_auth, get_db
 from ._messages_common import _role_set
 from ..ws import manager
 from ..discord_client import discord_client
-from ...db.models import Request as DbRequest, RequestStatus, RequestType, Urgency, User
+from ...db.models import (
+    Guild,
+    GuildChannel,
+    ChannelKind,
+    Request as DbRequest,
+    RequestStatus,
+    RequestType,
+    Urgency,
+    User,
+)
 from ...db.models import RequestTombstone
 from ...config import load_config
 
@@ -108,16 +117,40 @@ async def _broadcast(guild_id: int, request_id: int, delta: dict[str, Any]) -> N
 
 async def _requests_channel(
     discord_guild_id: int | None,
+    db: AsyncSession,
 ) -> discord.abc.Messageable | None:
     if not discord_client or discord_guild_id is None:
         return None
+
     guild = discord_client.get_guild(discord_guild_id)
     if not guild:
         return None
-    for channel in guild.text_channels:
-        if channel.name == "requests":
-            return channel
-    return None
+
+    channel_id = await db.scalar(
+        select(GuildChannel.channel_id)
+        .join(Guild, Guild.id == GuildChannel.guild_id)
+        .where(
+            Guild.discord_guild_id == discord_guild_id,
+            GuildChannel.kind == ChannelKind.REQUESTS,
+        )
+    )
+    if channel_id is None:
+        return None
+
+    channel = None
+    if hasattr(guild, "get_channel"):
+        channel = guild.get_channel(channel_id)
+    if channel is None:
+        try:
+            channel = discord_client.get_channel(channel_id)
+        except Exception:
+            channel = None
+    if channel is None:
+        try:
+            channel = await discord_client.fetch_channel(channel_id)  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - network errors
+            channel = None
+    return channel
 
 
 async def _send_dm(discord_id: int, message: str) -> None:
@@ -137,7 +170,7 @@ async def _notify(
     db: AsyncSession,
     ctx_user: User,
 ) -> None:
-    channel = await _requests_channel(discord_guild_id)
+    channel = await _requests_channel(discord_guild_id, db)
     if channel:
         cfg = load_config()
         url = f"http://{cfg.server.host}:{cfg.server.port}/board/requests/{req.id}"

--- a/tests/test_config_wizard_channel_filter.py
+++ b/tests/test_config_wizard_channel_filter.py
@@ -86,7 +86,7 @@ def test_selected_channels_are_hidden_across_steps():
         await view.render(DummyInteraction(), initial=True)
         assert _channel_labels(view) == {"two", "three"}
 
-        view.fc_chat_channel_ids = [2]
+        view.requests_channel_id = 2
         view.step = 2
         await view.render(DummyInteraction(), initial=True)
         assert _channel_labels(view) == {"three"}

--- a/tests/test_config_wizard_rerun.py
+++ b/tests/test_config_wizard_rerun.py
@@ -222,6 +222,7 @@ def test_rerun_setup_wizard_no_integrity_error() -> None:
         # First run of the wizard
         view1 = ConfigWizard(guild, "title", "final", "done")
         view1.event_channel_ids = [1]
+        view1.requests_channel_id = 4
         view1.fc_chat_channel_ids = [2]
         view1.officer_chat_channel_ids = [3]
         view1.officer_role_ids = [42]
@@ -247,6 +248,7 @@ def test_rerun_setup_wizard_no_integrity_error() -> None:
         # Change only the FC chat selection to ensure the previous FC
         # channel rows are replaced cleanly while leaving other kinds intact.
         view2.event_channel_ids = [1]
+        view2.requests_channel_id = 4
         view2.fc_chat_channel_ids = [5]
         view2.officer_chat_channel_ids = [3]
         view2.officer_role_ids = [42]
@@ -261,7 +263,7 @@ def test_rerun_setup_wizard_no_integrity_error() -> None:
                     )
                 )
             ).scalars().all()
-            assert len(chans) == 3
+            assert len(chans) == 4
             fc_channels = [
                 chan.channel_id for chan in chans if chan.kind == ChannelKind.FC_CHAT
             ]
@@ -277,6 +279,7 @@ def test_rerun_setup_wizard_no_integrity_error() -> None:
             }
             assert channel_map == {
                 (1, ChannelKind.EVENT): "one",
+                (4, ChannelKind.REQUESTS): "four",
                 (3, ChannelKind.OFFICER_CHAT): "three",
                 (5, ChannelKind.FC_CHAT): "five",
             }
@@ -300,6 +303,7 @@ def test_second_wizard_run_preserves_existing_webhook() -> None:
 
         view1 = ConfigWizard(guild, "title", "final", "done")
         view1.event_channel_ids = [101]
+        view1.requests_channel_id = 404
         view1.fc_chat_channel_ids = [202]
         view1.officer_chat_channel_ids = [303]
         view1.officer_role_ids = [84]
@@ -324,6 +328,7 @@ def test_second_wizard_run_preserves_existing_webhook() -> None:
 
         view2 = ConfigWizard(guild, "title", "final", "done")
         view2.event_channel_ids = [101]
+        view2.requests_channel_id = 404
         view2.fc_chat_channel_ids = [202]
         view2.officer_chat_channel_ids = [303]
         view2.officer_role_ids = [84]
@@ -406,6 +411,7 @@ def test_existing_chat_channel_promoted_to_fc_chat() -> None:
 
         view = ConfigWizard(guild, "title", "final", "done")
         view.event_channel_ids = [1001]
+        view.requests_channel_id = 4004
         view.fc_chat_channel_ids = [fc_channel_id]
         view.officer_chat_channel_ids = [3003]
         view.officer_role_ids = [21]

--- a/tests/test_config_wizard_role_union.py
+++ b/tests/test_config_wizard_role_union.py
@@ -93,6 +93,7 @@ def test_role_union_deduplication() -> None:
         guild = DummyGuild()
         view = ConfigWizard(guild, "title", "final", "done")
         view.event_channel_ids = [1]
+        view.requests_channel_id = 2
         view.fc_chat_channel_ids = [2]
         view.officer_chat_channel_ids = [3]
         view.officer_role_ids = [42]

--- a/tests/test_requests_delta.py
+++ b/tests/test_requests_delta.py
@@ -57,7 +57,9 @@ sys.modules["discord.ext.commands"] = commands_mod
 from types import SimpleNamespace
 
 from demibot.db.models import (
+    ChannelKind,
     Guild,
+    GuildChannel,
     User,
     Request as DbRequest,
     RequestStatus,
@@ -146,6 +148,15 @@ def test_notify_posts_to_requests_channel_when_discord_guild_id_present(
             db.add(req)
             await db.commit()
             await db.refresh(req)
+            db.add(
+                GuildChannel(
+                    guild_id=guild.id,
+                    channel_id=123,
+                    kind=ChannelKind.REQUESTS,
+                    name="requests",
+                )
+            )
+            await db.commit()
             ctx = RequestContext(user=user, guild=guild, key=SimpleNamespace(), roles=[])
 
             async def fake_send_dm(*args, **kwargs):
@@ -155,6 +166,7 @@ def test_notify_posts_to_requests_channel_when_discord_guild_id_present(
 
             class DummyChannel:
                 def __init__(self) -> None:
+                    self.id = 123
                     self.name = "requests"
                     self.sent = []
 
@@ -162,7 +174,18 @@ def test_notify_posts_to_requests_channel_when_discord_guild_id_present(
                     self.sent.append((args, kwargs))
 
             channel = DummyChannel()
-            dummy_guild = SimpleNamespace(text_channels=[channel])
+
+            class DummyGuild:
+                def __init__(self, channel_obj) -> None:
+                    self._channel = channel_obj
+                    self.text_channels = [channel_obj]
+
+                def get_channel(self, channel_id: int):
+                    if channel_id == self._channel.id:
+                        return self._channel
+                    return None
+
+            dummy_guild = DummyGuild(channel)
 
             class DummyClient:
                 def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- extend the shared channel enums with a new `requests` kind and add the database migration
- update the Discord admin wizard and guild role APIs to capture and persist a configured requests channel
- surface the stored requests channel through plugin config defaults and selection helpers so the Dalamud plugin can consume it automatically

## Testing
- pytest *(fails: missing fastapi/sqlalchemy dependencies in test environment)*
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1bbbef54832896d8fd5c46c0b9e7