### PR TITLE
Update ImGui text input callbacks

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -905,9 +905,12 @@ public class ChatWindow : IDisposable
 
         if (ImGui.BeginPopup("editMessage"))
         {
-            var editBuf = ImGuiTextUtil.MakeUtf8Buffer(_editContent, 2048);
-            ImGui.InputTextMultiline("##editContent", editBuf, new Vector2(400, ImGui.GetTextLineHeight() * 5));
-            _editContent = ImGuiTextUtil.ReadUtf8Buffer(editBuf);
+            _ = ImGui.InputTextMultiline(
+                "##editContent",
+                ref _editContent,
+                2048u,
+                new Vector2(400, ImGui.GetTextLineHeight() * 5)
+            );
 
             if (ImGui.Button("Save"))
             {
@@ -999,7 +1002,6 @@ public class ChatWindow : IDisposable
         ImGui.SameLine();
         if (ImGui.SmallButton("Link")) WrapSelection("[", "](url)");
 
-        var inputBuf = ImGuiTextUtil.MakeUtf8Buffer(_input, 2048);
         var availableWidth = ImGui.GetContentRegionAvail().X;
         var framePadding = style.FramePadding.X * 2f;
         var emojiButtonWidth = 0f;
@@ -1028,10 +1030,12 @@ public class ChatWindow : IDisposable
         }
         _ = ImGui.InputTextMultiline(
             "##chatInput",
-            inputBuf,
+            ref _input,
+            2048u,
             new Vector2(inputWidth, inputHeight),
             ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
-            new ImGui.ImGuiInputTextCallbackDelegate(OnInputEdited)
+            OnInputEdited,
+            IntPtr.Zero
         );
         if (MentionsEnabled)
         {
@@ -1039,7 +1043,6 @@ public class ChatWindow : IDisposable
             mentionState.AnchorMin = ImGui.GetItemRectMin();
             mentionState.AnchorMax = ImGui.GetItemRectMax();
         }
-        _input = ImGuiTextUtil.ReadUtf8Buffer(inputBuf);
 
         var composerActive = ImGui.IsItemActive();
         var inputEdited = ImGui.IsItemEdited();
@@ -1518,11 +1521,16 @@ public class ChatWindow : IDisposable
         ImGui.TextUnformatted(text);
     }
 
-    // Correct signature for Dalamud's callback: ref struct, returns int
-    private int OnInputEdited(ref ImGuiInputTextCallbackData data)
+    // Correct signature for Dalamud's callback: unsafe pointer, returns int
+    private unsafe int OnInputEdited(ImGuiInputTextCallbackData* data)
     {
-        _selectionStart = data.SelectionStart;
-        _selectionEnd = data.SelectionEnd;
+        if (data == null)
+        {
+            return 0;
+        }
+
+        _selectionStart = data->SelectionStart;
+        _selectionEnd = data->SelectionEnd;
         return 0;
     }
 

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -223,7 +223,6 @@ public class EventCreateWindow
 
                     var avail = ImGui.GetContentRegionAvail();
                     var descHeight = ImGui.GetTextLineHeight() * 6f;
-                    var descBuf = ImGuiTextUtil.MakeUtf8Buffer(_description, 4096);
                     if (_focusDescriptionNextFrame)
                     {
                         ImGui.SetKeyboardFocusHere();
@@ -231,12 +230,13 @@ public class EventCreateWindow
                     }
                     ImGui.InputTextMultiline(
                         "##Description",
-                        descBuf,
+                        ref _description,
+                        4096u,
                         new Vector2(avail.X, descHeight),
                         ImGuiInputTextFlags.CallbackAlways,
-                        new ImGui.ImGuiInputTextCallbackDelegate(OnDescriptionEdited)
+                        OnDescriptionEdited,
+                        IntPtr.Zero
                     );
-                    _description = ImGuiTextUtil.ReadUtf8Buffer(descBuf);
                     _descriptionEmojiPopup.Draw();
                 },
                 alignLabel: false,
@@ -451,7 +451,7 @@ public class EventCreateWindow
             {
                 var field = _fields[i];
                 ImGui.InputText($"Name##{i}", ref field.Name, 256);
-                ImGui.InputTextMultiline($"Value##{i}", ref field.Value, 1024, new Vector2(400, 60));
+                ImGui.InputTextMultiline($"Value##{i}", ref field.Value, 1024u, new Vector2(400, 60));
                 ImGui.Checkbox($"Inline##{i}", ref field.Inline);
                 if (ImGui.Button($"Remove##{i}"))
                 {
@@ -947,10 +947,15 @@ public class EventCreateWindow
         _focusDescriptionNextFrame = true;
     }
 
-    private int OnDescriptionEdited(ref ImGuiInputTextCallbackData data)
+    private unsafe int OnDescriptionEdited(ImGuiInputTextCallbackData* data)
     {
-        _descriptionSelectionStart = data.SelectionStart;
-        _descriptionSelectionEnd = data.SelectionEnd;
+        if (data == null)
+        {
+            return 0;
+        }
+
+        _descriptionSelectionStart = data->SelectionStart;
+        _descriptionSelectionEnd = data->SelectionEnd;
         return 0;
     }
 

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -404,16 +404,23 @@ public sealed class NotePadWindow : IDisposable
         if (IsReadOnly)
         {
             var content = page.Content ?? string.Empty;
-            var readOnlyBuffer = ImGuiTextUtil.MakeUtf8Buffer(content, Math.Max(1024, content.Length + 512));
+            var capacity = (uint)Math.Max(1024, content.Length + 512);
+            var readOnlyContent = content;
             ImGui.BeginDisabled();
-            ImGui.InputTextMultiline("##NotePadEditorReadOnly", readOnlyBuffer, new Vector2(-1, -1), ImGuiInputTextFlags.ReadOnly);
+            ImGui.InputTextMultiline(
+                "##NotePadEditorReadOnly",
+                ref readOnlyContent,
+                capacity,
+                new Vector2(-1, -1),
+                ImGuiInputTextFlags.ReadOnly
+            );
             ImGui.EndDisabled();
             _editorContent = content;
             _editorVersion = page.Version;
             return;
         }
 
-        var buffer = ImGuiTextUtil.MakeUtf8Buffer(_editorContent, Math.Max(1024, _editorContent.Length + 512));
+        var editorCapacity = (uint)Math.Max(1024, _editorContent.Length + 512);
         if (_focusEditorNextFrame)
         {
             ImGui.SetKeyboardFocusHere();
@@ -422,13 +429,19 @@ public sealed class NotePadWindow : IDisposable
 
         ImGui.PushItemWidth(-1);
         var flags = ImGuiInputTextFlags.AllowTabInput | ImGuiInputTextFlags.CallbackAlways | ImGuiInputTextFlags.CallbackHistory;
-        var edited = ImGui.InputTextMultiline("##NotePadEditor", buffer, new Vector2(-1, -1), flags, new ImGui.ImGuiInputTextCallbackDelegate(OnEditorEdited));
+        var edited = ImGui.InputTextMultiline(
+            "##NotePadEditor",
+            ref _editorContent,
+            editorCapacity,
+            new Vector2(-1, -1),
+            flags,
+            OnEditorEdited,
+            IntPtr.Zero
+        );
         ImGui.PopItemWidth();
 
-        var newValue = ImGuiTextUtil.ReadUtf8Buffer(buffer);
-        if (!string.Equals(newValue, _editorContent, StringComparison.Ordinal))
+        if (edited)
         {
-            _editorContent = newValue;
             _dirty = true;
             _lastEditUtc = DateTime.UtcNow;
         }
@@ -828,10 +841,15 @@ public sealed class NotePadWindow : IDisposable
         _lastEditUtc = DateTime.UtcNow;
     }
 
-    private int OnEditorEdited(ref ImGuiInputTextCallbackData data)
+    private unsafe int OnEditorEdited(ImGuiInputTextCallbackData* data)
     {
-        _selectionStart = data.SelectionStart;
-        _selectionEnd = data.SelectionEnd;
+        if (data == null)
+        {
+            return 0;
+        }
+
+        _selectionStart = data->SelectionStart;
+        _selectionEnd = data->SelectionEnd;
         return 0;
     }
 

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -21,6 +21,7 @@ using DemiCatPlugin.SyncShell;
 using Penumbra.Api.Enums;
 using Serilog;
 using Serilog.Events;
+using ImGuiNET;
 
 namespace DemiCatPlugin;
 
@@ -140,7 +141,7 @@ public class SyncshellWindow : IDisposable
     private Vector2 _inviteSuggestionWindowSize;
     private bool _inviteSuggestionFiltered;
     private bool _focusInviteInputNextFrame;
-    private readonly ImGui.ImGuiInputTextCallbackDelegate _inviteInputCallback;
+    private readonly ImGuiInputTextCallback _inviteInputCallback;
     private int _inviteInFlight;
     private DateTimeOffset _lastMembershipFetch;
     private bool _membershipNeedsRefresh = true;
@@ -208,7 +209,7 @@ public class SyncshellWindow : IDisposable
         }
         InitializeMembershipPanelRatios();
 
-        _inviteInputCallback = new ImGui.ImGuiInputTextCallbackDelegate(OnInviteInputEdited);
+        _inviteInputCallback = OnInviteInputEdited;
 
         foreach (var inviteEntry in state.Invites.ToList())
         {
@@ -1345,8 +1346,13 @@ public class SyncshellWindow : IDisposable
         }
     }
 
-    private int OnInviteInputEdited(ref ImGuiInputTextCallbackData data)
+    private unsafe int OnInviteInputEdited(ImGuiInputTextCallbackData* data)
     {
+        if (data == null)
+        {
+            return 0;
+        }
+
         _inviteSuggestionsDirty = true;
         return 0;
     }


### PR DESCRIPTION
## Summary
- migrate chat, notepad, and event editors to the ref string InputTextMultiline overload with explicit buffer lengths
- update Syncshell invite input to store an ImGuiInputTextCallback delegate and use the new callback signature

## Testing
- `dotnet build` *(fails: dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1831579888328837b40312663e042