### PR TITLE
Update ImGui drag drop payload overload usage

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -541,7 +541,7 @@ public class MainWindow : IDisposable
             if (ImGui.BeginDragDropSource())
             {
                 _draggingDockItemId = item.Id;
-                ImGui.SetDragDropPayload(DockDragPayloadType, ReadOnlySpan<byte>.Empty, ImGuiCond.None);
+                ImGui.SetDragDropPayload(DockDragPayloadType, nint.Zero, 0, ImGuiCond.None);
                 ImGui.TextUnformatted(item.Tooltip);
                 ImGui.EndDragDropSource();
             }

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -204,7 +204,7 @@ public sealed class NotePadWindow : IDisposable
                 if (ImGui.BeginDragDropSource())
                 {
                     _draggingSectionId = section.Id;
-                    ImGui.SetDragDropPayload("NotePadSection", ReadOnlySpan<byte>.Empty, ImGuiCond.None);
+                    ImGui.SetDragDropPayload("NotePadSection", nint.Zero, 0, ImGuiCond.None);
                     ImGui.TextUnformatted(title);
                     ImGui.EndDragDropSource();
                 }
@@ -322,7 +322,7 @@ public sealed class NotePadWindow : IDisposable
             if (ImGui.BeginDragDropSource())
             {
                 _draggingPageId = page.Id;
-                ImGui.SetDragDropPayload("NotePadPage", ReadOnlySpan<byte>.Empty, ImGuiCond.None);
+                ImGui.SetDragDropPayload("NotePadPage", nint.Zero, 0, ImGuiCond.None);
                 ImGui.TextUnformatted(label);
                 ImGui.EndDragDropSource();
             }


### PR DESCRIPTION
## Summary
- replace deprecated ReadOnlySpan-based SetDragDropPayload overloads with the pointer/size signature
- update dock, notepad section, and notepad page drag payloads to match the new API

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1ba92240c8328960cd8a2f9cc71d1