### PR TITLE
Guard plugin initialization until services injected

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -67,21 +67,23 @@ public class Plugin : IDalamudPlugin
 
     public Plugin()
     {
-        Dalamud.Interface.UiBuilder.Draw += EnsureInitializedOnce;
+        var uiBuilder = Dalamud.Interface.UiBuilder;
+        if (uiBuilder != null)
+            uiBuilder.Draw += EnsureInitializedOnce;
     }
 
     private void EnsureInitializedOnce()
     {
+        var uiBuilder = Dalamud.Interface.UiBuilder;
         var pluginInterface = PluginInterface;
         var textureProvider = TextureProvider;
         if (pluginInterface == null || textureProvider == null)
             return;
 
-        Dalamud.Interface.UiBuilder.Draw -= EnsureInitializedOnce;
-
         if (_initialized || _initError)
         {
-            pluginInterface.UiBuilder.Draw -= EnsureInitializedOnce;
+            if (uiBuilder != null)
+                uiBuilder.Draw -= EnsureInitializedOnce;
             return;
         }
 
@@ -218,18 +220,17 @@ public class Plugin : IDalamudPlugin
         {
             if (_initialized || _initError)
             {
-                Dalamud.Interface.UiBuilder.Draw -= EnsureInitializedOnce;
-                pluginInterface.UiBuilder.Draw -= EnsureInitializedOnce;
+                if (uiBuilder != null)
+                    uiBuilder.Draw -= EnsureInitializedOnce;
             }
         }
     }
 
     public void Dispose()
     {
-        var pluginInterface = PluginInterface;
-        Dalamud.Interface.UiBuilder.Draw -= EnsureInitializedOnce;
-        if (pluginInterface != null)
-            pluginInterface.UiBuilder.Draw -= EnsureInitializedOnce;
+        var uiBuilder = Dalamud.Interface.UiBuilder;
+        if (uiBuilder != null)
+            uiBuilder.Draw -= EnsureInitializedOnce;
 
         if (!_initialized)
             return;


### PR DESCRIPTION
## Summary
- guard the deferred initialization draw handler on the shared UiBuilder instance
- ensure the draw handler unsubscribes once initialization succeeds or fails, and during dispose

## Testing
- ⚠️ `dotnet build -c Release` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1deec39d883289ec9f4bfdb69b45a