### PR TITLE
Remove unused Dalamud ImGui using

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using System.Globalization;
-using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures;
 using Dalamud.Interface.Utility;
 using ImGuiNET;


### PR DESCRIPTION
## Summary
- remove the Dalamud.Bindings.ImGui using from ChatWindow so ImGui types resolve unambiguously to ImGuiNET

## Testing
- not run (dotnet build DemiCatPlugin/DemiCatPlugin.csproj)

------
https://chatgpt.com/codex/tasks/task_e_68e16e64e1d08328b1a24df3cceddeca