### PR TITLE
Fix unicode emoji migration dataset path lookup

### DIFF
--- a/demibot/demibot/db/migrations/versions/0041_add_unicode_emojis_table.py
+++ b/demibot/demibot/db/migrations/versions/0041_add_unicode_emojis_table.py
@@ -23,7 +23,21 @@ def upgrade() -> None:
         sa.Column("image_url", sa.String(length=255), nullable=False),
     )
 
-    data_path = Path(__file__).resolve().parents[2] / "data" / "unicode_emojis.json"
+    base_path = Path(__file__).resolve()
+    candidate_paths = [
+        base_path.parents[2] / "data" / "unicode_emojis.json",
+        base_path.parents[3] / "data" / "unicode_emojis.json",
+    ]
+
+    for data_path in candidate_paths:
+        if data_path.exists():
+            break
+    else:
+        raise FileNotFoundError(
+            "Unable to locate unicode_emojis.json. Checked: "
+            + ", ".join(str(path) for path in candidate_paths)
+        )
+
     with data_path.open("r", encoding="utf-8") as f:
         try:
             data = json.load(f)


### PR DESCRIPTION
## Summary
- allow the unicode emoji migration to look for its dataset in both the historical db/data path and the current demibot/data path
- raise a helpful error if the dataset is still missing after checking both locations

## Testing
- pytest tests/test_unicode_emojis.py::test_get_unicode_emojis *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68ddbea871d48328b1c4ab5140e59938