### PR TITLE
Guard channel watcher status logging

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -536,18 +536,21 @@ public class ChannelWatcher : IDisposable
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
         {
-            PluginServices.Instance!.Log.Warning(ex, "Failed to fetch channels for {Kind}. Status: {Status}", kind, ex.StatusCode);
+            var status = ex.StatusCode?.ToString() ?? "Unknown";
+            PluginServices.Instance!.Log.Warning(ex, "Failed to fetch channels for {Kind}. Status: {Status}", kind, status);
             _ = Task.Run(() => _tokenManager.Clear("Invalid API key"));
             return ChannelRefreshResult.Failure(kind, ChannelRefreshError.Unauthorized);
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
         {
-            PluginServices.Instance!.Log.Warning(ex, "Failed to fetch channels for {Kind}. Status: {Status}", kind, ex.StatusCode);
+            var status = ex.StatusCode?.ToString() ?? "Unknown";
+            PluginServices.Instance!.Log.Warning(ex, "Failed to fetch channels for {Kind}. Status: {Status}", kind, status);
             return ChannelRefreshResult.Failure(kind, ChannelRefreshError.Forbidden);
         }
         catch (HttpRequestException ex)
         {
-            PluginServices.Instance!.Log.Warning(ex, "Failed to fetch channels for {Kind}. Status: {Status}", kind, ex.StatusCode);
+            var status = ex.StatusCode?.ToString() ?? "Unknown";
+            PluginServices.Instance!.Log.Warning(ex, "Failed to fetch channels for {Kind}. Status: {Status}", kind, status);
             return ChannelRefreshResult.Failure(kind, ChannelRefreshError.Generic);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- guard channel watcher status logging against null HTTP status codes when fetching channels
- ensure each warning log uses a consistent fallback string for the status code value

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c75f35f48328b086b02188dd099e