### PR TITLE
Fix drag payload pointers

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -540,10 +540,13 @@ public class MainWindow : IDisposable
 
             if (ImGui.BeginDragDropSource())
             {
-                _draggingDockItemId = item.Id;
-                ImGui.SetDragDropPayload(DockDragPayloadType, nint.Zero, 0, ImGuiCond.None);
-                ImGui.TextUnformatted(item.Tooltip);
-                ImGui.EndDragDropSource();
+                unsafe
+                {
+                    _draggingDockItemId = item.Id;
+                    ImGui.SetDragDropPayload(DockDragPayloadType, (void*)0, 0, ImGuiCond.None);
+                    ImGui.TextUnformatted(item.Tooltip);
+                    ImGui.EndDragDropSource();
+                }
             }
 
             if (ImGui.BeginDragDropTarget())

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -203,10 +203,13 @@ public unsafe sealed class NotePadWindow : IDisposable
 
                 if (ImGui.BeginDragDropSource())
                 {
-                    _draggingSectionId = section.Id;
-                    ImGui.SetDragDropPayload("NotePadSection", nint.Zero, 0, ImGuiCond.None);
-                    ImGui.TextUnformatted(title);
-                    ImGui.EndDragDropSource();
+                    unsafe
+                    {
+                        _draggingSectionId = section.Id;
+                        ImGui.SetDragDropPayload("NotePadSection", (void*)0, 0, ImGuiCond.None);
+                        ImGui.TextUnformatted(title);
+                        ImGui.EndDragDropSource();
+                    }
                 }
 
                 if (ImGui.BeginDragDropTarget())
@@ -321,10 +324,13 @@ public unsafe sealed class NotePadWindow : IDisposable
 
             if (ImGui.BeginDragDropSource())
             {
-                _draggingPageId = page.Id;
-                ImGui.SetDragDropPayload("NotePadPage", nint.Zero, 0, ImGuiCond.None);
-                ImGui.TextUnformatted(label);
-                ImGui.EndDragDropSource();
+                unsafe
+                {
+                    _draggingPageId = page.Id;
+                    ImGui.SetDragDropPayload("NotePadPage", (void*)0, 0, ImGuiCond.None);
+                    ImGui.TextUnformatted(label);
+                    ImGui.EndDragDropSource();
+                }
             }
 
             if (ImGui.BeginDragDropTarget())


### PR DESCRIPTION
## Summary
- wrap dock drag source in an unsafe block and pass a null pointer payload for the updated ImGui signature
- update notepad section and page drag sources to use unsafe blocks with null pointer payloads
- verify no other SetDragDropPayload calls remain outside of unsafe pointer usage

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c08c92848328b8af84afd3457e6f