### PR TITLE
Update ImGui readiness guards for API level 13

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -719,7 +719,7 @@ public class ChatWindow : IDisposable
 
     public virtual void Draw()
     {
-        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -234,7 +234,7 @@ public class MainWindow : IDisposable
 
     public void Draw()
     {
-        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -125,7 +125,7 @@ public class OfficerChatWindow : ChatWindow
 
     public override void Draw()
     {
-        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }

--- a/DemiCatPlugin/ProgressOverlay.cs
+++ b/DemiCatPlugin/ProgressOverlay.cs
@@ -86,7 +86,7 @@ public sealed class ProgressOverlay
             return;
         }
 
-        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -79,7 +79,7 @@ public class SettingsWindow : IDisposable
 
     public void Draw()
     {
-        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -287,7 +287,7 @@ public class SyncshellWindow : IDisposable
     {
         PumpClientEvents();
 
-        if (!ImGuiHelpers.IsImGuiReady || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- replace obsolete ImGui readiness guard in each Draw method with the API-level-13 compatible `IsImGuiInitialized` plus context check
- ensure the readiness guard compiles by relying on existing Dalamud utility imports

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e289680fc083289f425a103b8b5860