### PR TITLE
Normalize custom emoji tokens across chat surfaces

### DIFF
--- a/DemiCatPlugin/BridgeMessageFormatter.cs
+++ b/DemiCatPlugin/BridgeMessageFormatter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using DiscordHelper;
+using DemiCatPlugin.Emoji;
 
 namespace DemiCatPlugin;
 
@@ -33,6 +34,7 @@ public static class BridgeMessageFormatter
         public uint? EmbedColor { get; init; }
         public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
         public Config.EmbedBorderSettings? EmbedBorder { get; init; }
+        public EmojiManager? EmojiManager { get; init; }
     }
 
     public sealed class BridgeFormattedAttachment
@@ -74,6 +76,7 @@ public static class BridgeMessageFormatter
         var content = resolution.Content;
         var displayContent = ChatWindow.ReplaceMentionTokens(content, resolution.Mentions);
         displayContent = displayContent.Replace("@\u200B", "@");
+        displayContent = EmojiFormatter.NormalizeCustomTokens(options.EmojiManager, displayContent);
 
         var warnings = new List<string>();
         var errors = new List<string>();

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1523,6 +1523,7 @@ public class ChatWindow : IDisposable
         var text = msg.Content ?? string.Empty;
         text = ReplaceMentionTokens(text, msg.Mentions);
         text = MarkdownFormatter.Format(text);
+        text = EmojiFormatter.NormalizeCustomTokens(_emojiManager, text);
         var parts = Regex.Split(text, "(<a?:[a-zA-Z0-9_]+:\\d+>)");
         ImGui.PushTextWrapPos();
         var first = true;
@@ -2667,7 +2668,8 @@ public class ChatWindow : IDisposable
             WorldName = worldName,
             EmbedColor = GetEmbedColorOverride(),
             EmbedBorder = _config.GetEmbedBorderSettingsCopy(_channelKind),
-            Timestamp = DateTimeOffset.UtcNow
+            Timestamp = DateTimeOffset.UtcNow,
+            EmojiManager = _emojiManager
         };
     }
 

--- a/DemiCatPlugin/Emoji/EmojiFormatter.cs
+++ b/DemiCatPlugin/Emoji/EmojiFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 
 namespace DemiCatPlugin.Emoji;
 
@@ -6,6 +7,7 @@ public static class EmojiFormatter
 {
     public const string CustomPrefix = "custom:";
     private const string DefaultCustomName = "emoji";
+    private static readonly Regex CustomTokenPattern = new($"{CustomPrefix}[0-9]+", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     public static string CreateUnicodeToken(UnicodeEmoji emoji) => CreateUnicodeToken(emoji.Emoji);
 
@@ -14,6 +16,21 @@ public static class EmojiFormatter
     public static string CreateCustomToken(CustomEmoji emoji) => CreateCustomToken(emoji.Id);
 
     public static string CreateCustomToken(string id) => string.Concat(CustomPrefix, id);
+
+    public static string NormalizeCustomTokens(EmojiManager? manager, string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        if (!CustomTokenPattern.IsMatch(text))
+        {
+            return text;
+        }
+
+        return CustomTokenPattern.Replace(text, match => NormalizeCustomToken(manager, match.Value));
+    }
 
     public static bool TryParseCustomToken(string value, out string id)
         => TryParseCustomToken(value, out id, out _, out _);
@@ -69,6 +86,28 @@ public static class EmojiFormatter
         {
             var prefix = animated ? "<a:" : "<:";
             return $"{prefix}{name}:{id}>";
+        }
+
+        return $"<:{DefaultCustomName}:{id}>";
+    }
+
+    private static string NormalizeCustomToken(EmojiManager? manager, string token)
+    {
+        if (!TryParseCustomToken(token, out var id, out var fallbackName, out var animated))
+        {
+            return token;
+        }
+
+        if (manager != null && manager.TryGetCustomEmoji(id, out var emoji) && emoji != null)
+        {
+            var prefix = emoji.Animated ? "<a:" : "<:";
+            return $"{prefix}{emoji.Name}:{emoji.Id}>";
+        }
+
+        if (!string.IsNullOrEmpty(fallbackName))
+        {
+            var prefix = animated ? "<a:" : "<:";
+            return $"{prefix}{fallbackName}:{id}>";
         }
 
         return $"<:{DefaultCustomName}:{id}>";

--- a/tests/BridgeMessageFormatterTests.cs
+++ b/tests/BridgeMessageFormatterTests.cs
@@ -1,13 +1,20 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using DemiCatPlugin;
+using DemiCatPlugin.Emoji;
 using Xunit;
 
 public class BridgeMessageFormatterTests
 {
     private static readonly DateTimeOffset FixedTimestamp = new(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
 
-    private static BridgeMessageFormatter.BridgeFormatterOptions CreateOptions()
+    private static BridgeMessageFormatter.BridgeFormatterOptions CreateOptions(EmojiManager? manager = null)
         => new()
         {
             UseCharacterName = false,
@@ -18,7 +25,8 @@ public class BridgeMessageFormatterTests
             AuthorName = "You",
             CharacterName = "Tester",
             WorldName = "World",
-            EmbedBorder = Config.EmbedBorderSettings.CreateDefault(ChannelKind.FcChat)
+            EmbedBorder = Config.EmbedBorderSettings.CreateDefault(ChannelKind.FcChat),
+            EmojiManager = manager
         };
 
     [Fact]
@@ -116,5 +124,38 @@ public class BridgeMessageFormatterTests
         Assert.Equal(input, embed.Description);
         Assert.Equal(input, result.DisplayContent);
         Assert.Contains(result.Warnings, w => w.Contains("border", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Format_NormalizesCustomEmojiDisplayContent()
+    {
+        using var manager = CreateEmojiManager();
+        var options = CreateOptions(manager);
+
+        var result = BridgeMessageFormatter.Format("Hello custom:42", Array.Empty<string>(), options);
+
+        Assert.Equal("Hello <:party:42>", result.DisplayContent);
+    }
+
+    private static EmojiManager CreateEmojiManager()
+    {
+        var handler = new NullHandler();
+        var client = new HttpClient(handler);
+        var manager = new EmojiManager(client, new TokenManager(), new Config());
+
+        var lookupField = typeof(EmojiManager).GetField("_customLookup", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var customField = typeof(EmojiManager).GetField("_custom", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var emoji = new CustomEmoji("42", "party", false, "http://image");
+        var lookup = new Dictionary<string, CustomEmoji>(StringComparer.Ordinal) { ["42"] = emoji };
+        lookupField.SetValue(manager, lookup);
+        customField.SetValue(manager, new[] { emoji });
+
+        return manager;
+    }
+
+    private sealed class NullHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
     }
 }

--- a/tests/EmojiPopupGuildTests.cs
+++ b/tests/EmojiPopupGuildTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -143,5 +144,37 @@ public class EmojiFormatterTests
         var normalized = EmojiFormatter.Normalize(manager, token);
 
         Assert.Equal(token, normalized);
+    }
+
+    [Fact]
+    public void NormalizeCustomTokensUsesLookupWhenAvailable()
+    {
+        SetupPluginServices();
+        using var client = new HttpClient(new StubHandler(HttpStatusCode.OK, "[]"));
+        var config = new Config { ApiBaseUrl = "http://host", GuildId = "1" };
+        using var manager = new EmojiManager(client, new TokenManager(), config);
+
+        var lookupField = typeof(EmojiManager).GetField("_customLookup", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var customField = typeof(EmojiManager).GetField("_custom", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var emoji = new CustomEmoji("77", "sparkles", false, "http://image");
+        lookupField.SetValue(manager, new Dictionary<string, CustomEmoji>(StringComparer.Ordinal) { ["77"] = emoji });
+        customField.SetValue(manager, new[] { emoji });
+
+        var normalized = EmojiFormatter.NormalizeCustomTokens(manager, "Say custom:77!");
+
+        Assert.Equal("Say <:sparkles:77>!", normalized);
+    }
+
+    [Fact]
+    public void NormalizeCustomTokensFallsBackWithoutLookup()
+    {
+        SetupPluginServices();
+        using var client = new HttpClient(new StubHandler(HttpStatusCode.OK, "[]"));
+        var config = new Config { ApiBaseUrl = "http://host", GuildId = "1" };
+        using var manager = new EmojiManager(client, new TokenManager(), config);
+
+        var normalized = EmojiFormatter.NormalizeCustomTokens(manager, "custom:88 testing");
+
+        Assert.Equal("<:emoji:88> testing", normalized);
     }
 }


### PR DESCRIPTION
## Summary
- add an EmojiFormatter helper that rewrites custom emoji tokens into Discord markup
- run the helper when rendering chat content and when building bridge message previews
- expose the EmojiManager through bridge formatting options and expand tests to cover normalization

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df0d7ea38c8328b820f8fa5aa54e2a