### PR TITLE
Mark ImGui windows as unsafe for callbacks

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -28,7 +28,7 @@ using SixLabors.ImageSharp.Processing;
 
 namespace DemiCatPlugin;
 
-public class ChatWindow : IDisposable
+public unsafe class ChatWindow : IDisposable
 {
     protected readonly Config _config;
     protected readonly HttpClient _httpClient;

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -20,7 +20,7 @@ using System.IO;
 
 namespace DemiCatPlugin;
 
-public class EventCreateWindow
+public unsafe class EventCreateWindow
 {
     private readonly Config _config;
     private readonly HttpClient _httpClient;

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -8,7 +8,7 @@ using ImGuiNET;
 
 namespace DemiCatPlugin;
 
-public sealed class NotePadWindow : IDisposable
+public unsafe sealed class NotePadWindow : IDisposable
 {
     private const int MaxTitleLength = 25;
     private static readonly ImGuiMouseCursor ResizeEwCursor = ResolveResizeEwCursor();

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -9,7 +9,7 @@ using DemiCatPlugin.Emoji;
 
 namespace DemiCatPlugin;
 
-public class SignupOptionEditor
+public unsafe class SignupOptionEditor
 {
     private bool _open;
     private Template.TemplateButton _working = new();

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -26,7 +26,7 @@ using ImGuiMouseCursor = ImGuiNET.ImGuiMouseCursor;
 
 namespace DemiCatPlugin;
 
-public class SyncshellWindow : IDisposable
+public unsafe class SyncshellWindow : IDisposable
 {
     public static SyncshellWindow? Instance { get; private set; }
 


### PR DESCRIPTION
## Summary
- add the unsafe modifier to the ImGui window classes that declare static ImGuiInputTextCallback fields so pointer-based delegates compile

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1bfd013c483288942f3b439d4927e