### PR TITLE
Refactor window lifecycle and inject token manager dependencies

### DIFF
--- a/DemiCatPlugin/ChannelNameResolver.cs
+++ b/DemiCatPlugin/ChannelNameResolver.cs
@@ -27,7 +27,8 @@ internal static class ChannelNameResolver
         HttpClient httpClient,
         Config config,
         bool refreshed,
-        Func<Task> reload)
+        Func<Task> reload,
+        TokenManager tokenManager)
     {
         var unresolved = Resolve(channels);
         if (unresolved && !refreshed && ApiHelpers.ValidateApiBaseUrl(config))
@@ -36,7 +37,7 @@ internal static class ChannelNameResolver
             {
                 var refreshReq = new HttpRequestMessage(HttpMethod.Post,
                     $"{config.ApiBaseUrl.TrimEnd('/')}/api/channels/refresh");
-                ApiHelpers.AddAuthHeader(refreshReq, TokenManager.Instance!);
+                ApiHelpers.AddAuthHeader(refreshReq, tokenManager);
                 var resp = await httpClient.SendAsync(refreshReq);
                 if (!resp.IsSuccessStatusCode)
                 {

--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -563,7 +563,13 @@ public class ChannelWatcher : IDisposable
     private async Task<IReadOnlyList<ChannelDto>> FetchChannelsForKindAsync(string kind, bool refreshed, CancellationToken ct = default)
     {
         var channels = (await _channelService.FetchAsync(kind, ct).ConfigureAwait(false)).ToList();
-        if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => Task.CompletedTask).ConfigureAwait(false))
+        if (await ChannelNameResolver.Resolve(
+                channels,
+                _httpClient,
+                _config,
+                refreshed,
+                () => Task.CompletedTask,
+                _tokenManager).ConfigureAwait(false))
         {
             return await FetchChannelsForKindAsync(kind, true, ct).ConfigureAwait(false);
         }

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -4087,7 +4087,13 @@ public class ChatWindow : IDisposable
         try
         {
             var channels = (await _channelService.FetchAsync(_channelKind, CancellationToken.None)).ToList();
-            if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true)))
+            if (await ChannelNameResolver.Resolve(
+                    channels,
+                    _httpClient,
+                    _config,
+                    refreshed,
+                    () => FetchChannels(true),
+                    _tokenManager))
             {
                 if (refreshed)
                 {

--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -21,6 +21,7 @@ public class DiscordPresenceService : IDisposable
 {
     private readonly Config _config;
     private readonly HttpClient _httpClient;
+    private readonly TokenManager _tokenManager;
     private readonly List<PresenceDto> _presences = new();
     private readonly SemaphoreSlim _resetGate = new(1, 1);
     private ClientWebSocket? _ws;
@@ -42,10 +43,11 @@ public class DiscordPresenceService : IDisposable
     public bool Loaded => _loaded;
     public bool IsPresenceReady => _presenceReady;
 
-    public DiscordPresenceService(Config config, HttpClient httpClient)
+    public DiscordPresenceService(Config config, HttpClient httpClient, TokenManager tokenManager)
     {
         _config = config;
         _httpClient = httpClient;
+        _tokenManager = tokenManager;
     }
 
     public void SetPresenceReady(bool ready)
@@ -152,7 +154,7 @@ public class DiscordPresenceService : IDisposable
             return;
         }
 
-        if (TokenManager.Instance?.IsReady() != true)
+        if (!_tokenManager.IsReady())
         {
             PluginServices.Instance!.Log.Warning("Cannot refresh presences: API key is not configured.");
             UpdateStatusMessage(ApiKeyMissingStatus);
@@ -162,7 +164,7 @@ public class DiscordPresenceService : IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -230,7 +232,7 @@ public class DiscordPresenceService : IDisposable
                 continue;
             }
 
-            if (TokenManager.Instance?.IsReady() != true)
+            if (!_tokenManager.IsReady())
             {
                 UpdateStatusMessage(ApiKeyMissingStatus);
                 await DelayWithBackoff(TimeSpan.FromSeconds(5), token).ConfigureAwait(false);
@@ -252,7 +254,7 @@ public class DiscordPresenceService : IDisposable
 
             try
             {
-                var pingService = PingService.Instance ?? new PingService(_httpClient, _config, TokenManager.Instance!);
+                var pingService = PingService.Instance ?? new PingService(_httpClient, _config, _tokenManager);
                 var pingResponse = await pingService.PingAsync(token).ConfigureAwait(false);
                 if (pingResponse?.IsSuccessStatusCode != true)
                 {
@@ -266,7 +268,7 @@ public class DiscordPresenceService : IDisposable
                 }
 
                 socket = CreateClientWebSocket();
-                ApiHelpers.AddAuthHeader(socket, TokenManager.Instance!);
+                ApiHelpers.AddAuthHeader(socket, _tokenManager);
                 Uri? uri;
                 try
                 {

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -26,6 +26,7 @@ public class EventCreateWindow
     private readonly HttpClient _httpClient;
     private readonly ChannelService _channelService;
     private readonly EmojiManager _emojiManager;
+    private readonly TokenManager _tokenManager;
 
     private string _title = string.Empty;
     private string _description = string.Empty;
@@ -75,12 +76,19 @@ public class EventCreateWindow
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
-    public EventCreateWindow(Config config, HttpClient httpClient, ChannelService channelService, ChannelSelectionService channelSelection, EmojiManager emojiManager)
+    public EventCreateWindow(
+        Config config,
+        HttpClient httpClient,
+        ChannelService channelService,
+        ChannelSelectionService channelSelection,
+        EmojiManager emojiManager,
+        TokenManager tokenManager)
     {
         _config = config;
         _httpClient = httpClient;
         _channelService = channelService;
         _emojiManager = emojiManager;
+        _tokenManager = tokenManager;
         _channelSelection = channelSelection;
         _optionEditor = new SignupOptionEditor(config, httpClient, emojiManager);
         _descriptionEmojiPopup = new EmojiPopup(config, emojiManager, "EventDescriptionEmoji", SaveConfig);
@@ -109,19 +117,19 @@ public class EventCreateWindow
 
     public void StartNetworking()
     {
-        if (!_config.Events || TokenManager.Instance?.IsReady() != true)
+        if (!_config.Events || !_tokenManager.IsReady())
         {
             return;
         }
 
-        _ = MembershipCache.EnsureLoaded(_httpClient, _config);
-        _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
+        _ = MembershipCache.EnsureLoaded(_httpClient, _config, _tokenManager);
+        _ = SignupPresetService.EnsureLoaded(_httpClient, _config, _tokenManager);
         _ = RefreshChannels();
     }
 
     public void Draw()
     {
-        if (TokenManager.Instance?.IsReady() != true)
+        if (!_tokenManager.IsReady())
         {
             ImGui.TextUnformatted("Link DemiCat to create events");
             return;
@@ -415,7 +423,7 @@ public class EventCreateWindow
         }
         _optionEditor.Draw();
 
-        _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
+        _ = SignupPresetService.EnsureLoaded(_httpClient, _config, _tokenManager);
         var presets = SignupPresetService.Presets;
         if (presets.Count > 0)
         {
@@ -489,6 +497,7 @@ public class EventCreateWindow
                 _httpClient,
                 () => Task.CompletedTask,
                 _emojiManager,
+                _tokenManager,
                 previewResult.Content,
                 previewResult.Warnings);
         }
@@ -579,7 +588,7 @@ public class EventCreateWindow
 
     private async Task LoadRoles()
     {
-        await RoleCache.EnsureLoaded(_httpClient, _config);
+        await RoleCache.EnsureLoaded(_httpClient, _config, _tokenManager);
         _ = PluginServices.Instance!.Framework.RunOnTick(() =>
         {
             IEnumerable<RoleDto> roles = RoleCache.Roles;
@@ -617,7 +626,7 @@ public class EventCreateWindow
         try
         {
             var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/repeat";
-            var tokenManager = TokenManager.Instance!;
+            var tokenManager = _tokenManager;
             var response = await ApiHelpers.SendWithRetries(() =>
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
@@ -662,7 +671,7 @@ public class EventCreateWindow
         try
         {
             var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/{id}/repeat";
-            var tokenManager = TokenManager.Instance!;
+            var tokenManager = _tokenManager;
             var response = await ApiHelpers.SendWithRetries(() =>
             {
                 var request = new HttpRequestMessage(HttpMethod.Delete, requestUri);
@@ -780,7 +789,7 @@ public class EventCreateWindow
             };
             var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates";
             var json = JsonSerializer.Serialize(body, JsonOpts);
-            var tokenManager = TokenManager.Instance!;
+            var tokenManager = _tokenManager;
             var response = await ApiHelpers.SendWithRetries(() =>
             {
                 var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
@@ -852,7 +861,7 @@ public class EventCreateWindow
 
             var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events";
             var json = JsonSerializer.Serialize(body, JsonOpts);
-            var tokenManager = TokenManager.Instance!;
+            var tokenManager = _tokenManager;
             var response = await ApiHelpers.SendWithRetries(() =>
             {
                 var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
@@ -1142,7 +1151,7 @@ public class EventCreateWindow
             return;
         }
 
-        var tokenManager = TokenManager.Instance;
+        var tokenManager = _tokenManager;
         if (tokenManager?.IsReady() != true)
         {
             SetUploadFailure(kind, "Link DemiCat to upload images");
@@ -1549,7 +1558,16 @@ public class EventCreateWindow
         try
         {
             var dto = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(ChannelKind.Event, CancellationToken.None)).ToList());
-            if (await ChannelNameResolver.Resolve(dto, _httpClient, _config, refreshed, () => FetchChannels(true))) return;
+            if (await ChannelNameResolver.Resolve(
+                    dto,
+                    _httpClient,
+                    _config,
+                    refreshed,
+                    () => FetchChannels(true),
+                    _tokenManager))
+            {
+                return;
+            }
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
                 _channels.Clear();
@@ -1628,7 +1646,7 @@ public class EventCreateWindow
                 Width = b.Width
             }).ToList()
         };
-        _ = SignupPresetService.Create(preset, _httpClient, _config);
+        _ = SignupPresetService.Create(preset, _httpClient, _config, _tokenManager);
         _presetName = string.Empty;
     }
 

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -24,6 +24,7 @@ public class EventView : IDisposable
     private readonly HttpClient _httpClient;
     private readonly Func<Task> _refresh;
     private readonly EmojiManager _emojiManager;
+    private readonly TokenManager _tokenManager;
 
     private EmbedDto _dto;
     private ISharedImmediateTexture? _authorIcon;
@@ -35,12 +36,21 @@ public class EventView : IDisposable
     private readonly List<string> _warnings = new();
     private static readonly Regex RoleMentionRegex = new("<@&(\\d+)>", RegexOptions.Compiled);
 
-    public EventView(EmbedDto dto, Config config, HttpClient httpClient, Func<Task> refresh, EmojiManager emojiManager, string? content = null, IEnumerable<string>? warnings = null)
+    public EventView(
+        EmbedDto dto,
+        Config config,
+        HttpClient httpClient,
+        Func<Task> refresh,
+        EmojiManager emojiManager,
+        TokenManager tokenManager,
+        string? content = null,
+        IEnumerable<string>? warnings = null)
     {
         _config = config;
         _httpClient = httpClient;
         _refresh = refresh;
         _emojiManager = emojiManager;
+        _tokenManager = tokenManager;
         _dto = dto;
         _content = content;
         SetWarnings(warnings);
@@ -679,7 +689,7 @@ public class EventView : IDisposable
             var request = new HttpRequestMessage(HttpMethod.Post, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/events/{_dto.Id}/rsvp");
             var body = new { tag = tag };
             request.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
             var response = await _httpClient.SendAsync(request);
             _lastResult = response.IsSuccessStatusCode ? "Signup updated" : "Signup failed";
             if (response.IsSuccessStatusCode)

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -64,7 +64,7 @@ public class FcChatWindow : ChatWindow
             return;
         }
 
-        _ = RoleCache.EnsureLoaded(_httpClient, _config);
+        _ = RoleCache.EnsureLoaded(_httpClient, _config, _tokenManager);
 
         if (_presenceSidebar != null)
         {

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -45,6 +45,7 @@ public class MainWindow : Window, IDisposable
     private readonly TemplatesWindow _templates;
     private readonly RequestBoardWindow _requestBoard;
     private readonly NotePadWindow _notePad;
+    private readonly TokenManager _tokenManager;
     private readonly EmojiManager _emojiManager;
     private readonly HttpClient _httpClient;
     private readonly List<DockItem> _dockItems = new();
@@ -71,7 +72,6 @@ public class MainWindow : Window, IDisposable
     private bool _syncshellEnabled;
     private bool _styleNeedsUpdate = true;
     private bool _hasOfficerAccess;
-    private bool _isOpen;
     private DockItem? _settingsDockItem;
 
     public bool HasOfficerAccess
@@ -117,6 +117,7 @@ public class MainWindow : Window, IDisposable
         ChannelSelectionService channelSelection,
         EmojiManager emojiManager,
         NotePadWindow notePad,
+        TokenManager tokenManager,
         Func<bool> isTokenReady,
         Func<bool> isLinked)
         : base("DemiCat Host")
@@ -128,17 +129,15 @@ public class MainWindow : Window, IDisposable
         _settings = settings;
         _httpClient = httpClient;
         _emojiManager = emojiManager;
-        _create = new EventCreateWindow(config, httpClient, channelService, channelSelection, emojiManager);
-        _templates = new TemplatesWindow(config, httpClient, channelService, channelSelection, emojiManager);
-        _requestBoard = new RequestBoardWindow(config, httpClient);
+        _tokenManager = tokenManager;
+        _create = new EventCreateWindow(config, httpClient, channelService, channelSelection, emojiManager, tokenManager);
+        _templates = new TemplatesWindow(config, httpClient, channelService, channelSelection, emojiManager, tokenManager);
+        _requestBoard = new RequestBoardWindow(config, httpClient, tokenManager);
         _notePad = notePad;
         _isTokenReady = isTokenReady ?? throw new ArgumentNullException(nameof(isTokenReady));
         _isLinked = isLinked ?? throw new ArgumentNullException(nameof(isLinked));
         _syncshellEnabled = config.FCSyncShell;
-        _syncshell = _syncshellEnabled ? new SyncshellWindow(config, httpClient) : null;
-        _isOpen = config.DockVisible;
-
-        IsOpen = _config.DockVisible;
+        _syncshell = _syncshellEnabled ? new SyncshellWindow(config, httpClient, tokenManager) : null;
         RespectCloseHotkey = false;
         Flags = ImGuiWindowFlags.NoDecoration
             | ImGuiWindowFlags.NoSavedSettings
@@ -191,23 +190,14 @@ public class MainWindow : Window, IDisposable
 
     public override void OnOpen()
     {
-        _isOpen = true;
-        if (!_config.DockVisible)
-        {
-            _config.DockVisible = true;
-            SaveConfig();
-        }
+        _config.DockVisible = true;
+        SaveConfig();
     }
 
     public override void OnClose()
     {
-        _isOpen = false;
-        if (_config.DockVisible)
-        {
-            _config.DockVisible = false;
-            SaveConfig();
-        }
-
+        _config.DockVisible = false;
+        SaveConfig();
         CloseAllFeatureWindows();
     }
 
@@ -225,7 +215,7 @@ public class MainWindow : Window, IDisposable
         if (_syncshellEnabled)
         {
             _syncshell?.Dispose();
-            _syncshell = new SyncshellWindow(_config, _httpClient);
+            _syncshell = new SyncshellWindow(_config, _httpClient, _tokenManager);
             _syncshellWindowHost = new SyncshellDockableWindow(_config, _syncshell, IsLinked);
             _windowHosts.Add(_syncshellWindowHost);
             BuildDockItems();
@@ -265,11 +255,6 @@ public class MainWindow : Window, IDisposable
     internal void DrawFeatures()
     {
         if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
-        {
-            return;
-        }
-
-        if (!_isOpen)
         {
             return;
         }
@@ -376,19 +361,7 @@ public class MainWindow : Window, IDisposable
     {
         CloseAllFeatureWindows();
 
-        if (IsOpen)
-        {
-            IsOpen = false;
-        }
-        else
-        {
-            _isOpen = false;
-            if (_config.DockVisible)
-            {
-                _config.DockVisible = false;
-                SaveConfig();
-            }
-        }
+        IsOpen = false;
     }
 
     public void OnAppearanceSettingsChanged()
@@ -409,7 +382,7 @@ public class MainWindow : Window, IDisposable
     public void ReloadSignupPresets()
     {
         SignupPresetService.Reset();
-        _ = SignupPresetService.EnsureLoaded(_httpClient, _config);
+        _ = SignupPresetService.EnsureLoaded(_httpClient, _config, _tokenManager);
     }
 
     public void ResetFadeTimer()

--- a/DemiCatPlugin/MembershipCache.cs
+++ b/DemiCatPlugin/MembershipCache.cs
@@ -44,9 +44,9 @@ internal static class MembershipCache
         }
     }
 
-    internal static async Task EnsureLoaded(HttpClient httpClient, Config config)
+    internal static async Task EnsureLoaded(HttpClient httpClient, Config config, TokenManager tokenManager)
     {
-        if (TokenManager.Instance?.IsReady() != true)
+        if (!tokenManager.IsReady())
         {
             return;
         }
@@ -69,7 +69,7 @@ internal static class MembershipCache
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/users/me/profile");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(request, tokenManager);
             var response = await httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -160,7 +160,7 @@ public class OfficerChatWindow : ChatWindow
         var showPresence = _presenceSidebar != null && _tokenManager.IsReady();
         if (showPresence)
         {
-            _ = RoleCache.EnsureLoaded(_httpClient, _config);
+        _ = RoleCache.EnsureLoaded(_httpClient, _config, _tokenManager);
             _presenceSidebar!.Draw(ref _presenceWidth);
             ImGui.SameLine();
             ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.None);
@@ -328,7 +328,13 @@ public class OfficerChatWindow : ChatWindow
         try
         {
             var channels = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(global::DemiCatPlugin.ChannelKind.OfficerChat, CancellationToken.None)).ToList());
-            if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true)))
+            if (await ChannelNameResolver.Resolve(
+                    channels,
+                    _httpClient,
+                    _config,
+                    refreshed,
+                    () => FetchChannels(true),
+                    _tokenManager))
             {
                 if (refreshed)
                 {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -149,7 +149,7 @@ public class Plugin : IDalamudPlugin
             _emojiManager = new EmojiManager(HttpClient, _tokenManager, _config);
             _emojiFontHandle = InitializeEmojiFont();
             _emojiManager.EmojiFontHandle = _emojiFontHandle;
-            _ui = new UiRenderer(_config, HttpClient, _channelSelection, _emojiManager);
+        _ui = new UiRenderer(_config, HttpClient, _channelSelection, _emojiManager, _tokenManager);
 
             _settings.ConfigureServices(
                 HttpClient,
@@ -158,9 +158,9 @@ public class Plugin : IDalamudPlugin
 
             RegisterDeveloperWindow();
 
-            _presenceService = _config.SyncedChat && _config.EnableFcChat
-                ? new DiscordPresenceService(_config, HttpClient)
-                : null;
+        _presenceService = _config.SyncedChat && _config.EnableFcChat
+            ? new DiscordPresenceService(_config, HttpClient, _tokenManager)
+            : null;
 
             _channelService = new ChannelService(_config, HttpClient, _tokenManager);
             var textureProvider = Services.TextureProvider;
@@ -173,20 +173,21 @@ public class Plugin : IDalamudPlugin
             _notePadService = new NotePadService(_config, HttpClient, _tokenManager);
             _notePadWindow = new NotePadWindow(_config, _notePadService);
 
-            _mainWindow = new MainWindow(
-                _config,
-                _ui,
-                _chatWindow,
-                _officerChatWindow,
-                _settings,
-                HttpClient,
-                _channelService,
-                _channelSelection,
-                _emojiManager,
-                _notePadWindow,
-                () => _tokenManager.IsReady(),
-                () => _tokenManager.State == LinkState.Linked
-            );
+        _mainWindow = new MainWindow(
+            _config,
+            _ui,
+            _chatWindow,
+            _officerChatWindow,
+            _settings,
+            HttpClient,
+            _channelService,
+            _channelSelection,
+            _emojiManager,
+            _notePadWindow,
+            _tokenManager,
+            () => _tokenManager.IsReady(),
+            () => _tokenManager.State == LinkState.Linked
+        );
 
             _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _mainWindow.TemplatesWindow, _chatWindow, _officerChatWindow, _tokenManager, HttpClient, _channelService);
             _requestWatcher = new RequestWatcher(_config, HttpClient, _tokenManager);
@@ -204,8 +205,9 @@ public class Plugin : IDalamudPlugin
             _mainWindow.SetNotePadReadOnly(!_tokenManager.IsReady());
 
             _windows.AddWindow(_mainWindow);
+            _mainWindow.IsOpen = _config.DockVisible;
 
-            _ = RoleCache.EnsureLoaded(HttpClient, _config);
+            _ = RoleCache.EnsureLoaded(HttpClient, _config, _tokenManager);
 
             _openMainUi = () =>
             {
@@ -1220,7 +1222,7 @@ public class Plugin : IDalamudPlugin
                 });
             });
 
-            await RoleCache.Refresh(HttpClient, _config);
+            await RoleCache.Refresh(HttpClient, _config, _tokenManager);
             return true;
         }
         catch (Exception ex)

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -17,6 +17,7 @@ public class RequestBoardWindow
     private readonly HttpClient _httpClient;
     private readonly Dictionary<string, bool> _conflicts = new();
     private readonly GameDataCache _gameData;
+    private readonly TokenManager _tokenManager;
     private readonly ConcurrentDictionary<string, byte> _itemLoads = new();
     private readonly ConcurrentDictionary<string, byte> _dutyLoads = new();
 
@@ -39,11 +40,12 @@ public class RequestBoardWindow
     private SortMode _sortMode = SortMode.MostRecent;
     private static readonly string[] SortLabels = { "Type", "Name", "Most Recent" };
 
-    public RequestBoardWindow(Config config, HttpClient httpClient)
+    public RequestBoardWindow(Config config, HttpClient httpClient, TokenManager tokenManager)
     {
         _config = config;
         _httpClient = httpClient;
         _gameData = new GameDataCache(httpClient);
+        _tokenManager = tokenManager;
     }
 
     public void Draw()
@@ -53,7 +55,7 @@ public class RequestBoardWindow
             ImGui.TextUnformatted("Feature disabled");
             return;
         }
-        if (TokenManager.Instance?.IsReady() != true)
+        if (!_tokenManager.IsReady())
         {
             ImGui.TextUnformatted("Link DemiCat to view requests");
             return;
@@ -162,7 +164,7 @@ public class RequestBoardWindow
 
     private void DrawActionButtons(RequestState req)
     {
-        var disabled = TokenManager.Instance?.IsReady() != true;
+        var disabled = !_tokenManager.IsReady();
         if (disabled)
             ImGui.BeginDisabled();
 
@@ -301,7 +303,7 @@ public class RequestBoardWindow
 
     private async Task Comment(RequestState req, string message)
     {
-        if (string.IsNullOrWhiteSpace(message) || TokenManager.Instance == null || !ApiHelpers.ValidateApiBaseUrl(_config))
+        if (string.IsNullOrWhiteSpace(message) || !ApiHelpers.ValidateApiBaseUrl(_config))
             return;
 
         try
@@ -310,7 +312,7 @@ public class RequestBoardWindow
             var body = new { message };
             var json = JsonSerializer.Serialize(body);
             var msg = new HttpRequestMessage(HttpMethod.Post, url);
-            ApiHelpers.AddAuthHeader(msg, TokenManager.Instance);
+            ApiHelpers.AddAuthHeader(msg, _tokenManager);
             msg.Content = new StringContent(json, Encoding.UTF8, "application/json");
             var resp = await _httpClient.SendAsync(msg);
             if (!resp.IsSuccessStatusCode)
@@ -369,7 +371,7 @@ public class RequestBoardWindow
                 var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/requests/{req.Id}/{action}";
                 var json = JsonSerializer.Serialize(new { version = req.Version });
                 var msg = new HttpRequestMessage(HttpMethod.Post, url);
-                ApiHelpers.AddAuthHeader(msg, TokenManager.Instance!);
+                ApiHelpers.AddAuthHeader(msg, _tokenManager);
                 msg.Content = new StringContent(json, Encoding.UTF8, "application/json");
                 var resp = await _httpClient.SendAsync(msg);
                 if (resp.IsSuccessStatusCode)
@@ -447,7 +449,7 @@ public class RequestBoardWindow
         {
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/requests/{id}";
             var msg = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(msg, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(msg, _tokenManager);
             var resp = await _httpClient.SendAsync(msg);
             if (resp.IsSuccessStatusCode)
             {
@@ -565,7 +567,7 @@ public class RequestBoardWindow
 
     private async Task CreateRequest()
     {
-        if (!ApiHelpers.ValidateApiBaseUrl(_config) || TokenManager.Instance == null)
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
             return;
         try
         {
@@ -579,7 +581,7 @@ public class RequestBoardWindow
             };
             var json = JsonSerializer.Serialize(body);
             var msg = new HttpRequestMessage(HttpMethod.Post, url);
-            ApiHelpers.AddAuthHeader(msg, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(msg, _tokenManager);
             msg.Content = new StringContent(json, Encoding.UTF8, "application/json");
             var resp = await _httpClient.SendAsync(msg);
             if (resp.IsSuccessStatusCode)

--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -104,10 +104,9 @@ internal static class RequestStateService
         }
     }
 
-    public static async Task RefreshAll(HttpClient httpClient, Config config)
+    public static async Task RefreshAll(HttpClient httpClient, Config config, TokenManager tokenManager)
     {
-        var tokenManager = TokenManager.Instance;
-        if (!ApiHelpers.ValidateApiBaseUrl(config) || tokenManager == null || !tokenManager.IsReady()) return;
+        if (!ApiHelpers.ValidateApiBaseUrl(config) || !tokenManager.IsReady()) return;
         _config = config;
         try
         {

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -84,7 +84,7 @@ public class RequestWatcher : IDisposable
                     continue;
                 }
 
-                try { await RequestStateService.RefreshAll(_httpClient, _config); } catch { }
+                try { await RequestStateService.RefreshAll(_httpClient, _config, _tokenManager); } catch { }
 
                 ws = new ClientWebSocket();
                 ApiHelpers.AddAuthHeader(ws, _tokenManager);
@@ -186,7 +186,7 @@ public class RequestWatcher : IDisposable
 
             if (_tokenManager.IsReady())
             {
-                try { await RequestStateService.RefreshAll(_httpClient, _config); } catch { }
+                try { await RequestStateService.RefreshAll(_httpClient, _config, _tokenManager); } catch { }
             }
 
             if (hadTransportError)

--- a/DemiCatPlugin/RoleCache.cs
+++ b/DemiCatPlugin/RoleCache.cs
@@ -23,7 +23,7 @@ internal static class RoleCache
         _lastErrorMessage = null;
     }
 
-    internal static async Task EnsureLoaded(HttpClient httpClient, Config config)
+    internal static async Task EnsureLoaded(HttpClient httpClient, Config config, TokenManager tokenManager)
     {
         if (_loaded)
             return;
@@ -33,10 +33,10 @@ internal static class RoleCache
             _loaded = true;
             return;
         }
-        await Refresh(httpClient, config);
+        await Refresh(httpClient, config, tokenManager);
     }
 
-    internal static async Task Refresh(HttpClient httpClient, Config config)
+    internal static async Task Refresh(HttpClient httpClient, Config config, TokenManager tokenManager)
     {
         if (!ApiHelpers.ValidateApiBaseUrl(config))
         {
@@ -47,11 +47,11 @@ internal static class RoleCache
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{config.ApiBaseUrl.TrimEnd('/')}/api/guild-roles");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(request, tokenManager);
             var response = await httpClient.SendAsync(request);
             if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
             {
-                TokenManager.Instance!.Clear("Authentication failed");
+                tokenManager.Clear("Authentication failed");
                 _lastErrorMessage = "Authentication failed";
                 _loaded = true;
                 return;

--- a/DemiCatPlugin/SignupPresetService.cs
+++ b/DemiCatPlugin/SignupPresetService.cs
@@ -20,22 +20,22 @@ internal static class SignupPresetService
         _loaded = false;
     }
 
-    internal static async Task EnsureLoaded(HttpClient httpClient, Config config)
+    internal static async Task EnsureLoaded(HttpClient httpClient, Config config, TokenManager tokenManager)
     {
         if (!_loaded)
         {
-            await Refresh(httpClient, config);
+            await Refresh(httpClient, config, tokenManager);
         }
     }
 
-    internal static async Task Refresh(HttpClient httpClient, Config config)
+    internal static async Task Refresh(HttpClient httpClient, Config config, TokenManager tokenManager)
     {
         if (!ApiHelpers.ValidateApiBaseUrl(config)) return;
         try
         {
             var url = $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets";
             var req = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(req, tokenManager);
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
             {
@@ -50,9 +50,9 @@ internal static class SignupPresetService
                 PluginServices.Instance!.Log.Warning($"Failed to refresh signup presets. URL: {url}, Status: {resp.StatusCode}. Response Body: {responseBody}");
                 if (resp.StatusCode == HttpStatusCode.Unauthorized || resp.StatusCode == HttpStatusCode.Forbidden)
                 {
-                    if (TokenManager.Instance?.IsReady() == true)
+                    if (tokenManager.IsReady())
                     {
-                        TokenManager.Instance.Clear("Invalid API key");
+                        tokenManager.Clear("Invalid API key");
                     }
                 }
             }
@@ -63,19 +63,19 @@ internal static class SignupPresetService
         }
     }
 
-    internal static async Task Create(SignupPreset preset, HttpClient httpClient, Config config)
+    internal static async Task Create(SignupPreset preset, HttpClient httpClient, Config config, TokenManager tokenManager)
     {
         if (!ApiHelpers.ValidateApiBaseUrl(config)) return;
         try
         {
             var url = $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets";
             var req = new HttpRequestMessage(HttpMethod.Post, url);
-            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(req, tokenManager);
             req.Content = new StringContent(JsonSerializer.Serialize(preset), Encoding.UTF8, "application/json");
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
             {
-                await Refresh(httpClient, config);
+                await Refresh(httpClient, config, tokenManager);
             }
             else
             {
@@ -83,9 +83,9 @@ internal static class SignupPresetService
                 PluginServices.Instance!.Log.Warning($"Failed to create signup preset. URL: {url}, Status: {resp.StatusCode}. Response Body: {responseBody}");
                 if (resp.StatusCode == HttpStatusCode.Unauthorized || resp.StatusCode == HttpStatusCode.Forbidden)
                 {
-                    if (TokenManager.Instance?.IsReady() == true)
+                    if (tokenManager.IsReady())
                     {
-                        TokenManager.Instance.Clear("Invalid API key");
+                        tokenManager.Clear("Invalid API key");
                     }
                 }
             }
@@ -96,18 +96,18 @@ internal static class SignupPresetService
         }
     }
 
-    internal static async Task Delete(string id, HttpClient httpClient, Config config)
+    internal static async Task Delete(string id, HttpClient httpClient, Config config, TokenManager tokenManager)
     {
         if (!ApiHelpers.ValidateApiBaseUrl(config)) return;
         try
         {
             var url = $"{config.ApiBaseUrl.TrimEnd('/')}/api/signup-presets/{id}";
             var req = new HttpRequestMessage(HttpMethod.Delete, url);
-            ApiHelpers.AddAuthHeader(req, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(req, tokenManager);
             var resp = await httpClient.SendAsync(req);
             if (resp.IsSuccessStatusCode)
             {
-                await Refresh(httpClient, config);
+                await Refresh(httpClient, config, tokenManager);
             }
             else
             {
@@ -115,9 +115,9 @@ internal static class SignupPresetService
                 PluginServices.Instance!.Log.Warning($"Failed to delete signup preset. URL: {url}, Status: {resp.StatusCode}. Response Body: {responseBody}");
                 if (resp.StatusCode == HttpStatusCode.Unauthorized || resp.StatusCode == HttpStatusCode.Forbidden)
                 {
-                    if (TokenManager.Instance?.IsReady() == true)
+                    if (tokenManager.IsReady())
                     {
-                        TokenManager.Instance.Clear("Invalid API key");
+                        tokenManager.Clear("Invalid API key");
                     }
                 }
             }

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -153,13 +153,14 @@ public class SyncshellWindow : IDisposable
     private int _membershipRefreshRequested;
     private string? _membershipError;
 
-    public SyncshellWindow(Config config, HttpClient httpClient)
+    public SyncshellWindow(Config config, HttpClient httpClient, TokenManager tokenManager)
     {
         if (!config.FCSyncShell)
             throw new InvalidOperationException("Syncshell disabled");
 
         _config = config;
         _httpClient = httpClient;
+        _tokenManager = tokenManager;
 
         var services = PluginServices.Instance;
         _progressOverlay = new ProgressOverlay();
@@ -179,7 +180,6 @@ public class SyncshellWindow : IDisposable
             _blobStore = new FileBlobStore(Path.Combine(configDir, ".syncshell", "cache"));
         }
 
-        _tokenManager = TokenManager.Instance ?? throw new InvalidOperationException("Token manager unavailable");
         var log = services?.Log ?? new NullPluginLog();
         _resolver = new Resolver(config, _blobStore, log, services?.PluginInterface);
         _syncClient = new SyncClient(_config, _tokenManager, _resolver, _blobStore);

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -24,6 +24,7 @@ public class TemplatesWindow
     private readonly HttpClient _httpClient;
     private readonly ChannelService _channelService;
     private readonly EmojiManager _emojiManager;
+    private readonly TokenManager _tokenManager;
     private readonly List<TemplateItem> _templates = new();
     private bool _templatesLoaded;
     private bool _templatesLoading;
@@ -56,31 +57,34 @@ public class TemplatesWindow
     private readonly ChatBridge? _bridge;
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
 
-    public TemplatesWindow(Config config, HttpClient httpClient, ChannelService channelService, ChannelSelectionService channelSelection, EmojiManager emojiManager)
+    public TemplatesWindow(
+        Config config,
+        HttpClient httpClient,
+        ChannelService channelService,
+        ChannelSelectionService channelSelection,
+        EmojiManager emojiManager,
+        TokenManager tokenManager)
     {
         _config = config;
         _httpClient = httpClient;
         _channelService = channelService;
         _emojiManager = emojiManager;
+        _tokenManager = tokenManager;
         _channelSelection = channelSelection;
         _timePicker = new DateTimePicker(DateTimePicker.GetDefaultTime());
-        var token = TokenManager.Instance;
-        if (token != null)
+        _bridge = new ChatBridge(config, httpClient, _tokenManager, BuildWebSocketUri, channelSelection);
+        _bridge.TemplatesUpdated += () =>
         {
-            _bridge = new ChatBridge(config, httpClient, token, BuildWebSocketUri, channelSelection);
-            _bridge.TemplatesUpdated += () =>
+            if (_templatesLoading)
             {
-                if (_templatesLoading)
-                {
-                    _templatesReloadPending = true;
-                    _templatesLoaded = false;
-                    return;
-                }
-
+                _templatesReloadPending = true;
                 _templatesLoaded = false;
-                _ = LoadTemplates();
-            };
-        }
+                return;
+            }
+
+            _templatesLoaded = false;
+            _ = LoadTemplates();
+        };
         _channelSelection.ChannelChanged += HandleChannelChanged;
     }
 
@@ -102,7 +106,7 @@ public class TemplatesWindow
 
     public void StartNetworking()
     {
-        _ = MembershipCache.EnsureLoaded(_httpClient, _config);
+        _ = MembershipCache.EnsureLoaded(_httpClient, _config, _tokenManager);
         _bridge?.Start();
         _templatesLoaded = false;
     }
@@ -129,7 +133,7 @@ public class TemplatesWindow
             return;
         }
 
-        if (TokenManager.Instance?.IsReady() != true)
+        if (!_tokenManager.IsReady())
         {
             ImGui.TextUnformatted("Link DemiCat to manage templates");
             return;
@@ -410,6 +414,7 @@ public class TemplatesWindow
             _httpClient,
             () => Task.CompletedTask,
             _emojiManager,
+            _tokenManager,
             preview.Content,
             preview.Warnings);
         _showPreview = true;
@@ -451,7 +456,13 @@ public class TemplatesWindow
         try
         {
             var channels = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(ChannelKind.Event, CancellationToken.None)).ToList());
-            if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true)))
+            if (await ChannelNameResolver.Resolve(
+                    channels,
+                    _httpClient,
+                    _config,
+                    refreshed,
+                    () => FetchChannels(true),
+                    _tokenManager))
             {
                 _channelsLoading = false;
                 return;
@@ -592,7 +603,7 @@ public class TemplatesWindow
         _rolesLoading = true;
         try
         {
-            await RoleCache.EnsureLoaded(_httpClient, _config);
+            await RoleCache.EnsureLoaded(_httpClient, _config, _tokenManager);
         }
         catch
         {
@@ -795,7 +806,7 @@ public class TemplatesWindow
             var id = _templates[_selectedIndex].Id;
             var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates/{id}/post";
             var json = JsonSerializer.Serialize(body);
-            var tokenManager = TokenManager.Instance!;
+            var tokenManager = _tokenManager;
             var response = await ApiHelpers.SendWithRetries(() =>
             {
                 var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
@@ -876,7 +887,7 @@ public class TemplatesWindow
         try
         {
             var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates";
-            var tokenManager = TokenManager.Instance!;
+            var tokenManager = _tokenManager;
             var response = await ApiHelpers.SendWithRetries(() =>
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
@@ -977,7 +988,7 @@ public class TemplatesWindow
         try
         {
             var requestUri = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/templates/{id}";
-            var tokenManager = TokenManager.Instance!;
+            var tokenManager = _tokenManager;
             var response = await ApiHelpers.SendWithRetries(() =>
             {
                 var request = new HttpRequestMessage(HttpMethod.Delete, requestUri);

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -21,6 +21,7 @@ namespace DemiCatPlugin;
 public class UiRenderer : IAsyncDisposable, IDisposable
 {
     private readonly HttpClient _httpClient;
+    private readonly TokenManager _tokenManager;
     private readonly Config _config;
     private readonly Dictionary<string, EventView> _embeds = new();
     private readonly object _embedLock = new();
@@ -61,12 +62,18 @@ public class UiRenderer : IAsyncDisposable, IDisposable
     private const string DefaultWebSocketPath = "/ws/embeds";
     private const string ForbiddenMessage = "Forbidden – check API key/roles";
 
-    public UiRenderer(Config config, HttpClient httpClient, ChannelSelectionService channelSelection, EmojiManager emojiManager)
+    public UiRenderer(
+        Config config,
+        HttpClient httpClient,
+        ChannelSelectionService channelSelection,
+        EmojiManager emojiManager,
+        TokenManager tokenManager)
     {
         _config = config;
         _httpClient = httpClient;
         _channelSelection = channelSelection;
         _emojiManager = emojiManager;
+        _tokenManager = tokenManager;
         _channelSelection.ChannelChanged += HandleChannelChanged;
     }
 
@@ -122,7 +129,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             socket.Dispose();
         }
 
-        if (!TokenManager.Instance!.IsReady() || !_config.Enabled || !_config.Events)
+        if (!_tokenManager.IsReady() || !_config.Enabled || !_config.Events)
         {
             return;
         }
@@ -193,7 +200,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             while (!token.IsCancellationRequested)
             {
                 await Task.Delay(delay, token);
-                if (!TokenManager.Instance!.IsReady() || !_config.Enabled || !_config.Events)
+                if (!_tokenManager.IsReady() || !_config.Enabled || !_config.Events)
                 {
                     continue;
                 }
@@ -233,14 +240,14 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     private async Task LoadPresences()
     {
-        if (!TokenManager.Instance!.IsReady()) return;
+        if (!_tokenManager.IsReady()) return;
         if (_presenceLoadAttempted) return;
         _presenceLoadAttempted = true;
         if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode) return;
             var stream = await response.Content.ReadAsStreamAsync();
@@ -308,7 +315,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     private async Task<bool> PollEmbeds()
     {
-        if (!ApiHelpers.ValidateApiBaseUrl(_config) || TokenManager.Instance?.IsReady() != true) return false;
+        if (!ApiHelpers.ValidateApiBaseUrl(_config) || !_tokenManager.IsReady()) return false;
 
         try
         {
@@ -319,12 +326,12 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 url += $"?channel_id={channelId}";
             }
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
             var response = await _httpClient.SendAsync(request);
             if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 PluginServices.Instance?.Log.Warning("Sync unauthorized; clearing token");
-                TokenManager.Instance?.Clear("Invalid API key");
+                _tokenManager.Clear("Invalid API key");
                 return false;
             }
             if (response.StatusCode == HttpStatusCode.Forbidden)
@@ -359,7 +366,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
         {
             PluginServices.Instance?.Log.Warning(ex, "Sync unauthorized; clearing token");
-            TokenManager.Instance?.Clear("Invalid API key");
+            _tokenManager.Clear("Invalid API key");
             return false;
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
@@ -438,7 +445,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 return;
             }
 
-            if (!ApiHelpers.ValidateApiBaseUrl(_config) || TokenManager.Instance?.IsReady() != true || !_config.Enabled)
+            if (!ApiHelpers.ValidateApiBaseUrl(_config) || !_tokenManager.IsReady() || !_config.Enabled)
             {
                 ScheduleNextWebSocketAttempt();
                 return;
@@ -446,12 +453,12 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
             try
             {
-                var pingService = PingService.Instance ?? new PingService(_httpClient, _config, TokenManager.Instance!);
+                var pingService = PingService.Instance ?? new PingService(_httpClient, _config, _tokenManager);
                 var pingResponse = await pingService.PingAsync(CancellationToken.None);
                 if (pingResponse?.StatusCode == HttpStatusCode.Unauthorized)
                 {
                     PluginServices.Instance?.Log.Warning("WebSocket ping unauthorized; clearing token");
-                    TokenManager.Instance?.Clear("Invalid API key");
+                    _tokenManager.Clear("Invalid API key");
                     return;
                 }
                 if (pingResponse?.StatusCode == HttpStatusCode.Forbidden)
@@ -473,7 +480,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
                 _webSocket?.Dispose();
                 _webSocket = new ClientWebSocket();
-                ApiHelpers.AddAuthHeader(_webSocket, TokenManager.Instance!);
+                ApiHelpers.AddAuthHeader(_webSocket, _tokenManager);
                 var wsUrl = BuildWebSocketUri();
                 if (wsUrl == null)
                 {
@@ -807,7 +814,14 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 }
                 else
                 {
-                    _embeds[dto.Id] = new EventView(dto, _config, _httpClient, RefreshEmbeds, _emojiManager, BuildMentionContent(dto));
+                    _embeds[dto.Id] = new EventView(
+                        dto,
+                        _config,
+                        _httpClient,
+                        RefreshEmbeds,
+                        _emojiManager,
+                        _tokenManager,
+                        BuildMentionContent(dto));
                 }
             }
 
@@ -831,7 +845,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     public async Task RefreshEmbeds()
     {
-        if (!TokenManager.Instance!.IsReady()) return;
+        if (!_tokenManager.IsReady()) return;
         if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
 
         try
@@ -843,7 +857,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 url += $"?channel_id={channelId}";
             }
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
             {
@@ -867,7 +881,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     public void Draw()
     {
-        if (!TokenManager.Instance!.IsReady())
+        if (!_tokenManager.IsReady())
         {
             ImGui.TextUnformatted("Link DemiCat to view events");
             return;
@@ -1175,7 +1189,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     private async Task FetchChannels(bool refreshed = false)
     {
-        if (!TokenManager.Instance!.IsReady()) return;
+        if (!_tokenManager.IsReady()) return;
         if (!ApiHelpers.ValidateApiBaseUrl(_config))
         {
             PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
@@ -1191,14 +1205,14 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         try
         {
             var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
             var response = await _httpClient.SendAsync(request);
             if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 var responseBody = await response.Content.ReadAsStringAsync();
                 PluginServices.Instance!.Log.Warning(
                     $"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}. Clearing token");
-                TokenManager.Instance?.Clear("Invalid API key");
+                _tokenManager.Clear("Invalid API key");
                 return;
             }
             if (response.StatusCode == HttpStatusCode.Forbidden)
@@ -1236,7 +1250,16 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             {
                 channel.EnsureKind(ChannelKind.Event);
             }
-            if (await ChannelNameResolver.Resolve(eventChannels, _httpClient, _config, refreshed, () => FetchChannels(true))) return;
+            if (await ChannelNameResolver.Resolve(
+                    eventChannels,
+                    _httpClient,
+                    _config,
+                    refreshed,
+                    () => FetchChannels(true),
+                    _tokenManager))
+            {
+                return;
+            }
             ResetPermissionToast();
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
@@ -1248,7 +1271,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             PluginServices.Instance!.Log.Warning(
                 ex,
                 "Failed to fetch channels due to authorization failure; clearing token");
-            TokenManager.Instance?.Clear("Invalid API key");
+            _tokenManager.Clear("Invalid API key");
             return;
         }
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)

--- a/tests/ChatWindowMentionTests.cs
+++ b/tests/ChatWindowMentionTests.cs
@@ -65,7 +65,7 @@ public class ChatWindowMentionTests
         var httpClient = new HttpClient(handler);
         var tokenManager = new TokenManager();
         var channelService = new ChannelService(config, httpClient, tokenManager);
-        var presence = new DiscordPresenceService(config, httpClient);
+        var presence = new DiscordPresenceService(config, httpClient, tokenManager);
         var presenceList = (List<PresenceDto>)typeof(DiscordPresenceService)
             .GetField("_presences", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(presence)!;
@@ -174,7 +174,7 @@ public class ChatWindowMentionTests
         var httpClient = new HttpClient(handler);
         var tokenManager = new TokenManager();
         var channelService = new ChannelService(config, httpClient, tokenManager);
-        var presence = new DiscordPresenceService(config, httpClient);
+            var presence = new DiscordPresenceService(config, httpClient, tokenManager);
         var presenceList = (List<PresenceDto>)typeof(DiscordPresenceService)
             .GetField("_presences", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(presence)!;

--- a/tests/DiscordPresenceServiceTests.cs
+++ b/tests/DiscordPresenceServiceTests.cs
@@ -78,8 +78,8 @@ public class DiscordPresenceServiceTests
         private int _started;
         private int _completed;
 
-        public TestDiscordPresenceService(Config config, HttpClient httpClient)
-            : base(config, httpClient)
+        public TestDiscordPresenceService(Config config, HttpClient httpClient, TokenManager tokenManager)
+            : base(config, httpClient, tokenManager)
         {
         }
 
@@ -181,9 +181,10 @@ public class DiscordPresenceServiceTests
             var log = new RecordingLog();
             ConfigurePluginServices(services, framework, log);
 
-            _ = new TokenManager();
+            var tokenManager = new TokenManager();
+            SetTokenManagerInstance(tokenManager);
 
-            var service = new DiscordPresenceService(config, httpClient);
+            var service = new DiscordPresenceService(config, httpClient, tokenManager);
 
             await service.Refresh().ConfigureAwait(false);
 
@@ -212,9 +213,10 @@ public class DiscordPresenceServiceTests
             var log = new RecordingLog();
             ConfigurePluginServices(services, framework, log);
 
-            SetTokenManagerInstance(null);
+            var tokenManager = new TokenManager();
+            SetTokenManagerInstance(tokenManager);
 
-            var service = new DiscordPresenceService(config, httpClient);
+            var service = new DiscordPresenceService(config, httpClient, tokenManager);
 
             await service.Refresh().ConfigureAwait(false);
 
@@ -244,9 +246,10 @@ public class DiscordPresenceServiceTests
             var log = new RecordingLog();
             ConfigurePluginServices(services, framework, log);
 
-            SetTokenManagerInstance(null);
+            var tokenManager = new TokenManager();
+            SetTokenManagerInstance(tokenManager);
 
-            service = new DiscordPresenceService(config, httpClient);
+            service = new DiscordPresenceService(config, httpClient, tokenManager);
 
             service.Reset();
 
@@ -278,9 +281,9 @@ public class DiscordPresenceServiceTests
             ConfigurePluginServices(services, framework, log);
 
             var tokenManager = new TokenManager();
-            _ = tokenManager;
+            SetTokenManagerInstance(tokenManager);
 
-            service = new DiscordPresenceService(config, httpClient);
+            service = new DiscordPresenceService(config, httpClient, tokenManager);
 
             service.Reset();
 
@@ -315,7 +318,7 @@ public class DiscordPresenceServiceTests
             typeof(PluginServices).GetProperty("Framework", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, framework);
             typeof(PluginServices).GetProperty("Log", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(services, log);
 
-            var service = new TestDiscordPresenceService(config, httpClient);
+            var service = new TestDiscordPresenceService(config, httpClient, tokenManager);
 
             service.Reset();
             await service.WaitForConnectionStartsAsync(1, TimeSpan.FromSeconds(1)).ConfigureAwait(false);
@@ -357,7 +360,8 @@ public class DiscordPresenceServiceTests
     {
         var config = new Config { ApiBaseUrl = "http://unit-test" };
         using var httpClient = new HttpClient(new StubPresenceHandler());
-        var service = new DiscordPresenceService(config, httpClient);
+        var tokenManager = new TokenManager();
+        var service = new DiscordPresenceService(config, httpClient, tokenManager);
 
         var field = typeof(DiscordPresenceService).GetField("_presences", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var list = (List<PresenceDto>)field.GetValue(service)!;
@@ -403,7 +407,8 @@ public class DiscordPresenceServiceTests
     {
         var config = new Config { ApiBaseUrl = "http://unit-test" };
         using var httpClient = new HttpClient(new StubPresenceHandler());
-        var service = new DiscordPresenceService(config, httpClient);
+        var tokenManager = new TokenManager();
+        var service = new DiscordPresenceService(config, httpClient, tokenManager);
 
         var field = typeof(DiscordPresenceService).GetField("_presences", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var list = (List<PresenceDto>)field.GetValue(service)!;

--- a/tests/DockVisibilityTokenLifecycleTests.cs
+++ b/tests/DockVisibilityTokenLifecycleTests.cs
@@ -72,7 +72,7 @@ public class DockVisibilityTokenLifecycleTests
             var channelService = new ChannelService(config, httpClient, tokenManager);
             var channelSelection = new ChannelSelectionService(config);
             var emojiManager = new EmojiManager(httpClient, tokenManager, config);
-            var uiRenderer = new UiRenderer(config, httpClient, channelSelection, emojiManager);
+            var uiRenderer = new UiRenderer(config, httpClient, channelSelection, emojiManager, tokenManager);
             var chatWindow = new ChatWindow(config, httpClient, null, tokenManager, channelService);
             var officerWindow = new OfficerChatWindow(config, httpClient, null, tokenManager, channelService);
             var settingsWindow = new SettingsWindow(
@@ -98,6 +98,7 @@ public class DockVisibilityTokenLifecycleTests
                 channelSelection,
                 emojiManager,
                 notePadWindow,
+                tokenManager,
                 () => tokenManager.IsReady(),
                 () => tokenManager.State == LinkState.Linked);
 

--- a/tests/PluginChannelValidationTests.cs
+++ b/tests/PluginChannelValidationTests.cs
@@ -64,7 +64,7 @@ public class PluginChannelValidationTests
         var channelService = new ChannelService(config, httpClient, tokenManager);
         var channelSelection = new ChannelSelectionService(config);
         var emojiManager = new EmojiManager(httpClient, tokenManager, config);
-        var ui = new UiRenderer(config, httpClient, channelSelection, emojiManager);
+        var ui = new UiRenderer(config, httpClient, channelSelection, emojiManager, tokenManager);
         var requestWatcher = new RequestWatcher(config, httpClient, tokenManager);
         var chatWindow = new ChatWindow(config, httpClient, null, tokenManager, channelService);
         var officerChatWindow = new OfficerChatWindow(config, httpClient, null, tokenManager, channelService);
@@ -93,6 +93,7 @@ public class PluginChannelValidationTests
             channelSelection,
             emojiManager,
             notePadWindow,
+            tokenManager,
             () => tokenManager.IsReady(),
             () => tokenManager.State == LinkState.Linked
         );

--- a/tests/PresenceServiceLifecycleTests.cs
+++ b/tests/PresenceServiceLifecycleTests.cs
@@ -34,7 +34,7 @@ public class PresenceServiceLifecycleTests : IDisposable
         var config = new Config { ApiBaseUrl = "https://example.invalid" };
         using var httpClient = new HttpClient(new StubPresenceHandler());
         var tokenManager = new TokenManager();
-        var presence = new DiscordPresenceService(config, httpClient);
+        var presence = new DiscordPresenceService(config, httpClient, tokenManager);
         presence.SetPresenceReady(true);
         var channelService = new ChannelService(config, httpClient, tokenManager);
 
@@ -66,7 +66,7 @@ public class PresenceServiceLifecycleTests : IDisposable
         var config = new Config { ApiBaseUrl = "https://example.invalid" };
         using var httpClient = new HttpClient(new StubPresenceHandler());
         var tokenManager = new TokenManager();
-        var presence = new DiscordPresenceService(config, httpClient);
+        var presence = new DiscordPresenceService(config, httpClient, tokenManager);
         var channelService = new ChannelService(config, httpClient, tokenManager);
 
         PingService.Instance = new PingService(httpClient, config, tokenManager);

--- a/tests/PresenceSidebarTests.cs
+++ b/tests/PresenceSidebarTests.cs
@@ -49,7 +49,8 @@ public class PresenceSidebarTests
     {
         var config = new Config();
         var httpClient = new HttpClient(new StubHandler());
-        var service = new DiscordPresenceService(config, httpClient);
+        var tokenManager = new TokenManager();
+        var service = new DiscordPresenceService(config, httpClient, tokenManager);
         return new PresenceSidebar(service);
     }
 

--- a/tests/SyncshellTabToggleTests.cs
+++ b/tests/SyncshellTabToggleTests.cs
@@ -16,7 +16,7 @@ public class SyncshellTabToggleTests
         var channelService = new ChannelService(cfg, http, token);
         var selection = new ChannelSelectionService(cfg);
         var emojiManager = new EmojiManager(http, token, cfg);
-        var ui = new UiRenderer(cfg, http, selection, emojiManager);
+        var ui = new UiRenderer(cfg, http, selection, emojiManager, token);
         var officer = new OfficerChatWindow(cfg, http, null, token, channelService, selection);
         var settings = (SettingsWindow)FormatterServices.GetUninitializedObject(typeof(SettingsWindow));
         var notePadService = new NotePadService(cfg, http, token);
@@ -32,6 +32,7 @@ public class SyncshellTabToggleTests
             selection,
             emojiManager,
             notePadWindow,
+            token,
             () => token.IsReady(),
             () => token.State == LinkState.Linked);
 

--- a/tests/UiRendererShutdownTests.cs
+++ b/tests/UiRendererShutdownTests.cs
@@ -120,7 +120,7 @@ public class UiRendererShutdownTests
             var emojiManager = new EmojiManager(new HttpClient(new StubEmojiHandler()), tokenManager, config);
             var handler = new TestHttpHandler();
             var httpClient = new HttpClient(handler);
-            var ui = new UiRenderer(config, httpClient, selection, emojiManager);
+            var ui = new UiRenderer(config, httpClient, selection, emojiManager, tokenManager);
 
             var pollCts = new CancellationTokenSource();
             SetPrivateField(ui, "_networkingActive", true);

--- a/tests/UiRendererWebSocketUriTests.cs
+++ b/tests/UiRendererWebSocketUriTests.cs
@@ -18,7 +18,9 @@ public class UiRendererWebSocketUriTests
         };
         using var httpClient = new HttpClient();
         var selection = new ChannelSelectionService(config);
-        using var ui = new UiRenderer(config, httpClient, selection);
+        var tokenManager = new TokenManager();
+        var emojiManager = new EmojiManager(httpClient, tokenManager, config);
+        using var ui = new UiRenderer(config, httpClient, selection, emojiManager, tokenManager);
 
         var uri = ui.BuildWebSocketUri();
 
@@ -38,7 +40,9 @@ public class UiRendererWebSocketUriTests
         };
         using var httpClient = new HttpClient();
         var selection = new ChannelSelectionService(config);
-        using var ui = new UiRenderer(config, httpClient, selection);
+        var tokenManager = new TokenManager();
+        var emojiManager = new EmojiManager(httpClient, tokenManager, config);
+        using var ui = new UiRenderer(config, httpClient, selection, emojiManager, tokenManager);
 
         var uri = ui.BuildWebSocketUri();
 


### PR DESCRIPTION
## Summary
- remove MainWindow's private open state and persist DockVisible in OnOpen/OnClose while setting the initial IsOpen after registration
- inject the TokenManager into UI components and related services instead of relying on TokenManager.Instance, updating plugin wiring accordingly
- update caches, background services, and tests to consume the injected token manager and refresh SignupPresetService helpers

## Testing
- not run (dotnet CLI unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68e3b6a5f95c83289ba88709df5d2a79