### PR TITLE
Update plugin icon URL to CDN

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.json
+++ b/DemiCatPlugin/DemiCatPlugin.json
@@ -11,7 +11,7 @@
   "LoadSync": false,
   "CanUnloadAsync": false,
   "LoadPriority": 0,
-  "IconUrl": "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/DemiCatPlugin/icon.png",
+  "IconUrl": "https://the-demiurge.com/icon.png",
   "Punchline": "Discord-linked FC tools and chat.",
   "AcceptsFeedback": true
 }

--- a/repo.json
+++ b/repo.json
@@ -9,6 +9,6 @@
     "ApplicableVersion": "any",
     "DalamudApiLevel": 13,
     "RepoUrl": "https://github.com/jackandcarter/DemiCat",
-    "IconUrl": "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/DemiCatPlugin/icon.png"
+    "IconUrl": "https://the-demiurge.com/icon.png"
   }
 ]


### PR DESCRIPTION
## Summary
- point the plugin manifest icon URL to https://the-demiurge.com/icon.png
- update the repository manifest to use the same CDN-backed icon URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04a9f2cf483288ec3300918bfc198