### PR TITLE
Gate DemiCat draw cycle on linked token

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -234,41 +234,21 @@ public class MainWindow : IDisposable
 
     public void Draw()
     {
+        DrawFeatures();
+    }
+
+    internal void DrawFeatures()
+    {
         if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }
 
-        var linked = IsLinked();
-
-        if (!linked)
-        {
-            CloseAllFeatureWindows();
-
-            if (!_settings.IsOpen)
-            {
-                if (IsOpen)
-                {
-                    IsOpen = false;
-                }
-                else if (_config.DockVisible)
-                {
-                    _config.DockVisible = false;
-                    SaveConfig();
-                }
-            }
-
-            return;
-        }
-
         UpdateSyncshell();
 
-        if (_styleNeedsUpdate)
+        if (_styleNeedsUpdate && TryApplyAccentColors())
         {
-            if (TryApplyAccentColors())
-            {
-                _styleNeedsUpdate = false;
-            }
+            _styleNeedsUpdate = false;
         }
 
         if (!IsOpen)
@@ -366,6 +346,26 @@ public class MainWindow : IDisposable
         }
 
         DrawFeatureWindows();
+    }
+
+    internal void HandleUnlinkedState()
+    {
+        CloseAllFeatureWindows();
+
+        if (_settings.IsOpen)
+        {
+            return;
+        }
+
+        if (IsOpen)
+        {
+            IsOpen = false;
+        }
+        else if (_config.DockVisible)
+        {
+            _config.DockVisible = false;
+            SaveConfig();
+        }
     }
 
     public void OnAppearanceSettingsChanged()

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -179,8 +179,7 @@ public class Plugin : IDalamudPlugin
 
             _ = RoleCache.EnsureLoaded(_httpClient, _config);
 
-            uiBuilder.Draw += _mainWindow.Draw;
-            uiBuilder.Draw += _settings.Draw;
+            uiBuilder.Draw += DrawAll;
             uiBuilder.Draw += DrawOverlay;
 
             _openMainUi = () => _mainWindow.IsOpen = true;
@@ -309,8 +308,7 @@ public class Plugin : IDalamudPlugin
         _emojiFontHandle?.Dispose();
 
         // Unsubscribe UI draw handlers
-        uiBuilder.Draw -= _mainWindow.Draw;
-        uiBuilder.Draw -= _settings.Draw;
+        uiBuilder.Draw -= DrawAll;
         uiBuilder.Draw -= DrawOverlay;
 
         _services.CommandManager.RemoveHandler(MewCommand);
@@ -377,6 +375,19 @@ public class Plugin : IDalamudPlugin
 
         if (!_initError)
             _queuedOpenConfigUi = true;
+    }
+
+    private void DrawAll()
+    {
+        _settings.Draw();
+
+        if (!_tokenManager.IsReady())
+        {
+            _mainWindow.HandleUnlinkedState();
+            return;
+        }
+
+        _mainWindow.DrawFeatures();
     }
 
     private void DrawOverlay()


### PR DESCRIPTION
## Summary
- replace the separate draw subscriptions with a unified handler that always renders settings and only draws the dock when the token is linked
- refactor the main window draw flow to assume a linked token, exposing helpers for linked and unlinked states

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2bb683f34832885e653bc25076aaf