### PR TITLE
Adjust unlink handling to preserve settings window

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -350,18 +350,25 @@ public class MainWindow : IDisposable
 
     internal void HandleUnlinkedState()
     {
-        CloseAllFeatureWindows();
-
         if (_settings.IsOpen)
         {
+            CloseAllFeatureWindows();
             return;
         }
 
-        if (IsOpen)
+        CloseDockForUnlink();
+    }
+
+    internal void CloseDockForUnlink()
+    {
+        CloseAllFeatureWindows();
+
+        if (_isOpen)
         {
-            IsOpen = false;
+            _isOpen = false;
         }
-        else if (_config.DockVisible)
+
+        if (_config.DockVisible)
         {
             _config.DockVisible = false;
             SaveConfig();

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -820,10 +820,7 @@ public class Plugin : IDalamudPlugin
             var savedDockVisibility = _config.DockVisible;
             _savedDockVisibilityPreference = savedDockVisibility;
 
-            if (_mainWindow.IsOpen)
-            {
-                _mainWindow.IsOpen = false;
-            }
+            _mainWindow.CloseDockForUnlink();
 
             if (_config.DockVisible != savedDockVisibility)
             {


### PR DESCRIPTION
## Summary
- add a helper on MainWindow to close dock feature hosts without touching the settings window
- update the token unlink handler to rely on the new helper instead of forcibly closing the main window
- reuse the helper from MainWindow.HandleUnlinkedState to keep feature windows closed while respecting the settings window

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2bf908d048328ad73cf5fa322a38b