### PR TITLE
Set hosted API endpoint as plugin default

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -74,8 +74,9 @@ public class Config : IPluginConfiguration
     }
 
     public bool Enabled { get; set; } = true;
-    public const string DefaultApiBaseUrl = "http://127.0.0.1:5050";
+    public const string DefaultApiBaseUrl = "https://mew.the-demiurge.com";
 
+    [JsonIgnore]
     public string ApiBaseUrl { get; set; } = DefaultApiBaseUrl;
     public string WebSocketPath { get; set; } = "/ws/embeds";
     public int PollIntervalSeconds { get; set; } = 5;

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -73,6 +73,7 @@ public class Plugin : IDalamudPlugin
 
         var oldVersion = _config.Version;
         _config.Migrate();
+        _config.ApiBaseUrl = Config.DefaultApiBaseUrl;
         var rolesRemoved = _config.Roles.RemoveAll(r => r == "chat") > 0;
         if (rolesRemoved || _config.Version != oldVersion)
             _services.PluginInterface.SavePluginConfig(_config);

--- a/docs/BUILD-RUN.md
+++ b/docs/BUILD-RUN.md
@@ -62,7 +62,7 @@ This guide walks through compiling the Dalamud plugin and running the DemiBot ba
 
    Uvicorn will host the FastAPI app while the Discord bot, recurring-event poster, channel-name resync, asset purge, and Syncshell cleanup workers run in parallel.
 
-5. Point the Dalamud plugin at the bot’s `ApiBaseUrl` (default `http://127.0.0.1:5050`) and link an API key via `/demibot embed` in Discord.
+5. Point the Dalamud plugin at the bot’s `ApiBaseUrl` (default `https://mew.the-demiurge.com`) and link an API key via `/demibot embed` in Discord.
 
 ## Tips
 


### PR DESCRIPTION
## Summary
- point the plugin configuration default API base URL to https://mew.the-demiurge.com and avoid persisting runtime overrides
- reset the configuration's API URL on plugin startup so each session uses the hosted endpoint
- document the hosted endpoint as the default in the build/run guide

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e07bc4009483288680c24a927816ab