### PR TITLE
Remove ImGuiNET directive from MainWindow

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -9,7 +9,6 @@ using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.TextureWraps;
 using DemiCatPlugin.Emoji;
 using Dalamud.Plugin.Services;
-using ImGuiNET;
 
 namespace DemiCatPlugin;
 


### PR DESCRIPTION
## Summary
- remove the ImGuiNET using directive from MainWindow so the class exclusively relies on Dalamud.Bindings.ImGui

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df35b1babc8328bc9edca0fe1ed08e