### PR TITLE
Ensure MySQL connections default to utf8mb4

### DIFF
--- a/demibot/demibot/config.py
+++ b/demibot/demibot/config.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import json
 import logging
 import getpass
-from urllib.parse import quote_plus
+from urllib.parse import parse_qsl, quote_plus, urlencode, urlparse, urlunparse
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -56,10 +56,18 @@ class DatabaseConfig:
     @property
     def url(self) -> str:
         cfg = self.active()
-        return (
+        base_url = (
             f"mysql+aiomysql://{quote_plus(cfg.user)}:{quote_plus(cfg.password)}"
             f"@{cfg.host}:{cfg.port}/{cfg.database}"
         )
+
+        parsed = urlparse(base_url)
+        query_params = parse_qsl(parsed.query, keep_blank_values=True)
+        if not any(key.lower() == "charset" for key, _ in query_params):
+            query_params.append(("charset", "utf8mb4"))
+
+        new_query = urlencode(query_params, doseq=True)
+        return urlunparse(parsed._replace(query=new_query))
 
 
 @dataclass

--- a/demibot/demibot/db/migrations/env.py
+++ b/demibot/demibot/db/migrations/env.py
@@ -104,7 +104,7 @@ else:
         os.getenv("DEMIBOT_DATABASE_URL")
         or os.getenv("DATABASE_URL")
         or config.get_main_option("sqlalchemy.url")
-        or "mysql+pymysql://demibot:Admin@127.0.0.1:3306/demibot"
+        or "mysql+pymysql://demibot:Admin@127.0.0.1:3306/demibot?charset=utf8mb4"
     )
 
 norm_url = _normalize_sqlalchemy_url(chosen)

--- a/demibot/scripts/first_run_wizard.py
+++ b/demibot/scripts/first_run_wizard.py
@@ -7,7 +7,9 @@ from demibot.config import CONFIG_PATH, AppConfig, DatabaseConfig, DiscordConfig
 
 def run_wizard() -> None:
     token = input("Discord bot token: ")
-    db_url = input("Database URL [mysql+aiomysql://demibot:Admin@127.0.0.1:3306/demibot]: ") or "mysql+aiomysql://demibot:Admin@127.0.0.1:3306/demibot"
+    db_url = input(
+        "Database URL [mysql+aiomysql://demibot:Admin@127.0.0.1:3306/demibot?charset=utf8mb4]: "
+    ) or "mysql+aiomysql://demibot:Admin@127.0.0.1:3306/demibot?charset=utf8mb4"
     host = input("HTTP host [127.0.0.1]: ") or "127.0.0.1"
     port = int(input("HTTP port [8123]: ") or "8123")
 

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -78,8 +78,8 @@ if [ ! -d .venv ]; then
 fi
 # shellcheck disable=SC1091
 source .venv/bin/activate
-: "${DEMIBOT_FORCED_URL:=mysql+pymysql://demibot:Admin@127.0.0.1:3306/demibot}"
-: "${DEMIBOT_DATABASE_URL:=mysql+aiomysql://demibot:Admin@127.0.0.1:3306/demibot}"
+: "${DEMIBOT_FORCED_URL:=mysql+pymysql://demibot:Admin@127.0.0.1:3306/demibot?charset=utf8mb4}"
+: "${DEMIBOT_DATABASE_URL:=mysql+aiomysql://demibot:Admin@127.0.0.1:3306/demibot?charset=utf8mb4}"
 export DEMIBOT_FORCED_URL DEMIBOT_DATABASE_URL
 pip install --upgrade pip
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,6 +4,20 @@ import pytest
 from sqlalchemy.ext.asyncio import create_async_engine
 
 
+def _bootstrap_demibot_package() -> None:
+    import sys
+    import types
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1] / "demibot"
+    if str(root) not in sys.path:
+        sys.path.append(str(root))
+    if "demibot" not in sys.modules:
+        demibot_pkg = types.ModuleType("demibot")
+        demibot_pkg.__path__ = [str(root / "demibot")]
+        sys.modules["demibot"] = demibot_pkg
+
+
 @pytest.mark.integration
 def test_password_with_special_chars() -> None:
     """Engine parses credentials with special characters."""
@@ -18,17 +32,19 @@ def test_password_with_special_chars() -> None:
 
 def test_sync_url_converts_aiomysql() -> None:
     """_sync_url converts aiomysql driver to a synchronous equivalent."""
-    import sys
-    import types
-    from pathlib import Path
-
-    root = Path(__file__).resolve().parents[1] / "demibot"
-    sys.path.append(str(root))
-    demibot_pkg = types.ModuleType("demibot")
-    demibot_pkg.__path__ = [str(root / "demibot")]
-    sys.modules.setdefault("demibot", demibot_pkg)
+    _bootstrap_demibot_package()
 
     from demibot.db.session import _sync_url
 
     url = "mysql+aiomysql://user:pass@127.0.0.1/test"
     assert _sync_url(url) == "mysql+pymysql://user:***@127.0.0.1/test"
+
+
+def test_database_config_appends_utf8mb4_charset() -> None:
+    """DatabaseConfig.url always ensures utf8mb4 charset."""
+    _bootstrap_demibot_package()
+
+    from demibot.config import DatabaseConfig
+
+    cfg = DatabaseConfig()
+    assert cfg.url.endswith("?charset=utf8mb4")


### PR DESCRIPTION
## Summary
- ensure DatabaseConfig always appends `charset=utf8mb4` to generated MySQL URLs
- propagate the utf8mb4 charset to Alembic defaults and setup helpers so migrations reuse the same encoding
- add a regression test covering the new DatabaseConfig behaviour

## Testing
- pytest tests/test_session.py -k charset -q *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68ddf47c328c8328a984035cda13c91d