### PR TITLE
Fix missing Dalamud namespace for UI builder injection

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -12,6 +12,7 @@ using Dalamud.Game.Command;
 using Dalamud.Game.Gui.Toast;
 using Dalamud.Game.Text.SeStringHandling;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
+using Dalamud.Interface;
 using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.Textures;
 using Dalamud.IoC;


### PR DESCRIPTION
## Summary
- add the Dalamud.Interface namespace import so the IUiBuilder plugin service resolves during compilation

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e264f9584c8328b8f71f6a5770b368