### PR TITLE
Bump plugin version to 13.0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## Unreleased
 - Added API tests covering Discord emoji warm-up responses and cached emoji listings.
 - Added officer message endpoint test ensuring unresolved channels return HTTP 409 with structured error details.
-- Updated plugin metadata to version 13.0.0.1.
+- Released version 13.0.0.5 aligning plugin metadata across manifests.

--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -11,9 +11,9 @@
     <RootNamespace>DemiCatPlugin</RootNamespace>
 
     <!-- Keep these in sync with manifest -->
-    <Version>13.0.0.1</Version>
-    <AssemblyVersion>13.0.0.1</AssemblyVersion>
-    <FileVersion>13.0.0.1</FileVersion>
+    <Version>13.0.0.5</Version>
+    <AssemblyVersion>13.0.0.5</AssemblyVersion>
+    <FileVersion>13.0.0.5</FileVersion>
 
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>

--- a/DemiCatPlugin/DemiCatPlugin.json
+++ b/DemiCatPlugin/DemiCatPlugin.json
@@ -2,7 +2,7 @@
   "Author": "Demi Dev Studio",
   "Name": "DemiCat",
   "InternalName": "DemiCatPlugin",
-  "AssemblyVersion": "13.0.0.1",
+  "AssemblyVersion": "13.0.0.5",
   "Description": "DemiCat Dalamud plugin. =Mew=",
   "ApplicableVersion": "any",
   "RepoUrl": "https://github.com/jackandcarter/DemiCat",

--- a/repo.json
+++ b/repo.json
@@ -5,7 +5,7 @@
     "InternalName": "DemiCatPlugin",
     "Punchline": "Discord-linked FC tools and chat.",
     "Description": "A mod to manage Discord FC communities and Events.",
-    "AssemblyVersion": "13.0.0.1",
+    "AssemblyVersion": "13.0.0.5",
     "ApplicableVersion": "any",
     "DalamudApiLevel": 13,
     "RepoUrl": "https://github.com/jackandcarter/DemiCat",


### PR DESCRIPTION
## Summary
- update DemiCat plugin project and manifest metadata to version 13.0.0.5
- sync repository manifest entry and changelog note with the new release number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e049bf37d88328b8230feb27a5956e