### PR TITLE
Add cancellation token support for chat window image loading

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -111,6 +111,7 @@ public class ChatWindow : IDisposable
     private readonly Dictionary<string, (Vector2 Min, Vector2 Max)> _messageRectCache = new();
     private IImmediateTextureFactory? _textureFactory;
     private ImageLoader? _imageLoader;
+    private CancellationTokenSource _imageCts;
 
     protected string CurrentChannelId => _channelSelection.GetChannel(_channelKind, _config.GuildId);
     protected string ChannelKindKey => _channelKind;
@@ -448,6 +449,7 @@ public class ChatWindow : IDisposable
             });
 
         _channelSelection.ChannelChanged += HandleChannelSelectionChanged;
+        _imageCts = new CancellationTokenSource();
         ReconfigureImageLoader();
     }
 
@@ -587,6 +589,10 @@ public class ChatWindow : IDisposable
             return;
         PluginServices.Instance!.Framework.RunOnTick(() =>
         {
+            _imageCts.Cancel();
+            _imageCts.Dispose();
+            _imageCts = new CancellationTokenSource();
+
             _pendingInitialScroll = true;
             _wasAtBottomLastFrame = true;
             _chatTopPadding = 0f;
@@ -3779,6 +3785,9 @@ public class ChatWindow : IDisposable
     public void Dispose()
     {
         StopNetworking();
+        _imageCts.Cancel();
+        _imageCts.Dispose();
+        _imageCts = new CancellationTokenSource();
         _channelSelection.ChannelChanged -= HandleChannelSelectionChanged;
         _bridge.Dispose();
         foreach (var message in _messages)
@@ -4098,20 +4107,51 @@ public class ChatWindow : IDisposable
         _textureCache[url] = new TextureCacheEntry(null, node);
         EnforceTextureCacheCapacity();
 
+        var token = _imageCts.Token;
+        if (token.IsCancellationRequested)
+        {
+            RemoveTextureEntry(url);
+            return;
+        }
+
         _ = Task.Run(async () =>
         {
             ISharedImmediateTexture? texture = null;
             try
             {
-                texture = await loader.LoadIntoTextureAsync(url).ConfigureAwait(false);
+                texture = await loader.LoadIntoTextureAsync(url, token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                return;
             }
             catch
             {
                 texture = null;
             }
 
+            if (token.IsCancellationRequested)
+            {
+                if (texture?.GetWrapOrEmpty() is IDisposable wrapCanceled)
+                {
+                    wrapCanceled.Dispose();
+                }
+                RemoveTextureEntry(url);
+                return;
+            }
+
             void Complete()
             {
+                if (token.IsCancellationRequested)
+                {
+                    if (texture?.GetWrapOrEmpty() is IDisposable wrapCanceled)
+                    {
+                        wrapCanceled.Dispose();
+                    }
+                    RemoveTextureEntry(url);
+                    return;
+                }
+
                 if (texture == null)
                 {
                     RemoveTextureEntry(url);
@@ -4142,7 +4182,7 @@ public class ChatWindow : IDisposable
             {
                 Complete();
             }
-        });
+        }, token);
     }
 
     public virtual void ReconfigureImageLoader()


### PR DESCRIPTION
## Summary
- add a dedicated cancellation token source for chat window image downloads and reset it on channel changes and disposal
- pass the cancellation token into background texture loading to tear down work that no longer applies

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1728a53f083289a7108ffab903a25