### PR TITLE
Update ImGui callbacks to use function pointers

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -94,6 +94,8 @@ public class ChatWindow : IDisposable
     private int _selectionStart;
     private int _selectionEnd;
     private bool _focusComposerNextFrame;
+    private static ChatWindow? _activeInputCallbackOwner;
+    private static readonly unsafe delegate* unmanaged[Cdecl]<ImGuiInputTextCallbackData*, int> _inputEditedCallback = &OnInputEdited;
     private BridgeMessageFormatter.BridgeFormattedMessage _previewMessage = BridgeMessageFormatter.BridgeFormattedMessage.Empty;
     private string _previewKey = string.Empty;
     private readonly Dictionary<string, ISharedImmediateTexture?> _attachmentPreviewTextures = new(StringComparer.OrdinalIgnoreCase);
@@ -906,12 +908,15 @@ public class ChatWindow : IDisposable
 
         if (ImGui.BeginPopup("editMessage"))
         {
-            _ = ImGui.InputTextMultiline(
-                "##editContent",
-                ref _editContent,
-                2048u,
-                new Vector2(400, ImGui.GetTextLineHeight() * 5)
-            );
+            unsafe
+            {
+                _ = ImGui.InputTextMultiline(
+                    "##editContent",
+                    ref _editContent,
+                    2048u,
+                    new Vector2(400, ImGui.GetTextLineHeight() * 5)
+                );
+            }
 
             if (ImGui.Button("Save"))
             {
@@ -1029,15 +1034,26 @@ public class ChatWindow : IDisposable
             ImGui.SetKeyboardFocusHere();
             _focusComposerNextFrame = false;
         }
-        _ = ImGui.InputTextMultiline(
-            "##chatInput",
-            ref _input,
-            2048u,
-            new Vector2(inputWidth, inputHeight),
-            ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
-            OnInputEdited,
-            IntPtr.Zero
-        );
+        unsafe
+        {
+            _activeInputCallbackOwner = this;
+            try
+            {
+                _ = ImGui.InputTextMultiline(
+                    "##chatInput",
+                    ref _input,
+                    2048u,
+                    new Vector2(inputWidth, inputHeight),
+                    ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
+                    _inputEditedCallback,
+                    IntPtr.Zero
+                );
+            }
+            finally
+            {
+                _activeInputCallbackOwner = null;
+            }
+        }
         if (MentionsEnabled)
         {
             var mentionState = EnsureMentionDrawerState();
@@ -1523,15 +1539,21 @@ public class ChatWindow : IDisposable
     }
 
     // Correct signature for Dalamud's callback: unsafe pointer, returns int
-    private unsafe int OnInputEdited(ImGuiInputTextCallbackData* data)
+    private static unsafe int OnInputEdited(ImGuiInputTextCallbackData* data)
     {
         if (data == null)
         {
             return 0;
         }
 
-        _selectionStart = data->SelectionStart;
-        _selectionEnd = data->SelectionEnd;
+        var owner = _activeInputCallbackOwner;
+        if (owner == null)
+        {
+            return 0;
+        }
+
+        owner._selectionStart = data->SelectionStart;
+        owner._selectionEnd = data->SelectionEnd;
         return 0;
     }
 

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -32,6 +32,8 @@ public class EventCreateWindow
     private int _descriptionSelectionStart;
     private int _descriptionSelectionEnd;
     private bool _focusDescriptionNextFrame;
+    private static EventCreateWindow? _activeDescriptionCallbackOwner;
+    private static readonly unsafe delegate* unmanaged[Cdecl]<ImGuiInputTextCallbackData*, int> _descriptionEditedCallback = &OnDescriptionEdited;
     private string _time = string.Empty;
     private string _imageUrl = string.Empty;
     private string _url = string.Empty;
@@ -228,15 +230,26 @@ public class EventCreateWindow
                         ImGui.SetKeyboardFocusHere();
                         _focusDescriptionNextFrame = false;
                     }
-                    ImGui.InputTextMultiline(
-                        "##Description",
-                        ref _description,
-                        4096u,
-                        new Vector2(avail.X, descHeight),
-                        ImGuiInputTextFlags.CallbackAlways,
-                        OnDescriptionEdited,
-                        IntPtr.Zero
-                    );
+                    unsafe
+                    {
+                        _activeDescriptionCallbackOwner = this;
+                        try
+                        {
+                            ImGui.InputTextMultiline(
+                                "##Description",
+                                ref _description,
+                                4096u,
+                                new Vector2(avail.X, descHeight),
+                                ImGuiInputTextFlags.CallbackAlways,
+                                _descriptionEditedCallback,
+                                IntPtr.Zero
+                            );
+                        }
+                        finally
+                        {
+                            _activeDescriptionCallbackOwner = null;
+                        }
+                    }
                     _descriptionEmojiPopup.Draw();
                 },
                 alignLabel: false,
@@ -451,7 +464,10 @@ public class EventCreateWindow
             {
                 var field = _fields[i];
                 ImGui.InputText($"Name##{i}", ref field.Name, 256);
-                ImGui.InputTextMultiline($"Value##{i}", ref field.Value, 1024u, new Vector2(400, 60));
+                unsafe
+                {
+                    ImGui.InputTextMultiline($"Value##{i}", ref field.Value, 1024u, new Vector2(400, 60));
+                }
                 ImGui.Checkbox($"Inline##{i}", ref field.Inline);
                 if (ImGui.Button($"Remove##{i}"))
                 {
@@ -947,15 +963,21 @@ public class EventCreateWindow
         _focusDescriptionNextFrame = true;
     }
 
-    private unsafe int OnDescriptionEdited(ImGuiInputTextCallbackData* data)
+    private static unsafe int OnDescriptionEdited(ImGuiInputTextCallbackData* data)
     {
         if (data == null)
         {
             return 0;
         }
 
-        _descriptionSelectionStart = data->SelectionStart;
-        _descriptionSelectionEnd = data->SelectionEnd;
+        var owner = _activeDescriptionCallbackOwner;
+        if (owner == null)
+        {
+            return 0;
+        }
+
+        owner._descriptionSelectionStart = data->SelectionStart;
+        owner._descriptionSelectionEnd = data->SelectionEnd;
         return 0;
     }
 

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -39,6 +39,8 @@ public sealed class NotePadWindow : IDisposable
     private bool _sectionOrderDirty;
     private bool _pageOrderDirty;
     private bool _focusEditorNextFrame;
+    private static NotePadWindow? _activeEditorCallbackOwner;
+    private static readonly unsafe delegate* unmanaged[Cdecl]<ImGuiInputTextCallbackData*, int> _editorEditedCallback = &OnEditorEdited;
     private string _newSectionName = string.Empty;
     private string _newPageTitle = string.Empty;
     private bool _showNewSectionPopup;
@@ -407,13 +409,16 @@ public sealed class NotePadWindow : IDisposable
             var capacity = (uint)Math.Max(1024, content.Length + 512);
             var readOnlyContent = content;
             ImGui.BeginDisabled();
-            ImGui.InputTextMultiline(
-                "##NotePadEditorReadOnly",
-                ref readOnlyContent,
-                capacity,
-                new Vector2(-1, -1),
-                ImGuiInputTextFlags.ReadOnly
-            );
+            unsafe
+            {
+                ImGui.InputTextMultiline(
+                    "##NotePadEditorReadOnly",
+                    ref readOnlyContent,
+                    capacity,
+                    new Vector2(-1, -1),
+                    ImGuiInputTextFlags.ReadOnly
+                );
+            }
             ImGui.EndDisabled();
             _editorContent = content;
             _editorVersion = page.Version;
@@ -429,15 +434,27 @@ public sealed class NotePadWindow : IDisposable
 
         ImGui.PushItemWidth(-1);
         var flags = ImGuiInputTextFlags.AllowTabInput | ImGuiInputTextFlags.CallbackAlways | ImGuiInputTextFlags.CallbackHistory;
-        var edited = ImGui.InputTextMultiline(
-            "##NotePadEditor",
-            ref _editorContent,
-            editorCapacity,
-            new Vector2(-1, -1),
-            flags,
-            OnEditorEdited,
-            IntPtr.Zero
-        );
+        bool edited;
+        unsafe
+        {
+            _activeEditorCallbackOwner = this;
+            try
+            {
+                edited = ImGui.InputTextMultiline(
+                    "##NotePadEditor",
+                    ref _editorContent,
+                    editorCapacity,
+                    new Vector2(-1, -1),
+                    flags,
+                    _editorEditedCallback,
+                    IntPtr.Zero
+                );
+            }
+            finally
+            {
+                _activeEditorCallbackOwner = null;
+            }
+        }
         ImGui.PopItemWidth();
 
         if (edited)
@@ -841,15 +858,21 @@ public sealed class NotePadWindow : IDisposable
         _lastEditUtc = DateTime.UtcNow;
     }
 
-    private unsafe int OnEditorEdited(ImGuiInputTextCallbackData* data)
+    private static unsafe int OnEditorEdited(ImGuiInputTextCallbackData* data)
     {
         if (data == null)
         {
             return 0;
         }
 
-        _selectionStart = data->SelectionStart;
-        _selectionEnd = data->SelectionEnd;
+        var owner = _activeEditorCallbackOwner;
+        if (owner == null)
+        {
+            return 0;
+        }
+
+        owner._selectionStart = data->SelectionStart;
+        owner._selectionEnd = data->SelectionEnd;
         return 0;
     }
 

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -21,7 +21,6 @@ using DemiCatPlugin.SyncShell;
 using Penumbra.Api.Enums;
 using Serilog;
 using Serilog.Events;
-using ImGuiInputTextCallback = ImGuiNET.ImGuiInputTextCallback;
 using ImGuiInputTextCallbackData = ImGuiNET.ImGuiInputTextCallbackData;
 using ImGuiMouseCursor = ImGuiNET.ImGuiMouseCursor;
 
@@ -143,7 +142,8 @@ public class SyncshellWindow : IDisposable
     private Vector2 _inviteSuggestionWindowSize;
     private bool _inviteSuggestionFiltered;
     private bool _focusInviteInputNextFrame;
-    private readonly ImGuiInputTextCallback _inviteInputCallback;
+    private static SyncshellWindow? _activeInviteCallbackOwner;
+    private readonly unsafe delegate* unmanaged[Cdecl]<ImGuiInputTextCallbackData*, int> _inviteInputCallback;
     private int _inviteInFlight;
     private DateTimeOffset _lastMembershipFetch;
     private bool _membershipNeedsRefresh = true;
@@ -211,7 +211,10 @@ public class SyncshellWindow : IDisposable
         }
         InitializeMembershipPanelRatios();
 
-        _inviteInputCallback = OnInviteInputEdited;
+        unsafe
+        {
+            _inviteInputCallback = &OnInviteInputEdited;
+        }
 
         foreach (var inviteEntry in state.Invites.ToList())
         {
@@ -969,14 +972,26 @@ public class SyncshellWindow : IDisposable
             _focusInviteInputNextFrame = false;
         }
         ImGui.SetNextItemWidth(-150f);
-        var submitted = ImGui.InputTextWithHint(
-            "##syncshell-invite",
-            "Character name",
-            ref invite,
-            64,
-            ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
-            _inviteInputCallback
-        );
+        bool submitted;
+        unsafe
+        {
+            _activeInviteCallbackOwner = this;
+            try
+            {
+                submitted = ImGui.InputTextWithHint(
+                    "##syncshell-invite",
+                    "Character name",
+                    ref invite,
+                    64,
+                    ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
+                    _inviteInputCallback
+                );
+            }
+            finally
+            {
+                _activeInviteCallbackOwner = null;
+            }
+        }
         invite ??= string.Empty;
         _inviteTarget = invite;
         var anchorMin = ImGui.GetItemRectMin();
@@ -1348,14 +1363,20 @@ public class SyncshellWindow : IDisposable
         }
     }
 
-    private unsafe int OnInviteInputEdited(ImGuiInputTextCallbackData* data)
+    private static unsafe int OnInviteInputEdited(ImGuiInputTextCallbackData* data)
     {
         if (data == null)
         {
             return 0;
         }
 
-        _inviteSuggestionsDirty = true;
+        var owner = _activeInviteCallbackOwner;
+        if (owner == null)
+        {
+            return 0;
+        }
+
+        owner._inviteSuggestionsDirty = true;
         return 0;
     }
 


### PR DESCRIPTION
## Summary
- wrap all ChatWindow, EventCreateWindow, and NotePadWindow multiline editors in unsafe blocks and dispatch their ImGui callbacks via unmanaged function pointers
- adjust SyncshellWindow invite entry to store the new unmanaged callback pointer and call InputTextWithHint with the updated argument order
- convert all ImGui text callbacks to static trampolines that update the active window instance during editing

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1afeae4a08328b6ca6673dfdcd998