### PR TITLE
Preserve dock visibility state on relink

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -338,6 +338,7 @@ public class Plugin : IDalamudPlugin
 
         if (!_tokenManager.IsReady())
         {
+            _savedDockVisibilityPreference ??= _config.DockVisible;
             _mainWindow.HandleUnlinkedState();
             return;
         }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.103",
+    "version": "9.0.300",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
## Summary
- remember the user's dock visibility preference while the plugin is unlinked so the dock reopens after authentication
- update the repository to target the .NET 9.0.300 SDK that ships with Dalamud API level 13

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e34eae10248328a526ec462a155d35