### PR TITLE
Ensure event previews use default embed color fallback

### DIFF
--- a/DemiCatPlugin/EventPreviewFormatter.cs
+++ b/DemiCatPlugin/EventPreviewFormatter.cs
@@ -74,6 +74,8 @@ public static class EventPreviewFormatter
 
         var footer = NormalizeFooter(creatorLabel);
 
+        var embedColor = color ?? Config.GetDefaultEmbedColor(null);
+
         var embed = new EmbedDto
         {
             Id = string.IsNullOrWhiteSpace(embedId) ? "preview" : embedId!,
@@ -82,7 +84,7 @@ public static class EventPreviewFormatter
             Url = string.IsNullOrWhiteSpace(url) ? null : url,
             ImageUrl = string.IsNullOrWhiteSpace(imageUrl) ? null : imageUrl,
             ThumbnailUrl = string.IsNullOrWhiteSpace(thumbnailUrl) ? null : thumbnailUrl,
-            Color = color,
+            Color = embedColor,
             Timestamp = timestamp,
             Fields = fieldList.Count > 0 ? fieldList : null,
             Buttons = buttonList.Count > 0 ? buttonList : null,

--- a/tests/EventPreviewFormatterTests.cs
+++ b/tests/EventPreviewFormatterTests.cs
@@ -166,6 +166,26 @@ public class EventPreviewFormatterTests
             });
     }
 
+    [Fact]
+    public void NullColorFallsBackToDefault()
+    {
+        var result = EventPreviewFormatter.Build(
+            "Fallback Color",
+            "Uses default when null",
+            Timestamp,
+            null,
+            null,
+            null,
+            null,
+            Enumerable.Empty<EmbedFieldDto>(),
+            Enumerable.Empty<EmbedButtonDto>(),
+            Enumerable.Empty<ulong>(),
+            creatorLabel: FcCreatorLabel,
+            embedId: "fallback-color-preview");
+
+        Assert.Equal(Config.GetDefaultEmbedColor(null), result.Embed.Color);
+    }
+
     private static void AssertPreviewMatches(JsonElement expected, EventPreviewFormatter.Result actual)
     {
         Assert.Equal(expected.GetProperty("content").GetString(), actual.Content);


### PR DESCRIPTION
## Summary
- ensure event preview embeds apply the configured default color when no explicit color is provided
- add a unit test covering the default color fallback behavior

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc41550848328aa9413e913987968