### PR TITLE
Guard ImGui draws when context is unavailable

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -719,6 +719,11 @@ public class ChatWindow : IDisposable
 
     public virtual void Draw()
     {
+        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        {
+            return;
+        }
+
         _fileDialog.Draw();
         if (!_bridge.IsReady())
         {

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Numerics;
 using ImGuiNET;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.Textures;
 using Dalamud.Interface.Textures.TextureWraps;
 using DemiCatPlugin.Emoji;
@@ -233,6 +234,11 @@ public class MainWindow : IDisposable
 
     public void Draw()
     {
+        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        {
+            return;
+        }
+
         if (!IsLinked())
         {
             CloseAllFeatureWindows();

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using DemiCatPlugin.Avatars;
 using DemiCatPlugin.Emoji;
+using Dalamud.Interface.Utility;
 
 namespace DemiCatPlugin;
 
@@ -124,6 +125,11 @@ public class OfficerChatWindow : ChatWindow
 
     public override void Draw()
     {
+        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        {
+            return;
+        }
+
         if (!OfficerPermissions.HasAccess(_config))
         {
             var message = string.IsNullOrEmpty(_statusMessage)

--- a/DemiCatPlugin/ProgressOverlay.cs
+++ b/DemiCatPlugin/ProgressOverlay.cs
@@ -86,6 +86,11 @@ public sealed class ProgressOverlay
             return;
         }
 
+        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        {
+            return;
+        }
+
         var now = DateTime.UtcNow;
 
         lock (_lock)

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Linq;
 using System.IO;
 using ImGuiNET;
+using Dalamud.Interface.Utility;
 using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
@@ -78,6 +79,11 @@ public class SettingsWindow : IDisposable
 
     public void Draw()
     {
+        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        {
+            return;
+        }
+
         if (IsOpen)
         {
             var colorPushCount = 0;

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -21,6 +21,7 @@ using DemiCatPlugin.SyncShell;
 using Penumbra.Api.Enums;
 using Serilog;
 using Serilog.Events;
+using Dalamud.Interface.Utility;
 using ImGuiInputTextCallbackData = ImGuiNET.ImGuiInputTextCallbackData;
 using ImGuiMouseCursor = ImGuiNET.ImGuiMouseCursor;
 
@@ -285,6 +286,11 @@ public class SyncshellWindow : IDisposable
     public void Draw()
     {
         PumpClientEvents();
+
+        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        {
+            return;
+        }
 
         if (!_config.FCSyncShell)
         {


### PR DESCRIPTION
## Summary
- add ImGui readiness checks to main plugin windows before issuing ImGui calls
- guard progress and syncshell overlays against missing ImGui contexts to skip frames safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e281ee8da48328af91ff114326f8cb