### PR TITLE
Fix missing ImGui.NET reference for DemiCatPlugin

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -32,6 +32,10 @@
     <Reference Include="Lumina.Excel.GeneratedSheets" Condition="Exists('$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll')">
       <HintPath>$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll</HintPath>
     </Reference>
+    <Reference Include="ImGui.NET" Condition="Exists('$(DalamudLibPath)/ImGui.NET.dll')">
+      <HintPath>$(DalamudLibPath)/ImGui.NET.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 
   <PropertyGroup Condition="Exists('$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll')">


### PR DESCRIPTION
## Summary
- ensure DemiCatPlugin explicitly references the Dalamud-provided ImGui.NET assembly
- guard the reference behind an existence check and mark it as non-private so it is resolved from Dalamud's runtime

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68df13ca389c8328b906f5695cac9fc9