### PR TITLE
Dispose HttpResponseMessage instances in ChannelService

### DIFF
--- a/DemiCatPlugin/ChannelService.cs
+++ b/DemiCatPlugin/ChannelService.cs
@@ -39,7 +39,7 @@ public class ChannelService
             linkedCts.CancelAfter(TimeSpan.FromSeconds(10));
             try
             {
-                var response = await _httpClient.SendAsync(request, linkedCts.Token);
+                using var response = await _httpClient.SendAsync(request, linkedCts.Token);
                 response.EnsureSuccessStatusCode();
                 var stream = await response.Content.ReadAsStreamAsync(linkedCts.Token);
                 var channels = await JsonSerializer.DeserializeAsync<List<ChannelDto>>(stream, JsonOpts, linkedCts.Token) ?? new List<ChannelDto>();
@@ -91,7 +91,7 @@ public class ChannelService
 
         try
         {
-            var response = await _httpClient.SendAsync(request, linkedCts.Token);
+            using var response = await _httpClient.SendAsync(request, linkedCts.Token);
             response.EnsureSuccessStatusCode();
 
             var stream = await response.Content.ReadAsStreamAsync(linkedCts.Token);


### PR DESCRIPTION
## Summary
- ensure HttpResponseMessage instances from SendAsync are disposed in FetchAsync and ValidateAsync

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0581eb84083289aded3297b47b74c