### PR TITLE
Serialize chat message refresh requests

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -85,6 +85,8 @@ public class ChatWindow : IDisposable
     private string? _lastSubscribedGuildId;
     private bool _pendingRefreshAfterSubscribe;
     private bool _pendingInitialScroll = true;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+    private volatile bool _refreshQueued;
     private bool _wasAtBottomLastFrame = true;
     private float _chatTopPadding;
     private int _selectionStart;
@@ -419,7 +421,7 @@ public class ChatWindow : IDisposable
         _bridge.ResyncRequested += (ch, cur) =>
             PluginServices.Instance!.Framework.RunOnTick(async () =>
             {
-                if (ch == CurrentChannelId) await RefreshMessages();
+                if (ch == CurrentChannelId) await RequestRefreshMessagesAsync();
             });
 
         _channelSelection.ChannelChanged += HandleChannelSelectionChanged;
@@ -509,7 +511,7 @@ public class ChatWindow : IDisposable
         {
             if (_pendingRefreshAfterSubscribe)
             {
-                _ = PluginServices.Instance!.Framework.RunOnTick(async () => await RefreshMessages());
+                _ = PluginServices.Instance!.Framework.RunOnTick(async () => await RequestRefreshMessagesAsync());
                 _pendingRefreshAfterSubscribe = false;
             }
 
@@ -525,7 +527,7 @@ public class ChatWindow : IDisposable
 
         if (_pendingRefreshAfterSubscribe)
         {
-            _ = PluginServices.Instance!.Framework.RunOnTick(async () => await RefreshMessages());
+            _ = PluginServices.Instance!.Framework.RunOnTick(async () => await RequestRefreshMessagesAsync());
             _pendingRefreshAfterSubscribe = false;
         }
 
@@ -3161,7 +3163,33 @@ public class ChatWindow : IDisposable
         }
     }
 
+    public Task RequestRefreshMessagesAsync()
+        => RefreshMessages();
+
     public virtual async Task RefreshMessages()
+    {
+        if (!await _refreshGate.WaitAsync(0).ConfigureAwait(false))
+        {
+            _refreshQueued = true;
+            return;
+        }
+
+        try
+        {
+            do
+            {
+                _refreshQueued = false;
+                await RefreshMessagesCore().ConfigureAwait(false);
+            }
+            while (_refreshQueued);
+        }
+        finally
+        {
+            _refreshGate.Release();
+        }
+    }
+
+    protected virtual async Task RefreshMessagesCore()
     {
         var channelId = CurrentChannelId;
         if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrEmpty(channelId))

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -1204,11 +1204,11 @@ public class SettingsWindow : IDisposable
             {
                 if (_config.EnableFcChat)
                 {
-                    _ = ChatWindow?.RefreshMessages();
+                    _ = ChatWindow?.RequestRefreshMessagesAsync();
                 }
                 if (OfficerPermissions.HasAccess(_config))
                 {
-                    _ = OfficerChatWindow?.RefreshMessages();
+                    _ = OfficerChatWindow?.RequestRefreshMessagesAsync();
                 }
             }
             catch (Exception ex)

--- a/tests/ChatWindowMessageLimitTests.cs
+++ b/tests/ChatWindowMessageLimitTests.cs
@@ -26,7 +26,7 @@ public class ChatWindowMessageLimitTests
 
         handler.EnqueueResponse(SerializeMessages(71, 120));
         handler.EnqueueResponse(SerializeMessages(21, 70));
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         var msgs = GetMessages(window);
         Assert.Equal(100, msgs.Count);
@@ -41,7 +41,7 @@ public class ChatWindowMessageLimitTests
 
         handler.Requests.Clear();
         handler.EnqueueResponse(SerializeMessages(121, 130));
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         msgs = GetMessages(window);
         Assert.Equal(100, msgs.Count);
@@ -67,7 +67,7 @@ public class ChatWindowMessageLimitTests
         var cursorKey = ChannelKeyHelper.BuildCursorKey(config.GuildId, ChannelKind.Chat, "1");
 
         handler.EnqueueResponse(SerializeMessages(1, 20));
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         Assert.Single(handler.Requests);
         Assert.DoesNotContain("after=", handler.Requests[0].Query);
@@ -88,10 +88,10 @@ public class ChatWindowMessageLimitTests
         var window = new ChatWindow(config, client, null, tm, channelService);
 
         handler.EnqueueResponse(SerializeMessages(1, 20));
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         handler.EnqueueResponse(SerializeMessages(201, 203));
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         var msgs = GetMessages(window);
         Assert.Equal(23, msgs.Count);
@@ -118,7 +118,7 @@ public class ChatWindowMessageLimitTests
         var cursorKey = ChannelKeyHelper.BuildCursorKey(config.GuildId, ChannelKind.Chat, "1");
 
         handler.EnqueueResponse(SerializeMessages(1, 5));
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         var initial = GetMessages(window);
         Assert.Equal(5, initial.Count);
@@ -126,7 +126,7 @@ public class ChatWindowMessageLimitTests
 
         handler.Requests.Clear();
         handler.EnqueueResponse("[]");
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         var refreshed = GetMessages(window);
         Assert.Equal(5, refreshed.Count);
@@ -150,7 +150,7 @@ public class ChatWindowMessageLimitTests
         var window = new ChatWindow(config, client, null, tm, channelService);
 
         handler.EnqueueResponse(SerializeMessages(1, 3));
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         var initial = GetMessages(window);
         Assert.Equal(3, initial.Count);
@@ -163,7 +163,7 @@ public class ChatWindowMessageLimitTests
 
         handler.Requests.Clear();
         handler.EnqueueResponse("[]");
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         var refreshed = GetMessages(window);
         Assert.Empty(refreshed);
@@ -187,7 +187,7 @@ public class ChatWindowMessageLimitTests
 
         handler.EnqueueResponse(SerializeMessages(71, 120));
         handler.EnqueueResponse(SerializeMessages(21, 70));
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         Assert.Equal(2, handler.Requests.Count);
         Assert.DoesNotContain("after=", handler.Requests[0].Query);

--- a/tests/ChatWindowWebSocketTests.cs
+++ b/tests/ChatWindowWebSocketTests.cs
@@ -630,7 +630,7 @@ public class ChatWindowWebSocketTests
         var window = new ChatWindow(config, restClient, null, tm, channelService);
         var cursorKey = ChannelKeyHelper.BuildCursorKey(config.GuildId, ChannelKind.Chat, "1");
 
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         Assert.True(config.RestChatCursors.TryGetValue(cursorKey, out var restCursor));
         Assert.Equal(5, restCursor);

--- a/tests/OfficerChatWindowTests.cs
+++ b/tests/OfficerChatWindowTests.cs
@@ -32,7 +32,7 @@ public class OfficerChatWindowTests
 
         handler.EnqueueResponse(SerializeMessages(71, 120));
         handler.EnqueueResponse(SerializeMessages(21, 70));
-        await window.RefreshMessages();
+        await window.RequestRefreshMessagesAsync();
 
         var msgs = GetMessages(window);
         Assert.Equal(100, msgs.Count);


### PR DESCRIPTION
## Summary
- add a SemaphoreSlim guard and queue flag so RefreshMessages only runs one fetch at a time
- provide a RequestRefreshMessagesAsync helper and update call sites/tests to use the gated refresh
- route SettingsWindow refresh requests through the new serialized path

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e08d5af0a48328abd882862684447c