### PR TITLE
Update image button usage for new signature

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1851,7 +1851,14 @@ public class ChatWindow : IDisposable
 
                     if (reaction.Texture != null && TryGetTextureWrap(reaction.Texture, out var wrap))
                     {
-                        if (ImGui.ImageButton(wrap.ToImGuiHandle(), new Vector2(20, 20)))
+                        if (ImGui.ImageButton(
+                                wrap.ToImGuiHandle(),
+                                new Vector2(20, 20),
+                                Vector2.Zero,
+                                Vector2.One,
+                                0,
+                                Vector4.Zero,
+                                Vector4.One))
                         {
                             _ = React(msg.Id, reaction.Emoji, reaction.Me);
                         }

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -283,7 +283,14 @@ public sealed class EmojiPicker
             {
                 var wrap = texture.GetWrapOrEmpty();
                 if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0 &&
-                    ImGui.ImageButton(wrap.ToImGuiHandle(), new Vector2(_tileSize, _tileSize)))
+                    ImGui.ImageButton(
+                        wrap.ToImGuiHandle(),
+                        new Vector2(_tileSize, _tileSize),
+                        Vector2.Zero,
+                        Vector2.One,
+                        0,
+                        Vector4.Zero,
+                        Vector4.One))
                 {
                     clicked = true;
                 }

--- a/DemiCatPlugin/WebTextureCache.cs
+++ b/DemiCatPlugin/WebTextureCache.cs
@@ -126,7 +126,14 @@ public static class WebTextureCache
         // IDs are provided via PushID/PopID (not a string label param).
         ImGui.PushID(id);
         if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0 &&
-            ImGui.ImageButton(wrap.ToImGuiHandle(), size))
+            ImGui.ImageButton(
+                wrap.ToImGuiHandle(),
+                size,
+                Vector2.Zero,
+                Vector2.One,
+                0,
+                Vector4.Zero,
+                Vector4.One))
         {
             onClick();
         }


### PR DESCRIPTION
## Summary
- update ImageButton invocations in chat reactions, emoji picker, and shared cache to use the expanded parameter list
- ensure utility helper continues to wrap calls in PushID/PopID while providing default UV, padding, and tint values

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e188e4fc7c8328b020e4ff467698f4