### PR TITLE
Fix missing ImGui.NET reference for DemiCatPlugin

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -32,6 +32,9 @@
     <Reference Include="Lumina.Excel.GeneratedSheets" Condition="Exists('$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll')">
       <HintPath>$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll</HintPath>
     </Reference>
+    <Reference Include="ImGui.NET">
+      <HintPath>$(DalamudLibPath)/ImGui.NET.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <PropertyGroup Condition="Exists('$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll')">


### PR DESCRIPTION
## Summary
- add the Dalamud-provided ImGui.NET assembly as a reference for the plugin project to restore ImGui symbols at build time

## Testing
- dotnet build (fails: command not found in container)


------
https://chatgpt.com/codex/tasks/task_e_68df13ca389c8328b906f5695cac9fc9