### PR TITLE
Fix SettingsWindow Draw braces to restore build

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -154,6 +154,7 @@ public class SettingsWindow : IDisposable
                 if (colorPushCount > 0)
                     ImGui.PopStyleColor(colorPushCount);
             }
+        }
 
         _devWindow?.Draw();
     }


### PR DESCRIPTION
## Summary
- close the SettingsWindow.Draw scope so the developer window draw call sits outside the try/finally block

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2fae07864832889f8c5c92278e9bd