### PR TITLE
Avoid redundant callbacks on unchanged channel subscription

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -513,7 +513,6 @@ public class ChatWindow : IDisposable
                 _pendingRefreshAfterSubscribe = false;
             }
 
-            OnSubscriptionStateChanged(true);
             return true;
         }
 


### PR DESCRIPTION
## Summary
- avoid firing subscription change callbacks when the channel subscription remains unchanged
- continue refreshing pending messages without triggering redundant presence updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e08b7aa7f08328920f8b90edbcf52d