### PR TITLE
Update ImGui ImageButton overload usage

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1853,11 +1853,11 @@ public class ChatWindow : IDisposable
                     if (reaction.Texture != null && TryGetTextureWrap(reaction.Texture, out var wrap))
                     {
                         if (ImGui.ImageButton(
+                                $"##react{msg.Id}{reaction.EmojiId ?? reaction.Emoji}",
                                 wrap.ToImGuiHandle(),
                                 new Vector2(20, 20),
                                 Vector2.Zero,
                                 Vector2.One,
-                                0,
                                 Vector4.Zero,
                                 Vector4.One))
                         {

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -284,11 +284,11 @@ public sealed class EmojiPicker
                 var wrap = texture.GetWrapOrEmpty();
                 if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0 &&
                     ImGui.ImageButton(
+                        $"##emoji{emoji.Id}",
                         wrap.ToImGuiHandle(),
                         new Vector2(_tileSize, _tileSize),
                         Vector2.Zero,
                         Vector2.One,
-                        0,
                         Vector4.Zero,
                         Vector4.One))
                 {

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -656,11 +656,11 @@ public class MainWindow : IDisposable
             if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
             {
                 return ImGui.ImageButton(
+                    $"##{item.Id}",
                     wrap.ToImGuiHandle(),
                     iconSize,
                     Vector2.Zero,
                     Vector2.One,
-                    0,
                     Vector4.Zero,
                     item.IconTint);
             }

--- a/DemiCatPlugin/WebTextureCache.cs
+++ b/DemiCatPlugin/WebTextureCache.cs
@@ -122,22 +122,18 @@ public static class WebTextureCache
         if (tex == null) return;
         var wrap = tex.GetWrapOrEmpty();
 
-        // In this binding, ImageButton takes (ImTextureID, Vector2) and
-        // IDs are provided via PushID/PopID (not a string label param).
-        ImGui.PushID(id);
         if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0 &&
             ImGui.ImageButton(
+                $"##{id}",
                 wrap.ToImGuiHandle(),
                 size,
                 Vector2.Zero,
                 Vector2.One,
-                0,
                 Vector4.Zero,
                 Vector4.One))
         {
             onClick();
         }
-        ImGui.PopID();
     }
 
 }


### PR DESCRIPTION
## Summary
- update texture button helpers and call sites to use the new string-first ImageButton overload and ToImGuiHandle texture IDs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1acc4d6f88328a4e718b5099cb4da