### PR TITLE
Bump DemiCat plugin metadata to 13.0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 - Added API tests covering Discord emoji warm-up responses and cached emoji listings.
 - Added officer message endpoint test ensuring unresolved channels return HTTP 409 with structured error details.
+- Updated plugin metadata to version 13.0.0.1.

--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -11,9 +11,9 @@
     <RootNamespace>DemiCatPlugin</RootNamespace>
 
     <!-- Keep these in sync with manifest -->
-    <Version>1.2.2.2</Version>
-    <AssemblyVersion>1.2.2.2</AssemblyVersion>
-    <FileVersion>1.2.2.2</FileVersion>
+    <Version>13.0.0.1</Version>
+    <AssemblyVersion>13.0.0.1</AssemblyVersion>
+    <FileVersion>13.0.0.1</FileVersion>
 
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>

--- a/DemiCatPlugin/DemiCatPlugin.json
+++ b/DemiCatPlugin/DemiCatPlugin.json
@@ -2,7 +2,7 @@
   "Author": "Demi Dev Studio",
   "Name": "DemiCat",
   "InternalName": "DemiCatPlugin",
-  "AssemblyVersion": "1.2.2.2",
+  "AssemblyVersion": "13.0.0.1",
   "Description": "DemiCat Dalamud plugin. =Mew=",
   "ApplicableVersion": "any",
   "RepoUrl": "https://github.com/jackandcarter/DemiCat",

--- a/repo.json
+++ b/repo.json
@@ -5,7 +5,7 @@
     "InternalName": "DemiCatPlugin",
     "Punchline": "Discord-linked FC tools and chat.",
     "Description": "A mod to manage Discord FC communities and Events.",
-    "AssemblyVersion": "1.2.2.2",
+    "AssemblyVersion": "13.0.0.1",
     "ApplicableVersion": "any",
     "DalamudApiLevel": 13,
     "RepoUrl": "https://github.com/jackandcarter/DemiCat",


### PR DESCRIPTION
## Summary
- bump the plugin project version metadata to 13.0.0.1
- synchronize the Dalamud manifest and repo manifest assembly versions
- document the version bump in the changelog

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df0d62bd5c832885896f3443369f3f