### PR TITLE
Ensure unicode emojis table uses utf8mb4 collation

### DIFF
--- a/demibot/demibot/db/migrations/versions/0041_add_unicode_emojis_table.py
+++ b/demibot/demibot/db/migrations/versions/0041_add_unicode_emojis_table.py
@@ -19,7 +19,11 @@ def _get_emoji_table() -> sa.Table:
     return sa.Table(
         "unicode_emojis",
         sa.MetaData(),
-        sa.Column("emoji", sa.String(length=16), primary_key=True),
+        sa.Column(
+            "emoji",
+            sa.String(length=16, collation="utf8mb4_bin"),
+            primary_key=True,
+        ),
         sa.Column("name", sa.String(length=255), nullable=False),
         sa.Column("image_url", sa.String(length=255), nullable=False),
     )
@@ -59,9 +63,22 @@ def upgrade() -> None:
     if not table_exists:
         op.create_table(
             "unicode_emojis",
-            sa.Column("emoji", sa.String(length=16), primary_key=True),
+            sa.Column(
+                "emoji",
+                sa.String(length=16, collation="utf8mb4_bin"),
+                primary_key=True,
+            ),
             sa.Column("name", sa.String(length=255), nullable=False),
             sa.Column("image_url", sa.String(length=255), nullable=False),
+            mysql_charset="utf8mb4",
+        )
+    elif bind.dialect.name == "mysql":
+        op.alter_column(
+            "unicode_emojis",
+            "emoji",
+            existing_type=sa.String(length=16),
+            type_=sa.String(length=16, collation="utf8mb4_bin"),
+            existing_nullable=False,
         )
 
     emoji_table = _get_emoji_table()
@@ -86,7 +103,7 @@ def upgrade() -> None:
         op.bulk_insert(
             table(
                 "unicode_emojis",
-                column("emoji", sa.String(length=16)),
+                column("emoji", sa.String(length=16, collation="utf8mb4_bin")),
                 column("name", sa.String(length=255)),
                 column("image_url", sa.String(length=255)),
             ),


### PR DESCRIPTION
## Summary
- ensure the unicode_emojis table definition uses utf8mb4_bin for the emoji column and utf8mb4 for the table charset
- alter existing unicode_emojis tables to utf8mb4_bin before reseeding to avoid duplicate key errors

## Testing
- not run (MySQL database unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddcae120908328bee8c12cda12de52