### PR TITLE
Ensure configuration window opens without heavy init

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -30,36 +30,34 @@ public class Plugin : IDalamudPlugin
 
     private readonly IDalamudPluginInterface _pluginInterface;
     private readonly IUiBuilder _uiBuilder;
+    private readonly IPluginLog _log;
+
+    private readonly Config _config;
+    private readonly TokenManager _tokenManager;
+    private readonly SettingsWindow _settings;
+    private readonly WindowSystem _windowSystem = new();
 
     private const uint InvalidTokenLinkCommandId = 0x44434B49;
     private const string MewCommand = "/mew";
     private const string MewCommandHelpMessage = "Open the DemiCat main window.";
 
-    private PluginServices _services = null!;
-    private UiRenderer _ui = null!;
-    private SettingsWindow _settings = null!;
-    private AvatarCache _avatarCache = null!;
-    private ChatWindow _chatWindow = null!;
-    private OfficerChatWindow _officerChatWindow = null!;
+    private PluginServices? _services;
+    private UiRenderer? _ui;
+    private AvatarCache? _avatarCache;
+    private ChatWindow? _chatWindow;
+    private OfficerChatWindow? _officerChatWindow;
     private DiscordPresenceService? _presenceService;
-    private MainWindow _mainWindow = null!;
-    private ChannelWatcher _channelWatcher = null!;
-    private RequestWatcher _requestWatcher = null!;
-    private NotePadService _notePadService = null!;
-    private NotePadWindow _notePadWindow = null!;
-    private ChannelSelectionService _channelSelection = null!;
-    private EmojiManager _emojiManager = null!;
+    private MainWindow? _mainWindow;
+    private ChannelWatcher? _channelWatcher;
+    private RequestWatcher? _requestWatcher;
+    private NotePadService? _notePadService;
+    private NotePadWindow? _notePadWindow;
+    private ChannelSelectionService? _channelSelection;
+    private EmojiManager? _emojiManager;
 
-    private Config _config = null!;
-    private HttpClient _httpClient = null!;
-    private ChannelService _channelService = null!;
+    private HttpClient? _httpClient;
+    private ChannelService? _channelService;
     private Action? _openMainUi;
-    private Action? _openConfigUi;
-    private Action? _preInitOpenMainUiHandler;
-    private Action? _preInitOpenConfigUiHandler;
-    private bool _queuedOpenMainUi;
-    private bool _queuedOpenConfigUi;
-    private TokenManager _tokenManager = null!;
     private bool _officerWatcherRunning;
     private bool _invalidTokenToastShown;
     private bool? _savedDockVisibilityPreference;
@@ -69,29 +67,43 @@ public class Plugin : IDalamudPlugin
 
     private bool _initialized;
     private bool _initError;
+    private bool _initializationAttempted;
 
     public Plugin(IDalamudPluginInterface pluginInterface)
     {
         _pluginInterface = pluginInterface ?? throw new ArgumentNullException(nameof(pluginInterface));
         _uiBuilder = pluginInterface.UiBuilder ?? throw new ArgumentNullException(nameof(pluginInterface.UiBuilder));
+        _log = pluginInterface.Create<IPluginLog>() ?? throw new InvalidOperationException("Failed to acquire plugin log.");
 
-        _uiBuilder.Draw += EnsureInitializedOnce;
-        _preInitOpenMainUiHandler = HandlePreInitOpenMainUi;
-        _uiBuilder.OpenMainUi += _preInitOpenMainUiHandler;
-        _preInitOpenConfigUiHandler = HandlePreInitOpenConfigUi;
-        _uiBuilder.OpenConfigUi += _preInitOpenConfigUiHandler;
+        _config = pluginInterface.GetPluginConfig() as Config ?? new Config();
+        _tokenManager = new TokenManager(pluginInterface);
+
+        _settings = new SettingsWindow(pluginInterface, _config, _tokenManager, _log);
+        _windowSystem.Add(_settings.Draw);
+
+        _uiBuilder.Draw += OnDraw;
+        _uiBuilder.OpenConfigUi += HandleOpenConfig;
     }
 
-    private void EnsureInitializedOnce()
+    private void OnDraw()
     {
-        var uiBuilder = _uiBuilder;
-        var pluginInterface = _pluginInterface;
-
-        if (_initialized || _initError)
+        if (!_initializationAttempted)
         {
-            uiBuilder.Draw -= EnsureInitializedOnce;
-            return;
+            _initializationAttempted = true;
+            Initialize();
         }
+
+        _windowSystem.Draw();
+
+        if (_initialized)
+        {
+            DrawOverlay();
+        }
+    }
+
+    private void Initialize()
+    {
+        var pluginInterface = _pluginInterface;
 
         try
         {
@@ -99,9 +111,6 @@ public class Plugin : IDalamudPlugin
                 ?? throw new InvalidOperationException("Failed to initialize plugin services.");
             if (_services.PluginInterface == null || _services.Log == null)
                 throw new InvalidOperationException("Failed to initialize plugin services.");
-
-            _config = _services.PluginInterface.GetPluginConfig() as Config ?? new Config();
-            _tokenManager = new TokenManager(_services.PluginInterface);
 
             var oldVersion = _config.Version;
             var originalApiBaseUrl = _config.ApiBaseUrl;
@@ -132,7 +141,11 @@ public class Plugin : IDalamudPlugin
             _emojiFontHandle = InitializeEmojiFont();
             _emojiManager.EmojiFontHandle = _emojiFontHandle;
             _ui = new UiRenderer(_config, _httpClient, _channelSelection, _emojiManager);
-            _settings = new SettingsWindow(_config, _tokenManager, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
+
+            _settings.ConfigureServices(
+                _httpClient,
+                () => RefreshRoles(_services.Log),
+                _ui.StartNetworking);
 
             _presenceService = _config.SyncedChat && _config.EnableFcChat
                 ? new DiscordPresenceService(_config, _httpClient)
@@ -177,30 +190,16 @@ public class Plugin : IDalamudPlugin
             _mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
             _mainWindow.SetNotePadReadOnly(!_tokenManager.IsReady());
 
+            _windowSystem.Add(DrawMainWindowArea);
+
             _ = RoleCache.EnsureLoaded(_httpClient, _config);
 
-            uiBuilder.Draw += DrawAll;
-            uiBuilder.Draw += DrawOverlay;
-
-            _openMainUi = () => _mainWindow.IsOpen = true;
-            if (_preInitOpenMainUiHandler != null)
+            _openMainUi = () =>
             {
-                uiBuilder.OpenMainUi -= _preInitOpenMainUiHandler;
-                _preInitOpenMainUiHandler = null;
-            }
-            uiBuilder.OpenMainUi += _openMainUi;
-
-            _openConfigUi = () =>
-            {
-                _settings.RequestFocus();
-                _settings.IsOpen = true;
+                if (_mainWindow != null)
+                    _mainWindow.IsOpen = true;
             };
-            if (_preInitOpenConfigUiHandler != null)
-            {
-                uiBuilder.OpenConfigUi -= _preInitOpenConfigUiHandler;
-                _preInitOpenConfigUiHandler = null;
-            }
-            uiBuilder.OpenConfigUi += _openConfigUi;
+            _uiBuilder.OpenMainUi += _openMainUi;
 
             _mewCommandInfo = new CommandInfo(OnMewCommand)
             {
@@ -215,19 +214,6 @@ public class Plugin : IDalamudPlugin
                 HandleTokenLinked();
 
             _services.Log.Info("DemiCat loaded.");
-            var openMainHandler = _openMainUi;
-            if (_queuedOpenMainUi && openMainHandler != null)
-            {
-                _queuedOpenMainUi = false;
-                openMainHandler();
-            }
-
-            var openConfigHandler = _openConfigUi;
-            if (_queuedOpenConfigUi && openConfigHandler != null)
-            {
-                _queuedOpenConfigUi = false;
-                openConfigHandler();
-            }
             _initialized = true;
         }
         catch (Exception ex)
@@ -252,46 +238,31 @@ public class Plugin : IDalamudPlugin
                 // ignored
             }
         }
-        finally
-        {
-            if (_initialized || _initError)
-            {
-                uiBuilder.Draw -= EnsureInitializedOnce;
-            }
-        }
+    }
+
+    private void HandleOpenConfig()
+    {
+        _log.Info("Config open requested");
+        _settings.IsOpen = true;
     }
 
     public void Dispose()
     {
-        var uiBuilder = _uiBuilder;
-        uiBuilder.Draw -= EnsureInitializedOnce;
-
-        if (_preInitOpenMainUiHandler != null)
-        {
-            uiBuilder.OpenMainUi -= _preInitOpenMainUiHandler;
-            _preInitOpenMainUiHandler = null;
-        }
-
-        if (_preInitOpenConfigUiHandler != null)
-        {
-            uiBuilder.OpenConfigUi -= _preInitOpenConfigUiHandler;
-            _preInitOpenConfigUiHandler = null;
-        }
+        _uiBuilder.Draw -= OnDraw;
+        _uiBuilder.OpenConfigUi -= HandleOpenConfig;
+        _windowSystem.Clear();
 
         if (_openMainUi != null)
         {
-            uiBuilder.OpenMainUi -= _openMainUi;
+            _uiBuilder.OpenMainUi -= _openMainUi;
             _openMainUi = null;
         }
 
-        if (_openConfigUi != null)
-        {
-            uiBuilder.OpenConfigUi -= _openConfigUi;
-            _openConfigUi = null;
-        }
-
         if (!_initialized)
+        {
+            _settings.Dispose();
             return;
+        }
 
         WebTextureCache.FetchOverride = null;
         try
@@ -300,39 +271,47 @@ public class Plugin : IDalamudPlugin
         }
         catch (Exception ex)
         {
-            _services.Log.Warning(ex, "Failed to clear web texture cache on framework thread.");
+            _services!.Log.Warning(ex, "Failed to clear web texture cache on framework thread.");
             WebTextureCache.Clear();
         }
 
-        _emojiManager.EmojiFontHandle = null;
+        if (_emojiManager != null)
+        {
+            _emojiManager.EmojiFontHandle = null;
+        }
         _emojiFontHandle?.Dispose();
 
-        // Unsubscribe UI draw handlers
-        uiBuilder.Draw -= DrawAll;
-        uiBuilder.Draw -= DrawOverlay;
-
-        _services.CommandManager.RemoveHandler(MewCommand);
+        if (_services != null)
+        {
+            _services.CommandManager.RemoveHandler(MewCommand);
+        }
 
         _tokenManager.OnLinked -= HandleTokenLinked;
         _tokenManager.OnUnlinked -= HandleTokenUnlinked;
 
-        try { _services.ChatGui.RemoveChatLinkHandler(InvalidTokenLinkCommandId); } catch { }
+        try { _services?.ChatGui.RemoveChatLinkHandler(InvalidTokenLinkCommandId); } catch { }
 
-        _channelSelection.ChannelChanged -= HandleChannelSelectionValidation;
+        if (_channelSelection != null)
+        {
+            _channelSelection.ChannelChanged -= HandleChannelSelectionValidation;
+        }
 
-        _channelWatcher.Dispose();
-        _requestWatcher.Dispose();
-        _notePadWindow.Dispose();
-        _notePadService.Dispose();
+        _channelWatcher?.Dispose();
+        _requestWatcher?.Dispose();
+        _notePadWindow?.Dispose();
+        _notePadService?.Dispose();
         _presenceService?.Dispose();
-        _chatWindow.Dispose();
-        _officerChatWindow.Dispose();
-        _mainWindow.Dispose();
-        _ui.DisposeAsync().GetAwaiter().GetResult();
+        _chatWindow?.Dispose();
+        _officerChatWindow?.Dispose();
+        _mainWindow?.Dispose();
+        if (_ui != null)
+        {
+            _ui.DisposeAsync().GetAwaiter().GetResult();
+        }
         _settings.Dispose();
-        _avatarCache.Dispose();
-        _emojiManager.Dispose();
-        _httpClient.Dispose();
+        _avatarCache?.Dispose();
+        _emojiManager?.Dispose();
+        _httpClient?.Dispose();
         if (PluginServices.Instance != null)
         {
             PluginServices.Instance.ProgressOverlay = null;
@@ -343,43 +322,18 @@ public class Plugin : IDalamudPlugin
     {
         if (!_tokenManager.IsReady())
         {
-            _settings.RequestFocus();
             _settings.IsOpen = true;
             return;
         }
 
-        _mainWindow.IsOpen = !_mainWindow.IsOpen;
+        if (_mainWindow != null)
+            _mainWindow.IsOpen = !_mainWindow.IsOpen;
     }
 
-    private void HandlePreInitOpenMainUi()
+    private void DrawMainWindowArea()
     {
-        var handler = _openMainUi;
-        if (_initialized && handler != null)
-        {
-            handler();
+        if (_mainWindow == null)
             return;
-        }
-
-        if (!_initError)
-            _queuedOpenMainUi = true;
-    }
-
-    private void HandlePreInitOpenConfigUi()
-    {
-        var handler = _openConfigUi;
-        if (_initialized && handler != null)
-        {
-            handler();
-            return;
-        }
-
-        if (!_initError)
-            _queuedOpenConfigUi = true;
-    }
-
-    private void DrawAll()
-    {
-        _settings.Draw();
 
         if (!_tokenManager.IsReady())
         {
@@ -962,10 +916,6 @@ public class Plugin : IDalamudPlugin
         if (toastGui == null || chatGui == null)
             return;
 
-        var openConfigHandler = _openConfigUi;
-        if (openConfigHandler == null)
-            return;
-
         _invalidTokenToastShown = true;
 
         try { chatGui.RemoveChatLinkHandler(InvalidTokenLinkCommandId); } catch { }
@@ -982,11 +932,11 @@ public class Plugin : IDalamudPlugin
                         var framework = _services.Framework;
                         if (framework != null)
                         {
-                            _ = framework.RunOnTick(() => openConfigHandler());
+                            _ = framework.RunOnTick(HandleOpenConfig);
                         }
                         else
                         {
-                            openConfigHandler();
+                            HandleOpenConfig();
                         }
                     }
                     catch

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -21,12 +21,12 @@ public class SettingsWindow : IDisposable
 {
     private readonly Config _config;
     private readonly TokenManager _tokenManager;
-    private readonly HttpClient _httpClient;
-    private readonly Func<Task<bool>> _refreshRoles;
-    private readonly Func<Task> _startNetworking;
-    private readonly DeveloperWindow _devWindow;
+    private readonly IDalamudPluginInterface _pluginInterface;
+    private HttpClient? _httpClient;
+    private Func<Task<bool>>? _refreshRoles;
+    private Func<Task>? _startNetworking;
+    private DeveloperWindow? _devWindow;
     private readonly IPluginLog _log;
-    private static readonly Vector2 DefaultWindowSize = new(960f, 720f);
 
     private string _apiKey = string.Empty;
     private string _penumbraModsDirectory = string.Empty;
@@ -37,7 +37,6 @@ public class SettingsWindow : IDisposable
     private readonly object _hardReloadLock = new();
     private Task? _hardReloadTask;
     private bool _requestMainWindowOpen;
-    private bool _focusNext;
     private bool _settingsLoaded;
     private bool _isLinked;
     private static readonly int[] FadeDurations = { 5, 10, 15, 20, 30 };
@@ -48,6 +47,8 @@ public class SettingsWindow : IDisposable
 
     public bool IsOpen;
 
+    private bool ServicesReady => _httpClient != null && _refreshRoles != null && _startNetworking != null;
+
     public MainWindow? MainWindow { get; set; }
     public ChatWindow? ChatWindow { get; set; }
     public OfficerChatWindow? OfficerChatWindow { get; set; }
@@ -55,27 +56,36 @@ public class SettingsWindow : IDisposable
     public RequestWatcher? RequestWatcher { get; set; }
     public NotePadService? NotePadService { get; set; }
 
-    public SettingsWindow(Config config, TokenManager tokenManager, HttpClient httpClient, Func<Task<bool>> refreshRoles, Func<Task> startNetworking, IPluginLog log, IDalamudPluginInterface pluginInterface)
+    public SettingsWindow(IDalamudPluginInterface pluginInterface, Config config, TokenManager tokenManager, IPluginLog log)
     {
+        _pluginInterface = pluginInterface;
         _config = config;
         _tokenManager = tokenManager;
-        _httpClient = httpClient;
-        _refreshRoles = refreshRoles;
-        _startNetworking = startNetworking;
         _apiKey = tokenManager.Token ?? string.Empty;
         _penumbraModsDirectory = config.PenumbraModsDirectory ?? string.Empty;
         _penumbraConfigDirectory = config.PenumbraConfigDirectory ?? string.Empty;
         _penumbraCollectionOverride = config.PenumbraCollectionOverride ?? string.Empty;
-        _devWindow = new DeveloperWindow(
-            config,
-            pluginInterface,
-            () => _tokenManager.IsReady(),
-            () => HardReloadIdentityAndStartAsync(),
-            StopAllWatchersAndPresence);
         _log = log;
         _isLinked = _tokenManager.State == LinkState.Linked;
         _tokenManager.OnLinked += OnLinked;
         _tokenManager.OnUnlinked += OnUnlinked;
+    }
+
+    public void ConfigureServices(
+        HttpClient httpClient,
+        Func<Task<bool>> refreshRoles,
+        Func<Task> startNetworking)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _refreshRoles = refreshRoles ?? throw new ArgumentNullException(nameof(refreshRoles));
+        _startNetworking = startNetworking ?? throw new ArgumentNullException(nameof(startNetworking));
+
+        _devWindow ??= new DeveloperWindow(
+            _config,
+            _pluginInterface,
+            () => _tokenManager.IsReady(),
+            () => HardReloadIdentityAndStartAsync(),
+            StopAllWatchersAndPresence);
     }
 
     public void Draw()
@@ -96,12 +106,6 @@ public class SettingsWindow : IDisposable
                 ImGui.PushStyleColor(ImGuiCol.ChildBg, primaryColor);
                 colorPushCount = 2;
 
-                ImGui.SetNextWindowSize(DefaultWindowSize, ImGuiCond.FirstUseEver);
-                if (_focusNext)
-                {
-                    ImGui.SetNextWindowFocus();
-                    _focusNext = false;
-                }
                 if (ImGui.Begin("DemiCat Settings", ref IsOpen))
                 {
                     if (!_settingsLoaded)
@@ -112,6 +116,11 @@ public class SettingsWindow : IDisposable
 
                     if (ImGui.BeginTabBar("SettingsTabs"))
                     {
+                        if (!ServicesReady)
+                        {
+                            ImGui.TextColored(new Vector4(1f, 0.85f, 0f, 1f), "Some services are still starting; features that depend on them are temporarily disabled.");
+                            ImGui.Separator();
+                        }
                         if (ImGui.BeginTabItem("General"))
                         {
                             DrawGeneralTab();
@@ -145,14 +154,8 @@ public class SettingsWindow : IDisposable
                 if (colorPushCount > 0)
                     ImGui.PopStyleColor(colorPushCount);
             }
-        }
 
-        _devWindow.Draw();
-    }
-
-    public void RequestFocus()
-    {
-        _focusNext = true;
+        _devWindow?.Draw();
     }
 
     private void DrawGeneralTab()
@@ -181,6 +184,19 @@ public class SettingsWindow : IDisposable
         // Allow room for longer server-generated API keys
         ImGui.InputText("API Key", ref _apiKey, 256);
 
+        var servicesReady = ServicesReady;
+        if (!servicesReady)
+            ImGui.BeginDisabled();
+
+        DrawGeneralTabControls(linked);
+
+        if (!servicesReady)
+            ImGui.EndDisabled();
+    }
+
+    private void DrawGeneralTabControls(bool linked)
+    {
+        
         var enableFc = _config.EnableFcChat;
         if (!linked)
             ImGui.BeginDisabled();
@@ -211,7 +227,7 @@ public class SettingsWindow : IDisposable
             if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
                 ImGui.SetTooltip("Link DemiCat to enable chat and presence.");
         }
-
+        
         foreach (var kvp in _categoryToggles.ToList())
         {
             var enabled = kvp.Value;
@@ -220,7 +236,7 @@ public class SettingsWindow : IDisposable
                 _categoryToggles[kvp.Key] = enabled;
                 _ = Task.Run(PushSettings);
             }
-
+        
             ImGui.SameLine();
             var autoApply = _config.AutoApply.TryGetValue(kvp.Key, out var ap) && ap;
             if (ImGui.Checkbox($"Auto-apply##{kvp.Key}", ref autoApply))
@@ -230,18 +246,18 @@ public class SettingsWindow : IDisposable
                 _ = Task.Run(PushSettings);
             }
         }
-
+        
         if (ImGui.Button("Clear my cached data"))
         {
             ClearCachedData();
         }
-
+        
         ImGui.SameLine();
         if (ImGui.Button("Forget me"))
         {
             _ = Task.Run(ForgetMe);
         }
-
+        
         ImGui.BeginDisabled(_syncInProgress);
         if (ImGui.Button("Sync"))
         {
@@ -259,7 +275,7 @@ public class SettingsWindow : IDisposable
             });
         }
         ImGui.EndDisabled();
-
+        
         if (!string.IsNullOrEmpty(_syncStatus))
         {
             Vector4 color;
@@ -275,10 +291,10 @@ public class SettingsWindow : IDisposable
             {
                 color = new Vector4(1, 1, 1, 1);
             }
-
+        
             ImGui.TextColored(color, _syncStatus);
         }
-
+        
         var style = ImGui.GetStyle();
         var piGlyph = "\u03C0";
         var piSize = ImGui.CalcTextSize(piGlyph);
@@ -287,13 +303,16 @@ public class SettingsWindow : IDisposable
         var bottomRight = new Vector2(
             windowPos.X + contentRegionMax.X - style.WindowPadding.X - piSize.X,
             windowPos.Y + contentRegionMax.Y - style.WindowPadding.Y - piSize.Y);
-
+        
         ImGui.SetCursorScreenPos(bottomRight);
         ImGui.TextDisabled(piGlyph);
         var io = ImGui.GetIO();
         if (ImGui.IsItemClicked() && io.KeyCtrl && io.KeyShift)
         {
-            _devWindow.IsOpen = true;
+            if (_devWindow != null)
+            {
+                _devWindow.IsOpen = true;
+            }
         }
     }
 
@@ -1182,6 +1201,12 @@ public class SettingsWindow : IDisposable
                 _log.Error(ex, "Failed to reload signup presets during hard reload.");
             }
 
+            if (_httpClient == null)
+            {
+                UpdateStatus("Service not ready");
+                return;
+            }
+
             HttpResponseMessage? pingResponse = null;
             try
             {
@@ -1234,13 +1259,20 @@ public class SettingsWindow : IDisposable
                 _log.Warning("RefreshRoles delegate is not set; roles will not be refreshed.");
             }
 
-            try
+            if (_startNetworking != null)
             {
-                await _startNetworking();
+                try
+                {
+                    await _startNetworking();
+                }
+                catch (Exception ex)
+                {
+                    _log.Error(ex, "Failed to start UI networking during hard reload.");
+                }
             }
-            catch (Exception ex)
+            else
             {
-                _log.Error(ex, "Failed to start UI networking during hard reload.");
+                _log.Warning("StartNetworking delegate is not set; skipping UI renderer start.");
             }
 
             try

--- a/DemiCatPlugin/WindowSystem.cs
+++ b/DemiCatPlugin/WindowSystem.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace DemiCatPlugin;
+
+internal sealed class WindowSystem
+{
+    private readonly List<Action> _drawCallbacks = new();
+
+    public void Add(Action drawCallback)
+    {
+        if (drawCallback == null)
+            throw new ArgumentNullException(nameof(drawCallback));
+
+        if (_drawCallbacks.Contains(drawCallback))
+            return;
+
+        _drawCallbacks.Add(drawCallback);
+    }
+
+    public void Draw()
+    {
+        foreach (var callback in _drawCallbacks)
+            callback();
+    }
+
+    public void Clear()
+    {
+        _drawCallbacks.Clear();
+    }
+}

--- a/tests/DockVisibilityTokenLifecycleTests.cs
+++ b/tests/DockVisibilityTokenLifecycleTests.cs
@@ -76,13 +76,14 @@ public class DockVisibilityTokenLifecycleTests
             var chatWindow = new ChatWindow(config, httpClient, null, tokenManager, channelService);
             var officerWindow = new OfficerChatWindow(config, httpClient, null, tokenManager, channelService);
             var settingsWindow = new SettingsWindow(
+                pluginInterfaceMock.Object,
                 config,
                 tokenManager,
+                logMock.Object);
+            settingsWindow.ConfigureServices(
                 httpClient,
                 () => Task.FromResult(true),
-                () => Task.CompletedTask,
-                logMock.Object,
-                pluginInterfaceMock.Object);
+                () => Task.CompletedTask);
             var notePadService = new NotePadService(config, httpClient, tokenManager);
             var notePadWindow = new NotePadWindow(config, notePadService);
 

--- a/tests/PluginChannelValidationTests.cs
+++ b/tests/PluginChannelValidationTests.cs
@@ -71,13 +71,15 @@ public class PluginChannelValidationTests
         var notePadService = new NotePadService(config, httpClient, tokenManager);
         var notePadWindow = new NotePadWindow(config, notePadService);
         var settingsWindow = new SettingsWindow(
+            pluginInterfaceMock.Object,
             config,
             tokenManager,
+            logMock.Object
+        );
+        settingsWindow.ConfigureServices(
             httpClient,
             () => Task.FromResult(true),
-            () => Task.CompletedTask,
-            logMock.Object,
-            pluginInterfaceMock.Object
+            () => Task.CompletedTask
         );
         settingsWindow.NotePadService = notePadService;
         var mainWindow = new MainWindow(

--- a/tests/PresenceServiceLifecycleTests.cs
+++ b/tests/PresenceServiceLifecycleTests.cs
@@ -39,13 +39,14 @@ public class PresenceServiceLifecycleTests : IDisposable
         var channelService = new ChannelService(config, httpClient, tokenManager);
 
         var settingsWindow = new SettingsWindow(
+            Mock.Of<IDalamudPluginInterface>(),
             config,
             tokenManager,
+            new TestLog());
+        settingsWindow.ConfigureServices(
             httpClient,
             () => Task.FromResult(true),
-            () => Task.CompletedTask,
-            new TestLog(),
-            Mock.Of<IDalamudPluginInterface>());
+            () => Task.CompletedTask);
 
         settingsWindow.ChatWindow = new ChatWindow(config, httpClient, presence, tokenManager, channelService);
 

--- a/tests/SettingsWindowIdentityTests.cs
+++ b/tests/SettingsWindowIdentityTests.cs
@@ -54,13 +54,14 @@ public class SettingsWindowIdentityTests
         var tokenManager = new TokenManager();
 
         var settings = new SettingsWindow(
+            pluginInterfaceMock.Object,
             config,
             tokenManager,
+            logMock.Object);
+        settings.ConfigureServices(
             httpClient,
             () => Task.FromResult(true),
-            () => Task.CompletedTask,
-            logMock.Object,
-            pluginInterfaceMock.Object);
+            () => Task.CompletedTask);
 
         var mainWindow = (MainWindow)FormatterServices.GetUninitializedObject(typeof(MainWindow));
         settings.MainWindow = mainWindow;
@@ -121,13 +122,14 @@ public class SettingsWindowIdentityTests
         var tokenManager = new TokenManager();
 
         var settings = new SettingsWindow(
+            pluginInterfaceMock.Object,
             config,
             tokenManager,
+            logMock.Object);
+        settings.ConfigureServices(
             httpClient,
             () => Task.FromResult(true),
-            () => Task.CompletedTask,
-            logMock.Object,
-            pluginInterfaceMock.Object);
+            () => Task.CompletedTask);
 
         var mainWindow = (MainWindow)FormatterServices.GetUninitializedObject(typeof(MainWindow));
         mainWindow.HasOfficerAccess = true;


### PR DESCRIPTION
## Summary
- create the settings window at plugin construction with only lightweight dependencies
- add a single always-on window system draw path and simplify the OpenConfig handler
- allow the settings UI to render when services are unavailable and update the affected tests

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2f627ec3883289dc55f92a9458483