### PR TITLE
Handle missing texture readback provider

### DIFF
--- a/DemiCatPlugin/GameDataCache.cs
+++ b/DemiCatPlugin/GameDataCache.cs
@@ -10,7 +10,7 @@ internal sealed class GameDataCache : IDisposable
 {
     private readonly IDataManager _dataManager;
     private readonly ITextureProvider _textureProvider;
-    private readonly ITextureReadbackProvider _textureReadback;
+    private readonly ITextureReadbackProvider? _textureReadback;
     private readonly HttpClient _httpClient;
     private readonly string _cacheDir;
     private readonly Dictionary<uint, CachedEntry> _items = new();
@@ -62,6 +62,7 @@ internal sealed class GameDataCache : IDisposable
 
     private async Task<CachedEntry?> ResolveItem(uint id)
     {
+        string? luminaName = null;
         try
         {
             #if LUMINA_GENERATED_SHEETS
@@ -69,9 +70,13 @@ internal sealed class GameDataCache : IDisposable
             var row = sheet?.GetRow(id);
             if (row != null)
             {
-                var name = row.Name.ExtractText();
-                var iconFile = await GetIconFile(row.Icon, id);
-                return new CachedEntry(name, iconFile, DateTime.UtcNow);
+                luminaName = row.Name.ExtractText();
+                if (_textureReadback != null)
+                {
+                    var iconFile = await TryGetIconFile(row.Icon, id);
+                    if (!string.IsNullOrEmpty(iconFile))
+                        return new CachedEntry(luminaName, iconFile!, DateTime.UtcNow);
+                }
             }
             #endif
         }
@@ -85,7 +90,9 @@ internal sealed class GameDataCache : IDisposable
             var json = await _httpClient.GetStringAsync($"https://xivapi.com/item/{id}");
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
-            var name = root.TryGetProperty("Name", out var nEl) ? nEl.GetString() ?? $"Item {id}" : $"Item {id}";
+            var name = root.TryGetProperty("Name", out var nEl)
+                ? nEl.GetString() ?? luminaName ?? $"Item {id}"
+                : luminaName ?? $"Item {id}";
             var iconRel = root.TryGetProperty("Icon", out var iEl) ? iEl.GetString() ?? string.Empty : string.Empty;
             var iconUrl = string.IsNullOrEmpty(iconRel) ? string.Empty : $"https://xivapi.com{iconRel}";
             var iconFile = await DownloadIcon(iconUrl, id);
@@ -99,6 +106,7 @@ internal sealed class GameDataCache : IDisposable
 
     private async Task<CachedEntry?> ResolveDuty(uint id)
     {
+        string? luminaName = null;
         try
         {
             #if LUMINA_GENERATED_SHEETS
@@ -106,9 +114,13 @@ internal sealed class GameDataCache : IDisposable
             var row = sheet?.GetRow(id);
             if (row != null)
             {
-                var name = row.Name.ExtractText();
-                var iconFile = await GetIconFile(row.Icon, id, "duty");
-                return new CachedEntry(name, iconFile, DateTime.UtcNow);
+                luminaName = row.Name.ExtractText();
+                if (_textureReadback != null)
+                {
+                    var iconFile = await TryGetIconFile(row.Icon, id, "duty");
+                    if (!string.IsNullOrEmpty(iconFile))
+                        return new CachedEntry(luminaName, iconFile!, DateTime.UtcNow);
+                }
             }
             #endif
         }
@@ -122,7 +134,9 @@ internal sealed class GameDataCache : IDisposable
             var json = await _httpClient.GetStringAsync($"https://xivapi.com/duty/{id}");
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
-            var name = root.TryGetProperty("Name", out var nEl) ? nEl.GetString() ?? $"Duty {id}" : $"Duty {id}";
+            var name = root.TryGetProperty("Name", out var nEl)
+                ? nEl.GetString() ?? luminaName ?? $"Duty {id}"
+                : luminaName ?? $"Duty {id}";
             var iconRel = root.TryGetProperty("Icon", out var iEl) ? iEl.GetString() ?? string.Empty : string.Empty;
             var iconUrl = string.IsNullOrEmpty(iconRel) ? string.Empty : $"https://xivapi.com{iconRel}";
             var iconFile = await DownloadIcon(iconUrl, id, "duty");
@@ -134,23 +148,30 @@ internal sealed class GameDataCache : IDisposable
         }
     }
 
-    private async Task<string> GetIconFile(uint iconId, uint id, string prefix = "item")
+    private async Task<string?> TryGetIconFile(uint iconId, uint id, string prefix = "item")
     {
+        if (_textureReadback == null)
+            return null;
+
         var filePath = Path.Combine(_cacheDir, $"{prefix}-{id}.png");
-        if (!File.Exists(filePath))
+        if (File.Exists(filePath))
+            return filePath;
+
+        try
         {
-            try
-            {
-                var texture = _textureProvider.GetFromGameIcon(iconId);
-                using var icon = await texture.RentAsync();
-                await _textureReadback.SaveToFileAsync(icon, GUID.GUID_ContainerFormatPng, filePath);
-            }
-            catch
-            {
-                // ignore
-            }
+            var texture = _textureProvider.GetFromGameIcon(iconId);
+            if (texture == null)
+                return null;
+
+            using var icon = await texture.RentAsync();
+            await _textureReadback.SaveToFileAsync(icon, GUID.GUID_ContainerFormatPng, filePath);
         }
-        return filePath;
+        catch
+        {
+            return null;
+        }
+
+        return File.Exists(filePath) ? filePath : null;
     }
 
     private async Task<string> DownloadIcon(string url, uint id, string prefix = "item")

--- a/DemiCatPlugin/PluginServices.cs
+++ b/DemiCatPlugin/PluginServices.cs
@@ -20,8 +20,9 @@ internal class PluginServices
     [PluginService]
     internal ITextureProvider TextureProvider { get; private set; } = null!;
 
-    [PluginService]
-    internal ITextureReadbackProvider TextureReadbackProvider { get; private set; } = null!;
+    [PluginService(ShouldFail = false)]
+    internal ITextureReadbackProvider? TextureReadbackProvider { get; private set; }
+        = null;
 
     [PluginService]
     internal IFramework Framework { get; private set; } = null!;

--- a/tests/GameDataCacheTests.cs
+++ b/tests/GameDataCacheTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
+using DemiCatPlugin;
+using Moq;
+using Xunit;
+
+public class GameDataCacheTests
+{
+    [Fact]
+    public async Task FallsBackToHttpWhenReadbackMissing()
+    {
+        var previousServices = PluginServices.Instance;
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var services = new PluginServices();
+
+            var pluginInterface = new Mock<IDalamudPluginInterface>();
+            pluginInterface
+                .Setup(pi => pi.GetPluginConfigDirectory())
+                .Returns(tempDir);
+
+            SetPrivateProperty(services, "PluginInterface", pluginInterface.Object);
+            SetPrivateProperty(services, "DataManager", Mock.Of<IDataManager>());
+            SetPrivateProperty(services, "TextureProvider", Mock.Of<ITextureProvider>());
+            SetPrivateProperty(services, "TextureReadbackProvider", null);
+
+            var handler = new FakeHandler();
+            using var httpClient = new HttpClient(handler);
+
+            var cache = new GameDataCache(httpClient);
+            var entry = await cache.GetItem(123);
+
+            Assert.NotNull(entry);
+            Assert.Equal("Example Item", entry!.Name);
+            Assert.True(File.Exists(entry.IconPath));
+            Assert.True(handler.ItemRequested);
+            Assert.True(handler.IconRequested);
+        }
+        finally
+        {
+            typeof(PluginServices)
+                .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic)!
+                .SetValue(null, previousServices);
+
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    private static void SetPrivateProperty(object instance, string name, object? value)
+    {
+        instance.GetType()
+            .GetProperty(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(instance, value);
+    }
+
+    private sealed class FakeHandler : HttpMessageHandler
+    {
+        public bool ItemRequested { get; private set; }
+        public bool IconRequested { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.RequestUri!.AbsolutePath == "/item/123")
+            {
+                ItemRequested = true;
+                var content = new StringContent("{\"Name\":\"Example Item\",\"Icon\":\"/icons/example.png\"}");
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = content
+                });
+            }
+
+            if (request.RequestUri.AbsolutePath == "/icons/example.png")
+            {
+                IconRequested = true;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(new byte[] { 1, 2, 3 })
+                });
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow the plugin to initialize when Dalamud omits the texture readback service
- guard `GameDataCache` to fall back to HTTP icon downloads when the readback provider is unavailable
- add a regression test that covers a null readback provider to verify the HTTP fallback path

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e26ae19b4083288d44a68ae2d62d59