### PR TITLE
Guard ImGui style pointer access

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -1188,9 +1188,12 @@ public class MainWindow : IDisposable
         }
 
         var style = ImGui.GetStyle();
-        if (style.NativePtr == null)
+        unsafe
         {
-            return false;
+            if (style.NativePtr == null)
+            {
+                return false;
+            }
         }
 
         var accent = Config.SanitizeColor(_config.SecondaryAccentColor, Config.DefaultSecondaryAccentColor);


### PR DESCRIPTION
## Summary
- wrap the ImGui style pointer null check in an unsafe block to satisfy compiler requirements

## Testing
- dotnet build DemiCatPlugin -c Release *(fails: dotnet CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d41510e883289f30ea51174d6942