### PR TITLE
Persist custom API base URL overrides

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -62,7 +62,7 @@ public class Config : IPluginConfiguration
     public const int DefaultPreloadRowsAhead = 24;
     public const int MinPreloadRowsAhead = 0;
     public const int MaxPreloadRowsAhead = 32;
-    public const int CurrentVersion = 25;
+    public const int CurrentVersion = 26;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -97,7 +97,7 @@ public class Config : IPluginConfiguration
     public bool Enabled { get; set; } = true;
     public const string DefaultApiBaseUrl = "https://mew.the-demiurge.com";
 
-    [JsonIgnore]
+    [JsonPropertyName("apiBaseUrl")]
     public string ApiBaseUrl { get; set; } = DefaultApiBaseUrl;
     public string WebSocketPath { get; set; } = "/ws/embeds";
     public int PollIntervalSeconds { get; set; } = 5;
@@ -739,6 +739,33 @@ public class Config : IPluginConfiguration
             Version = 25;
             ExtensionData = null;
         }
+        if (Version < 26)
+        {
+            if (ExtensionData != null)
+            {
+                string? candidate = null;
+                if (ExtensionData.TryGetValue("apiBaseUrl", out var apiBaseUrlElement) &&
+                    apiBaseUrlElement.ValueKind == JsonValueKind.String)
+                {
+                    candidate = apiBaseUrlElement.GetString();
+                }
+                else if (ExtensionData.TryGetValue("ApiBaseUrl", out var pascalApiBaseUrlElement) &&
+                         pascalApiBaseUrlElement.ValueKind == JsonValueKind.String)
+                {
+                    candidate = pascalApiBaseUrlElement.GetString();
+                }
+
+                if (!string.IsNullOrWhiteSpace(candidate))
+                {
+                    ApiBaseUrl = candidate;
+                }
+            }
+
+            ApiBaseUrl = SanitizeApiBaseUrl(ApiBaseUrl);
+
+            Version = 26;
+            ExtensionData = null;
+        }
     }
 
     public static uint GetDefaultEmbedColor(string? channelKind)
@@ -869,6 +896,23 @@ public class Config : IPluginConfiguration
         }
 
         return WindowFadePreferences.TryGetValue(id, out var enabled) ? enabled : defaultValue;
+    }
+
+    public static string SanitizeApiBaseUrl(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return DefaultApiBaseUrl;
+        }
+
+        var trimmed = value.Trim();
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return DefaultApiBaseUrl;
+        }
+
+        return trimmed;
     }
 
     public void SetWindowFadePreference(string? id, bool enabled)

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -100,10 +100,13 @@ public class Plugin : IDalamudPlugin
             _tokenManager = new TokenManager(_services.PluginInterface);
 
             var oldVersion = _config.Version;
+            var originalApiBaseUrl = _config.ApiBaseUrl;
             _config.Migrate();
-            _config.ApiBaseUrl = Config.DefaultApiBaseUrl;
+            var sanitizedApiBaseUrl = Config.SanitizeApiBaseUrl(_config.ApiBaseUrl);
+            var apiBaseUrlChanged = !string.Equals(originalApiBaseUrl, sanitizedApiBaseUrl, StringComparison.Ordinal);
+            _config.ApiBaseUrl = sanitizedApiBaseUrl;
             var rolesRemoved = _config.Roles.RemoveAll(r => r == "chat") > 0;
-            if (rolesRemoved || _config.Version != oldVersion)
+            if (rolesRemoved || _config.Version != oldVersion || apiBaseUrlChanged)
                 _services.PluginInterface.SavePluginConfig(_config);
 
             RequestStateService.Load(_config);

--- a/tests/DeveloperWindowPersistenceTests.cs
+++ b/tests/DeveloperWindowPersistenceTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
+using DemiCatPlugin;
+using Moq;
+using Xunit;
+
+public class DeveloperWindowPersistenceTests
+{
+    [Fact]
+    public void CustomApiBaseUrlPersistsAfterRestart()
+    {
+        var previousServices = PluginServices.Instance;
+
+        try
+        {
+            var services = new PluginServices();
+            var pluginInterface = new Mock<IDalamudPluginInterface>();
+            pluginInterface.Setup(pi => pi.SavePluginConfig(It.IsAny<Config>()));
+
+            SetPluginService(services, "PluginInterface", pluginInterface.Object);
+            SetPluginService(services, "Log", new TestLog());
+
+            var config = new Config();
+            var window = new DeveloperWindow(
+                config,
+                pluginInterface.Object,
+                () => false,
+                () => Task.CompletedTask,
+                () => { });
+
+            var method = typeof(DeveloperWindow).GetMethod(
+                "ApplyApiBaseUrlChange",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("ApplyApiBaseUrlChange not found");
+
+            method.Invoke(window, new object[] { "https://unit.test/custom" });
+
+            pluginInterface.Verify(pi => pi.SavePluginConfig(config), Times.Once);
+            Assert.Equal("https://unit.test/custom", config.ApiBaseUrl);
+
+            var json = JsonSerializer.Serialize(config);
+            var reloaded = JsonSerializer.Deserialize<Config>(json)
+                ?? throw new InvalidOperationException("Failed to deserialize config");
+            reloaded.Migrate();
+
+            Assert.Equal("https://unit.test/custom", reloaded.ApiBaseUrl);
+        }
+        finally
+        {
+            SetPluginServicesInstance(previousServices);
+        }
+    }
+
+    private static void SetPluginService(PluginServices services, string propertyName, object value)
+    {
+        typeof(PluginServices)
+            .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(services, value);
+    }
+
+    private static void SetPluginServicesInstance(PluginServices? value)
+    {
+        typeof(PluginServices)
+            .GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!
+            .SetValue(null, value);
+    }
+
+    private sealed class TestLog : IPluginLog
+    {
+        public void Verbose(string message) { }
+        public void Verbose(string message, Exception exception) { }
+        public void Debug(string message) { }
+        public void Debug(string message, Exception exception) { }
+        public void Info(string message) { }
+        public void Info(string message, Exception exception) { }
+        public void Warning(string message) { }
+        public void Warning(string message, Exception exception) { }
+        public void Error(string message) { }
+        public void Error(string message, Exception exception) { }
+        public void Fatal(string message) { }
+        public void Fatal(string message, Exception exception) { }
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow the API base URL setting to serialize and migrate any stored values
- stop resetting the base URL during initialization and sanitize invalid values instead
- add a developer window persistence test that simulates a restart retaining the custom URL

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e26ca8487c832898b82d7f82495ed2