### PR TITLE
Add shared channel refresh cache

### DIFF
--- a/DemiCatPlugin/ChannelRefreshResult.cs
+++ b/DemiCatPlugin/ChannelRefreshResult.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace DemiCatPlugin;
+
+internal enum ChannelRefreshError
+{
+    None,
+    TokenMissing,
+    InvalidApiUrl,
+    Unauthorized,
+    Forbidden,
+    Generic,
+    FeatureDisabled
+}
+
+internal readonly struct ChannelRefreshResult
+{
+    public string Kind { get; }
+    public IReadOnlyList<ChannelDto>? Channels { get; }
+    public ChannelRefreshError Error { get; }
+
+    public bool HasChannels => Channels != null;
+
+    private ChannelRefreshResult(string kind, IReadOnlyList<ChannelDto>? channels, ChannelRefreshError error)
+    {
+        Kind = kind;
+        Channels = channels;
+        Error = error;
+    }
+
+    public static ChannelRefreshResult Success(string kind, IReadOnlyList<ChannelDto> channels)
+        => new(kind, channels, ChannelRefreshError.None);
+
+    public static ChannelRefreshResult Failure(string kind, ChannelRefreshError error)
+        => new(kind, null, error);
+
+    public static ChannelRefreshResult FeatureDisabled(string kind)
+        => new(kind, Array.Empty<ChannelDto>(), ChannelRefreshError.FeatureDisabled);
+}

--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -6,6 +7,7 @@ using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
+using System.Linq;
 
 namespace DemiCatPlugin;
 
@@ -13,6 +15,7 @@ public class ChannelWatcher : IDisposable
 {
     private readonly Config _config;
     private readonly HttpClient _httpClient;
+    private readonly ChannelService _channelService;
     private readonly UiRenderer _ui;
     private readonly EventCreateWindow _eventCreateWindow;
     private readonly TemplatesWindow _templatesWindow;
@@ -24,6 +27,10 @@ public class ChannelWatcher : IDisposable
     private DateTime _lastRefresh = DateTime.MinValue;
     private readonly TimeSpan _refreshCooldown = TimeSpan.FromSeconds(2);
     private int _retryAttempt;
+    private readonly SemaphoreSlim _refreshGate = new(1, 1);
+    private readonly Dictionary<string, ChannelRefreshResult> _channelCache = new(StringComparer.OrdinalIgnoreCase);
+    private DateTime _channelCacheTimestamp = DateTime.MinValue;
+    private string _cachedGuildId = string.Empty;
     private string? _lastErrorSignature;
     private DateTime _lastErrorLog;
     private static readonly TimeSpan ErrorLogThrottle = TimeSpan.FromSeconds(30);
@@ -34,7 +41,7 @@ public class ChannelWatcher : IDisposable
 
     internal bool IsRunning => _cts != null;
 
-    public ChannelWatcher(Config config, UiRenderer ui, EventCreateWindow eventCreateWindow, TemplatesWindow templatesWindow, ChatWindow chatWindow, OfficerChatWindow officerChatWindow, TokenManager tokenManager, HttpClient httpClient)
+    public ChannelWatcher(Config config, UiRenderer ui, EventCreateWindow eventCreateWindow, TemplatesWindow templatesWindow, ChatWindow chatWindow, OfficerChatWindow officerChatWindow, TokenManager tokenManager, HttpClient httpClient, ChannelService channelService)
     {
         _config = config;
         _ui = ui;
@@ -44,8 +51,10 @@ public class ChannelWatcher : IDisposable
         _officerChatWindow = officerChatWindow;
         _tokenManager = tokenManager;
         _httpClient = httpClient;
+        _channelService = channelService;
 
         Instance = this;
+        _tokenManager.OnUnlinked += HandleTokenUnlinked;
     }
 
     public async Task Start()
@@ -380,20 +389,183 @@ public class ChannelWatcher : IDisposable
         if (!force && DateTime.UtcNow - _lastRefresh < _refreshCooldown)
             return;
 
-        _ = SafeRefresh(_ui.RefreshChannels);
-        _ = SafeRefresh(_eventCreateWindow.RefreshChannels);
-        _ = SafeRefresh(_templatesWindow.RefreshChannels);
-        if (_config.SyncedChat && _config.EnableFcChat)
-            _ = SafeRefresh(_chatWindow.RefreshChannels);
-        if (OfficerPermissions.HasAccess(_config))
-            _ = SafeRefresh(_officerChatWindow.RefreshChannels);
-
-        _lastRefresh = DateTime.UtcNow;
+        _ = SafeRefresh(() => RefreshConsumersAsync(force));
     }
 
     public void TriggerRefresh(bool force = false)
     {
         RefreshChannelsIfNeeded(force);
+    }
+
+    public void InvalidateCache()
+    {
+        lock (_channelCache)
+        {
+            _channelCache.Clear();
+            _channelCacheTimestamp = DateTime.MinValue;
+            _cachedGuildId = string.Empty;
+        }
+    }
+
+    private void HandleTokenUnlinked(string? _)
+    {
+        InvalidateCache();
+    }
+
+    private async Task RefreshConsumersAsync(bool force)
+    {
+        await _refreshGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var results = await GetChannelDataAsync(force).ConfigureAwait(false);
+
+            var eventResult = GetResult(results, ChannelKind.Event);
+            var fcResult = GetResult(results, ChannelKind.FcChat);
+            var officerResult = GetResult(results, ChannelKind.OfficerChat);
+
+            var tasks = new List<Task>
+            {
+                SafeRefresh(() => _ui.ApplyChannelRefreshResult(eventResult)),
+                SafeRefresh(() => _eventCreateWindow.ApplyChannelRefreshResult(eventResult)),
+                SafeRefresh(() => _templatesWindow.ApplyChannelRefreshResult(eventResult)),
+                SafeRefresh(() => _chatWindow.ApplyChannelRefreshResult(fcResult)),
+                SafeRefresh(() => _officerChatWindow.ApplyChannelRefreshResult(officerResult))
+            };
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+            _lastRefresh = DateTime.UtcNow;
+        }
+        finally
+        {
+            _refreshGate.Release();
+        }
+    }
+
+    private ChannelRefreshResult GetResult(Dictionary<string, ChannelRefreshResult> results, string kind)
+    {
+        if (results.TryGetValue(kind, out var result))
+        {
+            return result;
+        }
+
+        return ChannelRefreshResult.Failure(kind, ChannelRefreshError.Generic);
+    }
+
+    private async Task<Dictionary<string, ChannelRefreshResult>> GetChannelDataAsync(bool force)
+    {
+        var normalizedGuild = ChannelKeyHelper.NormalizeGuildId(_config.GuildId);
+        var now = DateTime.UtcNow;
+
+        lock (_channelCache)
+        {
+            if (!force
+                && _channelCacheTimestamp != DateTime.MinValue
+                && string.Equals(_cachedGuildId, normalizedGuild, StringComparison.Ordinal)
+                && now - _channelCacheTimestamp < _refreshCooldown)
+            {
+                return new Dictionary<string, ChannelRefreshResult>(_channelCache, StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        var results = await FetchChannelDataAsync().ConfigureAwait(false);
+
+        lock (_channelCache)
+        {
+            _channelCache.Clear();
+            foreach (var kvp in results)
+            {
+                _channelCache[kvp.Key] = kvp.Value;
+            }
+            _channelCacheTimestamp = now;
+            _cachedGuildId = normalizedGuild;
+        }
+
+        return results;
+    }
+
+    private async Task<Dictionary<string, ChannelRefreshResult>> FetchChannelDataAsync()
+    {
+        var results = new Dictionary<string, ChannelRefreshResult>(StringComparer.OrdinalIgnoreCase);
+
+        if (!_tokenManager.IsReady())
+        {
+            results[ChannelKind.Event] = ChannelRefreshResult.Failure(ChannelKind.Event, ChannelRefreshError.TokenMissing);
+            results[ChannelKind.FcChat] = ChannelRefreshResult.Failure(ChannelKind.FcChat, ChannelRefreshError.TokenMissing);
+            results[ChannelKind.OfficerChat] = ChannelRefreshResult.Failure(ChannelKind.OfficerChat, ChannelRefreshError.TokenMissing);
+            return results;
+        }
+
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
+            results[ChannelKind.Event] = ChannelRefreshResult.Failure(ChannelKind.Event, ChannelRefreshError.InvalidApiUrl);
+            results[ChannelKind.FcChat] = ChannelRefreshResult.Failure(ChannelKind.FcChat, ChannelRefreshError.InvalidApiUrl);
+            results[ChannelKind.OfficerChat] = ChannelRefreshResult.Failure(ChannelKind.OfficerChat, ChannelRefreshError.InvalidApiUrl);
+            return results;
+        }
+
+        results[ChannelKind.Event] = await FetchKindAsync(ChannelKind.Event).ConfigureAwait(false);
+
+        if (_config.SyncedChat && _config.EnableFcChat)
+        {
+            results[ChannelKind.FcChat] = await FetchKindAsync(ChannelKind.FcChat).ConfigureAwait(false);
+        }
+        else
+        {
+            results[ChannelKind.FcChat] = ChannelRefreshResult.FeatureDisabled(ChannelKind.FcChat);
+        }
+
+        if (OfficerPermissions.HasAccess(_config))
+        {
+            results[ChannelKind.OfficerChat] = await FetchKindAsync(ChannelKind.OfficerChat).ConfigureAwait(false);
+        }
+        else
+        {
+            results[ChannelKind.OfficerChat] = ChannelRefreshResult.FeatureDisabled(ChannelKind.OfficerChat);
+        }
+
+        return results;
+    }
+
+    private async Task<ChannelRefreshResult> FetchKindAsync(string kind)
+    {
+        try
+        {
+            var channels = await FetchChannelsForKindAsync(kind, refreshed: false).ConfigureAwait(false);
+            return ChannelRefreshResult.Success(kind, channels);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            PluginServices.Instance!.Log.Warning(ex, "Failed to fetch channels for {Kind}. Status: {Status}", kind, ex.StatusCode);
+            _ = Task.Run(() => _tokenManager.Clear("Invalid API key"));
+            return ChannelRefreshResult.Failure(kind, ChannelRefreshError.Unauthorized);
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
+        {
+            PluginServices.Instance!.Log.Warning(ex, "Failed to fetch channels for {Kind}. Status: {Status}", kind, ex.StatusCode);
+            return ChannelRefreshResult.Failure(kind, ChannelRefreshError.Forbidden);
+        }
+        catch (HttpRequestException ex)
+        {
+            PluginServices.Instance!.Log.Warning(ex, "Failed to fetch channels for {Kind}. Status: {Status}", kind, ex.StatusCode);
+            return ChannelRefreshResult.Failure(kind, ChannelRefreshError.Generic);
+        }
+        catch (Exception ex)
+        {
+            PluginServices.Instance!.Log.Error(ex, "Error fetching channels for {Kind}", kind);
+            return ChannelRefreshResult.Failure(kind, ChannelRefreshError.Generic);
+        }
+    }
+
+    private async Task<IReadOnlyList<ChannelDto>> FetchChannelsForKindAsync(string kind, bool refreshed, CancellationToken ct = default)
+    {
+        var channels = (await _channelService.FetchAsync(kind, ct).ConfigureAwait(false)).ToList();
+        if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => Task.CompletedTask).ConfigureAwait(false))
+        {
+            return await FetchChannelsForKindAsync(kind, true, ct).ConfigureAwait(false);
+        }
+
+        return channels;
     }
 
     private Uri BuildWebSocketUri()
@@ -412,6 +584,7 @@ public class ChannelWatcher : IDisposable
         _cts?.Dispose();
         _cts = null;
         _task = null;
+        _tokenManager.OnUnlinked -= HandleTokenUnlinked;
         if (Instance == this) Instance = null;
     }
 }

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1381,6 +1381,7 @@ public class ChatWindow : IDisposable
             {
                 normalizedStoredGuild = ChannelKeyHelper.NormalizeGuildId(channelWithGuild.GuildId);
                 _config.GuildId = normalizedStoredGuild;
+                ChannelWatcher.Instance?.InvalidateCache();
                 SaveConfig();
                 hasStoredGuild = true;
             }
@@ -3526,6 +3527,80 @@ public class ChatWindow : IDisposable
         }
         _channelsLoaded = false;
         return FetchChannels();
+    }
+
+    internal virtual Task ApplyChannelRefreshResult(ChannelRefreshResult result)
+    {
+        switch (result.Error)
+        {
+            case ChannelRefreshError.None:
+            case ChannelRefreshError.FeatureDisabled:
+            {
+                var channels = result.Channels ?? Array.Empty<ChannelDto>();
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    SetChannels(channels);
+                    _channelsLoaded = true;
+                    _channelsLoading = false;
+                    _channelFetchFailed = false;
+                    _channelErrorMessage = string.Empty;
+                });
+            }
+            case ChannelRefreshError.TokenMissing:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelsLoaded = false;
+                    _channelsLoading = false;
+                    _channelFetchFailed = false;
+                    _channelErrorMessage = string.Empty;
+                    _channels.Clear();
+                    UpdateChannelDisplayNames();
+                });
+            }
+            case ChannelRefreshError.InvalidApiUrl:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Invalid API URL";
+                    _channelsLoaded = true;
+                    _channelsLoading = false;
+                });
+            }
+            case ChannelRefreshError.Unauthorized:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Authentication failed";
+                    _channelsLoaded = true;
+                    _channelsLoading = false;
+                });
+            }
+            case ChannelRefreshError.Forbidden:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Forbidden – check API key/roles";
+                    _channelsLoaded = true;
+                    _channelsLoading = false;
+                });
+            }
+            case ChannelRefreshError.Generic:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Failed to load channels";
+                    _channelsLoaded = true;
+                    _channelsLoading = false;
+                });
+            }
+            default:
+                return Task.CompletedTask;
+        }
     }
 
     protected virtual async Task FetchChannels(bool refreshed = false)

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -1396,6 +1396,100 @@ public class EventCreateWindow
         public int? Size { get; set; }
     }
 
+    private void ApplyEventChannels(IReadOnlyList<ChannelDto> channels)
+    {
+        _channels.Clear();
+        foreach (var channel in channels)
+        {
+            if (channel != null)
+            {
+                _channels.Add(channel);
+            }
+        }
+        UpdateChannelDisplayNames();
+        var current = ChannelId;
+        if (!string.IsNullOrEmpty(current))
+        {
+            _selectedIndex = _channels.FindIndex(c => c.Id == current);
+            if (_selectedIndex < 0)
+            {
+                _selectedIndex = 0;
+            }
+        }
+        if (_channels.Count > 0)
+        {
+            _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, _channels[_selectedIndex].Id);
+        }
+        _channelsLoaded = true;
+        _channelFetchFailed = false;
+        _channelErrorMessage = string.Empty;
+    }
+
+    internal Task ApplyChannelRefreshResult(ChannelRefreshResult result)
+    {
+        switch (result.Error)
+        {
+            case ChannelRefreshError.None:
+            case ChannelRefreshError.FeatureDisabled:
+            {
+                var channels = result.Channels ?? Array.Empty<ChannelDto>();
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    ApplyEventChannels(channels);
+                });
+            }
+            case ChannelRefreshError.TokenMissing:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelsLoaded = false;
+                    _channelFetchFailed = false;
+                    _channelErrorMessage = string.Empty;
+                    _channels.Clear();
+                    UpdateChannelDisplayNames();
+                });
+            }
+            case ChannelRefreshError.InvalidApiUrl:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Invalid API URL";
+                    _channelsLoaded = true;
+                });
+            }
+            case ChannelRefreshError.Unauthorized:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Authentication failed";
+                    _channelsLoaded = true;
+                });
+            }
+            case ChannelRefreshError.Forbidden:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Forbidden – check API key/roles";
+                    _channelsLoaded = true;
+                });
+            }
+            case ChannelRefreshError.Generic:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Failed to load channels";
+                    _channelsLoaded = true;
+                });
+            }
+            default:
+                return Task.CompletedTask;
+        }
+    }
+
     public Task RefreshChannels()
     {
         if (!_config.Events)

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -126,7 +126,7 @@ public class Plugin : IDalamudPlugin
             _notePadWindow
         );
 
-        _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _mainWindow.TemplatesWindow, _chatWindow, _officerChatWindow, _tokenManager, _httpClient);
+        _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _mainWindow.TemplatesWindow, _chatWindow, _officerChatWindow, _tokenManager, _httpClient, _channelService);
         _requestWatcher = new RequestWatcher(_config, _httpClient, _tokenManager);
 
         _channelSelection.ChannelChanged += HandleChannelSelectionValidation;
@@ -495,6 +495,7 @@ public class Plugin : IDalamudPlugin
                 {
                     var guildChanged = !string.Equals(normalizedStoredGuild, normalizedResponseGuild, StringComparison.Ordinal);
                     _config.GuildId = normalizedResponseGuild;
+                    ChannelWatcher.Instance?.InvalidateCache();
                     _services.PluginInterface.SavePluginConfig(_config);
 
                     _chatWindow.OnGuildUpdated();

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -817,6 +817,7 @@ public class SettingsWindow : IDisposable
                 if (!string.Equals(_config.GuildId, normalizedGuild, StringComparison.Ordinal))
                 {
                     _config.GuildId = normalizedGuild;
+                    ChannelWatcher.Instance?.InvalidateCache();
                     configChanged = true;
                 }
             }
@@ -949,6 +950,7 @@ public class SettingsWindow : IDisposable
         }
 
         _config.GuildId = string.Empty;
+        ChannelWatcher.Instance?.InvalidateCache();
         _config.GuildRoles.Clear();
         _config.ChannelSelections.Clear();
         _config.ChatChannelId = string.Empty;

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -495,6 +495,80 @@ public class TemplatesWindow
         }
     }
 
+    internal Task ApplyChannelRefreshResult(ChannelRefreshResult result)
+    {
+        switch (result.Error)
+        {
+            case ChannelRefreshError.None:
+            case ChannelRefreshError.FeatureDisabled:
+            {
+                var channels = result.Channels ?? Array.Empty<ChannelDto>();
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    SetChannels(channels.ToList());
+                    _channelsLoaded = true;
+                    _channelsLoading = false;
+                    _channelFetchFailed = false;
+                    _channelErrorMessage = string.Empty;
+                });
+            }
+            case ChannelRefreshError.TokenMissing:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelsLoaded = false;
+                    _channelsLoading = false;
+                    _channelFetchFailed = false;
+                    _channelErrorMessage = string.Empty;
+                    _channels.Clear();
+                    UpdateChannelDisplayNames();
+                });
+            }
+            case ChannelRefreshError.InvalidApiUrl:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Invalid API URL";
+                    _channelsLoaded = true;
+                    _channelsLoading = false;
+                });
+            }
+            case ChannelRefreshError.Unauthorized:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Authentication failed";
+                    _channelsLoaded = true;
+                    _channelsLoading = false;
+                });
+            }
+            case ChannelRefreshError.Forbidden:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Forbidden – check API key/roles";
+                    _channelsLoaded = true;
+                    _channelsLoading = false;
+                });
+            }
+            case ChannelRefreshError.Generic:
+            {
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Failed to load channels";
+                    _channelsLoaded = true;
+                    _channelsLoading = false;
+                });
+            }
+            default:
+                return Task.CompletedTask;
+        }
+    }
+
     private void UpdateChannelDisplayNames()
     {
         if (_channels.Count == 0)

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -1043,6 +1043,131 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             .ToArray();
     }
 
+    private void ApplyEventChannels(IReadOnlyList<ChannelDto> channels)
+    {
+        _channels.Clear();
+        foreach (var channel in channels)
+        {
+            if (channel != null)
+            {
+                _channels.Add(channel);
+            }
+        }
+        UpdateChannelDisplayNames();
+
+        var guildId = _config.GuildId;
+        var selectedChannelId = _channelSelection.GetChannel(ChannelKind.Event, guildId, out var hasStoredSelection);
+        var usedFallback = !hasStoredSelection && !string.IsNullOrEmpty(selectedChannelId);
+        var targetIndex = -1;
+        if (!string.IsNullOrEmpty(selectedChannelId))
+        {
+            targetIndex = _channels.FindIndex(c => c != null && c.Id == selectedChannelId);
+        }
+
+        string? ensureChannelId = null;
+        if (targetIndex >= 0)
+        {
+            _selectedIndex = targetIndex;
+            if (usedFallback)
+            {
+                ensureChannelId = selectedChannelId;
+            }
+        }
+        else if (_channels.Count > 0)
+        {
+            _selectedIndex = 0;
+            ensureChannelId = _channels[_selectedIndex]?.Id;
+        }
+        else
+        {
+            _selectedIndex = -1;
+        }
+
+        if (_channels.Count > 0 && (_selectedIndex < 0 || _selectedIndex >= _channels.Count))
+        {
+            _selectedIndex = Math.Clamp(_selectedIndex, 0, _channels.Count - 1);
+            ensureChannelId ??= _channels[_selectedIndex]?.Id;
+        }
+
+        if (!string.IsNullOrEmpty(ensureChannelId))
+        {
+            _channelSelection.SetChannel(ChannelKind.Event, guildId, ensureChannelId);
+        }
+
+        _channelsLoaded = true;
+        _channelFetchFailed = false;
+        _channelErrorMessage = string.Empty;
+    }
+
+    internal Task ApplyChannelRefreshResult(ChannelRefreshResult result)
+    {
+        switch (result.Error)
+        {
+            case ChannelRefreshError.None:
+            case ChannelRefreshError.FeatureDisabled:
+            {
+                ResetPermissionToast();
+                var channels = result.Channels ?? Array.Empty<ChannelDto>();
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    ApplyEventChannels(channels);
+                });
+            }
+            case ChannelRefreshError.TokenMissing:
+            {
+                ResetPermissionToast();
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    ResetChannels();
+                    _channelFetchFailed = false;
+                    _channelErrorMessage = string.Empty;
+                });
+            }
+            case ChannelRefreshError.InvalidApiUrl:
+            {
+                ResetPermissionToast();
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Invalid API URL";
+                    _channelsLoaded = true;
+                });
+            }
+            case ChannelRefreshError.Unauthorized:
+            {
+                ResetPermissionToast();
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Authentication failed";
+                    _channelsLoaded = true;
+                });
+            }
+            case ChannelRefreshError.Forbidden:
+            {
+                ShowPermissionToast();
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = ForbiddenMessage;
+                    _channelsLoaded = true;
+                });
+            }
+            case ChannelRefreshError.Generic:
+            {
+                ResetPermissionToast();
+                return PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Failed to load channels";
+                    _channelsLoaded = true;
+                });
+            }
+            default:
+                return Task.CompletedTask;
+        }
+    }
+
     private void SaveConfig()
     {
         PluginServices.Instance!.PluginInterface.SavePluginConfig(_config);
@@ -1112,55 +1237,11 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 channel.EnsureKind(ChannelKind.Event);
             }
             if (await ChannelNameResolver.Resolve(eventChannels, _httpClient, _config, refreshed, () => FetchChannels(true))) return;
+            ResetPermissionToast();
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
-                _channels.Clear();
-                _channels.AddRange(eventChannels);
-                UpdateChannelDisplayNames();
-
-                var guildId = _config.GuildId;
-                var selectedChannelId = _channelSelection.GetChannel(ChannelKind.Event, guildId, out var hasStoredSelection);
-                var usedFallback = !hasStoredSelection && !string.IsNullOrEmpty(selectedChannelId);
-                var targetIndex = -1;
-                if (!string.IsNullOrEmpty(selectedChannelId))
-                {
-                    targetIndex = _channels.FindIndex(c => c != null && c.Id == selectedChannelId);
-                }
-
-                string? ensureChannelId = null;
-                if (targetIndex >= 0)
-                {
-                    _selectedIndex = targetIndex;
-                    if (usedFallback)
-                    {
-                        ensureChannelId = selectedChannelId;
-                    }
-                }
-                else if (_channels.Count > 0)
-                {
-                    _selectedIndex = 0;
-                    ensureChannelId = _channels[_selectedIndex]?.Id;
-                }
-                else
-                {
-                    _selectedIndex = -1;
-                }
-
-                if (_channels.Count > 0 && (_selectedIndex < 0 || _selectedIndex >= _channels.Count))
-                {
-                    _selectedIndex = Math.Clamp(_selectedIndex, 0, _channels.Count - 1);
-                    ensureChannelId ??= _channels[_selectedIndex]?.Id;
-                }
-
-                if (!string.IsNullOrEmpty(ensureChannelId))
-                {
-                    _channelSelection.SetChannel(ChannelKind.Event, guildId, ensureChannelId);
-                }
-                _channelsLoaded = true;
-                _channelFetchFailed = false;
-                _channelErrorMessage = string.Empty;
+                ApplyEventChannels(eventChannels);
             });
-            ResetPermissionToast();
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
         {


### PR DESCRIPTION
## Summary
- add a shared channel refresh routine that caches results in `ChannelWatcher` and feeds consumers while handling forced refreshes
- introduce `ChannelRefreshResult` so UI consumers can apply shared channel data and error states without issuing their own HTTP requests
- invalidate cached channel data when guild selections or authentication state change so subsequent refreshes refetch

## Testing
- dotnet test *(fails: dotnet not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e13fd707b48328b4d47bde167e394e