### PR TITLE
Ensure NotePad window refreshes selection after tab switch

### DIFF
--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -70,13 +70,14 @@ public sealed class NotePadWindow : IDisposable
 
         var sections = _service.Sections;
         EnsureSectionSelection(sections);
+
+        DrawSectionTabs(sections);
+
         var selectedSection = sections.FirstOrDefault(s => string.Equals(s.Id, _selectedSectionId, StringComparison.Ordinal));
         EnsurePageSelection(selectedSection);
         var selectedPage = selectedSection?.Pages.FirstOrDefault(p => string.Equals(p.Id, _selectedPageId, StringComparison.Ordinal));
 
         DrawConflictModal(selectedPage);
-
-        DrawSectionTabs(sections);
         ImGui.Separator();
 
         var region = ImGui.GetContentRegionAvail();


### PR DESCRIPTION
## Summary
- recompute the active section and page immediately after rendering the section tabs
- ensure page list, editor, and reorder logic use the refreshed selections so tab switches update in the same frame

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfc954ad1883288a4d50c23b183c7b