### PR TITLE
Use safe texture handles for ImGui rendering

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -135,7 +135,8 @@ public class ChatWindow : IDisposable
     private static bool TryGetTextureWrap(ISharedImmediateTexture? texture, out IDalamudTextureWrap? wrap)
     {
         wrap = texture?.GetWrapOrEmpty();
-        if (wrap == null || wrap.Handle.Handle == 0 || wrap.Width <= 0 || wrap.Height <= 0)
+        var handle = wrap.ToImGuiHandle();
+        if (wrap == null || handle == 0 || wrap.Width <= 0 || wrap.Height <= 0)
         {
             wrap = null;
             return false;
@@ -1728,7 +1729,15 @@ public class ChatWindow : IDisposable
         if (msg.AvatarTexture != null)
         {
             var wrapAvatar = msg.AvatarTexture.GetWrapOrEmpty();
-            ImGui.Image(wrapAvatar.Handle, new Vector2(20, 20));
+            var avatarHandle = wrapAvatar.ToImGuiHandle();
+            if (avatarHandle != 0)
+            {
+                ImGui.Image(avatarHandle, new Vector2(20, 20));
+            }
+            else
+            {
+                ImGui.Dummy(new Vector2(20, 20));
+            }
         }
         else
         {
@@ -1792,10 +1801,16 @@ public class ChatWindow : IDisposable
                     if (att.Texture != null)
                     {
                         var wrapAtt = att.Texture.GetWrapOrEmpty();
+                        var attachmentHandle = wrapAtt.ToImGuiHandle();
+                        if (attachmentHandle == 0)
+                        {
+                            continue;
+                        }
+
                         var originalSize = new Vector2(wrapAtt.Width, wrapAtt.Height);
                         var bounds = GetAttachmentBounds(attachmentCap);
                         var displaySize = CalculateAttachmentDisplaySize(originalSize, bounds);
-                        ImGui.Image(wrapAtt.Handle, displaySize);
+                        ImGui.Image(attachmentHandle, displaySize);
                         if (ImGui.IsItemHovered())
                         {
                             ImGui.BeginTooltip();
@@ -2330,10 +2345,11 @@ public class ChatWindow : IDisposable
             }
 
             var wrap = presence.AvatarTexture?.GetWrapOrEmpty();
-            if (wrap != null && wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+            var handle = wrap.ToImGuiHandle();
+            if (handle != 0 && wrap != null && wrap.Width > 0 && wrap.Height > 0)
             {
                 ImGui.SetCursorScreenPos(position);
-                ImGui.Image(wrap.ToImGuiHandle(), textureSize);
+                ImGui.Image(handle, textureSize);
                 return;
             }
         }
@@ -2671,12 +2687,13 @@ public class ChatWindow : IDisposable
             if (previewReady && previewTexture != null)
             {
                 var wrap = previewTexture.GetWrapOrEmpty();
-                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                var handle = wrap.ToImGuiHandle();
+                if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
                 {
                     var maxThumbnail = new Vector2(40f, 40f) * scale;
                     var bounds = GetAttachmentBounds(maxThumbnail, allowAutoStretch: false);
                     var size = CalculateAttachmentDisplaySize(new Vector2(wrap.Width, wrap.Height), bounds, allowAutoStretch: false);
-                    ImGui.Image(wrap.ToImGuiHandle(), size);
+                    ImGui.Image(handle, size);
                     renderedPreview = true;
                 }
             }
@@ -2978,12 +2995,13 @@ public class ChatWindow : IDisposable
         if (_attachmentPreviewTextures.TryGetValue(attachment.Path, out var texture) && texture != null)
         {
             var wrap = texture.GetWrapOrEmpty();
-            if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+            var handle = wrap.ToImGuiHandle();
+            if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
             {
                 var attachmentCap = GetConfiguredAttachmentCap();
                 var bounds = GetAttachmentBounds(attachmentCap);
                 var size = CalculateAttachmentDisplaySize(new Vector2(wrap.Width, wrap.Height), bounds);
-                ImGui.Image(wrap.ToImGuiHandle(), size);
+                ImGui.Image(handle, size);
             }
         }
     }

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -107,10 +107,11 @@ public static class EmbedPreviewRenderer
             {
                 BeginSection();
                 var wrap = tex.GetWrapOrEmpty();
-                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                var handle = wrap.ToImGuiHandle();
+                if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
                 {
                     var size = CalculateDisplaySize(new Vector2(wrap.Width, wrap.Height), maxThumbnailSize);
-                    ImGui.Image(wrap.ToImGuiHandle(), size);
+                    ImGui.Image(handle, size);
                     thumbnailRendered = true;
                 }
             }
@@ -132,10 +133,11 @@ public static class EmbedPreviewRenderer
             {
                 BeginSection();
                 var wrap = tex.GetWrapOrEmpty();
-                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                var handle = wrap.ToImGuiHandle();
+                if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
                 {
                     var size = CalculateDisplaySize(new Vector2(wrap.Width, wrap.Height), maxImageSize);
-                    ImGui.Image(wrap.ToImGuiHandle(), size);
+                    ImGui.Image(handle, size);
                     imageRendered = true;
                 }
             }

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -84,9 +84,10 @@ public static class EmbedRenderer
             if (tex != null)
             {
                 var wrap = tex.GetWrapOrEmpty();
-                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                var handle = wrap.ToImGuiHandle();
+                if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
                 {
-                    ImGui.Image(wrap.ToImGuiHandle(), new Vector2(wrap.Width, wrap.Height));
+                    ImGui.Image(handle, new Vector2(wrap.Width, wrap.Height));
                 }
             }
         }

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -282,10 +282,11 @@ public sealed class EmojiPicker
                 texture != null)
             {
                 var wrap = texture.GetWrapOrEmpty();
-                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0 &&
+                var handle = wrap.ToImGuiHandle();
+                if (handle != 0 && wrap.Width > 0 && wrap.Height > 0 &&
                     ImGui.ImageButton(
                         $"##emoji{emoji.Id}",
-                        wrap.ToImGuiHandle(),
+                        handle,
                         new Vector2(_tileSize, _tileSize),
                         Vector2.Zero,
                         Vector2.One,

--- a/DemiCatPlugin/Emoji/EmojiRenderer.cs
+++ b/DemiCatPlugin/Emoji/EmojiRenderer.cs
@@ -39,9 +39,10 @@ public static class EmojiRenderer
             if (tex != null)
             {
                 var wrap = tex.GetWrapOrEmpty();
-                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                var handle = wrap.ToImGuiHandle();
+                if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
                 {
-                    ImGui.Image(wrap.ToImGuiHandle(), new Vector2(size, size));
+                    ImGui.Image(handle, new Vector2(size, size));
                 }
             }
             else

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -336,9 +336,10 @@ public class EventView : IDisposable
         if (_authorIcon != null)
         {
             var wrap = _authorIcon.GetWrapOrEmpty();
-            if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+            var handle = wrap.ToImGuiHandle();
+            if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
             {
-                ImGui.Image(wrap.ToImGuiHandle(), new Vector2(32, 32));
+                ImGui.Image(handle, new Vector2(32, 32));
                 if (names.Count > 0)
                 {
                     ImGui.SameLine();
@@ -446,9 +447,10 @@ public class EventView : IDisposable
         }
 
         var wrap = _thumbnail.GetWrapOrEmpty();
-        if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+        var handle = wrap.ToImGuiHandle();
+        if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
         {
-            ImGui.Image(wrap.ToImGuiHandle(), new Vector2(wrap.Width, wrap.Height));
+            ImGui.Image(handle, new Vector2(wrap.Width, wrap.Height));
         }
     }
 
@@ -460,9 +462,10 @@ public class EventView : IDisposable
         }
 
         var wrap = _image.GetWrapOrEmpty();
-        if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+        var handle = wrap.ToImGuiHandle();
+        if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
         {
-            ImGui.Image(wrap.ToImGuiHandle(), new Vector2(wrap.Width, wrap.Height));
+            ImGui.Image(handle, new Vector2(wrap.Width, wrap.Height));
         }
     }
 
@@ -485,9 +488,10 @@ public class EventView : IDisposable
         if (_footerIcon != null)
         {
             var wrap = _footerIcon.GetWrapOrEmpty();
-            if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+            var handle = wrap.ToImGuiHandle();
+            if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
             {
-                ImGui.Image(wrap.ToImGuiHandle(), new Vector2(16, 16));
+                ImGui.Image(handle, new Vector2(16, 16));
                 if (hasText)
                 {
                     ImGui.SameLine();

--- a/DemiCatPlugin/ImGuiTextureHelpers.cs
+++ b/DemiCatPlugin/ImGuiTextureHelpers.cs
@@ -4,6 +4,6 @@ namespace DemiCatPlugin;
 
 internal static class ImGuiTextureHelpers
 {
-    public static nint ToImGuiHandle(this IDalamudTextureWrap wrap)
-        => wrap.Handle.Handle;
+    public static nint ToImGuiHandle(this IDalamudTextureWrap? wrap)
+        => wrap is null ? 0 : (nint)(ulong)wrap.Handle.Handle;
 }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -653,11 +653,12 @@ public class MainWindow : IDisposable
         if (item.Icon != null)
         {
             var wrap = item.Icon.GetWrapOrEmpty();
-            if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+            var handle = wrap.ToImGuiHandle();
+            if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
             {
                 return ImGui.ImageButton(
                     $"##{item.Id}",
-                    wrap.ToImGuiHandle(),
+                    handle,
                     iconSize,
                     Vector2.Zero,
                     Vector2.One,

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -303,9 +303,10 @@ public class PresenceSidebar : IDisposable
             try
             {
                 var wrap = p.AvatarTexture.GetWrapOrEmpty();
-                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                var handle = wrap.ToImGuiHandle();
+                if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
                 {
-                    ImGui.Image(wrap.ToImGuiHandle(), avatarSize);
+                    ImGui.Image(handle, avatarSize);
                     drewAvatar = true;
                 }
             }
@@ -416,9 +417,10 @@ public class PresenceSidebar : IDisposable
             try
             {
                 var wrap = presence.BannerTexture.GetWrapOrEmpty();
-                if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0)
+                var handle = wrap.ToImGuiHandle();
+                if (handle != 0 && wrap.Width > 0 && wrap.Height > 0)
                 {
-                    drawList.AddImage(wrap.ToImGuiHandle(), min, max);
+                    drawList.AddImage(handle, min, max);
                     bannerDrawn = true;
                 }
             }

--- a/DemiCatPlugin/WebTextureCache.cs
+++ b/DemiCatPlugin/WebTextureCache.cs
@@ -122,10 +122,11 @@ public static class WebTextureCache
         if (tex == null) return;
         var wrap = tex.GetWrapOrEmpty();
 
-        if (wrap.Handle.Handle != 0 && wrap.Width > 0 && wrap.Height > 0 &&
+        var handle = wrap.ToImGuiHandle();
+        if (handle != 0 && wrap.Width > 0 && wrap.Height > 0 &&
             ImGui.ImageButton(
                 $"##{id}",
-                wrap.ToImGuiHandle(),
+                handle,
                 size,
                 Vector2.Zero,
                 Vector2.One,


### PR DESCRIPTION
## Summary
- allow `ImGuiTextureHelpers.ToImGuiHandle` to safely handle null wraps
- update chat, sidebar, event, and emoji rendering to use the helper for ImGui texture IDs
- gate all texture rendering on the helper result instead of raw handle comparisons

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1b1b371ec8328817b1f2d2264eb32