### PR TITLE
Add configurable chat performance and image loading controls

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -111,6 +111,8 @@ public class ChatWindow : IDisposable
     private readonly Dictionary<string, (Vector2 Min, Vector2 Max)> _messageRectCache = new();
     private SemaphoreSlim _imageDownloadSemaphore = new(Config.DefaultImageDownloadConcurrency, Config.DefaultImageDownloadConcurrency);
     private SemaphoreSlim _imageDecodeSemaphore = new(Config.DefaultImageDecodeConcurrency, Config.DefaultImageDecodeConcurrency);
+    private int _imageDownloadSemaphoreCapacity = Config.DefaultImageDownloadConcurrency;
+    private int _imageDecodeSemaphoreCapacity = Config.DefaultImageDecodeConcurrency;
 
     protected string CurrentChannelId => _channelSelection.GetChannel(_channelKind, _config.GuildId);
     protected string ChannelKindKey => _channelKind;
@@ -3944,14 +3946,14 @@ public class ChatWindow : IDisposable
         {
             _config.ImageDownloadConcurrency = sanitizedDownloadConcurrency;
         }
-        ReplaceSemaphore(ref _imageDownloadSemaphore, sanitizedDownloadConcurrency);
+        ReplaceSemaphore(ref _imageDownloadSemaphore, ref _imageDownloadSemaphoreCapacity, sanitizedDownloadConcurrency);
 
         var sanitizedDecodeConcurrency = Config.SanitizeImageDecodeConcurrency(_config.ImageDecodeConcurrency);
         if (_config.ImageDecodeConcurrency != sanitizedDecodeConcurrency)
         {
             _config.ImageDecodeConcurrency = sanitizedDecodeConcurrency;
         }
-        ReplaceSemaphore(ref _imageDecodeSemaphore, sanitizedDecodeConcurrency);
+        ReplaceSemaphore(ref _imageDecodeSemaphore, ref _imageDecodeSemaphoreCapacity, sanitizedDecodeConcurrency);
 
         var sanitizedBudget = Config.SanitizeImageBytesInFlightBudget(_config.ImageBytesInFlightBudget);
         if (_config.ImageBytesInFlightBudget != sanitizedBudget)
@@ -4066,9 +4068,11 @@ public class ChatWindow : IDisposable
         return rowsAway <= _preloadRowsAhead;
     }
 
-    private void ReplaceSemaphore(ref SemaphoreSlim semaphore, int concurrency)
+    private void ReplaceSemaphore(ref SemaphoreSlim semaphore, ref int capacityField, int concurrency)
     {
         var old = semaphore;
+        var previousCapacity = capacityField;
+        capacityField = concurrency;
         semaphore = new SemaphoreSlim(concurrency, concurrency);
         if (old == null)
         {
@@ -4079,8 +4083,18 @@ public class ChatWindow : IDisposable
         {
             try
             {
-                await Task.Delay(5000).ConfigureAwait(false);
+                if (previousCapacity > 0)
+                {
+                    while (old.CurrentCount < previousCapacity)
+                    {
+                        await Task.Delay(100).ConfigureAwait(false);
+                    }
+                }
                 old.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+                // already disposed
             }
             catch
             {

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -66,8 +66,6 @@ public class ChatWindow : IDisposable
     {
         PropertyNameCaseInsensitive = true
     };
-    private const int TextureCacheCapacity = 100;
-    private const int MaxMessages = 100;
     private const float DefaultComposeSplitRatio = 0.35f;
     private const float MinComposeSplitRatio = 0.2f;
     private const float MaxComposeSplitRatio = 0.8f;
@@ -102,6 +100,17 @@ public class ChatWindow : IDisposable
     private const float MentionDrawerBaseOffset = 4f;
     private const float MentionDrawerTravelDistance = 10f;
     private MentionDrawerState? _mentionDrawerState;
+    private int _chatMaxMessages = Config.DefaultChatMaxMessages;
+    private int _textureCacheCapacity = Config.DefaultTextureCacheCapacity;
+    private int _imageMaxDecodeWidth = Config.DefaultImageMaxDecodeWidth;
+    private int _imageMaxDecodeHeight = Config.DefaultImageMaxDecodeHeight;
+    private long _imageBytesBudget = Config.DefaultImageBytesInFlightBudget;
+    private int _preloadRowsAhead = Config.DefaultPreloadRowsAhead;
+    private bool _lazyLoadEmbedsEnabled;
+    private bool _allowTextureLoads = true;
+    private readonly Dictionary<string, (Vector2 Min, Vector2 Max)> _messageRectCache = new();
+    private SemaphoreSlim _imageDownloadSemaphore = new(Config.DefaultImageDownloadConcurrency, Config.DefaultImageDownloadConcurrency);
+    private SemaphoreSlim _imageDecodeSemaphore = new(Config.DefaultImageDecodeConcurrency, Config.DefaultImageDecodeConcurrency);
 
     protected string CurrentChannelId => _channelSelection.GetChannel(_channelKind, _config.GuildId);
     protected string ChannelKindKey => _channelKind;
@@ -425,6 +434,7 @@ public class ChatWindow : IDisposable
             });
 
         _channelSelection.ChannelChanged += HandleChannelSelectionChanged;
+        ReconfigureImageLoader();
     }
 
 #if TEST
@@ -712,6 +722,8 @@ public class ChatWindow : IDisposable
         {
             var msg = _messages[i];
             ImGui.PushID(msg.Id);
+            var shouldLoadTextures = ShouldLoadRowTextures(msg.Id);
+            using var textureScope = new TextureLoadScope(this, shouldLoadTextures);
             using var emojiFont = _emojiManager.PushEmojiFont();
             var drawList = ImGui.GetWindowDrawList();
             drawList.ChannelsSplit(2);
@@ -912,6 +924,10 @@ public class ChatWindow : IDisposable
             var rowMax = ImGui.GetItemRectMax();
             var rowHovered = ImGui.IsItemHovered(hoverFlags);
             _messageHoverStates[msg.Id] = rowHovered;
+            if (!string.IsNullOrEmpty(msg.Id))
+            {
+                _messageRectCache[msg.Id] = (rowMin, rowMax);
+            }
 
             if (ImGui.BeginPopupContextItem("messageContext"))
             {
@@ -3449,6 +3465,10 @@ public class ChatWindow : IDisposable
 
     private void DisposeMessageTextures(DiscordMessageDto msg)
     {
+        if (!string.IsNullOrEmpty(msg.Id))
+        {
+            _messageRectCache.Remove(msg.Id);
+        }
         msg.AvatarTexture = null;
         if (msg.Attachments != null)
         {
@@ -3497,6 +3517,8 @@ public class ChatWindow : IDisposable
             DisposeMessageTextures(message);
         }
         ClearTextureCache();
+        _imageDownloadSemaphore?.Dispose();
+        _imageDecodeSemaphore?.Dispose();
     }
 
     protected void SaveConfig()
@@ -3783,6 +3805,12 @@ public class ChatWindow : IDisposable
             return;
         }
 
+        if (_lazyLoadEmbedsEnabled && !_allowTextureLoads)
+        {
+            set(null);
+            return;
+        }
+
         if (_textureCache.TryGetValue(url, out var cached))
         {
             _textureLru.Remove(cached.Node);
@@ -3793,43 +3821,289 @@ public class ChatWindow : IDisposable
 
         var node = _textureLru.AddFirst(url);
         _textureCache[url] = new TextureCacheEntry(null, node);
+        EnforceTextureCacheCapacity();
 
-        if (_textureCache.Count > TextureCacheCapacity)
+        _ = Task.Run(async () =>
+        {
+            var downloadSemaphore = _imageDownloadSemaphore;
+            var decodeSemaphore = _imageDecodeSemaphore;
+            try
+            {
+                await downloadSemaphore.WaitAsync().ConfigureAwait(false);
+                try
+                {
+                    using var response = await _httpClient
+                        .SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseHeadersRead)
+                        .ConfigureAwait(false);
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        var framework = PluginServices.Instance!.Framework;
+                        _ = framework.RunOnTick(() =>
+                        {
+                            RemoveTextureEntry(url);
+                            set(null);
+                        });
+                        return;
+                    }
+
+                    var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                    if (_imageBytesBudget > 0 && bytes.LongLength > _imageBytesBudget)
+                    {
+                        var framework = PluginServices.Instance!.Framework;
+                        _ = framework.RunOnTick(() =>
+                        {
+                            RemoveTextureEntry(url);
+                            set(null);
+                        });
+                        return;
+                    }
+
+                    await decodeSemaphore.WaitAsync().ConfigureAwait(false);
+                    try
+                    {
+                        using var stream = new MemoryStream(bytes);
+                        var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
+                        if ((_imageMaxDecodeWidth > 0 && image.Width > _imageMaxDecodeWidth) ||
+                            (_imageMaxDecodeHeight > 0 && image.Height > _imageMaxDecodeHeight))
+                        {
+                            var framework = PluginServices.Instance!.Framework;
+                            _ = framework.RunOnTick(() =>
+                            {
+                                RemoveTextureEntry(url);
+                                set(null);
+                            });
+                            return;
+                        }
+
+                        var wrap = PluginServices.Instance!.TextureProvider.CreateFromRaw(
+                            RawImageSpecification.Rgba32(image.Width, image.Height),
+                            image.Data);
+                        var texture = new ForwardingSharedImmediateTexture(wrap);
+                        if (_textureCache.TryGetValue(url, out var entry))
+                        {
+                            entry.Texture = texture;
+                        }
+                        _ = PluginServices.Instance!.Framework.RunOnTick(() => set(texture));
+                    }
+                    finally
+                    {
+                        decodeSemaphore.Release();
+                    }
+                }
+                finally
+                {
+                    downloadSemaphore.Release();
+                }
+            }
+            catch
+            {
+                var framework = PluginServices.Instance!.Framework;
+                _ = framework.RunOnTick(() =>
+                {
+                    RemoveTextureEntry(url);
+                    set(null);
+                });
+            }
+        });
+    }
+
+    public virtual void ReconfigureImageLoader()
+    {
+        var sanitizedMaxMessages = Config.SanitizeChatMaxMessages(_config.ChatMaxMessages);
+        if (_config.ChatMaxMessages != sanitizedMaxMessages)
+        {
+            _config.ChatMaxMessages = sanitizedMaxMessages;
+        }
+        _chatMaxMessages = sanitizedMaxMessages;
+        TrimMessages();
+
+        var sanitizedCache = Config.SanitizeTextureCacheCapacity(_config.TextureCacheCapacity);
+        if (_config.TextureCacheCapacity != sanitizedCache)
+        {
+            _config.TextureCacheCapacity = sanitizedCache;
+        }
+        _textureCacheCapacity = sanitizedCache;
+        EnforceTextureCacheCapacity();
+
+        var sanitizedDecodeWidth = Config.SanitizeImageDecodeDimension(_config.ImageMaxDecodeWidth);
+        if (_config.ImageMaxDecodeWidth != sanitizedDecodeWidth)
+        {
+            _config.ImageMaxDecodeWidth = sanitizedDecodeWidth;
+        }
+        _imageMaxDecodeWidth = sanitizedDecodeWidth;
+
+        var sanitizedDecodeHeight = Config.SanitizeImageDecodeDimension(_config.ImageMaxDecodeHeight);
+        if (_config.ImageMaxDecodeHeight != sanitizedDecodeHeight)
+        {
+            _config.ImageMaxDecodeHeight = sanitizedDecodeHeight;
+        }
+        _imageMaxDecodeHeight = sanitizedDecodeHeight;
+
+        var sanitizedDownloadConcurrency = Config.SanitizeImageDownloadConcurrency(_config.ImageDownloadConcurrency);
+        if (_config.ImageDownloadConcurrency != sanitizedDownloadConcurrency)
+        {
+            _config.ImageDownloadConcurrency = sanitizedDownloadConcurrency;
+        }
+        ReplaceSemaphore(ref _imageDownloadSemaphore, sanitizedDownloadConcurrency);
+
+        var sanitizedDecodeConcurrency = Config.SanitizeImageDecodeConcurrency(_config.ImageDecodeConcurrency);
+        if (_config.ImageDecodeConcurrency != sanitizedDecodeConcurrency)
+        {
+            _config.ImageDecodeConcurrency = sanitizedDecodeConcurrency;
+        }
+        ReplaceSemaphore(ref _imageDecodeSemaphore, sanitizedDecodeConcurrency);
+
+        var sanitizedBudget = Config.SanitizeImageBytesInFlightBudget(_config.ImageBytesInFlightBudget);
+        if (_config.ImageBytesInFlightBudget != sanitizedBudget)
+        {
+            _config.ImageBytesInFlightBudget = sanitizedBudget;
+        }
+        _imageBytesBudget = sanitizedBudget;
+
+        var sanitizedPreload = Config.SanitizePreloadRowsAhead(_config.PreloadRowsAhead);
+        if (_config.PreloadRowsAhead != sanitizedPreload)
+        {
+            _config.PreloadRowsAhead = sanitizedPreload;
+        }
+        _preloadRowsAhead = sanitizedPreload;
+
+        _lazyLoadEmbedsEnabled = _config.LazyLoadEmbeds;
+    }
+
+    private int MaxMessages => _chatMaxMessages > 0 ? _chatMaxMessages : Config.DefaultChatMaxMessages;
+
+    private void EnforceTextureCacheCapacity()
+    {
+        if (_textureCacheCapacity <= 0)
+        {
+            return;
+        }
+
+        while (_textureCache.Count > _textureCacheCapacity)
         {
             var last = _textureLru.Last;
-            if (last != null)
+            if (last == null)
             {
-                if (_textureCache.TryGetValue(last.Value, out var toRemove))
-                {
-                    if (toRemove.Texture?.GetWrapOrEmpty() is IDisposable wrap)
-                        wrap.Dispose();
-                    _textureCache.Remove(last.Value);
-                }
-                _textureLru.RemoveLast();
+                break;
             }
+
+            if (_textureCache.TryGetValue(last.Value, out var toRemove))
+            {
+                if (toRemove.Texture?.GetWrapOrEmpty() is IDisposable wrap)
+                {
+                    wrap.Dispose();
+                }
+                _textureCache.Remove(last.Value);
+            }
+            _textureLru.Remove(last);
+        }
+    }
+
+    private void RemoveTextureEntry(string url)
+    {
+        if (!_textureCache.TryGetValue(url, out var entry))
+        {
+            return;
+        }
+
+        if (entry.Texture?.GetWrapOrEmpty() is IDisposable wrap)
+        {
+            wrap.Dispose();
+        }
+
+        _textureCache.Remove(url);
+        _textureLru.Remove(entry.Node);
+    }
+
+    private bool ShouldLoadRowTextures(string? messageId)
+    {
+        if (!_lazyLoadEmbedsEnabled || string.IsNullOrEmpty(messageId))
+        {
+            return true;
+        }
+
+        if (!_messageRectCache.TryGetValue(messageId, out var rect))
+        {
+            return true;
+        }
+
+        if (ImGui.IsRectVisible(rect.Min, rect.Max))
+        {
+            return true;
+        }
+
+        if (_preloadRowsAhead <= 0)
+        {
+            return false;
+        }
+
+        var windowPos = ImGui.GetWindowPos();
+        var scrollY = ImGui.GetScrollY();
+        var windowHeight = ImGui.GetWindowHeight();
+
+        var visibleMin = scrollY;
+        var visibleMax = scrollY + windowHeight;
+
+        var rowMinY = rect.Min.Y - windowPos.Y + scrollY;
+        var rowMaxY = rect.Max.Y - windowPos.Y + scrollY;
+
+        float distance;
+        if (rowMaxY < visibleMin)
+        {
+            distance = visibleMin - rowMaxY;
+        }
+        else if (rowMinY > visibleMax)
+        {
+            distance = rowMinY - visibleMax;
+        }
+        else
+        {
+            return true;
+        }
+
+        var rowHeight = Math.Max(1f, rect.Max.Y - rect.Min.Y);
+        var rowsAway = distance / rowHeight;
+        return rowsAway <= _preloadRowsAhead;
+    }
+
+    private void ReplaceSemaphore(ref SemaphoreSlim semaphore, int concurrency)
+    {
+        var old = semaphore;
+        semaphore = new SemaphoreSlim(concurrency, concurrency);
+        if (old == null)
+        {
+            return;
         }
 
         _ = Task.Run(async () =>
         {
             try
             {
-                var bytes = await _httpClient.GetByteArrayAsync(url).ConfigureAwait(false);
-                using var stream = new MemoryStream(bytes);
-                var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
-                var wrap = PluginServices.Instance!.TextureProvider.CreateFromRaw(
-                    RawImageSpecification.Rgba32(image.Width, image.Height),
-                    image.Data);
-                var texture = new ForwardingSharedImmediateTexture(wrap);
-                if (_textureCache.TryGetValue(url, out var entry))
-                {
-                    entry.Texture = texture;
-                }
-                _ = PluginServices.Instance!.Framework.RunOnTick(() => set(texture));
+                await Task.Delay(5000).ConfigureAwait(false);
+                old.Dispose();
             }
             catch
             {
-                _ = PluginServices.Instance!.Framework.RunOnTick(() => set(null));
+                // ignored
             }
         });
+    }
+
+    private readonly struct TextureLoadScope : IDisposable
+    {
+        private readonly ChatWindow _owner;
+        private readonly bool _previous;
+
+        public TextureLoadScope(ChatWindow owner, bool allow)
+        {
+            _owner = owner;
+            _previous = owner._allowTextureLoads;
+            owner._allowTextureLoads = allow;
+        }
+
+        public void Dispose()
+        {
+            _owner._allowTextureLoads = _previous;
+        }
     }
 }

--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -41,7 +41,28 @@ public class Config : IPluginConfiguration
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
     public const string DefaultEmbedBorderGlyph = "⬛";
-    public const int CurrentVersion = 23;
+    public const int DefaultChatMaxMessages = 100;
+    public const int MinChatMaxMessages = 20;
+    public const int MaxChatMaxMessages = 500;
+    public const int DefaultTextureCacheCapacity = 100;
+    public const int MinTextureCacheCapacity = 10;
+    public const int MaxTextureCacheCapacity = 500;
+    public const int DefaultImageMaxDecodeWidth = 4096;
+    public const int DefaultImageMaxDecodeHeight = 4096;
+    public const int MinImageDecodeDimension = 256;
+    public const int MaxImageDecodeDimension = 8192;
+    public const int DefaultImageDownloadConcurrency = 4;
+    public const int DefaultImageDecodeConcurrency = 2;
+    public const int MinImageConcurrency = 1;
+    public const int MaxImageDownloadConcurrency = 16;
+    public const int MaxImageDecodeConcurrency = 8;
+    public const long DefaultImageBytesInFlightBudget = 32L * 1024L * 1024L;
+    public const long MinImageBytesInFlightBudget = 4L * 1024L * 1024L;
+    public const long MaxImageBytesInFlightBudget = 512L * 1024L * 1024L;
+    public const int DefaultPreloadRowsAhead = 2;
+    public const int MinPreloadRowsAhead = 0;
+    public const int MaxPreloadRowsAhead = 10;
+    public const int CurrentVersion = 24;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -148,6 +169,15 @@ public class Config : IPluginConfiguration
     public float ChatFontScale { get; set; } = 1f;
     public bool ChatImageAutoStretch { get; set; } = true;
     public float ChatImageManualScale { get; set; } = 1f;
+    public int ChatMaxMessages { get; set; } = DefaultChatMaxMessages;
+    public int TextureCacheCapacity { get; set; } = DefaultTextureCacheCapacity;
+    public int ImageMaxDecodeWidth { get; set; } = DefaultImageMaxDecodeWidth;
+    public int ImageMaxDecodeHeight { get; set; } = DefaultImageMaxDecodeHeight;
+    public int ImageDownloadConcurrency { get; set; } = DefaultImageDownloadConcurrency;
+    public int ImageDecodeConcurrency { get; set; } = DefaultImageDecodeConcurrency;
+    public long ImageBytesInFlightBudget { get; set; } = DefaultImageBytesInFlightBudget;
+    public int PreloadRowsAhead { get; set; } = DefaultPreloadRowsAhead;
+    public bool LazyLoadEmbeds { get; set; } = false;
 
     [JsonPropertyName("emojiTileSize")]
     public float EmojiTileSize { get; set; } = 28f;
@@ -682,6 +712,20 @@ public class Config : IPluginConfiguration
             Version = 23;
             ExtensionData = null;
         }
+        if (Version < 24)
+        {
+            ChatMaxMessages = SanitizeChatMaxMessages(ChatMaxMessages);
+            TextureCacheCapacity = SanitizeTextureCacheCapacity(TextureCacheCapacity);
+            ImageMaxDecodeWidth = SanitizeImageDecodeDimension(ImageMaxDecodeWidth);
+            ImageMaxDecodeHeight = SanitizeImageDecodeDimension(ImageMaxDecodeHeight);
+            ImageDownloadConcurrency = SanitizeImageDownloadConcurrency(ImageDownloadConcurrency);
+            ImageDecodeConcurrency = SanitizeImageDecodeConcurrency(ImageDecodeConcurrency);
+            ImageBytesInFlightBudget = SanitizeImageBytesInFlightBudget(ImageBytesInFlightBudget);
+            PreloadRowsAhead = SanitizePreloadRowsAhead(PreloadRowsAhead);
+
+            Version = 24;
+            ExtensionData = null;
+        }
     }
 
     public static uint GetDefaultEmbedColor(string? channelKind)
@@ -898,4 +942,74 @@ public class Config : IPluginConfiguration
 
     internal static Vector4 SanitizeDockGradientColor(Vector4 color)
         => SanitizeDockBackgroundColor(color);
+
+    public static int SanitizeChatMaxMessages(int value)
+    {
+        if (value <= 0)
+        {
+            return DefaultChatMaxMessages;
+        }
+
+        return Math.Clamp(value, MinChatMaxMessages, MaxChatMaxMessages);
+    }
+
+    public static int SanitizeTextureCacheCapacity(int value)
+    {
+        if (value <= 0)
+        {
+            return DefaultTextureCacheCapacity;
+        }
+
+        return Math.Clamp(value, MinTextureCacheCapacity, MaxTextureCacheCapacity);
+    }
+
+    public static int SanitizeImageDecodeDimension(int value)
+    {
+        if (value <= 0)
+        {
+            return DefaultImageMaxDecodeWidth;
+        }
+
+        return Math.Clamp(value, MinImageDecodeDimension, MaxImageDecodeDimension);
+    }
+
+    public static int SanitizeImageDownloadConcurrency(int value)
+    {
+        if (value <= 0)
+        {
+            return DefaultImageDownloadConcurrency;
+        }
+
+        return Math.Clamp(value, MinImageConcurrency, MaxImageDownloadConcurrency);
+    }
+
+    public static int SanitizeImageDecodeConcurrency(int value)
+    {
+        if (value <= 0)
+        {
+            return DefaultImageDecodeConcurrency;
+        }
+
+        return Math.Clamp(value, MinImageConcurrency, MaxImageDecodeConcurrency);
+    }
+
+    public static long SanitizeImageBytesInFlightBudget(long value)
+    {
+        if (value <= 0)
+        {
+            return DefaultImageBytesInFlightBudget;
+        }
+
+        return Math.Clamp(value, MinImageBytesInFlightBudget, MaxImageBytesInFlightBudget);
+    }
+
+    public static int SanitizePreloadRowsAhead(int value)
+    {
+        if (value < 0)
+        {
+            return DefaultPreloadRowsAhead;
+        }
+
+        return Math.Clamp(value, MinPreloadRowsAhead, MaxPreloadRowsAhead);
+    }
 }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -371,6 +371,110 @@ public class SettingsWindow : IDisposable
         }
 
         ImGui.Spacing();
+        ImGui.Separator();
+        ImGui.TextUnformatted("Chat Performance");
+        ImGui.Spacing();
+
+        var maxMessages = _config.ChatMaxMessages;
+        if (ImGui.SliderInt("Message history limit", ref maxMessages, Config.MinChatMaxMessages, Config.MaxChatMaxMessages))
+        {
+            maxMessages = Config.SanitizeChatMaxMessages(maxMessages);
+            if (maxMessages != _config.ChatMaxMessages)
+            {
+                _config.ChatMaxMessages = maxMessages;
+                ApplyChatRuntimeConfigChanges();
+            }
+        }
+
+        var cacheCapacity = _config.TextureCacheCapacity;
+        if (ImGui.SliderInt("Texture cache size", ref cacheCapacity, Config.MinTextureCacheCapacity, Config.MaxTextureCacheCapacity))
+        {
+            cacheCapacity = Config.SanitizeTextureCacheCapacity(cacheCapacity);
+            if (cacheCapacity != _config.TextureCacheCapacity)
+            {
+                _config.TextureCacheCapacity = cacheCapacity;
+                ApplyChatRuntimeConfigChanges();
+            }
+        }
+
+        var maxDecodeWidth = _config.ImageMaxDecodeWidth;
+        if (ImGui.SliderInt("Max image decode width", ref maxDecodeWidth, Config.MinImageDecodeDimension, Config.MaxImageDecodeDimension))
+        {
+            maxDecodeWidth = Config.SanitizeImageDecodeDimension(maxDecodeWidth);
+            if (maxDecodeWidth != _config.ImageMaxDecodeWidth)
+            {
+                _config.ImageMaxDecodeWidth = maxDecodeWidth;
+                ApplyChatRuntimeConfigChanges();
+            }
+        }
+
+        var maxDecodeHeight = _config.ImageMaxDecodeHeight;
+        if (ImGui.SliderInt("Max image decode height", ref maxDecodeHeight, Config.MinImageDecodeDimension, Config.MaxImageDecodeDimension))
+        {
+            maxDecodeHeight = Config.SanitizeImageDecodeDimension(maxDecodeHeight);
+            if (maxDecodeHeight != _config.ImageMaxDecodeHeight)
+            {
+                _config.ImageMaxDecodeHeight = maxDecodeHeight;
+                ApplyChatRuntimeConfigChanges();
+            }
+        }
+
+        var downloadConcurrency = _config.ImageDownloadConcurrency;
+        if (ImGui.SliderInt("Concurrent image downloads", ref downloadConcurrency, Config.MinImageConcurrency, Config.MaxImageDownloadConcurrency))
+        {
+            downloadConcurrency = Config.SanitizeImageDownloadConcurrency(downloadConcurrency);
+            if (downloadConcurrency != _config.ImageDownloadConcurrency)
+            {
+                _config.ImageDownloadConcurrency = downloadConcurrency;
+                ApplyChatRuntimeConfigChanges();
+            }
+        }
+
+        var decodeConcurrency = _config.ImageDecodeConcurrency;
+        if (ImGui.SliderInt("Concurrent image decodes", ref decodeConcurrency, Config.MinImageConcurrency, Config.MaxImageDecodeConcurrency))
+        {
+            decodeConcurrency = Config.SanitizeImageDecodeConcurrency(decodeConcurrency);
+            if (decodeConcurrency != _config.ImageDecodeConcurrency)
+            {
+                _config.ImageDecodeConcurrency = decodeConcurrency;
+                ApplyChatRuntimeConfigChanges();
+            }
+        }
+
+        var minBudgetMb = Config.MinImageBytesInFlightBudget / (1024f * 1024f);
+        var maxBudgetMb = Config.MaxImageBytesInFlightBudget / (1024f * 1024f);
+        var budgetMb = _config.ImageBytesInFlightBudget / (1024f * 1024f);
+        if (ImGui.SliderFloat("Image memory budget", ref budgetMb, minBudgetMb, maxBudgetMb, "%.0f MB"))
+        {
+            var sanitizedMb = Math.Clamp(budgetMb, minBudgetMb, maxBudgetMb);
+            var bytes = (long)Math.Round(sanitizedMb * 1024f * 1024f);
+            bytes = Config.SanitizeImageBytesInFlightBudget(bytes);
+            if (bytes != _config.ImageBytesInFlightBudget)
+            {
+                _config.ImageBytesInFlightBudget = bytes;
+                ApplyChatRuntimeConfigChanges();
+            }
+        }
+
+        var preloadRows = _config.PreloadRowsAhead;
+        if (ImGui.SliderInt("Preload rows ahead", ref preloadRows, Config.MinPreloadRowsAhead, Config.MaxPreloadRowsAhead))
+        {
+            preloadRows = Config.SanitizePreloadRowsAhead(preloadRows);
+            if (preloadRows != _config.PreloadRowsAhead)
+            {
+                _config.PreloadRowsAhead = preloadRows;
+                ApplyChatRuntimeConfigChanges();
+            }
+        }
+
+        var lazyLoadEmbeds = _config.LazyLoadEmbeds;
+        if (ImGui.Checkbox("Lazy-load embeds and attachments", ref lazyLoadEmbeds))
+        {
+            _config.LazyLoadEmbeds = lazyLoadEmbeds;
+            ApplyChatRuntimeConfigChanges();
+        }
+
+        ImGui.Spacing();
 
         ImGui.TextUnformatted("Theme");
         ImGui.Spacing();
@@ -635,6 +739,14 @@ public class SettingsWindow : IDisposable
     {
         ChatWindow?.OnAppearanceSettingsChanged();
         OfficerChatWindow?.OnAppearanceSettingsChanged();
+    }
+
+    private void ApplyChatRuntimeConfigChanges()
+    {
+        SaveConfig();
+        ChatWindow?.ReconfigureImageLoader();
+        OfficerChatWindow?.ReconfigureImageLoader();
+        RefreshChatWindows();
     }
 
     private static bool ColorsAlmostEqual(Vector4 a, Vector4 b)


### PR DESCRIPTION
## Summary
- add persisted configuration for chat history limits, cache sizing, and image loader parameters
- update ChatWindow to respect the new knobs, lazily load embeds, and reconfigure runtime state when settings change
- expose the performance tuning controls in the settings UI and refresh chat windows when values are adjusted

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e14e8c2afc8328a19af3ab983bd6f7