### PR TITLE
Replace unmanaged input callbacks with delegates

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -95,7 +95,7 @@ public class ChatWindow : IDisposable
     private int _selectionEnd;
     private bool _focusComposerNextFrame;
     private static ChatWindow? _activeInputCallbackOwner;
-    private static readonly unsafe delegate* unmanaged[Cdecl]<ImGuiInputTextCallbackData*, int> _inputEditedCallback = &OnInputEdited;
+    private static readonly ImGuiInputTextCallback _inputEditedCallback = OnInputEdited;
     private BridgeMessageFormatter.BridgeFormattedMessage _previewMessage = BridgeMessageFormatter.BridgeFormattedMessage.Empty;
     private string _previewKey = string.Empty;
     private readonly Dictionary<string, ISharedImmediateTexture?> _attachmentPreviewTextures = new(StringComparer.OrdinalIgnoreCase);
@@ -1035,25 +1035,22 @@ public class ChatWindow : IDisposable
             ImGui.SetKeyboardFocusHere();
             _focusComposerNextFrame = false;
         }
-        unsafe
+        _activeInputCallbackOwner = this;
+        try
         {
-            _activeInputCallbackOwner = this;
-            try
-            {
-                _ = ImGui.InputTextMultiline(
-                    "##chatInput",
-                    ref _input,
-                    2048u,
-                    new Vector2(inputWidth, inputHeight),
-                    ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
-                    _inputEditedCallback,
-                    IntPtr.Zero
-                );
-            }
-            finally
-            {
-                _activeInputCallbackOwner = null;
-            }
+            _ = ImGui.InputTextMultiline(
+                "##chatInput",
+                ref _input,
+                2048u,
+                new Vector2(inputWidth, inputHeight),
+                ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
+                _inputEditedCallback,
+                IntPtr.Zero
+            );
+        }
+        finally
+        {
+            _activeInputCallbackOwner = null;
         }
         if (MentionsEnabled)
         {

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -33,7 +33,7 @@ public class EventCreateWindow
     private int _descriptionSelectionEnd;
     private bool _focusDescriptionNextFrame;
     private static EventCreateWindow? _activeDescriptionCallbackOwner;
-    private static readonly unsafe delegate* unmanaged[Cdecl]<ImGuiInputTextCallbackData*, int> _descriptionEditedCallback = &OnDescriptionEdited;
+    private static readonly ImGuiInputTextCallback _descriptionEditedCallback = OnDescriptionEdited;
     private string _time = string.Empty;
     private string _imageUrl = string.Empty;
     private string _url = string.Empty;
@@ -230,25 +230,22 @@ public class EventCreateWindow
                         ImGui.SetKeyboardFocusHere();
                         _focusDescriptionNextFrame = false;
                     }
-                    unsafe
+                    _activeDescriptionCallbackOwner = this;
+                    try
                     {
-                        _activeDescriptionCallbackOwner = this;
-                        try
-                        {
-                            ImGui.InputTextMultiline(
-                                "##Description",
-                                ref _description,
-                                4096u,
-                                new Vector2(avail.X, descHeight),
-                                ImGuiInputTextFlags.CallbackAlways,
-                                _descriptionEditedCallback,
-                                IntPtr.Zero
-                            );
-                        }
-                        finally
-                        {
-                            _activeDescriptionCallbackOwner = null;
-                        }
+                        ImGui.InputTextMultiline(
+                            "##Description",
+                            ref _description,
+                            4096u,
+                            new Vector2(avail.X, descHeight),
+                            ImGuiInputTextFlags.CallbackAlways,
+                            _descriptionEditedCallback,
+                            IntPtr.Zero
+                        );
+                    }
+                    finally
+                    {
+                        _activeDescriptionCallbackOwner = null;
                     }
                     _descriptionEmojiPopup.Draw();
                 },

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -40,7 +40,7 @@ public sealed class NotePadWindow : IDisposable
     private bool _pageOrderDirty;
     private bool _focusEditorNextFrame;
     private static NotePadWindow? _activeEditorCallbackOwner;
-    private static readonly unsafe delegate* unmanaged[Cdecl]<ImGuiInputTextCallbackData*, int> _editorEditedCallback = &OnEditorEdited;
+    private static readonly ImGuiInputTextCallback _editorEditedCallback = OnEditorEdited;
     private string _newSectionName = string.Empty;
     private string _newPageTitle = string.Empty;
     private bool _showNewSectionPopup;
@@ -420,16 +420,13 @@ public sealed class NotePadWindow : IDisposable
             var capacity = (uint)Math.Max(1024, content.Length + 512);
             var readOnlyContent = content;
             ImGui.BeginDisabled();
-            unsafe
-            {
-                ImGui.InputTextMultiline(
-                    "##NotePadEditorReadOnly",
-                    ref readOnlyContent,
-                    capacity,
-                    new Vector2(-1, -1),
-                    ImGuiInputTextFlags.ReadOnly
-                );
-            }
+            ImGui.InputTextMultiline(
+                "##NotePadEditorReadOnly",
+                ref readOnlyContent,
+                capacity,
+                new Vector2(-1, -1),
+                ImGuiInputTextFlags.ReadOnly
+            );
             ImGui.EndDisabled();
             _editorContent = content;
             _editorVersion = page.Version;
@@ -446,25 +443,22 @@ public sealed class NotePadWindow : IDisposable
         ImGui.PushItemWidth(-1);
         var flags = ImGuiInputTextFlags.AllowTabInput | ImGuiInputTextFlags.CallbackAlways | ImGuiInputTextFlags.CallbackHistory;
         bool edited;
-        unsafe
+        _activeEditorCallbackOwner = this;
+        try
         {
-            _activeEditorCallbackOwner = this;
-            try
-            {
-                edited = ImGui.InputTextMultiline(
-                    "##NotePadEditor",
-                    ref _editorContent,
-                    editorCapacity,
-                    new Vector2(-1, -1),
-                    flags,
-                    _editorEditedCallback,
-                    IntPtr.Zero
-                );
-            }
-            finally
-            {
-                _activeEditorCallbackOwner = null;
-            }
+            edited = ImGui.InputTextMultiline(
+                "##NotePadEditor",
+                ref _editorContent,
+                editorCapacity,
+                new Vector2(-1, -1),
+                flags,
+                _editorEditedCallback,
+                IntPtr.Zero
+            );
+        }
+        finally
+        {
+            _activeEditorCallbackOwner = null;
         }
         ImGui.PopItemWidth();
 

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -21,7 +21,7 @@ public class SignupOptionEditor
     private int _emojiSelectionEnd;
     private bool _focusEmojiNextFrame;
     private static SignupOptionEditor? _activeEmojiCallbackOwner;
-    private static readonly unsafe delegate* unmanaged[Cdecl]<ImGuiInputTextCallbackData*, int> _emojiEditedCallback = &OnEmojiEdited;
+    private static readonly ImGuiInputTextCallback _emojiEditedCallback = OnEmojiEdited;
 
     public SignupOptionEditor(Config config, HttpClient httpClient, EmojiManager emojiManager)
     {
@@ -68,23 +68,20 @@ public class SignupOptionEditor
                 ImGui.SetKeyboardFocusHere();
                 _focusEmojiNextFrame = false;
             }
-            unsafe
+            _activeEmojiCallbackOwner = this;
+            try
             {
-                _activeEmojiCallbackOwner = this;
-                try
-                {
-                    ImGui.InputText(
-                        "Emoji",
-                        emojiBuf,
-                        (uint)emojiBuf.Length,
-                        ImGuiInputTextFlags.CallbackAlways,
-                        _emojiEditedCallback
-                    );
-                }
-                finally
-                {
-                    _activeEmojiCallbackOwner = null;
-                }
+                ImGui.InputText(
+                    "Emoji",
+                    emojiBuf,
+                    (uint)emojiBuf.Length,
+                    ImGuiInputTextFlags.CallbackAlways,
+                    _emojiEditedCallback
+                );
+            }
+            finally
+            {
+                _activeEmojiCallbackOwner = null;
             }
             var emoji = ImGuiTextUtil.ReadUtf8Buffer(emojiBuf);
             if (_working.Emoji != emoji)

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -143,7 +143,7 @@ public class SyncshellWindow : IDisposable
     private bool _inviteSuggestionFiltered;
     private bool _focusInviteInputNextFrame;
     private static SyncshellWindow? _activeInviteCallbackOwner;
-    private readonly unsafe delegate* unmanaged[Cdecl]<ImGuiInputTextCallbackData*, int> _inviteInputCallback;
+    private static readonly ImGuiInputTextCallback _inviteInputCallback = OnInviteInputEdited;
     private int _inviteInFlight;
     private DateTimeOffset _lastMembershipFetch;
     private bool _membershipNeedsRefresh = true;
@@ -210,11 +210,6 @@ public class SyncshellWindow : IDisposable
             _syncSettingsHeight = Math.Clamp(storedHeight, MinSyncSettingsHeight, MaxSyncSettingsHeight);
         }
         InitializeMembershipPanelRatios();
-
-        unsafe
-        {
-            _inviteInputCallback = &OnInviteInputEdited;
-        }
 
         foreach (var inviteEntry in state.Invites.ToList())
         {
@@ -973,24 +968,21 @@ public class SyncshellWindow : IDisposable
         }
         ImGui.SetNextItemWidth(-150f);
         bool submitted;
-        unsafe
+        _activeInviteCallbackOwner = this;
+        try
         {
-            _activeInviteCallbackOwner = this;
-            try
-            {
-                submitted = ImGui.InputTextWithHint(
-                    "##syncshell-invite",
-                    "Character name",
-                    ref invite,
-                    64,
-                    ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
-                    _inviteInputCallback
-                );
-            }
-            finally
-            {
-                _activeInviteCallbackOwner = null;
-            }
+            submitted = ImGui.InputTextWithHint(
+                "##syncshell-invite",
+                "Character name",
+                ref invite,
+                64,
+                ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackAlways,
+                _inviteInputCallback
+            );
+        }
+        finally
+        {
+            _activeInviteCallbackOwner = null;
         }
         invite ??= string.Empty;
         _inviteTarget = invite;


### PR DESCRIPTION
## Summary
- replace unsafe delegate* unmanaged callbacks in plugin windows with static ImGuiInputTextCallback fields
- update composer and editor input handlers to use managed delegates while preserving existing callback logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1b91d1a648328ae4bf4157da1c86d