### PR TITLE
Align MainWindow lifecycle with Dalamud window system

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -48,6 +48,8 @@ public class MainWindow : Window, IDisposable
     private readonly EmojiManager _emojiManager;
     private readonly HttpClient _httpClient;
     private readonly List<DockItem> _dockItems = new();
+    private readonly Func<bool> _isTokenReady;
+    private readonly Func<bool> _isLinked;
     private string? _draggingDockItemId;
     private readonly HashSet<string> _autoShownDockItems = new();
 
@@ -90,28 +92,6 @@ public class MainWindow : Window, IDisposable
         }
     }
 
-    public new bool IsOpen
-    {
-        get => _isOpen;
-        set
-        {
-            if (_isOpen == value)
-                return;
-
-            _isOpen = value;
-            if (_config.DockVisible != value)
-            {
-                _config.DockVisible = value;
-                SaveConfig();
-            }
-
-            if (!value)
-            {
-                CloseAllFeatureWindows();
-            }
-        }
-    }
-
     public UiRenderer Ui => _ui;
     public EventCreateWindow EventCreateWindow => _create;
     public TemplatesWindow TemplatesWindow => _templates;
@@ -136,7 +116,9 @@ public class MainWindow : Window, IDisposable
         ChannelService channelService,
         ChannelSelectionService channelSelection,
         EmojiManager emojiManager,
-        NotePadWindow notePad)
+        NotePadWindow notePad,
+        Func<bool> isTokenReady,
+        Func<bool> isLinked)
         : base("DemiCat Host")
     {
         _config = config;
@@ -150,17 +132,17 @@ public class MainWindow : Window, IDisposable
         _templates = new TemplatesWindow(config, httpClient, channelService, channelSelection, emojiManager);
         _requestBoard = new RequestBoardWindow(config, httpClient);
         _notePad = notePad;
+        _isTokenReady = isTokenReady ?? throw new ArgumentNullException(nameof(isTokenReady));
+        _isLinked = isLinked ?? throw new ArgumentNullException(nameof(isLinked));
         _syncshellEnabled = config.FCSyncShell;
         _syncshell = _syncshellEnabled ? new SyncshellWindow(config, httpClient) : null;
         _isOpen = config.DockVisible;
 
-        base.IsOpen = true;
+        IsOpen = _config.DockVisible;
         RespectCloseHotkey = false;
         Flags = ImGuiWindowFlags.NoDecoration
-            | ImGuiWindowFlags.NoInputs
             | ImGuiWindowFlags.NoSavedSettings
-            | ImGuiWindowFlags.NoFocusOnAppearing
-            | ImGuiWindowFlags.NoBackground;
+            | ImGuiWindowFlags.NoFocusOnAppearing;
 
         _eventsWindowHost = new EventsDockableWindow(config, ui, IsLinked);
         _eventCreateWindowHost = new EventCreateDockableWindow(config, _create, IsLinked);
@@ -207,6 +189,28 @@ public class MainWindow : Window, IDisposable
         BuildDockItems();
     }
 
+    public override void OnOpen()
+    {
+        _isOpen = true;
+        if (!_config.DockVisible)
+        {
+            _config.DockVisible = true;
+            SaveConfig();
+        }
+    }
+
+    public override void OnClose()
+    {
+        _isOpen = false;
+        if (_config.DockVisible)
+        {
+            _config.DockVisible = false;
+            SaveConfig();
+        }
+
+        CloseAllFeatureWindows();
+    }
+
     public void SetNotePadReadOnly(bool isReadOnly)
     {
         _notePad.IsReadOnly = isReadOnly;
@@ -249,7 +253,7 @@ public class MainWindow : Window, IDisposable
             return;
         }
 
-        if (!TokenManager.Instance?.IsReady() ?? true)
+        if (!_isTokenReady())
         {
             HandleUnlinkedState();
             return;
@@ -265,6 +269,11 @@ public class MainWindow : Window, IDisposable
             return;
         }
 
+        if (!_isOpen)
+        {
+            return;
+        }
+
         UpdateSyncshell();
 
         if (_styleNeedsUpdate && TryApplyAccentColors())
@@ -272,96 +281,79 @@ public class MainWindow : Window, IDisposable
             _styleNeedsUpdate = false;
         }
 
-        if (!IsOpen)
+        var visibleFeatures = _dockItems.Where(i => i.IsVisible()).ToList();
+        var settingsItem = _settingsDockItem;
+        var settingsVisible = settingsItem?.IsVisible() ?? false;
+        if (settingsVisible || visibleFeatures.Count > 0)
         {
-            if (_config.DockVisible)
+            var iconScale = GetIconScale();
+            var padding = GetPadding(iconScale);
+            var spacing = GetSpacing(iconScale);
+            var separatorThickness = settingsVisible && visibleFeatures.Count > 0
+                ? GetSeparatorThickness(spacing)
+                : 0f;
+            var iconSize = new Vector2(BaseIconSize * iconScale, BaseIconSize * iconScale);
+            var indicatorHeight = IndicatorRadius * 2f * iconScale + spacing * 0.75f;
+            var buttonCount = visibleFeatures.Count + (settingsVisible ? 1 : 0);
+            var spacingCount = Math.Max(0, visibleFeatures.Count - 1);
+            if (settingsVisible && visibleFeatures.Count > 0)
             {
-                _config.DockVisible = false;
-                SaveConfig();
+                spacingCount += 2;
             }
-        }
-        else
-        {
-            if (!_config.DockVisible)
+            var iconAreaWidth = iconSize.X * buttonCount + spacing * spacingCount + separatorThickness;
+            var iconAreaHeight = iconSize.Y;
+            var totalWidth = iconAreaWidth + padding * 2f;
+            var totalHeight = iconAreaHeight + padding * 2f + indicatorHeight;
+            var dockSize = new Vector2(totalWidth, totalHeight);
+
+            var dockPosition = GetDockPosition(dockSize);
+
+            ImGui.SetNextWindowPos(dockPosition, ImGuiCond.Appearing);
+            ImGui.SetNextWindowSize(dockSize, ImGuiCond.Appearing);
+
+            var windowFlags = ImGuiWindowFlags.NoDecoration
+                | ImGuiWindowFlags.NoScrollbar
+                | ImGuiWindowFlags.NoCollapse
+                | ImGuiWindowFlags.NoSavedSettings
+                | ImGuiWindowFlags.AlwaysAutoResize;
+
+            if (_config.DockLocked)
             {
-                _config.DockVisible = true;
-                SaveConfig();
+                windowFlags |= ImGuiWindowFlags.NoMove;
             }
 
-            var visibleFeatures = _dockItems.Where(i => i.IsVisible()).ToList();
-            var settingsItem = _settingsDockItem;
-            var settingsVisible = settingsItem?.IsVisible() ?? false;
-            if (settingsVisible || visibleFeatures.Count > 0)
+            var dockBgColor = GetDockBackgroundColor();
+            var accentColor = Config.SanitizeColor(_config.SecondaryAccentColor, Config.DefaultSecondaryAccentColor);
+
+            ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, MathF.Max(14f, padding * 1.5f));
+            ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(padding, padding));
+            ImGui.PushStyleColor(ImGuiCol.WindowBg, dockBgColor);
+            ImGui.PushStyleColor(ImGuiCol.Border, Vector4.Zero);
+
+            var open = true;
+            if (ImGui.Begin(DockWindowTitle, ref open, windowFlags))
             {
-                var iconScale = GetIconScale();
-                var padding = GetPadding(iconScale);
-                var spacing = GetSpacing(iconScale);
-                var separatorThickness = settingsVisible && visibleFeatures.Count > 0
-                    ? GetSeparatorThickness(spacing)
-                    : 0f;
-                var iconSize = new Vector2(BaseIconSize * iconScale, BaseIconSize * iconScale);
-                var indicatorHeight = IndicatorRadius * 2f * iconScale + spacing * 0.75f;
-                var buttonCount = visibleFeatures.Count + (settingsVisible ? 1 : 0);
-                var spacingCount = Math.Max(0, visibleFeatures.Count - 1);
-                if (settingsVisible && visibleFeatures.Count > 0)
+                _ = DrawDockStrip(visibleFeatures, settingsItem, iconSize, spacing, separatorThickness, indicatorHeight, accentColor, dockBgColor);
+                DrawDockContextMenu();
+            }
+            var windowPos = ImGui.GetWindowPos();
+            ImGui.End();
+
+            ImGui.PopStyleColor(2);
+            ImGui.PopStyleVar(2);
+
+            if (!open)
+            {
+                IsOpen = false;
+            }
+
+            if (_config.DockRememberPosition && !_config.DockLocked && !ImGui.IsMouseDown(ImGuiMouseButton.Left))
+            {
+                if (!_config.DockPositionInitialized || Vector2.Distance(windowPos, _config.DockPosition) > 0.5f)
                 {
-                    spacingCount += 2;
-                }
-                var iconAreaWidth = iconSize.X * buttonCount + spacing * spacingCount + separatorThickness;
-                var iconAreaHeight = iconSize.Y;
-                var totalWidth = iconAreaWidth + padding * 2f;
-                var totalHeight = iconAreaHeight + padding * 2f + indicatorHeight;
-                var dockSize = new Vector2(totalWidth, totalHeight);
-
-                var dockPosition = GetDockPosition(dockSize);
-
-                ImGui.SetNextWindowPos(dockPosition, ImGuiCond.Appearing);
-                ImGui.SetNextWindowSize(dockSize, ImGuiCond.Appearing);
-
-                var windowFlags = ImGuiWindowFlags.NoDecoration
-                    | ImGuiWindowFlags.NoScrollbar
-                    | ImGuiWindowFlags.NoCollapse
-                    | ImGuiWindowFlags.NoSavedSettings
-                    | ImGuiWindowFlags.AlwaysAutoResize;
-
-                if (_config.DockLocked)
-                {
-                    windowFlags |= ImGuiWindowFlags.NoMove;
-                }
-
-                var dockBgColor = GetDockBackgroundColor();
-                var accentColor = Config.SanitizeColor(_config.SecondaryAccentColor, Config.DefaultSecondaryAccentColor);
-
-                ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, MathF.Max(14f, padding * 1.5f));
-                ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(padding, padding));
-                ImGui.PushStyleColor(ImGuiCol.WindowBg, dockBgColor);
-                ImGui.PushStyleColor(ImGuiCol.Border, Vector4.Zero);
-
-                var open = true;
-                if (ImGui.Begin(DockWindowTitle, ref open, windowFlags))
-                {
-                    _ = DrawDockStrip(visibleFeatures, settingsItem, iconSize, spacing, separatorThickness, indicatorHeight, accentColor, dockBgColor);
-                    DrawDockContextMenu();
-                }
-                var windowPos = ImGui.GetWindowPos();
-                ImGui.End();
-
-                ImGui.PopStyleColor(2);
-                ImGui.PopStyleVar(2);
-
-                if (!open)
-                {
-                    IsOpen = false;
-                }
-
-                if (_config.DockRememberPosition && !_config.DockLocked && !ImGui.IsMouseDown(ImGuiMouseButton.Left))
-                {
-                    if (!_config.DockPositionInitialized || Vector2.Distance(windowPos, _config.DockPosition) > 0.5f)
-                    {
-                        _config.DockPosition = windowPos;
-                        _config.DockPositionInitialized = true;
-                        SaveConfig();
-                    }
+                    _config.DockPosition = windowPos;
+                    _config.DockPositionInitialized = true;
+                    SaveConfig();
                 }
             }
         }
@@ -384,15 +376,18 @@ public class MainWindow : Window, IDisposable
     {
         CloseAllFeatureWindows();
 
-        if (_isOpen)
+        if (IsOpen)
+        {
+            IsOpen = false;
+        }
+        else
         {
             _isOpen = false;
-        }
-
-        if (_config.DockVisible)
-        {
-            _config.DockVisible = false;
-            SaveConfig();
+            if (_config.DockVisible)
+            {
+                _config.DockVisible = false;
+                SaveConfig();
+            }
         }
     }
 
@@ -788,7 +783,7 @@ public class MainWindow : Window, IDisposable
     }
 
     private bool IsLinked()
-        => TokenManager.Instance?.State == LinkState.Linked;
+        => _isLinked();
 
     private float GetIconScale()
     {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -183,7 +183,9 @@ public class Plugin : IDalamudPlugin
                 _channelService,
                 _channelSelection,
                 _emojiManager,
-                _notePadWindow
+                _notePadWindow,
+                () => _tokenManager.IsReady(),
+                () => _tokenManager.State == LinkState.Linked
             );
 
             _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _mainWindow.TemplatesWindow, _chatWindow, _officerChatWindow, _tokenManager, HttpClient, _channelService);

--- a/tests/DockVisibilityTokenLifecycleTests.cs
+++ b/tests/DockVisibilityTokenLifecycleTests.cs
@@ -97,7 +97,9 @@ public class DockVisibilityTokenLifecycleTests
                 channelService,
                 channelSelection,
                 emojiManager,
-                notePadWindow);
+                notePadWindow,
+                () => tokenManager.IsReady(),
+                () => tokenManager.State == LinkState.Linked);
 
             var channelWatcher = new ChannelWatcher(
                 config,

--- a/tests/PluginChannelValidationTests.cs
+++ b/tests/PluginChannelValidationTests.cs
@@ -92,7 +92,9 @@ public class PluginChannelValidationTests
             channelService,
             channelSelection,
             emojiManager,
-            notePadWindow
+            notePadWindow,
+            () => tokenManager.IsReady(),
+            () => tokenManager.State == LinkState.Linked
         );
         var channelWatcher = new ChannelWatcher(
             config,

--- a/tests/SyncshellTabToggleTests.cs
+++ b/tests/SyncshellTabToggleTests.cs
@@ -1,7 +1,7 @@
 using System.Net.Http;
 using System.Runtime.Serialization;
-using System.Threading.Tasks;
 using DemiCatPlugin;
+using DemiCatPlugin.Emoji;
 using Xunit;
 
 public class SyncshellTabToggleTests
@@ -15,12 +15,25 @@ public class SyncshellTabToggleTests
         var token = new TokenManager();
         var channelService = new ChannelService(cfg, http, token);
         var selection = new ChannelSelectionService(cfg);
-        var ui = new UiRenderer(cfg, http, selection);
+        var emojiManager = new EmojiManager(http, token, cfg);
+        var ui = new UiRenderer(cfg, http, selection, emojiManager);
         var officer = new OfficerChatWindow(cfg, http, null, token, channelService, selection);
         var settings = (SettingsWindow)FormatterServices.GetUninitializedObject(typeof(SettingsWindow));
         var notePadService = new NotePadService(cfg, http, token);
         var notePadWindow = new NotePadWindow(cfg, notePadService);
-        var main = new MainWindow(cfg, ui, null, officer, settings, http, channelService, selection, () => Task.FromResult(true), notePadWindow);
+        var main = new MainWindow(
+            cfg,
+            ui,
+            null,
+            officer,
+            settings,
+            http,
+            channelService,
+            selection,
+            emojiManager,
+            notePadWindow,
+            () => token.IsReady(),
+            () => token.State == LinkState.Linked);
 
         Assert.Null(SyncshellWindow.Instance);
 


### PR DESCRIPTION
## Summary
- remove the MainWindow IsOpen shadow property and use Dalamud's window lifecycle to keep the dock visibility flag in sync
- inject delegates for token readiness/link state so the UI no longer touches TokenManager.Instance and adjust the plugin/tests accordingly
- allow interaction with the dock host by dropping the NoInputs/NoBackground flags while keeping the rest of the dock drawing logic intact

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b412797c8328af6c3cbda4bab286