### PR TITLE
Add fallback ImGui.NET reference for standalone builds

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -25,6 +25,10 @@
     <PackageReference Include="Glamourer.Api" Version="2.6.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="!Exists('$(DalamudLibPath)/ImGui.NET.dll')">
+    <PackageReference Include="ImGui.NET" Version="1.90.8.1" />
+  </ItemGroup>
+
   <ItemGroup>
     <Reference Include="Lumina.Excel">
       <HintPath>$(DalamudLibPath)/Lumina.Excel.dll</HintPath>
@@ -32,10 +36,8 @@
     <Reference Include="Lumina.Excel.GeneratedSheets" Condition="Exists('$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll')">
       <HintPath>$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll</HintPath>
     </Reference>
-
-    <Reference Include="ImGui.NET">
+    <Reference Include="ImGui.NET" Condition="Exists('$(DalamudLibPath)/ImGui.NET.dll')">
       <HintPath>$(DalamudLibPath)/ImGui.NET.dll</HintPath>
-
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add a conditional package reference to ImGui.NET when Dalamud libraries are unavailable
- guard the existing direct assembly reference so it is only used when the dll is present

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release *(fails: dotnet is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df330d96f48328a6ce5baaac7595f5