### PR TITLE
Fix emoji input callback usage

### DIFF
--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -20,6 +20,8 @@ public class SignupOptionEditor
     private int _emojiSelectionStart;
     private int _emojiSelectionEnd;
     private bool _focusEmojiNextFrame;
+    private static SignupOptionEditor? _activeEmojiCallbackOwner;
+    private static readonly unsafe delegate* unmanaged[Cdecl]<ImGuiInputTextCallbackData*, int> _emojiEditedCallback = &OnEmojiEdited;
 
     public SignupOptionEditor(Config config, HttpClient httpClient, EmojiManager emojiManager)
     {
@@ -66,12 +68,24 @@ public class SignupOptionEditor
                 ImGui.SetKeyboardFocusHere();
                 _focusEmojiNextFrame = false;
             }
-            ImGui.InputText(
-                "Emoji",
-                emojiBuf,
-                ImGuiInputTextFlags.CallbackAlways,
-                OnEmojiEdited
-            );
+            unsafe
+            {
+                _activeEmojiCallbackOwner = this;
+                try
+                {
+                    ImGui.InputText(
+                        "Emoji",
+                        emojiBuf,
+                        (uint)emojiBuf.Length,
+                        ImGuiInputTextFlags.CallbackAlways,
+                        _emojiEditedCallback
+                    );
+                }
+                finally
+                {
+                    _activeEmojiCallbackOwner = null;
+                }
+            }
             var emoji = ImGuiTextUtil.ReadUtf8Buffer(emojiBuf);
             if (_working.Emoji != emoji)
             {
@@ -179,10 +193,21 @@ public class SignupOptionEditor
         _focusEmojiNextFrame = true;
     }
 
-    private int OnEmojiEdited(scoped ref ImGuiInputTextCallbackData data)
+    private static unsafe int OnEmojiEdited(ImGuiInputTextCallbackData* data)
     {
-        _emojiSelectionStart = data.SelectionStart;
-        _emojiSelectionEnd = data.SelectionEnd;
+        if (data == null)
+        {
+            return 0;
+        }
+
+        var owner = _activeEmojiCallbackOwner;
+        if (owner == null)
+        {
+            return 0;
+        }
+
+        owner._emojiSelectionStart = data->SelectionStart;
+        owner._emojiSelectionEnd = data->SelectionEnd;
         return 0;
     }
 


### PR DESCRIPTION
## Summary
- call the ImGui.InputText overload that accepts a buffer length and callback pointer for the emoji field
- route the emoji input callback through a static function pointer that updates the active editor's selection state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1b42352508328be6add2ae1c24d39