### PR TITLE
Update ImageSharp dependency

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StbImageSharp" Version="2.30.15" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="Penumbra.Api" Version="5.12.0" />


### PR DESCRIPTION
## Summary
- bump SixLabors.ImageSharp to 3.1.11 to address security advisories

## Testing
- dotnet restore DemiCatPlugin/DemiCatPlugin.csproj
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: Dalamud installation not found at /root/.xlcore/dalamud/Hooks/dev/)*

------
https://chatgpt.com/codex/tasks/task_e_68e18f37f0688328825fca12b45e9a7c