### PR TITLE
Fix dock gradient vertex access

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -481,16 +481,16 @@ public class MainWindow : IDisposable
                 {
                     var drawListPtr = drawList.NativePtr;
                     var vertexBuffer = drawListPtr->VtxBuffer;
-                    var vertices = new Span<ImDrawVert>(vertexBuffer.Data, vertexBuffer.Size);
+                    var vertices = new Span<ImDrawVert>((ImDrawVert*)vertexBuffer.Data, vertexBuffer.Size);
                     var gradientVertices = vertices.Slice(vertexStartIndex, vertexCount);
 
                     for (var i = 0; i < gradientVertices.Length; i++)
                     {
                         ref var vertex = ref gradientVertices[i];
-                        var position = vertex.Pos;
+                        var position = vertex.pos;
                         var t = Math.Clamp((position.Y - stripMin.Y) / height, 0f, 1f);
                         var color = Vector4.Lerp(topColor, bottomColor, t);
-                        vertex.Col = ImGui.ColorConvertFloat4ToU32(color);
+                        vertex.col = ImGui.ColorConvertFloat4ToU32(color);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- cast the ImGui vertex buffer data to `ImDrawVert*` before creating the span
- update the gradient recoloring loop to use the current vertex field names

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1bc2cce448328bfc0b73742ed1757