### PR TITLE
Update child window flags for ImGui BeginChild

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -726,7 +726,7 @@ public class ChatWindow : IDisposable
         }
         composeRatio = actualRatio;
         const float ScrollTolerance = 1f;
-        ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), ImGuiChildFlags.Borders);
+        ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
 
         var fontScale = GetFontScale();
         var chatFontScope = PushWindowFontScale(fontScale);
@@ -1143,7 +1143,7 @@ public class ChatWindow : IDisposable
                 var desiredPreviewHeight = _previewContentHeight > 0f ? _previewContentHeight : fallbackHeight;
                 var previewHeight = Math.Clamp(desiredPreviewHeight, minPreviewHeight, maxPreviewHeight);
 
-                ImGui.BeginChild("##inputPreview", new Vector2(0, previewHeight), ImGuiChildFlags.Borders);
+                ImGui.BeginChild("##inputPreview", new Vector2(0, previewHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
                 var childStartCursor = ImGui.GetCursorPosY();
                 if (!string.IsNullOrEmpty(plainTextPreview))
                 {
@@ -1475,7 +1475,7 @@ public class ChatWindow : IDisposable
         var codeBlock = Regex.Match(text, "^\\[CODEBLOCK\\](.+?)\\[/CODEBLOCK\\]$", RegexOptions.Singleline);
         if (codeBlock.Success)
         {
-            ImGui.BeginChild($"codeblock{GetHashCode()}{text.GetHashCode()}", new Vector2(0, 0), ImGuiChildFlags.Borders);
+            ImGui.BeginChild($"codeblock{GetHashCode()}{text.GetHashCode()}", new Vector2(0, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
             ImGui.TextUnformatted(codeBlock.Groups[1].Value);
             ImGui.EndChild();
             return;
@@ -2641,7 +2641,7 @@ public class ChatWindow : IDisposable
             ImGuiWindowFlags.AlwaysAutoResize |
             ImGuiWindowFlags.NoScrollbar |
             ImGuiWindowFlags.NoScrollWithMouse;
-        if (ImGui.BeginChild("##attachmentChip", new Vector2(0, 0), ImGuiChildFlags.Borders, childFlags))
+        if (ImGui.BeginChild("##attachmentChip", new Vector2(0, 0), ImGuiChildFlags.Border, childFlags))
         {
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(6f * scale, style.ItemSpacing.Y));
 

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -42,7 +42,7 @@ public static class EmbedPreviewRenderer
             avail = 400;
         }
 
-        ImGui.BeginChild($"embedprev{dto.Id}", new Vector2(avail, 0), true);
+        ImGui.BeginChild($"embedprev{dto.Id}", new Vector2(avail, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
 
         ImGui.Indent(indent);
         ImGui.Dummy(new Vector2(0f, verticalPadding));

--- a/DemiCatPlugin/EmbedStyleControls.cs
+++ b/DemiCatPlugin/EmbedStyleControls.cs
@@ -281,7 +281,7 @@ public static class EmbedStyleControls
             {
                 var tileSize = Math.Clamp(context.EmojiTileSize, Config.MinEmojiTileSize, Config.MaxEmojiTileSize);
                 var childSize = context.EmojiGridHeight > 0f ? new Vector2(0f, context.EmojiGridHeight) : Vector2.Zero;
-                ImGui.BeginChild($"##borderEmojiGrid_{searchKey}", childSize, false);
+                ImGui.BeginChild($"##borderEmojiGrid_{searchKey}", childSize, ImGuiChildFlags.None, ImGuiWindowFlags.None);
 
                 var avail = Math.Max(1f, ImGui.GetContentRegionAvail().X);
                 var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (tileSize + 4f)));

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -139,7 +139,7 @@ public sealed class EmojiPicker
         }
 
         var childSize = _gridHeight > 0f ? new Vector2(0, _gridHeight) : Vector2.Zero;
-        ImGui.BeginChild("##emoji_std_grid", childSize, false);
+        ImGui.BeginChild("##emoji_std_grid", childSize, ImGuiChildFlags.None, ImGuiWindowFlags.None);
         var avail = ImGui.GetContentRegionAvail().X;
         var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (_tileSize + 4f)));
         var column = 0;
@@ -238,7 +238,7 @@ public sealed class EmojiPicker
         }
 
         var childSize = _gridHeight > 0f ? new Vector2(0, _gridHeight) : Vector2.Zero;
-        ImGui.BeginChild("##emoji_custom_grid", childSize, false);
+        ImGui.BeginChild("##emoji_custom_grid", childSize, ImGuiChildFlags.None, ImGuiWindowFlags.None);
         var avail = ImGui.GetContentRegionAvail().X;
         var columns = Math.Max(1, (int)Math.Floor((avail + 6f) / (_tileSize + 6f)));
         var column = 0;

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -136,7 +136,7 @@ public class EventCreateWindow
 
         var footer = ImGui.GetFrameHeightWithSpacing() * 2;
         var avail = ImGui.GetContentRegionAvail();
-        ImGui.BeginChild("eventCreateScroll", new Vector2(avail.X, avail.Y - footer), true);
+        ImGui.BeginChild("eventCreateScroll", new Vector2(avail.X, avail.Y - footer), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
 
         if (!_channelsLoaded)
         {

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -234,7 +234,7 @@ public class EventView : IDisposable
             childHeight = 0f;
         }
 
-        ImGui.BeginChild($"eventEmbed{dto.Id}", new Vector2(availWidth, childHeight), false);
+        ImGui.BeginChild($"eventEmbed{dto.Id}", new Vector2(availWidth, childHeight), ImGuiChildFlags.None, ImGuiWindowFlags.None);
 
         ImGui.Indent(indent);
         ImGui.Dummy(new Vector2(0f, verticalPadding));
@@ -708,7 +708,7 @@ public class EventView : IDisposable
 
 internal static class EventViewImGuiHelpers
 {
-    public static float BeginPreviewChild(string childId, bool border = false, float minHeight = 0f, ImGuiWindowFlags flags = ImGuiWindowFlags.None)
+    public static float BeginPreviewChild(string childId, ImGuiChildFlags childFlags = ImGuiChildFlags.None, float minHeight = 0f, ImGuiWindowFlags windowFlags = ImGuiWindowFlags.None)
     {
         var avail = ImGui.GetContentRegionAvail();
         var width = float.IsFinite(avail.X) ? Math.Max(avail.X, 0f) : 0f;
@@ -720,7 +720,7 @@ internal static class EventViewImGuiHelpers
         }
 
         var size = new Vector2(width, height);
-        ImGui.BeginChild(childId, size, border, flags);
+        ImGui.BeginChild(childId, size, childFlags, windowFlags);
         return size.Y;
     }
 }

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -72,7 +72,7 @@ public class FcChatWindow : ChatWindow
             ImGui.SameLine();
         }
 
-        ImGui.BeginChild("##fcChat", ImGui.GetContentRegionAvail(), false);
+        ImGui.BeginChild("##fcChat", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.None);
         base.Draw();
         ImGui.EndChild();
     }

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -91,7 +91,7 @@ public sealed class NotePadWindow : IDisposable
         var pageListWidth = Math.Clamp(region.X * ratio, 160f, Math.Max(160f, region.X - 200f));
         var editorWidth = Math.Max(200f, region.X - pageListWidth - splitterWidth);
 
-        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), true);
+        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
         DrawPageList(selectedSection, selectedPage);
         ImGui.EndChild();
 
@@ -117,7 +117,7 @@ public sealed class NotePadWindow : IDisposable
         }
 
         ImGui.SameLine();
-        ImGui.BeginChild("NotePadEditor", new Vector2(editorWidth, region.Y), false);
+        ImGui.BeginChild("NotePadEditor", new Vector2(editorWidth, region.Y), ImGuiChildFlags.None, ImGuiWindowFlags.None);
         DrawEditor(selectedSection, selectedPage);
         ImGui.EndChild();
 

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -157,7 +157,7 @@ public class OfficerChatWindow : ChatWindow
             _ = RoleCache.EnsureLoaded(_httpClient, _config);
             _presenceSidebar!.Draw(ref _presenceWidth);
             ImGui.SameLine();
-            ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), false);
+            ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.None);
         }
 
         base.Draw();

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -65,7 +65,7 @@ public class PresenceSidebar : IDisposable
             shouldReturn = true;
         }
 
-        ImGui.BeginChild("##presence", new Vector2(width, 0), true);
+        ImGui.BeginChild("##presence", new Vector2(width, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
 
         try
         {

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -88,7 +88,7 @@ public class RequestBoardWindow
             {
                 ImGui.PushID(req.Id);
                 ImGui.PushStyleColor(ImGuiCol.ChildBg, UrgencyColor(req.Urgency));
-                ImGui.BeginChild("card", new Vector2(-1, 0), true);
+                ImGui.BeginChild("card", new Vector2(-1, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
 
                 ImGui.TextUnformatted(req.Title);
                 ImGui.Spacing();

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -348,7 +348,7 @@ public class SyncshellWindow : IDisposable
             _syncSettingsHeight = DefaultSyncSettingsHeight;
         maxSettingsHeight = MathF.Max(MinSyncSettingsHeight, maxSettingsHeight);
         _syncSettingsHeight = Math.Clamp(_syncSettingsHeight, MinSyncSettingsHeight, maxSettingsHeight);
-        ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), true);
+        ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
         if (ImGui.BeginTabBar("syncshell-settings-tabs"))
         {
             if (ImGui.BeginTabItem("Sync"))
@@ -509,7 +509,7 @@ public class SyncshellWindow : IDisposable
             var childHeight = 70f;
             if (asset.Kind == "BUNDLE" && asset.Items != null)
                 childHeight += ImGui.GetTextLineHeightWithSpacing() * asset.Items.Count;
-            ImGui.BeginChild("card", new Vector2(-1, childHeight), true);
+            ImGui.BeginChild("card", new Vector2(-1, childHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
             ImGui.TextUnformatted(asset.Name);
             if (!_seenAssetIds.Contains(asset.Id))
             {
@@ -849,7 +849,7 @@ public class SyncshellWindow : IDisposable
     {
         var id = $"syncshell-panel-{label.Replace(' ', '-').ToLowerInvariant()}";
         var size = fillRemaining ? new Vector2(-1, 0f) : new Vector2(-1, height);
-        ImGui.BeginChild(id, size, true);
+        ImGui.BeginChild(id, size, ImGuiChildFlags.Border, ImGuiWindowFlags.None);
         ImGui.TextUnformatted(label);
         ImGui.Separator();
         content();

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -165,7 +165,7 @@ public class TemplatesWindow
             ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
         }
 
-        ImGui.BeginChild("TemplateList", new Vector2(150, 0), true);
+        ImGui.BeginChild("TemplateList", new Vector2(150, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
         {
             using var emojiFont = _emojiManager.PushEmojiFont();
             for (var i = 0; i < _templates.Count; i++)
@@ -182,7 +182,7 @@ public class TemplatesWindow
 
         ImGui.SameLine();
 
-        ImGui.BeginChild("TemplateContent", ImGui.GetContentRegionAvail(), false);
+        ImGui.BeginChild("TemplateContent", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.None);
         if (_selectedIndex >= 0 && _selectedIndex < _templates.Count)
         {
             var tmpl = _templates[_selectedIndex].Template;

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -981,7 +981,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
         _embedWarningShown = false;
 
-        ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), true);
+        ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
         foreach (var view in embeds)
         {
             view?.Draw();


### PR DESCRIPTION
## Summary
- update all plugin child window invocations to use the new BeginChild signature with explicit child and window flags
- replace deprecated border booleans with ImGuiChildFlags.Border or ImGuiChildFlags.None as appropriate and update helper utilities accordingly

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1aa1dfb8883288a227ea234c54fd6