### PR TITLE
Add creator metadata to request API responses

### DIFF
--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -646,6 +646,10 @@ class Request(Base):
 
     __mapper_args__ = {"version_id_col": version}
 
+    requester: Mapped["User"] = relationship("User", foreign_keys=[user_id])
+    assignee: Mapped[Optional["User"]] = relationship(
+        "User", foreign_keys=[assignee_id]
+    )
     items: Mapped[list["RequestItem"]] = relationship(
         back_populates="request", cascade="all, delete-orphan"
     )

--- a/demibot/demibot/http/routes/requests.py
+++ b/demibot/demibot/http/routes/requests.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 import logging
 import discord
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -57,6 +57,7 @@ class StatusBody(BaseModel):
 
 # lightweight DTO for plugin consumption
 class RequestDto(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
     id: str
     title: str
     description: str | None = None
@@ -69,6 +70,8 @@ class RequestDto(BaseModel):
     hq: bool | None = None
     quantity: int | None = None
     assignee_id: int | None = Field(default=None, alias="assigneeId")
+    created_by: str | None = Field(default=None, alias="createdBy")
+    created: datetime | None = None
 
 
 def _status(status: RequestStatus) -> str:
@@ -80,6 +83,15 @@ def _dto(req: DbRequest) -> dict[str, Any]:
     quantity = req.items[0].quantity if req.items else None
     hq = req.items[0].hq if req.items else None
     duty_id = req.runs[0].run_id if req.runs else None
+    created_by: str | None = None
+    requester = getattr(req, "requester", None)
+    if requester is not None:
+        created_by = (
+            requester.global_name
+            or requester.character_name
+            or (str(requester.discord_user_id) if requester.discord_user_id is not None else None)
+            or str(requester.id)
+        )
     dto = RequestDto(
         id=str(req.id),
         title=req.title,
@@ -93,6 +105,8 @@ def _dto(req: DbRequest) -> dict[str, Any]:
         hq=hq,
         quantity=quantity,
         assignee_id=req.assignee_id,
+        created_by=created_by,
+        created=req.created_at,
     )
     return dto.model_dump(mode="json", by_alias=True, exclude_none=True)
 
@@ -103,7 +117,11 @@ async def _load_request_with_children(
     result = await db.execute(
         select(DbRequest)
         .where(DbRequest.id == request_id)
-        .options(selectinload(DbRequest.items), selectinload(DbRequest.runs))
+        .options(
+            selectinload(DbRequest.items),
+            selectinload(DbRequest.runs),
+            selectinload(DbRequest.requester),
+        )
     )
     return result.scalars().one_or_none()
 
@@ -214,7 +232,11 @@ async def list_requests(
     result = await db.execute(
         select(DbRequest)
         .where(DbRequest.guild_id == ctx.guild.id)
-        .options(selectinload(DbRequest.items), selectinload(DbRequest.runs))
+        .options(
+            selectinload(DbRequest.items),
+            selectinload(DbRequest.runs),
+            selectinload(DbRequest.requester),
+        )
     )
     return [_dto(r) for r in result.scalars()]
 
@@ -231,7 +253,11 @@ async def list_request_deltas(
             DbRequest.guild_id == ctx.guild.id,
             DbRequest.updated_at > since,
         )
-        .options(selectinload(DbRequest.items), selectinload(DbRequest.runs))
+        .options(
+            selectinload(DbRequest.items),
+            selectinload(DbRequest.runs),
+            selectinload(DbRequest.requester),
+        )
     )
     deltas = [_dto(r) for r in result.scalars()]
     tombstones = await db.execute(
@@ -354,7 +380,11 @@ async def _update_status(
     result = await db.execute(
         select(DbRequest)
         .where(DbRequest.id == request_id)
-        .options(selectinload(DbRequest.items), selectinload(DbRequest.runs))
+        .options(
+            selectinload(DbRequest.items),
+            selectinload(DbRequest.runs),
+            selectinload(DbRequest.requester),
+        )
     )
     return result.scalars().one()
 

--- a/tests/test_requests_delta.py
+++ b/tests/test_requests_delta.py
@@ -2,6 +2,7 @@ import sys
 import types
 from pathlib import Path
 import asyncio
+from datetime import datetime
 
 root = Path(__file__).resolve().parents[1] / "demibot"
 sys.path.append(str(root))
@@ -97,7 +98,7 @@ async def _setup_db(db_path: str) -> None:
     await init_db(f"sqlite+aiosqlite:///{db_path}")
     async with get_session() as db:
         guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
-        user = User(id=1, discord_user_id=1)
+        user = User(id=1, discord_user_id=1, global_name="Test User")
         db.add_all([guild, user])
         await db.commit()
 
@@ -127,6 +128,7 @@ def test_requests_delta(db_setup):
             db.add(req)
             await db.commit()
             await db.refresh(req)
+            created_at = req.created_at
             ctx = RequestContext(user=user, guild=guild, key=SimpleNamespace(), roles=[])
             since = req.updated_at
             # no changes yet
@@ -139,14 +141,45 @@ def test_requests_delta(db_setup):
             # delete request
             await request_routes.delete_request(request_id=req.id, ctx=ctx, db=db)
             res3 = await request_routes.list_request_deltas(since=since2, ctx=ctx, db=db)
-            return res1, res2, res3
-    first, second, third = asyncio.run(run())
+            return res1, res2, res3, created_at
+    first, second, third, created_at = asyncio.run(run())
     assert first == []
     assert len(second) == 1
     assert second[0]["title"] == "Updated"
+    assert second[0]["createdBy"] == "Test User"
+    assert datetime.fromisoformat(second[0]["created"]) == created_at
     assert len(third) == 1
     assert third[0]["deleted"] is True
     assert third[0]["id"] == "1"
+
+
+def test_list_requests_includes_creator_fields(db_setup):
+    async def run():
+        async with get_session() as db:
+            guild = await db.get(Guild, 1)
+            user = await db.get(User, 1)
+            req = DbRequest(
+                id=2,
+                guild_id=guild.id,
+                user_id=user.id,
+                title="List Test",
+                type=RequestType.ITEM,
+                status=RequestStatus.OPEN,
+                urgency=Urgency.MEDIUM,
+            )
+            db.add(req)
+            await db.commit()
+            await db.refresh(req)
+            created_at = req.created_at
+            ctx = RequestContext(user=user, guild=guild, key=SimpleNamespace(), roles=[])
+            results = await request_routes.list_requests(ctx=ctx, db=db)
+            return results, created_at
+
+    results, created_at = asyncio.run(run())
+    assert len(results) == 1
+    payload = results[0]
+    assert payload["createdBy"] == "Test User"
+    assert datetime.fromisoformat(payload["created"]) == created_at
 
 
 def test_notify_posts_to_requests_channel_when_discord_guild_id_present(db_setup):


### PR DESCRIPTION
## Summary
- add creator name/timestamp fields to the request DTO and populate them from the requester record
- eagerly load the requester relationship for request fetches to avoid extra database round trips
- extend request list and delta tests to cover the new creator metadata

## Testing
- pytest tests/test_requests_delta.py

------
https://chatgpt.com/codex/tasks/task_e_68ddbb953438832889f346cab3c82df7