### PR TITLE
Refine request notifications to use configured channel

### DIFF
--- a/demibot/demibot/http/routes/requests.py
+++ b/demibot/demibot/http/routes/requests.py
@@ -13,18 +13,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from ..deps import RequestContext, api_key_auth, get_db
-from ._messages_common import _role_set
+from ._messages_common import (
+    CHANNEL_NOT_CONFIGURED_DETAIL,
+    _role_set,
+    require_guild_channel,
+)
 from ..ws import manager
 from ..discord_client import discord_client
 from ...db.models import (
-    Guild,
     GuildChannel,
     ChannelKind,
     Request as DbRequest,
     RequestStatus,
     RequestType,
     Urgency,
-    User,
 )
 from ...db.models import RequestTombstone
 from ...config import load_config
@@ -116,82 +118,91 @@ async def _broadcast(guild_id: int, request_id: int, delta: dict[str, Any]) -> N
 
 
 async def _requests_channel(
-    discord_guild_id: int | None,
+    ctx: RequestContext,
     db: AsyncSession,
-) -> discord.abc.Messageable | None:
-    if not discord_client or discord_guild_id is None:
+) -> tuple[GuildChannel, discord.abc.Messageable | None] | None:
+    if not discord_client or ctx.guild.discord_guild_id is None:
         return None
 
-    guild = discord_client.get_guild(discord_guild_id)
-    if not guild:
-        return None
-
-    channel_id = await db.scalar(
-        select(GuildChannel.channel_id)
-        .join(Guild, Guild.id == GuildChannel.guild_id)
-        .where(
-            Guild.discord_guild_id == discord_guild_id,
-            GuildChannel.kind == ChannelKind.REQUESTS,
+    try:
+        guild_channel = await require_guild_channel(
+            ctx,
+            db,
+            channel_kind=ChannelKind.REQUESTS,
         )
-    )
-    if channel_id is None:
-        return None
+    except HTTPException as exc:
+        if (
+            exc.status_code == 400
+            and exc.detail == CHANNEL_NOT_CONFIGURED_DETAIL
+        ):
+            logging.warning(
+                "Requests channel not configured for guild %s", ctx.guild.id
+            )
+            return None
+        raise
 
+    guild = discord_client.get_guild(ctx.guild.discord_guild_id)
     channel = None
-    if hasattr(guild, "get_channel"):
-        channel = guild.get_channel(channel_id)
+    if guild and hasattr(guild, "get_channel"):
+        channel = guild.get_channel(guild_channel.channel_id)
     if channel is None:
         try:
-            channel = discord_client.get_channel(channel_id)
+            channel = discord_client.get_channel(guild_channel.channel_id)
         except Exception:
             channel = None
-    if channel is None:
+    if channel is None and hasattr(discord_client, "fetch_channel"):
         try:
-            channel = await discord_client.fetch_channel(channel_id)  # type: ignore[attr-defined]
+            channel = await discord_client.fetch_channel(  # type: ignore[attr-defined]
+                guild_channel.channel_id
+            )
         except Exception:  # pragma: no cover - network errors
             channel = None
-    return channel
-
-
-async def _send_dm(discord_id: int, message: str) -> None:
-    if not discord_client:
-        return
-    try:
-        user = await discord_client.fetch_user(discord_id)
-        await user.send(message)
-    except Exception:  # pragma: no cover - network errors
-        logging.warning("Failed to send DM to %s", discord_id)
+    return guild_channel, channel
 
 
 async def _notify(
-    discord_guild_id: int | None,
+    ctx: RequestContext,
     req: DbRequest,
     action: str,
     db: AsyncSession,
-    ctx_user: User,
 ) -> None:
-    channel = await _requests_channel(discord_guild_id, db)
-    if channel:
-        cfg = load_config()
-        url = f"http://{cfg.server.host}:{cfg.server.port}/board/requests/{req.id}"
-        embed = discord.Embed(
-            title=req.title, url=url, description=req.description or ""
-        )
-        embed.add_field(name="Status", value=req.status.value, inline=False)
+    resolved = await _requests_channel(ctx, db)
+    if not resolved:
+        return
+
+    guild_channel, channel = resolved
+    cfg = load_config()
+    url = f"http://{cfg.server.host}:{cfg.server.port}/board/requests/{req.id}"
+    embed = discord.Embed(title=req.title, url=url, description=req.description or "")
+    embed.add_field(name="Status", value=req.status.value, inline=False)
+
+    sent = False
+    if guild_channel.webhook_url and discord_client:
+        try:
+            webhook = discord.Webhook.from_url(
+                guild_channel.webhook_url,
+                client=discord_client,
+            )
+            username = guild_channel.name or getattr(channel, "name", None)
+            await webhook.send(embed=embed, username=username)
+            sent = True
+        except Exception:  # pragma: no cover - network errors
+            logging.warning(
+                "Failed to post request embed for %s via webhook", req.id
+            )
+
+    if not sent and channel is not None:
         try:
             await channel.send(embed=embed)
+            sent = True
         except Exception:  # pragma: no cover - network errors
             logging.warning("Failed to post request embed for %s", req.id)
-    requester = await db.get(User, req.user_id)
-    if requester:
-        await _send_dm(
-            requester.discord_user_id,
-            f"Your request '{req.title}' was {action}.",
-        )
-    if ctx_user.id != req.user_id:
-        await _send_dm(
-            ctx_user.discord_user_id,
-            f"You {action} the request '{req.title}'.",
+
+    if not sent:
+        logging.warning(
+            "Requests channel %s unavailable for guild %s",
+            guild_channel.channel_id,
+            ctx.guild.id,
         )
 
 
@@ -255,7 +266,7 @@ async def create_request(
     if req is None:
         raise HTTPException(status_code=500)
     await _broadcast(ctx.guild.id, req.id, _dto(req))
-    await _notify(ctx.guild.discord_guild_id, req, "created", db, ctx.user)
+    await _notify(ctx, req, "created", db)
     return {"id": str(req.id)}
 
 
@@ -369,7 +380,7 @@ async def accept_request(
     )
     delta = _dto(req)
     await _broadcast(ctx.guild.id, req.id, delta)
-    await _notify(ctx.guild.discord_guild_id, req, "claimed", db, ctx.user)
+    await _notify(ctx, req, "claimed", db)
     return delta
 
 
@@ -420,7 +431,7 @@ async def complete_request(
     )
     delta = _dto(req)
     await _broadcast(ctx.guild.id, req.id, delta)
-    await _notify(ctx.guild.discord_guild_id, req, "completed", db, ctx.user)
+    await _notify(ctx, req, "completed", db)
     return delta
 
 

--- a/tests/test_requests_delta.py
+++ b/tests/test_requests_delta.py
@@ -45,6 +45,27 @@ class _DummyHTTPException(Exception):
 
 
 discord_mod.HTTPException = _DummyHTTPException
+
+
+class _DummyWebhook:
+    last_instance = None
+
+    def __init__(self, url: str, client=None) -> None:
+        self.url = url
+        self.client = client
+        self.sent: list[tuple[tuple, dict]] = []
+
+    @classmethod
+    def from_url(cls, url: str, *, client=None):
+        instance = cls(url, client=client)
+        cls.last_instance = instance
+        return instance
+
+    async def send(self, *args, **kwargs):
+        self.sent.append((args, kwargs))
+
+
+discord_mod.Webhook = _DummyWebhook
 sys.modules["discord"] = discord_mod
 sys.modules["discord.abc"] = abc_mod
 ext_mod = _types.ModuleType("discord.ext")
@@ -70,6 +91,7 @@ from demibot.db.session import init_db, get_session
 from demibot.http.deps import RequestContext
 from demibot.http.discord_client import set_discord_client
 import demibot.http.routes.requests as request_routes
+from sqlalchemy import select
 
 async def _setup_db(db_path: str) -> None:
     await init_db(f"sqlite+aiosqlite:///{db_path}")
@@ -127,9 +149,7 @@ def test_requests_delta(db_setup):
     assert third[0]["id"] == "1"
 
 
-def test_notify_posts_to_requests_channel_when_discord_guild_id_present(
-    db_setup, monkeypatch
-):
+def test_notify_posts_to_requests_channel_when_discord_guild_id_present(db_setup):
     async def run():
         async with get_session() as db:
             guild = await db.get(Guild, 1)
@@ -158,11 +178,6 @@ def test_notify_posts_to_requests_channel_when_discord_guild_id_present(
             )
             await db.commit()
             ctx = RequestContext(user=user, guild=guild, key=SimpleNamespace(), roles=[])
-
-            async def fake_send_dm(*args, **kwargs):
-                return None
-
-            monkeypatch.setattr(request_routes, "_send_dm", fake_send_dm)
 
             class DummyChannel:
                 def __init__(self) -> None:
@@ -198,9 +213,7 @@ def test_notify_posts_to_requests_channel_when_discord_guild_id_present(
             dummy_client = DummyClient()
             set_discord_client(dummy_client)
             try:
-                await request_routes._notify(
-                    ctx.guild.discord_guild_id, req, "created", db, ctx.user
-                )
+                await request_routes._notify(ctx, req, "created", db)
             finally:
                 set_discord_client(None)
 
@@ -209,3 +222,210 @@ def test_notify_posts_to_requests_channel_when_discord_guild_id_present(
     sent_messages, calls, expected_id = asyncio.run(run())
     assert calls == [expected_id]
     assert len(sent_messages) == 1
+
+
+def test_create_request_notifies_channel_without_dm(db_setup, monkeypatch):
+    async def run():
+        async with get_session() as db:
+            guild = await db.get(Guild, 1)
+            user = await db.get(User, 1)
+            discord_id = 111111111111111111
+            guild.discord_guild_id = discord_id
+
+            result = await db.execute(
+                select(GuildChannel).where(
+                    GuildChannel.guild_id == guild.id,
+                    GuildChannel.kind == ChannelKind.REQUESTS,
+                )
+            )
+            mapping = result.scalar_one_or_none()
+            if mapping is None:
+                mapping = GuildChannel(
+                    guild_id=guild.id,
+                    channel_id=456,
+                    kind=ChannelKind.REQUESTS,
+                    name="requests",
+                )
+                db.add(mapping)
+            else:
+                mapping.channel_id = 456
+                mapping.name = "requests"
+                mapping.webhook_url = None
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=guild, key=SimpleNamespace(), roles=[])
+
+            class DummyChannel:
+                def __init__(self) -> None:
+                    self.id = 456
+                    self.name = "requests"
+                    self.sent: list[tuple[tuple, dict]] = []
+
+                async def send(self, *args, **kwargs):
+                    self.sent.append((args, kwargs))
+
+            channel = DummyChannel()
+
+            class DummyGuild:
+                def __init__(self, channel_obj) -> None:
+                    self._channel = channel_obj
+
+                def get_channel(self, channel_id: int):
+                    if channel_id == self._channel.id:
+                        return self._channel
+                    return None
+
+            class DummyClient:
+                def __init__(self, channel_obj) -> None:
+                    self._channel = channel_obj
+                    self.guild_calls: list[int] = []
+
+                def get_guild(self, guild_id: int):
+                    self.guild_calls.append(guild_id)
+                    return DummyGuild(self._channel)
+
+                def get_channel(self, channel_id: int):
+                    if channel_id == self._channel.id:
+                        return self._channel
+                    return None
+
+            dummy_client = DummyClient(channel)
+            set_discord_client(dummy_client)
+
+            async def fake_broadcast(*args, **kwargs):
+                return None
+
+            monkeypatch.setattr(request_routes.manager, "broadcast_text", fake_broadcast)
+
+            body = request_routes.RequestCreateBody(
+                title="Created",
+                description=None,
+                type=RequestType.ITEM,
+                urgency=Urgency.MEDIUM,
+            )
+
+            try:
+                await request_routes.create_request(body=body, ctx=ctx, db=db)
+            finally:
+                set_discord_client(None)
+
+            return channel.sent, dummy_client.guild_calls, discord_id
+
+    sent_messages, calls, expected_id = asyncio.run(run())
+    assert calls == [expected_id]
+    assert len(sent_messages) == 1
+
+
+def test_complete_request_notifies_channel_via_webhook(db_setup, monkeypatch):
+    async def run():
+        async with get_session() as db:
+            guild = await db.get(Guild, 1)
+            user = await db.get(User, 1)
+            discord_id = 222222222222222222
+            guild.discord_guild_id = discord_id
+
+            result = await db.execute(
+                select(GuildChannel).where(
+                    GuildChannel.guild_id == guild.id,
+                    GuildChannel.kind == ChannelKind.REQUESTS,
+                )
+            )
+            mapping = result.scalar_one_or_none()
+            webhook_url = "https://example.com/webhook"
+            if mapping is None:
+                mapping = GuildChannel(
+                    guild_id=guild.id,
+                    channel_id=789,
+                    kind=ChannelKind.REQUESTS,
+                    name="requests",
+                    webhook_url=webhook_url,
+                )
+                db.add(mapping)
+            else:
+                mapping.channel_id = 789
+                mapping.name = "requests"
+                mapping.webhook_url = webhook_url
+            await db.commit()
+
+            req = DbRequest(
+                id=10,
+                guild_id=guild.id,
+                user_id=user.id,
+                assignee_id=user.id,
+                title="Complete",
+                type=RequestType.ITEM,
+                status=RequestStatus.IN_PROGRESS,
+                urgency=Urgency.HIGH,
+            )
+            db.add(req)
+            await db.commit()
+            await db.refresh(req)
+
+            ctx = RequestContext(user=user, guild=guild, key=SimpleNamespace(), roles=[])
+
+            class DummyChannel:
+                def __init__(self) -> None:
+                    self.id = 789
+                    self.name = "requests"
+                    self.sent: list[tuple[tuple, dict]] = []
+
+                async def send(self, *args, **kwargs):
+                    self.sent.append((args, kwargs))
+
+            channel = DummyChannel()
+
+            class DummyGuild:
+                def __init__(self, channel_obj) -> None:
+                    self._channel = channel_obj
+
+                def get_channel(self, channel_id: int):
+                    if channel_id == self._channel.id:
+                        return self._channel
+                    return None
+
+            class DummyClient:
+                def __init__(self, channel_obj) -> None:
+                    self._channel = channel_obj
+                    self.guild_calls: list[int] = []
+
+                def get_guild(self, guild_id: int):
+                    self.guild_calls.append(guild_id)
+                    return DummyGuild(self._channel)
+
+                def get_channel(self, channel_id: int):
+                    if channel_id == self._channel.id:
+                        return self._channel
+                    return None
+
+            dummy_client = DummyClient(channel)
+            set_discord_client(dummy_client)
+
+            async def fake_broadcast(*args, **kwargs):
+                return None
+
+            monkeypatch.setattr(request_routes.manager, "broadcast_text", fake_broadcast)
+
+            # reset webhook capture
+            discord_mod.Webhook.last_instance = None
+
+            body = request_routes.StatusBody(version=req.version)
+
+            try:
+                await request_routes.complete_request(
+                    request_id=req.id, body=body, ctx=ctx, db=db
+                )
+            finally:
+                set_discord_client(None)
+
+            return (
+                channel.sent,
+                dummy_client.guild_calls,
+                discord_id,
+                discord_mod.Webhook.last_instance,
+            )
+
+    sent_messages, calls, expected_id, webhook_instance = asyncio.run(run())
+    assert calls == [expected_id]
+    assert len(sent_messages) == 0
+    assert webhook_instance is not None
+    assert len(webhook_instance.sent) == 1


### PR DESCRIPTION
## Summary
- resolve the configured requests channel via stored guild metadata and log when missing
- deliver request embeds through the configured channel/webhook and stop sending DMs to actors
- add regression tests ensuring create/complete flows notify the channel without DM side effects

## Testing
- pytest tests/test_requests_delta.py

------
https://chatgpt.com/codex/tasks/task_e_68dd213b5b6483289581872721feb0e9