### PR TITLE
Handle Syncshell token watcher disposal

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -72,6 +72,7 @@ public class SyncshellWindow : IDisposable
     private readonly FileBlobStore _blobStore;
     private readonly Resolver _resolver;
     private readonly SyncClient _syncClient;
+    private readonly IDisposable? _tokenWatcher;
     private readonly ProgressOverlay _progressOverlay;
     private readonly Config.CategoryState _syncshellState;
     private readonly ConcurrentQueue<Action> _uiThreadActions = new();
@@ -255,7 +256,7 @@ public class SyncshellWindow : IDisposable
         _ = TrimCacheAsync();
 
         SubscribeToStateChanges();
-        _tokenManager.RegisterWatcher(HandleTokenLinked, HandleTokenUnlinked);
+        _tokenWatcher = _tokenManager.RegisterWatcher(HandleTokenLinked, HandleTokenUnlinked);
 
         RequestMembershipRefresh();
     }
@@ -4670,6 +4671,11 @@ public class SyncshellWindow : IDisposable
 
     private void HandleTokenLinked()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _ = EnsurePairingAsync();
         StartPeriodicRefresh();
         UpdateSyncClientState();
@@ -4677,6 +4683,11 @@ public class SyncshellWindow : IDisposable
 
     private void HandleTokenUnlinked()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _ = StopSyncClientAsync();
         StopPeriodicRefresh();
         _pairingExpiresAt = null;
@@ -4762,6 +4773,7 @@ public class SyncshellWindow : IDisposable
     public void Dispose()
     {
         _disposed = true;
+        _tokenWatcher?.Dispose();
         StopPeriodicRefresh();
         CancelActiveDownloads();
         foreach (var unsubscribe in _ipcUnsubscribers)

--- a/DemiCatPlugin/TokenManager.cs
+++ b/DemiCatPlugin/TokenManager.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Security.Cryptography;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
+using System.Threading;
 using Dalamud.Plugin;
 
 namespace DemiCatPlugin;
@@ -351,13 +352,45 @@ public class TokenManager
         OnUnlinked?.Invoke(reason);
     }
 
-    public void RegisterWatcher(Action start, Action stop)
+    public IDisposable RegisterWatcher(Action start, Action stop)
     {
         OnLinked += start;
-        OnUnlinked += _ => stop();
+        Action<string?> onUnlinked = _ => stop();
+        OnUnlinked += onUnlinked;
+
         if (IsReady())
         {
             start();
+        }
+
+        return new WatcherHandle(this, start, onUnlinked);
+    }
+
+    private sealed class WatcherHandle : IDisposable
+    {
+        private readonly TokenManager _manager;
+        private Action? _start;
+        private Action<string?>? _stop;
+
+        public WatcherHandle(TokenManager manager, Action start, Action<string?> stop)
+        {
+            _manager = manager;
+            _start = start;
+            _stop = stop;
+        }
+
+        public void Dispose()
+        {
+            var start = Interlocked.Exchange(ref _start, null);
+            var stop = Interlocked.Exchange(ref _stop, null);
+            if (start != null)
+            {
+                _manager.OnLinked -= start;
+            }
+            if (stop != null)
+            {
+                _manager.OnUnlinked -= stop;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- return an IDisposable handle from `TokenManager.RegisterWatcher` so linked/unlinked delegates can be removed
- store and dispose the Syncshell token watcher while ignoring token events once the window is torn down

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: `dotnet` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d7197c648328a1e90800df096165