### PR TITLE
Update settings icon path to Dock directory

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -861,7 +861,7 @@ public class MainWindow : IDisposable
 
         if (_settingsIconTexture == null)
         {
-            var settingsIconPath = Path.Combine(pluginDirectory.FullName, "settingscog.png");
+            var settingsIconPath = Path.Combine(dockDirectory, "settingscog.png");
             _settingsIconTexture = TryLoadTextureFromFile(provider, settingsIconPath);
         }
     }


### PR DESCRIPTION
## Summary
- load the settings icon from the Dock asset directory so it aligns with other dock textures
- rely on the existing project configuration that packages Dock assets to keep settingscog.png in the plugin bundle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04bc19ee0832893317ba2b82248f9