### PR TITLE
Use streaming reads for chat and emoji fetches

### DIFF
--- a/DemiCatPlugin/ChannelService.cs
+++ b/DemiCatPlugin/ChannelService.cs
@@ -39,9 +39,13 @@ public class ChannelService
             linkedCts.CancelAfter(TimeSpan.FromSeconds(10));
             try
             {
-                using var response = await _httpClient.SendAsync(request, linkedCts.Token);
+                using var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    linkedCts.Token
+                );
                 response.EnsureSuccessStatusCode();
-                var stream = await response.Content.ReadAsStreamAsync(linkedCts.Token);
+                await using var stream = await response.Content.ReadAsStreamAsync(linkedCts.Token);
                 var channels = await JsonSerializer.DeserializeAsync<List<ChannelDto>>(stream, JsonOpts, linkedCts.Token) ?? new List<ChannelDto>();
                 foreach (var channel in channels)
                 {
@@ -91,10 +95,14 @@ public class ChannelService
 
         try
         {
-            using var response = await _httpClient.SendAsync(request, linkedCts.Token);
+            using var response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                linkedCts.Token
+            );
             response.EnsureSuccessStatusCode();
 
-            var stream = await response.Content.ReadAsStreamAsync(linkedCts.Token);
+            await using var stream = await response.Content.ReadAsStreamAsync(linkedCts.Token);
             var result = await JsonSerializer.DeserializeAsync<ChannelValidationResponse>(
                 stream,
                 JsonOpts,

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -3495,10 +3495,13 @@ public class ChatWindow : IDisposable
                     appliedStoredCursor = true;
                 }
 
-                var request = new HttpRequestMessage(HttpMethod.Get, url);
+                using var request = new HttpRequestMessage(HttpMethod.Get, url);
                 ApiHelpers.AddAuthHeader(request, _tokenManager);
 
-                var response = await _httpClient.SendAsync(request);
+                using var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead
+                );
                 if (!response.IsSuccessStatusCode)
                 {
                     var responseBody = await response.Content.ReadAsStringAsync();
@@ -3511,7 +3514,7 @@ public class ChatWindow : IDisposable
                     break;
                 }
 
-                var stream = await response.Content.ReadAsStreamAsync();
+                await using var stream = await response.Content.ReadAsStreamAsync();
 
                 var msgs = await JsonSerializer.DeserializeAsync<List<DiscordMessageDto>>(stream, JsonOpts) ?? new List<DiscordMessageDto>();
 

--- a/DemiCatPlugin/Emoji/EmojiManager.cs
+++ b/DemiCatPlugin/Emoji/EmojiManager.cs
@@ -205,7 +205,11 @@ public sealed class EmojiManager : IDisposable
         using var req = new HttpRequestMessage(HttpMethod.Get, url);
         ApiHelpers.AddAuthHeader(req, _tokens);
 
-        using var res = await _httpClient.SendAsync(req, ct).ConfigureAwait(false);
+        using var res = await _httpClient.SendAsync(
+            req,
+            HttpCompletionOption.ResponseHeadersRead,
+            ct
+        ).ConfigureAwait(false);
         if (res.StatusCode == HttpStatusCode.Unauthorized)
         {
             _tokens.Clear("Invalid API key");
@@ -234,7 +238,11 @@ public sealed class EmojiManager : IDisposable
         using var req = new HttpRequestMessage(HttpMethod.Get, url);
         ApiHelpers.AddAuthHeader(req, _tokens);
 
-        using var res = await _httpClient.SendAsync(req, ct).ConfigureAwait(false);
+        using var res = await _httpClient.SendAsync(
+            req,
+            HttpCompletionOption.ResponseHeadersRead,
+            ct
+        ).ConfigureAwait(false);
         if (res.StatusCode == HttpStatusCode.Unauthorized)
         {
             _tokens.Clear("Invalid API key");


### PR DESCRIPTION
## Summary
- request channel fetch and validation with ResponseHeadersRead and stream disposal
- stream chat message pagination responses while retaining existing error handling
- align emoji fetches with streaming response handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e16435a1b48328b5f620eed4be942e