### PR TITLE
Move API override controls into developer window

### DIFF
--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Plugin;
 
@@ -8,15 +9,26 @@ public class DeveloperWindow
 {
     private readonly Config _config;
     private readonly IDalamudPluginInterface? _pluginInterface;
+    private readonly Func<bool> _isIdentityReady;
+    private readonly Func<Task> _hardReload;
+    private readonly Action _stopNetworking;
     private string _apiBaseUrl;
     private string _wsPath;
 
     public bool IsOpen;
 
-    public DeveloperWindow(Config config, IDalamudPluginInterface? pluginInterface)
+    public DeveloperWindow(
+        Config config,
+        IDalamudPluginInterface? pluginInterface,
+        Func<bool> isIdentityReady,
+        Func<Task> hardReload,
+        Action stopNetworking)
     {
         _config = config;
         _pluginInterface = pluginInterface;
+        _isIdentityReady = isIdentityReady;
+        _hardReload = hardReload;
+        _stopNetworking = stopNetworking;
         _apiBaseUrl = config.ApiBaseUrl;
         _wsPath = config.WebSocketPath;
     }
@@ -37,15 +49,57 @@ public class DeveloperWindow
         ImGui.InputText("API Base URL", ref _apiBaseUrl, 256);
         ImGui.InputText("WebSocket Path", ref _wsPath, 64);
 
-        if (ImGui.Button("Save"))
+        if (ImGui.Button("Apply"))
         {
-            _config.ApiBaseUrl = _apiBaseUrl;
-            _config.WebSocketPath = _wsPath;
+            ApplyApiBaseUrlChange(_apiBaseUrl);
+        }
 
-            if (_pluginInterface != null)
-                _pluginInterface!.SavePluginConfig(_config);
+        ImGui.SameLine();
+
+        if (ImGui.Button("Reset to default"))
+        {
+            ApplyApiBaseUrlChange(Config.DefaultApiBaseUrl);
         }
 
         ImGui.End();
+    }
+
+    private void ApplyApiBaseUrlChange(string candidate)
+    {
+        var trimmed = candidate.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+        {
+            trimmed = Config.DefaultApiBaseUrl;
+        }
+
+        var previousUrl = _config.ApiBaseUrl;
+        var urlChanged = !string.Equals(previousUrl, trimmed, StringComparison.OrdinalIgnoreCase);
+
+        _config.ApiBaseUrl = trimmed;
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            _config.ApiBaseUrl = previousUrl;
+            _apiBaseUrl = _config.ApiBaseUrl;
+            return;
+        }
+
+        _config.WebSocketPath = _wsPath;
+        _pluginInterface?.SavePluginConfig(_config);
+
+        _apiBaseUrl = _config.ApiBaseUrl;
+
+        if (!urlChanged)
+        {
+            return;
+        }
+
+        if (_isIdentityReady())
+        {
+            _ = _hardReload();
+        }
+        else
+        {
+            _stopNetworking();
+        }
     }
 }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -64,7 +64,12 @@ public class SettingsWindow : IDisposable
         _penumbraModsDirectory = config.PenumbraModsDirectory ?? string.Empty;
         _penumbraConfigDirectory = config.PenumbraConfigDirectory ?? string.Empty;
         _penumbraCollectionOverride = config.PenumbraCollectionOverride ?? string.Empty;
-        _devWindow = new DeveloperWindow(config, pluginInterface);
+        _devWindow = new DeveloperWindow(
+            config,
+            pluginInterface,
+            () => _tokenManager.IsReady(),
+            () => HardReloadIdentityAndStartAsync(),
+            StopAllWatchersAndPresence);
         _log = log;
         _isLinked = _tokenManager.State == LinkState.Linked;
         _tokenManager.OnLinked += OnLinked;


### PR DESCRIPTION
## Summary
- extend the developer window to drive API base URL overrides with callbacks into the settings window
- add Apply and Reset to default actions that validate URLs before updating config and restarting networking as needed
- persist websocket path updates via SavePluginConfig while leaving the API base override transient

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e07c41244c8328846b669fe7b69194