### PR TITLE
Add ImageSharp-based image loading pipeline

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -15,13 +14,16 @@ using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures;
 using Dalamud.Interface.Utility;
 using ImGuiNET;
-using StbImageSharp;
 using System.IO;
 using DiscordHelper;
 using System.Diagnostics;
 using Dalamud.Interface.ImGuiFileDialog;
 using DemiCatPlugin.Emoji;
 using DemiCatPlugin.Avatars;
+using DemiCatPlugin.Images;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 
 namespace DemiCatPlugin;
 
@@ -103,15 +105,12 @@ public class ChatWindow : IDisposable
     private MentionDrawerState? _mentionDrawerState;
     private int _imageMaxDecodeWidth = Config.DefaultImageMaxDecodeWidth;
     private int _imageMaxDecodeHeight = Config.DefaultImageMaxDecodeHeight;
-    private long _imageBytesBudget = Config.DefaultImageBytesInFlightBudget;
     private int _preloadRowsAhead = Config.DefaultPreloadRowsAhead;
     private bool _lazyLoadEmbedsEnabled;
     private bool _allowTextureLoads = true;
     private readonly Dictionary<string, (Vector2 Min, Vector2 Max)> _messageRectCache = new();
-    private SemaphoreSlim _imageDownloadSemaphore = new(Config.DefaultImageDownloadConcurrency, Config.DefaultImageDownloadConcurrency);
-    private SemaphoreSlim _imageDecodeSemaphore = new(Config.DefaultImageDecodeConcurrency, Config.DefaultImageDecodeConcurrency);
-    private int _imageDownloadSemaphoreCapacity = Config.DefaultImageDownloadConcurrency;
-    private int _imageDecodeSemaphoreCapacity = Config.DefaultImageDecodeConcurrency;
+    private IImmediateTextureFactory? _textureFactory;
+    private ImageLoader? _imageLoader;
 
     protected string CurrentChannelId => _channelSelection.GetChannel(_channelKind, _config.GuildId);
     protected string ChannelKindKey => _channelKind;
@@ -2915,24 +2914,82 @@ public class ChatWindow : IDisposable
             return;
 
         _attachmentPreviewTextures[path] = null;
-        _ = Task.Run(() =>
+        _ = Task.Run(async () =>
         {
             try
             {
-                var bytes = File.ReadAllBytes(path);
-                using var stream = new MemoryStream(bytes);
-                var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
-                var wrap = PluginServices.Instance!.TextureProvider.CreateFromRaw(
-                    RawImageSpecification.Rgba32(image.Width, image.Height),
-                    image.Data);
-                var texture = new ForwardingSharedImmediateTexture(wrap);
-                PluginServices.Instance!.Framework.RunOnTick(() => _attachmentPreviewTextures[path] = texture);
+                var factory = _textureFactory;
+                if (factory == null)
+                {
+                    var framework = PluginServices.Instance?.Framework;
+                    if (framework != null)
+                    {
+                        _ = framework.RunOnTick(() => _attachmentPreviewTextures.Remove(path));
+                    }
+                    else
+                    {
+                        _attachmentPreviewTextures.Remove(path);
+                    }
+                    return;
+                }
+
+                await using var stream = File.OpenRead(path);
+                using var image = await Image.LoadAsync<Rgba32>(stream).ConfigureAwait(false);
+                ResizeAttachmentImage(image);
+                var texture = await factory.CreateAsync(image).ConfigureAwait(false);
+                if (texture == null)
+                {
+                    var framework = PluginServices.Instance?.Framework;
+                    if (framework != null)
+                    {
+                        _ = framework.RunOnTick(() => _attachmentPreviewTextures.Remove(path));
+                    }
+                    else
+                    {
+                        _attachmentPreviewTextures.Remove(path);
+                    }
+                    return;
+                }
+
+                var frameworkInstance = PluginServices.Instance?.Framework;
+                if (frameworkInstance != null)
+                {
+                    _ = frameworkInstance.RunOnTick(() => _attachmentPreviewTextures[path] = texture);
+                }
+                else
+                {
+                    _attachmentPreviewTextures[path] = texture;
+                }
             }
             catch
             {
-                PluginServices.Instance?.Framework.RunOnTick(() => _attachmentPreviewTextures.Remove(path));
+                var framework = PluginServices.Instance?.Framework;
+                if (framework != null)
+                {
+                    _ = framework.RunOnTick(() => _attachmentPreviewTextures.Remove(path));
+                }
+                else
+                {
+                    _attachmentPreviewTextures.Remove(path);
+                }
             }
         });
+    }
+
+    private void ResizeAttachmentImage(Image<Rgba32> image)
+    {
+        if (image.Width <= _imageMaxDecodeWidth && image.Height <= _imageMaxDecodeHeight)
+        {
+            return;
+        }
+
+        image.Mutate(ctx => ctx.Resize(new ResizeOptions
+        {
+            Mode = ResizeMode.Max,
+            Size = new Size(_imageMaxDecodeWidth, _imageMaxDecodeHeight),
+            Sampler = KnownResamplers.Lanczos3,
+            Compand = true
+        }));
     }
 
     private void CleanupAttachmentPreviews(IEnumerable<string> activePaths)
@@ -3697,8 +3754,7 @@ public class ChatWindow : IDisposable
             DisposeMessageTextures(message);
         }
         ClearTextureCache();
-        _imageDownloadSemaphore?.Dispose();
-        _imageDecodeSemaphore?.Dispose();
+        DisposeImageLoader();
     }
 
     protected void SaveConfig()
@@ -3999,90 +4055,60 @@ public class ChatWindow : IDisposable
             return;
         }
 
+        var loader = _imageLoader;
+        if (loader == null || _textureFactory == null)
+        {
+            set(null);
+            return;
+        }
+
         var node = _textureLru.AddFirst(url);
         _textureCache[url] = new TextureCacheEntry(null, node);
         EnforceTextureCacheCapacity();
 
         _ = Task.Run(async () =>
         {
-            var downloadSemaphore = _imageDownloadSemaphore;
-            var decodeSemaphore = _imageDecodeSemaphore;
+            ISharedImmediateTexture? texture = null;
             try
             {
-                await downloadSemaphore.WaitAsync().ConfigureAwait(false);
-                try
-                {
-                    using var response = await _httpClient
-                        .SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseHeadersRead)
-                        .ConfigureAwait(false);
-                    if (!response.IsSuccessStatusCode)
-                    {
-                        var framework = PluginServices.Instance!.Framework;
-                        _ = framework.RunOnTick(() =>
-                        {
-                            RemoveTextureEntry(url);
-                            set(null);
-                        });
-                        return;
-                    }
-
-                    var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
-                    if (_imageBytesBudget > 0 && bytes.LongLength > _imageBytesBudget)
-                    {
-                        var framework = PluginServices.Instance!.Framework;
-                        _ = framework.RunOnTick(() =>
-                        {
-                            RemoveTextureEntry(url);
-                            set(null);
-                        });
-                        return;
-                    }
-
-                    await decodeSemaphore.WaitAsync().ConfigureAwait(false);
-                    try
-                    {
-                        using var stream = new MemoryStream(bytes);
-                        var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
-                        if ((_imageMaxDecodeWidth > 0 && image.Width > _imageMaxDecodeWidth) ||
-                            (_imageMaxDecodeHeight > 0 && image.Height > _imageMaxDecodeHeight))
-                        {
-                            var framework = PluginServices.Instance!.Framework;
-                            _ = framework.RunOnTick(() =>
-                            {
-                                RemoveTextureEntry(url);
-                                set(null);
-                            });
-                            return;
-                        }
-
-                        var wrap = PluginServices.Instance!.TextureProvider.CreateFromRaw(
-                            RawImageSpecification.Rgba32(image.Width, image.Height),
-                            image.Data);
-                        var texture = new ForwardingSharedImmediateTexture(wrap);
-                        if (_textureCache.TryGetValue(url, out var entry))
-                        {
-                            entry.Texture = texture;
-                        }
-                        _ = PluginServices.Instance!.Framework.RunOnTick(() => set(texture));
-                    }
-                    finally
-                    {
-                        decodeSemaphore.Release();
-                    }
-                }
-                finally
-                {
-                    downloadSemaphore.Release();
-                }
+                texture = await loader.LoadIntoTextureAsync(url).ConfigureAwait(false);
             }
             catch
             {
-                var framework = PluginServices.Instance!.Framework;
-                _ = framework.RunOnTick(() =>
+                texture = null;
+            }
+
+            void Complete()
+            {
+                if (texture == null)
                 {
                     RemoveTextureEntry(url);
                     set(null);
-                });
+                    return;
+                }
+
+                if (!_textureCache.TryGetValue(url, out var entry))
+                {
+                    if (texture.GetWrapOrEmpty() is IDisposable wrap)
+                    {
+                        wrap.Dispose();
+                    }
+                    set(null);
+                    return;
+                }
+
+                entry.Texture = texture;
+                set(texture);
+            }
+
+            var framework = PluginServices.Instance?.Framework;
+            if (framework != null)
+            {
+                _ = framework.RunOnTick(Complete);
+            }
+            else
+            {
+                Complete();
             }
         });
     }
@@ -4122,21 +4148,18 @@ public class ChatWindow : IDisposable
         {
             _config.ImageDownloadConcurrency = sanitizedDownloadConcurrency;
         }
-        ReplaceSemaphore(ref _imageDownloadSemaphore, ref _imageDownloadSemaphoreCapacity, sanitizedDownloadConcurrency);
 
         var sanitizedDecodeConcurrency = Config.SanitizeImageDecodeConcurrency(_config.ImageDecodeConcurrency);
         if (_config.ImageDecodeConcurrency != sanitizedDecodeConcurrency)
         {
             _config.ImageDecodeConcurrency = sanitizedDecodeConcurrency;
         }
-        ReplaceSemaphore(ref _imageDecodeSemaphore, ref _imageDecodeSemaphoreCapacity, sanitizedDecodeConcurrency);
 
         var sanitizedBudget = Config.SanitizeImageBytesInFlightBudget(_config.ImageBytesInFlightBudget);
         if (_config.ImageBytesInFlightBudget != sanitizedBudget)
         {
             _config.ImageBytesInFlightBudget = sanitizedBudget;
         }
-        _imageBytesBudget = sanitizedBudget;
 
         var sanitizedPreload = Config.SanitizePreloadRowsAhead(_config.PreloadRowsAhead);
         if (_config.PreloadRowsAhead != sanitizedPreload)
@@ -4146,6 +4169,8 @@ public class ChatWindow : IDisposable
         _preloadRowsAhead = sanitizedPreload;
 
         _lazyLoadEmbedsEnabled = _config.LazyLoadEmbeds;
+
+        RebuildImageLoader(sanitizedDownloadConcurrency, sanitizedDecodeConcurrency, sanitizedBudget);
     }
 
     private int MaxMessages => Config.SanitizeChatMaxMessages(_config.ChatMaxMessages);
@@ -4247,39 +4272,35 @@ public class ChatWindow : IDisposable
         return rowsAway <= _preloadRowsAhead;
     }
 
-    private void ReplaceSemaphore(ref SemaphoreSlim semaphore, ref int capacityField, int concurrency)
+    private void RebuildImageLoader(int downloadConcurrency, int decodeConcurrency, long byteBudget)
     {
-        var old = semaphore;
-        var previousCapacity = capacityField;
-        capacityField = concurrency;
-        semaphore = new SemaphoreSlim(concurrency, concurrency);
-        if (old == null)
+        var services = PluginServices.Instance;
+        if (services?.TextureProvider == null)
         {
+            DisposeImageLoader();
             return;
         }
 
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                if (previousCapacity > 0)
-                {
-                    while (old.CurrentCount < previousCapacity)
-                    {
-                        await Task.Delay(100).ConfigureAwait(false);
-                    }
-                }
-                old.Dispose();
-            }
-            catch (ObjectDisposedException)
-            {
-                // already disposed
-            }
-            catch
-            {
-                // ignored
-            }
-        });
+        var newFactory = new ImmediateTextureFactory(services.TextureProvider);
+        var newLoader = new ImageLoader(
+            _httpClient,
+            newFactory,
+            downloadConcurrency,
+            decodeConcurrency,
+            byteBudget,
+            _imageMaxDecodeWidth,
+            _imageMaxDecodeHeight);
+
+        var oldLoader = Interlocked.Exchange(ref _imageLoader, newLoader);
+        _textureFactory = newFactory;
+        oldLoader?.Dispose();
+    }
+
+    private void DisposeImageLoader()
+    {
+        var oldLoader = Interlocked.Exchange(ref _imageLoader, null);
+        oldLoader?.Dispose();
+        _textureFactory = null;
     }
 
     private readonly struct TextureLoadScope : IDisposable

--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StbImageSharp" Version="2.30.15" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="Penumbra.Api" Version="5.12.0" />

--- a/DemiCatPlugin/Images/IImmediateTextureFactory.cs
+++ b/DemiCatPlugin/Images/IImmediateTextureFactory.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Interface.Textures;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace DemiCatPlugin.Images;
+
+internal interface IImmediateTextureFactory
+{
+    ValueTask<ISharedImmediateTexture?> CreateAsync(Image<Rgba32> image, CancellationToken cancellationToken = default);
+}

--- a/DemiCatPlugin/Images/ImageLoader.cs
+++ b/DemiCatPlugin/Images/ImageLoader.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Interface.Textures;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace DemiCatPlugin.Images;
+
+internal sealed class ImageLoader : IDisposable
+{
+    private const int BufferSize = 80 * 1024;
+
+    private readonly HttpClient _httpClient;
+    private readonly IImmediateTextureFactory _textureFactory;
+    private readonly SemaphoreSlim _downloadSemaphore;
+    private readonly SemaphoreSlim _decodeSemaphore;
+    private readonly long _byteBudget;
+    private readonly int _maxDecodeWidth;
+    private readonly int _maxDecodeHeight;
+    private long _bytesInFlight;
+    private bool _disposed;
+
+    public ImageLoader(
+        HttpClient httpClient,
+        IImmediateTextureFactory textureFactory,
+        int downloadConcurrency,
+        int decodeConcurrency,
+        long byteBudget,
+        int maxDecodeWidth,
+        int maxDecodeHeight)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _textureFactory = textureFactory ?? throw new ArgumentNullException(nameof(textureFactory));
+        _downloadSemaphore = new SemaphoreSlim(Math.Max(1, downloadConcurrency), Math.Max(1, downloadConcurrency));
+        _decodeSemaphore = new SemaphoreSlim(Math.Max(1, decodeConcurrency), Math.Max(1, decodeConcurrency));
+        _byteBudget = Math.Max(0, byteBudget);
+        _maxDecodeWidth = Math.Max(1, maxDecodeWidth);
+        _maxDecodeHeight = Math.Max(1, maxDecodeHeight);
+    }
+
+    public async Task<ISharedImmediateTexture?> LoadIntoTextureAsync(string url, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return null;
+        }
+
+        ThrowIfDisposed();
+
+        await _downloadSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        long reservedBytes = 0;
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            using var response = await _httpClient
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            var contentLength = response.Content.Headers.ContentLength;
+            if (_byteBudget > 0 && contentLength.HasValue && contentLength.Value > _byteBudget)
+            {
+                return null;
+            }
+
+            if (_byteBudget > 0 && contentLength.HasValue && contentLength.Value > 0)
+            {
+                if (!TryReserveBytes(contentLength.Value))
+                {
+                    return null;
+                }
+
+                reservedBytes = contentLength.Value;
+            }
+
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            using var memoryStream = contentLength is { } length && length > 0 && length <= int.MaxValue
+                ? new MemoryStream((int)length)
+                : new MemoryStream();
+            var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+            try
+            {
+                long bytesReadTotal = 0;
+                while (true)
+                {
+                    var read = await contentStream
+                        .ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)
+                        .ConfigureAwait(false);
+                    if (read <= 0)
+                    {
+                        break;
+                    }
+
+                    if (_byteBudget > 0)
+                    {
+                        if (!contentLength.HasValue)
+                        {
+                            if (!TryReserveBytes(read))
+                            {
+                                return null;
+                            }
+
+                            reservedBytes += read;
+                        }
+                        else
+                        {
+                            bytesReadTotal += read;
+                            if (bytesReadTotal > reservedBytes)
+                            {
+                                var extra = bytesReadTotal - reservedBytes;
+                                if (!TryReserveBytes(extra))
+                                {
+                                    return null;
+                                }
+
+                                reservedBytes += extra;
+                            }
+                        }
+                    }
+
+                    memoryStream.Write(buffer, 0, read);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+
+            memoryStream.Position = 0;
+
+            await _decodeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                using var image = await Image.LoadAsync<Rgba32>(memoryStream, cancellationToken).ConfigureAwait(false);
+                ResizeToFit(image);
+                return await _textureFactory.CreateAsync(image, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _decodeSemaphore.Release();
+            }
+        }
+        finally
+        {
+            if (reservedBytes > 0)
+            {
+                ReleaseBytes(reservedBytes);
+            }
+
+            _downloadSemaphore.Release();
+        }
+    }
+
+    private void ResizeToFit(Image<Rgba32> image)
+    {
+        if (image.Width <= _maxDecodeWidth && image.Height <= _maxDecodeHeight)
+        {
+            return;
+        }
+
+        image.Mutate(ctx => ctx.Resize(new ResizeOptions
+        {
+            Mode = ResizeMode.Max,
+            Size = new Size(_maxDecodeWidth, _maxDecodeHeight),
+            Sampler = KnownResamplers.Lanczos3,
+            Compand = true
+        }));
+    }
+
+    private bool TryReserveBytes(long bytes)
+    {
+        if (_byteBudget <= 0 || bytes <= 0)
+        {
+            return true;
+        }
+
+        while (true)
+        {
+            var current = Volatile.Read(ref _bytesInFlight);
+            var next = current + bytes;
+            if (next > _byteBudget)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _bytesInFlight, next, current) == current)
+            {
+                return true;
+            }
+        }
+    }
+
+    private void ReleaseBytes(long bytes)
+    {
+        if (_byteBudget <= 0 || bytes <= 0)
+        {
+            return;
+        }
+
+        Interlocked.Add(ref _bytesInFlight, -bytes);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(ImageLoader));
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _downloadSemaphore.Dispose();
+        _decodeSemaphore.Dispose();
+    }
+}

--- a/DemiCatPlugin/Images/ImmediateTextureFactory.cs
+++ b/DemiCatPlugin/Images/ImmediateTextureFactory.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Interface.Textures;
+using Dalamud.Plugin.Services;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace DemiCatPlugin.Images;
+
+internal sealed class ImmediateTextureFactory : IImmediateTextureFactory
+{
+    private readonly ITextureProvider _textureProvider;
+
+    public ImmediateTextureFactory(ITextureProvider textureProvider)
+    {
+        _textureProvider = textureProvider ?? throw new ArgumentNullException(nameof(textureProvider));
+    }
+
+    public ValueTask<ISharedImmediateTexture?> CreateAsync(Image<Rgba32> image, CancellationToken cancellationToken = default)
+    {
+        if (image == null)
+        {
+            throw new ArgumentNullException(nameof(image));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!image.DangerousTryGetSinglePixelMemory(out var memory))
+        {
+            throw new InvalidOperationException("Image pixels are not stored contiguously.");
+        }
+
+        var span = memory.Span;
+        if (span.Length == 0)
+        {
+            return ValueTask.FromResult<ISharedImmediateTexture?>(null);
+        }
+
+        var bytes = MemoryMarshal.AsBytes(span);
+        var wrap = _textureProvider.CreateFromRaw(
+            RawImageSpecification.Rgba32(image.Width, image.Height),
+            bytes);
+        var texture = new ForwardingSharedImmediateTexture(wrap);
+        return ValueTask.FromResult<ISharedImmediateTexture?>(texture);
+    }
+}


### PR DESCRIPTION
## Summary
- add SixLabors.ImageSharp to the plugin project
- introduce an ImageLoader and ImmediateTextureFactory that enforce byte budgets, resize-to-fit logic, and concurrency gates
- update ChatWindow to use the new loader, rebuild it when settings change, and process attachment previews through ImageSharp

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e158af1fa88328bffe6207a9674ad8