### PR TITLE
Allow settings while unlinked

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -245,20 +245,23 @@ public class MainWindow : IDisposable
         {
             CloseAllFeatureWindows();
 
-            if (IsOpen)
+            if (!_settings.IsOpen)
             {
-                IsOpen = false;
+                if (IsOpen)
+                {
+                    IsOpen = false;
+                }
+                else if (_config.DockVisible)
+                {
+                    _config.DockVisible = false;
+                    SaveConfig();
+                }
             }
-            else if (_config.DockVisible)
-            {
-                _config.DockVisible = false;
-                SaveConfig();
-            }
+
+            return;
         }
-        else
-        {
-            UpdateSyncshell();
-        }
+
+        UpdateSyncshell();
 
         if (_styleNeedsUpdate)
         {
@@ -268,98 +271,95 @@ public class MainWindow : IDisposable
             }
         }
 
-        if (linked)
+        if (!IsOpen)
         {
-            if (!IsOpen)
+            if (_config.DockVisible)
             {
-                if (_config.DockVisible)
-                {
-                    _config.DockVisible = false;
-                    SaveConfig();
-                }
+                _config.DockVisible = false;
+                SaveConfig();
             }
-            else
+        }
+        else
+        {
+            if (!_config.DockVisible)
             {
-                if (!_config.DockVisible)
+                _config.DockVisible = true;
+                SaveConfig();
+            }
+
+            var visibleFeatures = _dockItems.Where(i => i.IsVisible()).ToList();
+            var settingsItem = _settingsDockItem;
+            var settingsVisible = settingsItem?.IsVisible() ?? false;
+            if (settingsVisible || visibleFeatures.Count > 0)
+            {
+                var iconScale = GetIconScale();
+                var padding = GetPadding(iconScale);
+                var spacing = GetSpacing(iconScale);
+                var separatorThickness = settingsVisible && visibleFeatures.Count > 0
+                    ? GetSeparatorThickness(spacing)
+                    : 0f;
+                var iconSize = new Vector2(BaseIconSize * iconScale, BaseIconSize * iconScale);
+                var indicatorHeight = IndicatorRadius * 2f * iconScale + spacing * 0.75f;
+                var buttonCount = visibleFeatures.Count + (settingsVisible ? 1 : 0);
+                var spacingCount = Math.Max(0, visibleFeatures.Count - 1);
+                if (settingsVisible && visibleFeatures.Count > 0)
                 {
-                    _config.DockVisible = true;
-                    SaveConfig();
+                    spacingCount += 2;
+                }
+                var iconAreaWidth = iconSize.X * buttonCount + spacing * spacingCount + separatorThickness;
+                var iconAreaHeight = iconSize.Y;
+                var totalWidth = iconAreaWidth + padding * 2f;
+                var totalHeight = iconAreaHeight + padding * 2f + indicatorHeight;
+                var dockSize = new Vector2(totalWidth, totalHeight);
+
+                var dockPosition = GetDockPosition(dockSize);
+
+                ImGui.SetNextWindowPos(dockPosition, ImGuiCond.Appearing);
+                ImGui.SetNextWindowSize(dockSize, ImGuiCond.Appearing);
+
+                var windowFlags = ImGuiWindowFlags.NoDecoration
+                    | ImGuiWindowFlags.NoScrollbar
+                    | ImGuiWindowFlags.NoCollapse
+                    | ImGuiWindowFlags.NoSavedSettings
+                    | ImGuiWindowFlags.AlwaysAutoResize;
+
+                if (_config.DockLocked)
+                {
+                    windowFlags |= ImGuiWindowFlags.NoMove;
                 }
 
-                var visibleFeatures = _dockItems.Where(i => i.IsVisible()).ToList();
-                var settingsItem = _settingsDockItem;
-                var settingsVisible = settingsItem?.IsVisible() ?? false;
-                if (settingsVisible || visibleFeatures.Count > 0)
+                var dockBgColor = GetDockBackgroundColor();
+                var accentColor = Config.SanitizeColor(_config.SecondaryAccentColor, Config.DefaultSecondaryAccentColor);
+
+                ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, MathF.Max(14f, padding * 1.5f));
+                ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(padding, padding));
+                ImGui.PushStyleColor(ImGuiCol.WindowBg, dockBgColor);
+                ImGui.PushStyleColor(ImGuiCol.Border, Vector4.Zero);
+
+                var open = true;
+                if (ImGui.Begin(DockWindowTitle, ref open, windowFlags))
                 {
-                    var iconScale = GetIconScale();
-                    var padding = GetPadding(iconScale);
-                    var spacing = GetSpacing(iconScale);
-                    var separatorThickness = settingsVisible && visibleFeatures.Count > 0
-                        ? GetSeparatorThickness(spacing)
-                        : 0f;
-                    var iconSize = new Vector2(BaseIconSize * iconScale, BaseIconSize * iconScale);
-                    var indicatorHeight = IndicatorRadius * 2f * iconScale + spacing * 0.75f;
-                    var buttonCount = visibleFeatures.Count + (settingsVisible ? 1 : 0);
-                    var spacingCount = Math.Max(0, visibleFeatures.Count - 1);
-                    if (settingsVisible && visibleFeatures.Count > 0)
+                    _ = DrawDockStrip(visibleFeatures, settingsItem, iconSize, spacing, separatorThickness, indicatorHeight, accentColor, dockBgColor);
+                    DrawDockContextMenu();
+                }
+                var windowPos = ImGui.GetWindowPos();
+                ImGui.End();
+
+                ImGui.PopStyleColor(2);
+                ImGui.PopStyleVar(2);
+
+                if (!open)
+                {
+                    IsOpen = false;
+                }
+
+                if (_config.DockRememberPosition && !_config.DockLocked && !ImGui.IsMouseDown(ImGuiMouseButton.Left))
+                {
+                    if (!_config.DockPositionInitialized || Vector2.Distance(windowPos, _config.DockPosition) > 0.5f)
                     {
-                        spacingCount += 2;
-                    }
-                    var iconAreaWidth = iconSize.X * buttonCount + spacing * spacingCount + separatorThickness;
-                    var iconAreaHeight = iconSize.Y;
-                    var totalWidth = iconAreaWidth + padding * 2f;
-                    var totalHeight = iconAreaHeight + padding * 2f + indicatorHeight;
-                    var dockSize = new Vector2(totalWidth, totalHeight);
-
-                    var dockPosition = GetDockPosition(dockSize);
-
-                    ImGui.SetNextWindowPos(dockPosition, ImGuiCond.Appearing);
-                    ImGui.SetNextWindowSize(dockSize, ImGuiCond.Appearing);
-
-                    var windowFlags = ImGuiWindowFlags.NoDecoration
-                        | ImGuiWindowFlags.NoScrollbar
-                        | ImGuiWindowFlags.NoCollapse
-                        | ImGuiWindowFlags.NoSavedSettings
-                        | ImGuiWindowFlags.AlwaysAutoResize;
-
-                    if (_config.DockLocked)
-                    {
-                        windowFlags |= ImGuiWindowFlags.NoMove;
-                    }
-
-                    var dockBgColor = GetDockBackgroundColor();
-                    var accentColor = Config.SanitizeColor(_config.SecondaryAccentColor, Config.DefaultSecondaryAccentColor);
-
-                    ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, MathF.Max(14f, padding * 1.5f));
-                    ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(padding, padding));
-                    ImGui.PushStyleColor(ImGuiCol.WindowBg, dockBgColor);
-                    ImGui.PushStyleColor(ImGuiCol.Border, Vector4.Zero);
-
-                    var open = true;
-                    if (ImGui.Begin(DockWindowTitle, ref open, windowFlags))
-                    {
-                        _ = DrawDockStrip(visibleFeatures, settingsItem, iconSize, spacing, separatorThickness, indicatorHeight, accentColor, dockBgColor);
-                        DrawDockContextMenu();
-                    }
-                    var windowPos = ImGui.GetWindowPos();
-                    ImGui.End();
-
-                    ImGui.PopStyleColor(2);
-                    ImGui.PopStyleVar(2);
-
-                    if (!open)
-                    {
-                        IsOpen = false;
-                    }
-
-                    if (_config.DockRememberPosition && !_config.DockLocked && !ImGui.IsMouseDown(ImGuiMouseButton.Left))
-                    {
-                        if (!_config.DockPositionInitialized || Vector2.Distance(windowPos, _config.DockPosition) > 0.5f)
-                        {
-                            _config.DockPosition = windowPos;
-                            _config.DockPositionInitialized = true;
-                            SaveConfig();
-                        }
+                        _config.DockPosition = windowPos;
+                        _config.DockPositionInitialized = true;
+                        SaveConfig();
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- skip closing the dock when the settings window is already open while unlinked
- exit the draw routine early for unlinked characters so dock visibility syncing only runs when the dock can render
- keep dock visibility state changes tied to the dock window being open

## Testing
- not run (Dalamud UI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2aee496ac8328a8ece17aa0f3a614