### PR TITLE
Bump plugin metadata versions to 13.0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Added API tests covering Discord emoji warm-up responses and cached emoji listings.
 - Added officer message endpoint test ensuring unresolved channels return HTTP 409 with structured error details.
 
+## 13.0.0.8 - 2025-10-06
+- Bumped plugin manifest versions to 13.0.0.8 for Dalamud distribution.
+
 ## 13.0.0.7 - 2025-10-05
 - Bumped plugin manifest versions to 13.0.0.7 for Dalamud distribution.
 

--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -11,9 +11,9 @@
     <RootNamespace>DemiCatPlugin</RootNamespace>
 
     <!-- Keep these in sync with manifest -->
-    <Version>13.0.0.7</Version>
-    <AssemblyVersion>13.0.0.7</AssemblyVersion>
-    <FileVersion>13.0.0.7</FileVersion>
+    <Version>13.0.0.8</Version>
+    <AssemblyVersion>13.0.0.8</AssemblyVersion>
+    <FileVersion>13.0.0.8</FileVersion>
 
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>

--- a/DemiCatPlugin/DemiCatPlugin.json
+++ b/DemiCatPlugin/DemiCatPlugin.json
@@ -2,7 +2,7 @@
   "Author": "Demi Dev Studio",
   "Name": "DemiCat",
   "InternalName": "DemiCatPlugin",
-  "AssemblyVersion": "13.0.0.7",
+  "AssemblyVersion": "13.0.0.8",
   "Description": "DemiCat Dalamud plugin. =Mew=",
   "ApplicableVersion": "any",
   "RepoUrl": "https://github.com/jackandcarter/DemiCat",

--- a/repo.json
+++ b/repo.json
@@ -5,7 +5,7 @@
     "InternalName": "DemiCatPlugin",
     "Punchline": "Discord-linked FC tools and chat.",
     "Description": "A mod to manage Discord FC communities and Events.",
-    "AssemblyVersion": "13.0.0.7",
+    "AssemblyVersion": "13.0.0.8",
     "ApplicableVersion": "any",
     "DalamudApiLevel": 13,
     "RepoUrl": "https://github.com/jackandcarter/DemiCat",


### PR DESCRIPTION
## Summary
- bump the DemiCat plugin manifest and build metadata to version 13.0.0.8
- record the new release in the changelog

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e08a7302bc832888c3359adc6f345d