### PR TITLE
Fix ImGui type aliases in SyncshellWindow

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -21,7 +21,9 @@ using DemiCatPlugin.SyncShell;
 using Penumbra.Api.Enums;
 using Serilog;
 using Serilog.Events;
-using ImGuiNET;
+using ImGuiInputTextCallback = Dalamud.Bindings.ImGui.ImGuiInputTextCallback;
+using ImGuiInputTextCallbackData = Dalamud.Bindings.ImGui.ImGuiInputTextCallbackData;
+using ImGuiMouseCursor = Dalamud.Bindings.ImGui.ImGuiMouseCursor;
 
 namespace DemiCatPlugin;
 


### PR DESCRIPTION
## Summary
- align SyncshellWindow's ImGui type usage with Dalamud bindings by introducing explicit aliases

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e18cc57c408328958d06acfb675492