### PR TITLE
Fix unsafe context regressions for new Dalamud APIs

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -28,7 +28,7 @@ using SixLabors.ImageSharp.Processing;
 
 namespace DemiCatPlugin;
 
-public unsafe class ChatWindow : IDisposable
+public class ChatWindow : IDisposable
 {
     protected readonly Config _config;
     protected readonly HttpClient _httpClient;
@@ -95,7 +95,7 @@ public unsafe class ChatWindow : IDisposable
     private int _selectionEnd;
     private bool _focusComposerNextFrame;
     private static ChatWindow? _activeInputCallbackOwner;
-    private static readonly ImGuiInputTextCallback _inputEditedCallback = OnInputEdited;
+    private static unsafe readonly ImGuiInputTextCallback _inputEditedCallback = OnInputEdited;
     private BridgeMessageFormatter.BridgeFormattedMessage _previewMessage = BridgeMessageFormatter.BridgeFormattedMessage.Empty;
     private string _previewKey = string.Empty;
     private readonly Dictionary<string, ISharedImmediateTexture?> _attachmentPreviewTextures = new(StringComparer.OrdinalIgnoreCase);

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -20,7 +20,7 @@ using System.IO;
 
 namespace DemiCatPlugin;
 
-public unsafe class EventCreateWindow
+public class EventCreateWindow
 {
     private readonly Config _config;
     private readonly HttpClient _httpClient;
@@ -33,7 +33,7 @@ public unsafe class EventCreateWindow
     private int _descriptionSelectionEnd;
     private bool _focusDescriptionNextFrame;
     private static EventCreateWindow? _activeDescriptionCallbackOwner;
-    private static readonly ImGuiInputTextCallback _descriptionEditedCallback = OnDescriptionEdited;
+    private static unsafe readonly ImGuiInputTextCallback _descriptionEditedCallback = OnDescriptionEdited;
     private string _time = string.Empty;
     private string _imageUrl = string.Empty;
     private string _url = string.Empty;

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -540,13 +540,10 @@ public class MainWindow : IDisposable
 
             if (ImGui.BeginDragDropSource())
             {
-                unsafe
-                {
-                    _draggingDockItemId = item.Id;
-                    ImGui.SetDragDropPayload(DockDragPayloadType, (void*)0, 0, ImGuiCond.None);
-                    ImGui.TextUnformatted(item.Tooltip);
-                    ImGui.EndDragDropSource();
-                }
+                _draggingDockItemId = item.Id;
+                ImGui.SetDragDropPayload(DockDragPayloadType, nint.Zero, 0, ImGuiCond.None);
+                ImGui.TextUnformatted(item.Tooltip);
+                ImGui.EndDragDropSource();
             }
 
             if (ImGui.BeginDragDropTarget())

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -8,7 +8,7 @@ using ImGuiNET;
 
 namespace DemiCatPlugin;
 
-public unsafe sealed class NotePadWindow : IDisposable
+public sealed class NotePadWindow : IDisposable
 {
     private const int MaxTitleLength = 25;
     private static readonly ImGuiMouseCursor ResizeEwCursor = ResolveResizeEwCursor();
@@ -40,7 +40,7 @@ public unsafe sealed class NotePadWindow : IDisposable
     private bool _pageOrderDirty;
     private bool _focusEditorNextFrame;
     private static NotePadWindow? _activeEditorCallbackOwner;
-    private static readonly ImGuiInputTextCallback _editorEditedCallback = OnEditorEdited;
+    private static unsafe readonly ImGuiInputTextCallback _editorEditedCallback = OnEditorEdited;
     private string _newSectionName = string.Empty;
     private string _newPageTitle = string.Empty;
     private bool _showNewSectionPopup;
@@ -203,13 +203,10 @@ public unsafe sealed class NotePadWindow : IDisposable
 
                 if (ImGui.BeginDragDropSource())
                 {
-                    unsafe
-                    {
-                        _draggingSectionId = section.Id;
-                        ImGui.SetDragDropPayload("NotePadSection", (void*)0, 0, ImGuiCond.None);
-                        ImGui.TextUnformatted(title);
-                        ImGui.EndDragDropSource();
-                    }
+                    _draggingSectionId = section.Id;
+                    ImGui.SetDragDropPayload("NotePadSection", nint.Zero, 0, ImGuiCond.None);
+                    ImGui.TextUnformatted(title);
+                    ImGui.EndDragDropSource();
                 }
 
                 if (ImGui.BeginDragDropTarget())
@@ -324,13 +321,10 @@ public unsafe sealed class NotePadWindow : IDisposable
 
             if (ImGui.BeginDragDropSource())
             {
-                unsafe
-                {
-                    _draggingPageId = page.Id;
-                    ImGui.SetDragDropPayload("NotePadPage", (void*)0, 0, ImGuiCond.None);
-                    ImGui.TextUnformatted(label);
-                    ImGui.EndDragDropSource();
-                }
+                _draggingPageId = page.Id;
+                ImGui.SetDragDropPayload("NotePadPage", nint.Zero, 0, ImGuiCond.None);
+                ImGui.TextUnformatted(label);
+                ImGui.EndDragDropSource();
             }
 
             if (ImGui.BeginDragDropTarget())

--- a/DemiCatPlugin/SignupOptionEditor.cs
+++ b/DemiCatPlugin/SignupOptionEditor.cs
@@ -9,7 +9,7 @@ using DemiCatPlugin.Emoji;
 
 namespace DemiCatPlugin;
 
-public unsafe class SignupOptionEditor
+public class SignupOptionEditor
 {
     private bool _open;
     private Template.TemplateButton _working = new();
@@ -21,7 +21,7 @@ public unsafe class SignupOptionEditor
     private int _emojiSelectionEnd;
     private bool _focusEmojiNextFrame;
     private static SignupOptionEditor? _activeEmojiCallbackOwner;
-    private static readonly ImGuiInputTextCallback _emojiEditedCallback = OnEmojiEdited;
+    private static unsafe readonly ImGuiInputTextCallback _emojiEditedCallback = OnEmojiEdited;
 
     public SignupOptionEditor(Config config, HttpClient httpClient, EmojiManager emojiManager)
     {

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -26,7 +26,7 @@ using ImGuiMouseCursor = ImGuiNET.ImGuiMouseCursor;
 
 namespace DemiCatPlugin;
 
-public unsafe class SyncshellWindow : IDisposable
+public class SyncshellWindow : IDisposable
 {
     public static SyncshellWindow? Instance { get; private set; }
 
@@ -143,7 +143,7 @@ public unsafe class SyncshellWindow : IDisposable
     private bool _inviteSuggestionFiltered;
     private bool _focusInviteInputNextFrame;
     private static SyncshellWindow? _activeInviteCallbackOwner;
-    private static readonly ImGuiInputTextCallback _inviteInputCallback = OnInviteInputEdited;
+    private static unsafe readonly ImGuiInputTextCallback _inviteInputCallback = OnInviteInputEdited;
     private int _inviteInFlight;
     private DateTimeOffset _lastMembershipFetch;
     private bool _membershipNeedsRefresh = true;


### PR DESCRIPTION
## Summary
- scope ImGui input callback fields with unsafe modifiers instead of marking whole windows unsafe
- update drag-and-drop payload calls to the nint-based ImGui.NET signature to remove pointer usage in safe code
- keep asynchronous logic compiling by returning the windows to safe classes while still supporting ImGui pointer callbacks

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1b6ce304c832896d2d29230263fbc