### PR TITLE
Bump DemiCat release to 13.0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,6 @@
 ## Unreleased
 - Added API tests covering Discord emoji warm-up responses and cached emoji listings.
 - Added officer message endpoint test ensuring unresolved channels return HTTP 409 with structured error details.
-- Released version 13.0.0.5 aligning plugin metadata across manifests.
+
+## 13.0.0.6 - 2025-10-04
+- Aligned plugin metadata across manifests for the 13.0.0.6 release.

--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -11,9 +11,9 @@
     <RootNamespace>DemiCatPlugin</RootNamespace>
 
     <!-- Keep these in sync with manifest -->
-    <Version>13.0.0.5</Version>
-    <AssemblyVersion>13.0.0.5</AssemblyVersion>
-    <FileVersion>13.0.0.5</FileVersion>
+    <Version>13.0.0.6</Version>
+    <AssemblyVersion>13.0.0.6</AssemblyVersion>
+    <FileVersion>13.0.0.6</FileVersion>
 
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>

--- a/DemiCatPlugin/DemiCatPlugin.json
+++ b/DemiCatPlugin/DemiCatPlugin.json
@@ -2,7 +2,7 @@
   "Author": "Demi Dev Studio",
   "Name": "DemiCat",
   "InternalName": "DemiCatPlugin",
-  "AssemblyVersion": "13.0.0.5",
+  "AssemblyVersion": "13.0.0.6",
   "Description": "DemiCat Dalamud plugin. =Mew=",
   "ApplicableVersion": "any",
   "RepoUrl": "https://github.com/jackandcarter/DemiCat",

--- a/repo.json
+++ b/repo.json
@@ -5,7 +5,7 @@
     "InternalName": "DemiCatPlugin",
     "Punchline": "Discord-linked FC tools and chat.",
     "Description": "A mod to manage Discord FC communities and Events.",
-    "AssemblyVersion": "13.0.0.5",
+    "AssemblyVersion": "13.0.0.6",
     "ApplicableVersion": "any",
     "DalamudApiLevel": 13,
     "RepoUrl": "https://github.com/jackandcarter/DemiCat",


### PR DESCRIPTION
## Summary
- align the repo manifest, plugin manifest, and project metadata to version 13.0.0.6
- record the 13.0.0.6 release in the changelog

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release` *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68e0766983588328aca84e423e87dfc9