### PR TITLE
Avoid forcing channel resubscription on bridge reconnection

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -3650,7 +3650,7 @@ public class ChatWindow : IDisposable
     {
         _presence?.Reload();
         _ = _presence?.Refresh();
-        TrySubscribeCurrentChannel(force: true, refreshMessages: false);
+        TrySubscribeCurrentChannel(refreshMessages: false);
     }
 
     private void HandleBridgeUnlinked()


### PR DESCRIPTION
## Summary
- stop forcing channel resubscription when the bridge reconnects so cached channel state can short-circuit

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e089cbc39083289d4de9634b5fc9ca