### PR TITLE
Handle missing texture readback provider gracefully

### DIFF
--- a/DemiCatPlugin/PluginServices.cs
+++ b/DemiCatPlugin/PluginServices.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Dalamud.Game.ClientState;
 using Dalamud.Game.Command;
 using Dalamud.Game.Gui.Toast;
@@ -9,10 +11,23 @@ namespace DemiCatPlugin;
 
 internal class PluginServices
 {
+    private IDalamudPluginInterface _pluginInterface = null!;
+    private IPluginLog? _log;
+    private bool _textureReadbackResolved;
+    private Exception? _textureReadbackFailure;
+
     internal static PluginServices? Instance { get; private set; }
 
     [PluginService]
-    internal IDalamudPluginInterface PluginInterface { get; private set; } = null!;
+    internal IDalamudPluginInterface PluginInterface
+    {
+        get => _pluginInterface;
+        private set
+        {
+            _pluginInterface = value;
+            TryResolveTextureReadbackProvider();
+        }
+    }
 
     [PluginService]
     internal IClientState ClientState { get; private set; } = null!;
@@ -20,7 +35,6 @@ internal class PluginServices
     [PluginService]
     internal ITextureProvider TextureProvider { get; private set; } = null!;
 
-    [PluginService(ShouldFail = false)]
     internal ITextureReadbackProvider? TextureReadbackProvider { get; private set; }
         = null;
 
@@ -28,7 +42,16 @@ internal class PluginServices
     internal IFramework Framework { get; private set; } = null!;
 
     [PluginService]
-    internal IPluginLog Log { get; private set; } = null!;
+    internal IPluginLog Log
+    {
+        get => _log ?? throw new InvalidOperationException("Plugin log has not been initialized yet.");
+        private set
+        {
+            _log = value;
+            TryResolveTextureReadbackProvider();
+            FlushDeferredTextureReadbackFailure();
+        }
+    }
 
     [PluginService]
     internal IDataManager DataManager { get; private set; } = null!;
@@ -47,5 +70,49 @@ internal class PluginServices
     public PluginServices()
     {
         Instance = this;
+    }
+
+    private void TryResolveTextureReadbackProvider()
+    {
+        if (_textureReadbackResolved || _pluginInterface == null)
+            return;
+
+        _textureReadbackResolved = true;
+
+        try
+        {
+            TextureReadbackProvider = _pluginInterface.Create<ITextureReadbackProvider>();
+        }
+        catch (Exception ex) when (IsServiceUnavailable(ex))
+        {
+            TextureReadbackProvider = null;
+        }
+        catch (Exception ex)
+        {
+            TextureReadbackProvider = null;
+            _textureReadbackFailure = ex;
+            FlushDeferredTextureReadbackFailure();
+        }
+    }
+
+    private void FlushDeferredTextureReadbackFailure()
+    {
+        if (_textureReadbackFailure == null || _log == null)
+            return;
+
+        _log.Warning(
+            _textureReadbackFailure,
+            "Failed to resolve ITextureReadbackProvider; falling back to HTTP-based icons.");
+        _textureReadbackFailure = null;
+    }
+
+    private static bool IsServiceUnavailable(Exception exception)
+    {
+        Exception current = exception;
+        while (current is AggregateException aggregate && aggregate.InnerExceptions.Count == 1)
+            current = aggregate.InnerExceptions.Single();
+
+        return current is InvalidOperationException invalidOperation
+               && invalidOperation.Message.IndexOf("could not be found", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }

--- a/tests/GameDataCacheTests.cs
+++ b/tests/GameDataCacheTests.cs
@@ -32,7 +32,7 @@ public class GameDataCacheTests
             SetPrivateProperty(services, "PluginInterface", pluginInterface.Object);
             SetPrivateProperty(services, "DataManager", Mock.Of<IDataManager>());
             SetPrivateProperty(services, "TextureProvider", Mock.Of<ITextureProvider>());
-            SetPrivateProperty(services, "TextureReadbackProvider", null);
+            SetPrivateProperty(services, "Log", Mock.Of<IPluginLog>());
 
             var handler = new FakeHandler();
             using var httpClient = new HttpClient(handler);
@@ -55,6 +55,24 @@ public class GameDataCacheTests
             if (Directory.Exists(tempDir))
                 Directory.Delete(tempDir, true);
         }
+    }
+
+    [Fact]
+    public void PluginServicesHandlesMissingTextureReadbackProvider()
+    {
+        var services = new PluginServices();
+
+        var pluginInterface = new Mock<IDalamudPluginInterface>();
+        pluginInterface
+            .Setup(pi => pi.Create<ITextureReadbackProvider>(It.IsAny<object[]>()))
+            .Throws(
+                new AggregateException(
+                    new InvalidOperationException("Requested type Dalamud.Plugin.Services.ITextureReadbackProvider could not be found")));
+
+        SetPrivateProperty(services, "PluginInterface", pluginInterface.Object);
+        SetPrivateProperty(services, "Log", Mock.Of<IPluginLog>());
+
+        Assert.Null(services.TextureReadbackProvider);
     }
 
     private static void SetPrivateProperty(object instance, string name, object? value)


### PR DESCRIPTION
## Summary
- resolve the texture readback provider lazily and gracefully fall back to HTTP icons when the service is absent
- ensure PluginServices logs unexpected resolution failures instead of crashing during bootstrap
- add a regression test covering the missing texture readback provider case

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e267c3bc6483289ee437f8e61b2c98