### PR TITLE
Return RenderResult from EmbedPreviewRenderer.Draw

### DIFF
--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -225,6 +225,8 @@ public static class EmbedPreviewRenderer
             var inset = new Vector2(1f, 1f);
             drawList.AddRect(rectMin + inset, rectMax - inset, color, 0f, ImDrawFlags.None, 1.5f);
         }
+
+        return new RenderResult(thumbnailRendered, thumbnailDeferred, imageRendered, imageDeferred);
     }
 
     private static void DrawFields(EmbedDto dto)
@@ -281,7 +283,6 @@ public static class EmbedPreviewRenderer
                 }
             }
         }
-        return new RenderResult(thumbnailRendered, thumbnailDeferred, imageRendered, imageDeferred);
     }
 
     private static ISharedImmediateTexture? GetTexture(


### PR DESCRIPTION
## Summary
- ensure EmbedPreviewRenderer.Draw returns the computed RenderResult
- keep DrawFields as a void helper by removing the erroneous return statement

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1806a98e08328a58636ae4f724db5