### PR TITLE
Add configurable dock gradient background

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -18,6 +18,8 @@ public class Config : IPluginConfiguration
     public static readonly Vector4 DefaultPrimaryWindowColor = new(0.11f, 0.11f, 0.12f, 1f);
     public static readonly Vector4 DefaultSecondaryAccentColor = new(0.2f, 0.6f, 1f, 1f);
     public static readonly Vector4 DefaultDockBackgroundColor = new(0.11f, 0.11f, 0.12f, 0.9f);
+    public static readonly Vector4 DefaultDockGradientTopColor = new(0.16f, 0.16f, 0.17f, 0.9f);
+    public static readonly Vector4 DefaultDockGradientBottomColor = new(0.08f, 0.08f, 0.09f, 0.9f);
 
     public static class FadePreferenceKeys
     {
@@ -39,7 +41,7 @@ public class Config : IPluginConfiguration
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
     public const string DefaultEmbedBorderGlyph = "⬛";
-    public const int CurrentVersion = 22;
+    public const int CurrentVersion = 23;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -115,6 +117,15 @@ public class Config : IPluginConfiguration
 
     [JsonPropertyName("dockBackgroundColor")]
     public Vector4 DockBackgroundColor { get; set; } = DefaultDockBackgroundColor;
+
+    [JsonPropertyName("dockGradientEnabled")]
+    public bool DockGradientEnabled { get; set; }
+
+    [JsonPropertyName("dockGradientTopColor")]
+    public Vector4 DockGradientTopColor { get; set; } = DefaultDockGradientTopColor;
+
+    [JsonPropertyName("dockGradientBottomColor")]
+    public Vector4 DockGradientBottomColor { get; set; } = DefaultDockGradientBottomColor;
 
     [JsonPropertyName("dockPosition")]
     public Vector2 DockPosition { get; set; } = Vector2.Zero;
@@ -659,6 +670,15 @@ public class Config : IPluginConfiguration
             Version = 22;
             ExtensionData = null;
         }
+        if (Version < 23)
+        {
+            DockGradientTopColor = SanitizeDockGradientColor(DockGradientTopColor);
+            DockGradientBottomColor = SanitizeDockGradientColor(DockGradientBottomColor);
+            DockGradientEnabled = false;
+
+            Version = 23;
+            ExtensionData = null;
+        }
     }
 
     public static uint GetDefaultEmbedColor(string? channelKind)
@@ -872,4 +892,7 @@ public class Config : IPluginConfiguration
         sanitized.W = Math.Clamp(sanitized.W, 0.1f, 1f);
         return sanitized;
     }
+
+    internal static Vector4 SanitizeDockGradientColor(Vector4 color)
+        => SanitizeDockBackgroundColor(color);
 }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -320,7 +320,7 @@ public class MainWindow : IDisposable
         var open = true;
         if (ImGui.Begin(DockWindowTitle, ref open, windowFlags))
         {
-            _ = DrawDockStrip(visibleFeatures, settingsItem, iconSize, spacing, separatorThickness, indicatorHeight, accentColor);
+            _ = DrawDockStrip(visibleFeatures, settingsItem, iconSize, spacing, separatorThickness, indicatorHeight, accentColor, dockBgColor);
             DrawDockContextMenu();
         }
         var windowPos = ImGui.GetWindowPos();
@@ -426,7 +426,8 @@ public class MainWindow : IDisposable
         float spacing,
         float separatorThickness,
         float indicatorHeight,
-        Vector4 accentColor)
+        Vector4 accentColor,
+        Vector4 dockBackgroundColor)
     {
         var drawList = ImGui.GetWindowDrawList();
         var iconStart = ImGui.GetCursorScreenPos();
@@ -457,6 +458,17 @@ public class MainWindow : IDisposable
         var stripMax = iconStart + iconAreaSize + new Vector2(spacing * 0.75f, indicatorHeight + spacing * 0.75f);
         var borderThickness = MathF.Max(1f, spacing * 0.15f);
         var rounding = MathF.Max(spacing * 2f, 18f);
+        if (_config.DockGradientEnabled)
+        {
+            var (gradientTop, gradientBottom) = GetDockGradientColors();
+            var topColor = ImGui.ColorConvertFloat4ToU32(gradientTop);
+            var bottomColor = ImGui.ColorConvertFloat4ToU32(gradientBottom);
+            drawList.AddRectFilledMultiColor(stripMin, stripMax, topColor, topColor, bottomColor, bottomColor);
+        }
+        else
+        {
+            drawList.AddRectFilled(stripMin, stripMax, ImGui.ColorConvertFloat4ToU32(dockBackgroundColor), rounding);
+        }
         drawList.AddRect(stripMin, stripMax, ImGui.ColorConvertFloat4ToU32(accentColor), rounding, ImDrawFlags.None, borderThickness);
 
         ImGui.SetCursorScreenPos(iconStart);
@@ -748,6 +760,32 @@ public class MainWindow : IDisposable
         }
 
         return sanitized;
+    }
+
+    private (Vector4 Top, Vector4 Bottom) GetDockGradientColors()
+    {
+        var top = Config.SanitizeDockGradientColor(_config.DockGradientTopColor);
+        var bottom = Config.SanitizeDockGradientColor(_config.DockGradientBottomColor);
+        var changed = false;
+
+        if (!ColorsAlmostEqual(top, _config.DockGradientTopColor))
+        {
+            _config.DockGradientTopColor = top;
+            changed = true;
+        }
+
+        if (!ColorsAlmostEqual(bottom, _config.DockGradientBottomColor))
+        {
+            _config.DockGradientBottomColor = bottom;
+            changed = true;
+        }
+
+        if (changed)
+        {
+            SaveConfig();
+        }
+
+        return (top, bottom);
     }
 
     private static bool ColorsAlmostEqual(Vector4 a, Vector4 b)

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -509,7 +509,8 @@ public class SettingsWindow : IDisposable
         }
 
         var dockColor = _config.DockBackgroundColor;
-        if (ImGui.ColorEdit4("Dock background color", ref dockColor, ImGuiColorEditFlags.AlphaBar | ImGuiColorEditFlags.AlphaPreviewHalf))
+        var colorEditFlags = ImGuiColorEditFlags.AlphaBar | ImGuiColorEditFlags.AlphaPreviewHalf;
+        if (ImGui.ColorEdit4("Dock background color", ref dockColor, colorEditFlags))
         {
             var sanitized = Config.SanitizeDockBackgroundColor(dockColor);
             if (!ColorsAlmostEqual(sanitized, _config.DockBackgroundColor))
@@ -519,6 +520,49 @@ public class SettingsWindow : IDisposable
                 SaveConfig();
                 MainWindow?.OnAppearanceSettingsChanged();
             }
+        }
+
+        var gradientEnabled = _config.DockGradientEnabled;
+        if (ImGui.Checkbox("Enable dock gradient", ref gradientEnabled))
+        {
+            _config.DockGradientEnabled = gradientEnabled;
+            SaveConfig();
+            MainWindow?.OnAppearanceSettingsChanged();
+        }
+
+        var shouldDisableGradientOptions = !gradientEnabled;
+        if (shouldDisableGradientOptions)
+        {
+            ImGui.BeginDisabled();
+        }
+
+        var gradientTop = _config.DockGradientTopColor;
+        if (ImGui.ColorEdit4("Gradient top color", ref gradientTop, colorEditFlags))
+        {
+            var sanitized = Config.SanitizeDockGradientColor(gradientTop);
+            if (!ColorsAlmostEqual(sanitized, _config.DockGradientTopColor))
+            {
+                _config.DockGradientTopColor = sanitized;
+                SaveConfig();
+                MainWindow?.OnAppearanceSettingsChanged();
+            }
+        }
+
+        var gradientBottom = _config.DockGradientBottomColor;
+        if (ImGui.ColorEdit4("Gradient bottom color", ref gradientBottom, colorEditFlags))
+        {
+            var sanitized = Config.SanitizeDockGradientColor(gradientBottom);
+            if (!ColorsAlmostEqual(sanitized, _config.DockGradientBottomColor))
+            {
+                _config.DockGradientBottomColor = sanitized;
+                SaveConfig();
+                MainWindow?.OnAppearanceSettingsChanged();
+            }
+        }
+
+        if (shouldDisableGradientOptions)
+        {
+            ImGui.EndDisabled();
         }
 
         ImGui.Spacing();


### PR DESCRIPTION
## Summary
- add dock gradient configuration defaults, sanitizers, and migration support
- expose gradient enablement and color pickers in the settings appearance section
- render the dock background with a vertical gradient when enabled, falling back to the solid color otherwise

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df11ee82cc8328b905bdd404dfd17e