### PR TITLE
Switch DemiCatPlugin to ImGuiNET

### DIFF
--- a/DemiCatPlugin/ButtonRowsImGui.cs
+++ b/DemiCatPlugin/ButtonRowsImGui.cs
@@ -1,4 +1,4 @@
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using DemiCat.UI;
 
 namespace DemiCatPlugin;

--- a/DemiCatPlugin/DateTimePicker.cs
+++ b/DemiCatPlugin/DateTimePicker.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
 using System.Numerics;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 
 namespace DemiCatPlugin;
 

--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Plugin;
 
 namespace DemiCatPlugin;

--- a/DemiCatPlugin/DockableWindow.cs
+++ b/DemiCatPlugin/DockableWindow.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Numerics;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 
 namespace DemiCatPlugin;
 

--- a/DemiCatPlugin/DockableWindowHosts.cs
+++ b/DemiCatPlugin/DockableWindowHosts.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Numerics;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 
 namespace DemiCatPlugin;
 

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Linq;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Interface.Textures;
 using DiscordHelper;
 using DemiCat.UI;

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
 using System.Linq;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Interface.Textures;
 using DiscordHelper;
 using DemiCat.UI;

--- a/DemiCatPlugin/EmbedStyleControls.cs
+++ b/DemiCatPlugin/EmbedStyleControls.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Interface.Utility;
 using DemiCatPlugin.Emoji;
 

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Numerics;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using DemiCatPlugin;
 
 namespace DemiCatPlugin.Emoji;

--- a/DemiCatPlugin/Emoji/EmojiPopup.cs
+++ b/DemiCatPlugin/Emoji/EmojiPopup.cs
@@ -1,5 +1,5 @@
 using System;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 
 namespace DemiCatPlugin.Emoji;
 

--- a/DemiCatPlugin/Emoji/EmojiRenderer.cs
+++ b/DemiCatPlugin/Emoji/EmojiRenderer.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Numerics;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using DemiCatPlugin;
 
 namespace DemiCatPlugin.Emoji;

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -11,7 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Interface.ImGuiFileDialog;
 using DiscordHelper;
 using DemiCat.UI;

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using System.IO;
 using DiscordHelper;
 using Dalamud.Interface.Textures;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using StbImageSharp;
 using System.Diagnostics;
 using System.Linq;

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using System.Numerics;
 using DemiCatPlugin.Avatars;
 using DemiCatPlugin.Emoji;

--- a/DemiCatPlugin/ImGuiDirectoryPickerHelper.cs
+++ b/DemiCatPlugin/ImGuiDirectoryPickerHelper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Numerics;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Interface.ImGuiFileDialog;
 
 namespace DemiCatPlugin;

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Numerics;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.TextureWraps;
 using DemiCatPlugin.Emoji;

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 
 namespace DemiCatPlugin;
 

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -1,4 +1,4 @@
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -3,9 +3,9 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Threading.Tasks;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Interface.Textures;
-using ImGuiMouseCursor = Dalamud.Bindings.ImGui.ImGuiMouseCursor;
+using ImGuiMouseCursor = ImGuiNET.ImGuiMouseCursor;
 
 namespace DemiCatPlugin;
 

--- a/DemiCatPlugin/ProgressOverlay.cs
+++ b/DemiCatPlugin/ProgressOverlay.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Interface.Utility;
 
 namespace DemiCatPlugin;

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -6,7 +6,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using System.Numerics;
 
 namespace DemiCatPlugin;

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using System.IO;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -1,5 +1,5 @@
 using System;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using DiscordHelper;
 using System.Numerics;
 using System.Net.Http;

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -14,16 +14,16 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Services;
 using DemiCatPlugin.SyncShell;
 using Penumbra.Api.Enums;
 using Serilog;
 using Serilog.Events;
-using ImGuiInputTextCallback = Dalamud.Bindings.ImGui.ImGuiInputTextCallback;
-using ImGuiInputTextCallbackData = Dalamud.Bindings.ImGui.ImGuiInputTextCallbackData;
-using ImGuiMouseCursor = Dalamud.Bindings.ImGui.ImGuiMouseCursor;
+using ImGuiInputTextCallback = ImGuiNET.ImGuiInputTextCallback;
+using ImGuiInputTextCallbackData = ImGuiNET.ImGuiInputTextCallbackData;
+using ImGuiMouseCursor = ImGuiNET.ImGuiMouseCursor;
 
 namespace DemiCatPlugin;
 

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using System.Linq;
 using System.Collections.Generic;
 using System.Globalization;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using DiscordHelper;
 using DemiCat.UI;
 using DemiCatPlugin.Emoji;

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -13,7 +13,7 @@ using System.Text;
 using System.Threading;
 using System.Text.RegularExpressions;
 using DiscordHelper;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using DemiCatPlugin.Emoji;
 
 namespace DemiCatPlugin;

--- a/DemiCatPlugin/WebTextureCache.cs
+++ b/DemiCatPlugin/WebTextureCache.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
-using Dalamud.Bindings.ImGui;
+using ImGuiNET;
 using Dalamud.Interface.Textures;
 
 namespace DemiCatPlugin;


### PR DESCRIPTION
## Summary
- replace Dalamud.Bindings.ImGui imports with ImGuiNET across the DemiCatPlugin sources
- update the SyncshellWindow and PresenceSidebar ImGui callback aliases to their ImGuiNET counterparts

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e18f19d4648328a8ff4d2df7500e03