### PR TITLE
Cache channel display names for combo boxes

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -30,6 +30,7 @@ public class ChatWindow : IDisposable
     protected readonly HttpClient _httpClient;
     protected readonly List<DiscordMessageDto> _messages = new();
     protected readonly List<ChannelDto> _channels = new();
+    private string[] _channelDisplayNames = Array.Empty<string>();
     protected int _selectedIndex;
     protected bool _channelsLoaded;
     protected bool _channelsLoading;
@@ -609,7 +610,7 @@ public class ChatWindow : IDisposable
 
         if (_channels.Count > 0)
         {
-            var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
+            var channelNames = _channelDisplayNames;
             var previousIndex = _selectedIndex;
             var activeChannelId = CurrentChannelId;
             string? selectedChannelId = null;
@@ -1409,6 +1410,7 @@ public class ChatWindow : IDisposable
     {
         _channels.Clear();
         _channels.AddRange(channels);
+        UpdateChannelDisplayNames();
         if (_channels.Count == 0)
         {
             _selectedIndex = 0;
@@ -1429,6 +1431,19 @@ public class ChatWindow : IDisposable
 
         var newId = _channels[_selectedIndex].Id;
         _channelSelection.SetChannel(_channelKind, _config.GuildId, newId);
+    }
+
+    private void UpdateChannelDisplayNames()
+    {
+        if (_channels.Count == 0)
+        {
+            _channelDisplayNames = Array.Empty<string>();
+            return;
+        }
+
+        _channelDisplayNames = _channels
+            .Select(c => c.ParentId == null ? c.Name : "  " + c.Name)
+            .ToArray();
     }
 
     internal void OnGuildUpdated()

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -52,6 +52,7 @@ public class EventCreateWindow
     private readonly HashSet<string> _mentions = new();
     private bool _rolesLoaded;
     private readonly List<ChannelDto> _channels = new();
+    private string[] _channelDisplayNames = Array.Empty<string>();
     private bool _channelsLoaded;
     private bool _channelFetchFailed;
     private string _channelErrorMessage = string.Empty;
@@ -143,7 +144,7 @@ public class EventCreateWindow
         }
         if (_channels.Count > 0)
         {
-            var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
+            var channelNames = _channelDisplayNames;
             {
                 using var emojiFont = _emojiManager.PushEmojiFont();
                 if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
@@ -1435,6 +1436,7 @@ public class EventCreateWindow
             {
                 _channels.Clear();
                 _channels.AddRange(dto);
+                UpdateChannelDisplayNames();
                 var current = ChannelId;
                 if (!string.IsNullOrEmpty(current))
                 {
@@ -1474,6 +1476,19 @@ public class EventCreateWindow
                 _channelsLoaded = true;
             });
         }
+    }
+
+    private void UpdateChannelDisplayNames()
+    {
+        if (_channels.Count == 0)
+        {
+            _channelDisplayNames = Array.Empty<string>();
+            return;
+        }
+
+        _channelDisplayNames = _channels
+            .Select(c => c.ParentId == null ? c.Name : "  " + c.Name)
+            .ToArray();
     }
 
     private void SavePreset()

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -33,6 +33,7 @@ public class TemplatesWindow
     private EventView? _previewEvent;
     private string? _lastResult;
     private readonly List<ChannelDto> _channels = new();
+    private string[] _channelDisplayNames = Array.Empty<string>();
     private bool _channelsLoaded;
     private bool _channelsLoading;
     private bool _channelFetchFailed;
@@ -149,7 +150,7 @@ public class TemplatesWindow
         }
         if (_channels.Count > 0)
         {
-            var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
+            var channelNames = _channelDisplayNames;
             {
                 using var emojiFont = _emojiManager.PushEmojiFont();
                 if (ImGui.Combo("Channel", ref _channelIndex, channelNames, channelNames.Length))
@@ -481,6 +482,7 @@ public class TemplatesWindow
     {
         _channels.Clear();
         _channels.AddRange(ChannelDtoExtensions.SortForDisplay(channels));
+        UpdateChannelDisplayNames();
         var current = ChannelId;
         if (!string.IsNullOrEmpty(current))
         {
@@ -491,6 +493,19 @@ public class TemplatesWindow
         {
             _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, _channels[_channelIndex].Id);
         }
+    }
+
+    private void UpdateChannelDisplayNames()
+    {
+        if (_channels.Count == 0)
+        {
+            _channelDisplayNames = Array.Empty<string>();
+            return;
+        }
+
+        _channelDisplayNames = _channels
+            .Select(c => c.ParentId == null ? c.Name : "  " + c.Name)
+            .ToArray();
     }
 
     private async Task LoadRoles()

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -30,6 +30,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
     private ClientWebSocket? _webSocket;
     private CancellationTokenSource? _pollCts;
     private readonly List<ChannelDto> _channels = new();
+    private string[] _channelDisplayNames = Array.Empty<string>();
     private bool _channelsLoaded;
     private bool _channelFetchFailed;
     private string _channelErrorMessage = string.Empty;
@@ -891,9 +892,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             return;
         }
 
-        var channelNames = _channels
-            .Select(c => c?.Name ?? c?.Id ?? string.Empty)
-            .ToArray();
+        var channelNames = _channelDisplayNames;
 
         if (channelNames.Length == 0)
         {
@@ -1022,12 +1021,26 @@ public class UiRenderer : IAsyncDisposable, IDisposable
     {
         _channelsLoaded = false;
         _channels.Clear();
+        UpdateChannelDisplayNames();
     }
 
     public Task RefreshChannels()
     {
         ResetChannels();
         return FetchChannels();
+    }
+
+    private void UpdateChannelDisplayNames()
+    {
+        if (_channels.Count == 0)
+        {
+            _channelDisplayNames = Array.Empty<string>();
+            return;
+        }
+
+        _channelDisplayNames = _channels
+            .Select(c => c?.Name ?? c?.Id ?? string.Empty)
+            .ToArray();
     }
 
     private void SaveConfig()
@@ -1103,6 +1116,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             {
                 _channels.Clear();
                 _channels.AddRange(eventChannels);
+                UpdateChannelDisplayNames();
 
                 var guildId = _config.GuildId;
                 var selectedChannelId = _channelSelection.GetChannel(ChannelKind.Event, guildId, out var hasStoredSelection);


### PR DESCRIPTION
## Summary
- cache channel display names in the chat window and reuse them when rendering the selector
- reuse cached channel display names across the event creation and templates windows
- cache resolved channel names for the UI renderer combo box to avoid per-frame allocations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e05d19fc448328afc747f5e111a09c