### PR TITLE
Focus settings window when opened

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -191,7 +191,11 @@ public class Plugin : IDalamudPlugin
             }
             uiBuilder.OpenMainUi += _openMainUi;
 
-            _openConfigUi = () => _settings.IsOpen = true;
+            _openConfigUi = () =>
+            {
+                _settings.RequestFocus();
+                _settings.IsOpen = true;
+            };
             if (_preInitOpenConfigUiHandler != null)
             {
                 uiBuilder.OpenConfigUi -= _preInitOpenConfigUiHandler;
@@ -341,6 +345,7 @@ public class Plugin : IDalamudPlugin
     {
         if (!_tokenManager.IsReady())
         {
+            _settings.RequestFocus();
             _settings.IsOpen = true;
             return;
         }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -37,6 +37,7 @@ public class SettingsWindow : IDisposable
     private readonly object _hardReloadLock = new();
     private Task? _hardReloadTask;
     private bool _requestMainWindowOpen;
+    private bool _focusNext;
     private bool _settingsLoaded;
     private bool _isLinked;
     private static readonly int[] FadeDurations = { 5, 10, 15, 20, 30 };
@@ -96,6 +97,11 @@ public class SettingsWindow : IDisposable
                 colorPushCount = 2;
 
                 ImGui.SetNextWindowSize(DefaultWindowSize, ImGuiCond.FirstUseEver);
+                if (_focusNext)
+                {
+                    ImGui.SetNextWindowFocus();
+                    _focusNext = false;
+                }
                 if (ImGui.Begin("DemiCat Settings", ref IsOpen))
                 {
                     if (!_settingsLoaded)
@@ -142,6 +148,11 @@ public class SettingsWindow : IDisposable
         }
 
         _devWindow.Draw();
+    }
+
+    public void RequestFocus()
+    {
+        _focusNext = true;
     }
 
     private void DrawGeneralTab()


### PR DESCRIPTION
## Summary
- add a focus request flag to the settings window so the next frame brings it to the front
- ensure both config entry points request focus before opening the window

## Testing
- ⚠️ `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b03e0bd88328a81bd0524dc70444