### PR TITLE
Use raw Dalamud texture handles for ImGui draws

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -132,7 +132,7 @@ public class ChatWindow : IDisposable
     private static bool TryGetTextureWrap(ISharedImmediateTexture? texture, out IDalamudTextureWrap? wrap)
     {
         wrap = texture?.GetWrapOrEmpty();
-        if (wrap == null || wrap.Handle == IntPtr.Zero || wrap.Width <= 0 || wrap.Height <= 0)
+        if (wrap == null || wrap.Handle.Handle == 0 || wrap.Width <= 0 || wrap.Height <= 0)
         {
             wrap = null;
             return false;
@@ -1428,7 +1428,7 @@ public class ChatWindow : IDisposable
                     LoadTexture(emoji.ImageUrl, t => emoji.Texture = t);
                 if (emoji.Texture != null && TryGetTextureWrap(emoji.Texture, out var wrap))
                 {
-                    ImGui.Image(wrap.Handle, new Vector2(20, 20));
+                    ImGui.Image(wrap.ToImGuiHandle(), new Vector2(20, 20));
                 }
                 else
                 {
@@ -1851,7 +1851,7 @@ public class ChatWindow : IDisposable
 
                     if (reaction.Texture != null && TryGetTextureWrap(reaction.Texture, out var wrap))
                     {
-                        if (ImGui.ImageButton(wrap.Handle, new Vector2(20, 20)))
+                        if (ImGui.ImageButton(wrap.ToImGuiHandle(), new Vector2(20, 20)))
                         {
                             _ = React(msg.Id, reaction.Emoji, reaction.Me);
                         }
@@ -2300,10 +2300,10 @@ public class ChatWindow : IDisposable
             }
 
             var wrap = presence.AvatarTexture?.GetWrapOrEmpty();
-            if (wrap != null && wrap.Handle != IntPtr.Zero && wrap.Width > 0 && wrap.Height > 0)
+            if (wrap != null && wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
             {
                 ImGui.SetCursorScreenPos(position);
-                ImGui.Image(wrap.Handle, textureSize);
+                ImGui.Image(wrap.ToImGuiHandle(), textureSize);
                 return;
             }
         }
@@ -2641,12 +2641,12 @@ public class ChatWindow : IDisposable
             if (previewReady && previewTexture != null)
             {
                 var wrap = previewTexture.GetWrapOrEmpty();
-                if (wrap.Handle != IntPtr.Zero && wrap.Width > 0 && wrap.Height > 0)
+                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
                 {
                     var maxThumbnail = new Vector2(40f, 40f) * scale;
                     var bounds = GetAttachmentBounds(maxThumbnail, allowAutoStretch: false);
                     var size = CalculateAttachmentDisplaySize(new Vector2(wrap.Width, wrap.Height), bounds, allowAutoStretch: false);
-                    ImGui.Image(wrap.Handle, size);
+                    ImGui.Image(wrap.ToImGuiHandle(), size);
                     renderedPreview = true;
                 }
             }
@@ -2948,12 +2948,12 @@ public class ChatWindow : IDisposable
         if (_attachmentPreviewTextures.TryGetValue(attachment.Path, out var texture) && texture != null)
         {
             var wrap = texture.GetWrapOrEmpty();
-            if (wrap.Handle != IntPtr.Zero && wrap.Width > 0 && wrap.Height > 0)
+            if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
             {
                 var attachmentCap = GetConfiguredAttachmentCap();
                 var bounds = GetAttachmentBounds(attachmentCap);
                 var size = CalculateAttachmentDisplaySize(new Vector2(wrap.Width, wrap.Height), bounds);
-                ImGui.Image(wrap.Handle, size);
+                ImGui.Image(wrap.ToImGuiHandle(), size);
             }
         }
     }

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -107,9 +107,12 @@ public static class EmbedPreviewRenderer
             {
                 BeginSection();
                 var wrap = tex.GetWrapOrEmpty();
-                var size = CalculateDisplaySize(new Vector2(wrap.Width, wrap.Height), maxThumbnailSize);
-                ImGui.Image(wrap.Handle, size);
-                thumbnailRendered = true;
+                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                {
+                    var size = CalculateDisplaySize(new Vector2(wrap.Width, wrap.Height), maxThumbnailSize);
+                    ImGui.Image(wrap.ToImGuiHandle(), size);
+                    thumbnailRendered = true;
+                }
             }
         }
 
@@ -129,9 +132,12 @@ public static class EmbedPreviewRenderer
             {
                 BeginSection();
                 var wrap = tex.GetWrapOrEmpty();
-                var size = CalculateDisplaySize(new Vector2(wrap.Width, wrap.Height), maxImageSize);
-                ImGui.Image(wrap.Handle, size);
-                imageRendered = true;
+                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                {
+                    var size = CalculateDisplaySize(new Vector2(wrap.Width, wrap.Height), maxImageSize);
+                    ImGui.Image(wrap.ToImGuiHandle(), size);
+                    imageRendered = true;
+                }
             }
         }
 

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -84,7 +84,10 @@ public static class EmbedRenderer
             if (tex != null)
             {
                 var wrap = tex.GetWrapOrEmpty();
-                ImGui.Image(wrap.Handle, new Vector2(wrap.Width, wrap.Height));
+                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                {
+                    ImGui.Image(wrap.ToImGuiHandle(), new Vector2(wrap.Width, wrap.Height));
+                }
             }
         }
 

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
+using DemiCatPlugin;
 
 namespace DemiCatPlugin.Emoji;
 
@@ -281,7 +282,8 @@ public sealed class EmojiPicker
                 texture != null)
             {
                 var wrap = texture.GetWrapOrEmpty();
-                if (ImGui.ImageButton(wrap.Handle, new Vector2(_tileSize, _tileSize)))
+                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0 &&
+                    ImGui.ImageButton(wrap.ToImGuiHandle(), new Vector2(_tileSize, _tileSize)))
                 {
                     clicked = true;
                 }

--- a/DemiCatPlugin/Emoji/EmojiRenderer.cs
+++ b/DemiCatPlugin/Emoji/EmojiRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
+using DemiCatPlugin;
 
 namespace DemiCatPlugin.Emoji;
 
@@ -38,7 +39,10 @@ public static class EmojiRenderer
             if (tex != null)
             {
                 var wrap = tex.GetWrapOrEmpty();
-                ImGui.Image(wrap.Handle, new Vector2(size, size));
+                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                {
+                    ImGui.Image(wrap.ToImGuiHandle(), new Vector2(size, size));
+                }
             }
             else
             {

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -336,10 +336,13 @@ public class EventView : IDisposable
         if (_authorIcon != null)
         {
             var wrap = _authorIcon.GetWrapOrEmpty();
-            ImGui.Image(wrap.Handle, new Vector2(32, 32));
-            if (names.Count > 0)
+            if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
             {
-                ImGui.SameLine();
+                ImGui.Image(wrap.ToImGuiHandle(), new Vector2(32, 32));
+                if (names.Count > 0)
+                {
+                    ImGui.SameLine();
+                }
             }
         }
 
@@ -443,7 +446,10 @@ public class EventView : IDisposable
         }
 
         var wrap = _thumbnail.GetWrapOrEmpty();
-        ImGui.Image(wrap.Handle, new Vector2(wrap.Width, wrap.Height));
+        if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+        {
+            ImGui.Image(wrap.ToImGuiHandle(), new Vector2(wrap.Width, wrap.Height));
+        }
     }
 
     private void DrawImageSection()
@@ -454,7 +460,10 @@ public class EventView : IDisposable
         }
 
         var wrap = _image.GetWrapOrEmpty();
-        ImGui.Image(wrap.Handle, new Vector2(wrap.Width, wrap.Height));
+        if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+        {
+            ImGui.Image(wrap.ToImGuiHandle(), new Vector2(wrap.Width, wrap.Height));
+        }
     }
 
     private void DrawFooterSection(EmbedDto dto)
@@ -476,10 +485,13 @@ public class EventView : IDisposable
         if (_footerIcon != null)
         {
             var wrap = _footerIcon.GetWrapOrEmpty();
-            ImGui.Image(wrap.Handle, new Vector2(16, 16));
-            if (hasText)
+            if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
             {
-                ImGui.SameLine();
+                ImGui.Image(wrap.ToImGuiHandle(), new Vector2(16, 16));
+                if (hasText)
+                {
+                    ImGui.SameLine();
+                }
             }
         }
 

--- a/DemiCatPlugin/ImGuiTextureHelpers.cs
+++ b/DemiCatPlugin/ImGuiTextureHelpers.cs
@@ -1,0 +1,9 @@
+using Dalamud.Interface.Textures.TextureWraps;
+
+namespace DemiCatPlugin;
+
+internal static class ImGuiTextureHelpers
+{
+    public static nint ToImGuiHandle(this IDalamudTextureWrap wrap)
+        => wrap.Handle.Handle;
+}

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -653,14 +653,17 @@ public class MainWindow : IDisposable
         if (item.Icon != null)
         {
             var wrap = item.Icon.GetWrapOrEmpty();
-            return ImGui.ImageButton(
-                wrap.Handle,
-                iconSize,
-                Vector2.Zero,
-                Vector2.One,
-                0,
-                Vector4.Zero,
-                item.IconTint);
+            if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+            {
+                return ImGui.ImageButton(
+                    wrap.ToImGuiHandle(),
+                    iconSize,
+                    Vector2.Zero,
+                    Vector2.One,
+                    0,
+                    Vector4.Zero,
+                    item.IconTint);
+            }
         }
 
         return ImGui.Button(item.Tooltip, iconSize);

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -303,8 +303,11 @@ public class PresenceSidebar : IDisposable
             try
             {
                 var wrap = p.AvatarTexture.GetWrapOrEmpty();
-                ImGui.Image(wrap.Handle, avatarSize);
-                drewAvatar = true;
+                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                {
+                    ImGui.Image(wrap.ToImGuiHandle(), avatarSize);
+                    drewAvatar = true;
+                }
             }
             catch (ObjectDisposedException)
             {
@@ -413,8 +416,11 @@ public class PresenceSidebar : IDisposable
             try
             {
                 var wrap = presence.BannerTexture.GetWrapOrEmpty();
-                drawList.AddImage(wrap.Handle, min, max);
-                bannerDrawn = true;
+                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                {
+                    drawList.AddImage(wrap.ToImGuiHandle(), min, max);
+                    bannerDrawn = true;
+                }
             }
             catch (ObjectDisposedException)
             {

--- a/DemiCatPlugin/WebTextureCache.cs
+++ b/DemiCatPlugin/WebTextureCache.cs
@@ -125,8 +125,11 @@ public static class WebTextureCache
         // In this binding, ImageButton takes (ImTextureID, Vector2) and
         // IDs are provided via PushID/PopID (not a string label param).
         ImGui.PushID(id);
-        if (ImGui.ImageButton(wrap.Handle, size))
+        if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0 &&
+            ImGui.ImageButton(wrap.ToImGuiHandle(), size))
+        {
             onClick();
+        }
         ImGui.PopID();
     }
 


### PR DESCRIPTION
## Summary
- add a helper to convert Dalamud texture wraps into ImGui-compatible handles
- update chat, embed, emoji, presence, and other ImGui renderers to guard against zero handles and pass raw handles to ImGui APIs

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e185e826d88328bdfdd36b52f74ef3