### PR TITLE
Fix Dispose unsubscribe guard

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -228,7 +228,8 @@ public class Plugin : IDalamudPlugin
     {
         var pluginInterface = PluginInterface;
         Dalamud.Interface.UiBuilder.Draw -= EnsureInitializedOnce;
-        pluginInterface?.UiBuilder.Draw -= EnsureInitializedOnce;
+        if (pluginInterface != null)
+            pluginInterface.UiBuilder.Draw -= EnsureInitializedOnce;
 
         if (!_initialized)
             return;


### PR DESCRIPTION
## Summary
- replace the null-conditional unsubscribe in `Plugin.Dispose` with an explicit null check to avoid CS0079

## Testing
- ❌ `dotnet build` (command not found in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2560657b48328928d44a433fa051c