### PR TITLE
Update emoji glyph range to cover emoji plane

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -400,8 +400,7 @@ public class Plugin : IDalamudPlugin
                     var glyphRanges = default(FluentGlyphRangeBuilder)
                         .With(0x2000, 0x27FF) // general punctuation, arrows, dingbats, enclosed & geometric symbols
                         .With(0x2B00, 0x2BFF) // misc symbols and arrows (e.g. stars, triangles)
-                        .With(0xD83C, 0xD83E) // high-surrogates covering U+1F000-U+1FAFF
-                        .With(0xDC00, 0xDFFF) // low-surrogates for the same range
+                        .With(0x1F000, 0x1FAFF) // primary emoji blocks (U+1F000-U+1FAFF)
                         .With(0x200D, 0x200D) // zero width joiner for multi-glyph emoji sequences
                         .With(0x20E3, 0x20E3) // combining enclosing keycap used by keycap emoji
                         .With(0xFE0E, 0xFE0F) // text & emoji presentation selectors


### PR DESCRIPTION
## Summary
- replace the surrogate pair glyph ranges with the direct Unicode emoji block when loading the emoji font

## Testing
- dotnet build *(fails: `dotnet` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e018b04d148328a1450685709e939e