### PR TITLE
Add missing HttpClient headers namespace

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Net;
 using System.Text;
 using System.Text.Json;


### PR DESCRIPTION
## Summary
- add the System.Net.Http.Headers namespace to ChatWindow to support MediaTypeHeaderValue usage

## Testing
- `dotnet build` *(fails: dotnet command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1895ee8d483289d6f585334544f11