### PR TITLE
Update tests to pass token managers to window constructors

### DIFF
--- a/tests/ColorConversionTests.cs
+++ b/tests/ColorConversionTests.cs
@@ -99,7 +99,7 @@ public class ColorConversionTests
         var channelService = new ChannelService(config, http, tokenManager);
         var selection = new ChannelSelectionService(config);
         var emojiManager = new EmojiManager(http, tokenManager, config);
-        var window = new EventCreateWindow(config, http, channelService, selection, emojiManager);
+        var window = new EventCreateWindow(config, http, channelService, selection, emojiManager, tokenManager);
         typeof(EventCreateWindow).GetField("_color", BindingFlags.NonPublic | BindingFlags.Instance)!
             .SetValue(window, ColorUtils.RgbToImGui(rgb));
         var preview = (EmbedDto)typeof(EventCreateWindow).GetMethod("BuildPreview", BindingFlags.NonPublic | BindingFlags.Instance)!

--- a/tests/ConfigDefaultsTests.cs
+++ b/tests/ConfigDefaultsTests.cs
@@ -27,7 +27,7 @@ public class ConfigDefaultsTests
     {
         SyncshellWindow.Instance?.Dispose();
         var cfg = new Config { FCSyncShell = false };
-        Assert.Throws<InvalidOperationException>(() => new SyncshellWindow(cfg, new HttpClient()));
+        Assert.Throws<InvalidOperationException>(() => new SyncshellWindow(cfg, new HttpClient(), new TokenManager()));
         Assert.Null(SyncshellWindow.Instance);
     }
 

--- a/tests/EventButtonWidthTests.cs
+++ b/tests/EventButtonWidthTests.cs
@@ -26,7 +26,7 @@ public class EventButtonWidthTests
         var channelService = new ChannelService(config, http, tokenManager);
         var selection = new ChannelSelectionService(config);
         var emojiManager = new EmojiManager(http, tokenManager, config);
-        var window = new EventCreateWindow(config, http, channelService, selection, emojiManager);
+        var window = new EventCreateWindow(config, http, channelService, selection, emojiManager, tokenManager);
         var buttonsField = typeof(EventCreateWindow).GetField("_buttons", BindingFlags.NonPublic | BindingFlags.Instance)!;
         buttonsField.SetValue(window, new List<Template.TemplateButton>
         {

--- a/tests/EventCreateWindowFormattingTests.cs
+++ b/tests/EventCreateWindowFormattingTests.cs
@@ -35,7 +35,7 @@ public class EventCreateWindowFormattingTests
         var channelService = new ChannelService(config, http, tokenManager);
         var selection = new ChannelSelectionService(config);
         var emojiManager = new EmojiManager(http, tokenManager, config);
-        return new EventCreateWindow(config, http, channelService, selection, emojiManager);
+        return new EventCreateWindow(config, http, channelService, selection, emojiManager, tokenManager);
     }
 
     private static void SetDescription(EventCreateWindow window, string text, int start, int end)

--- a/tests/MentionRoleFilteringTests.cs
+++ b/tests/MentionRoleFilteringTests.cs
@@ -36,7 +36,7 @@ public class MentionRoleFilteringTests
             var channelService = new ChannelService(config, http, tokenManager);
             var selection = new ChannelSelectionService(config);
             using var emojiManager = new EmojiManager(http, tokenManager, config);
-            var window = new EventCreateWindow(config, http, channelService, selection, emojiManager);
+            var window = new EventCreateWindow(config, http, channelService, selection, emojiManager, tokenManager);
 
             var mentionsField = typeof(EventCreateWindow).GetField("_mentions", BindingFlags.Instance | BindingFlags.NonPublic)!;
             var mentions = (HashSet<string>)mentionsField.GetValue(window)!;
@@ -86,7 +86,7 @@ public class MentionRoleFilteringTests
             var channelService = new ChannelService(config, http, tokenManager);
             var selection = new ChannelSelectionService(config);
             using var emojiManager = new EmojiManager(http, tokenManager, config);
-            var window = new TemplatesWindow(config, http, channelService, selection, emojiManager);
+            var window = new TemplatesWindow(config, http, channelService, selection, emojiManager, tokenManager);
 
             var mentionsField = typeof(TemplatesWindow).GetField("_mentions", BindingFlags.Instance | BindingFlags.NonPublic)!;
             var mentions = (HashSet<string>)mentionsField.GetValue(window)!;

--- a/tests/SyncshellStateChangeFallbackTests.cs
+++ b/tests/SyncshellStateChangeFallbackTests.cs
@@ -80,7 +80,7 @@ public class SyncshellStateChangeFallbackTests
 
             SetPluginService(services, "PluginInterface", pluginInterface.Object);
 
-            _ = new TokenManager();
+            var tokenManager = new TokenManager();
 
             var config = new Config
             {
@@ -89,7 +89,7 @@ public class SyncshellStateChangeFallbackTests
                 SyncshellManualSyncAllUsers = true,
             };
 
-            window = new SyncshellWindow(config, httpClient);
+            window = new SyncshellWindow(config, httpClient, tokenManager);
 
             Assert.NotNull(glamourerHandler);
 

--- a/tests/TemplateButtonRoundTripTests.cs
+++ b/tests/TemplateButtonRoundTripTests.cs
@@ -86,7 +86,7 @@ public class TemplateButtonRoundTripTests
         var channelService = new ChannelService(config, http, tokenManager);
         var selection = new ChannelSelectionService(config);
         var emojiManager = new EmojiManager(http, tokenManager, config);
-        var window = new TemplatesWindow(config, http, channelService, selection, emojiManager);
+        var window = new TemplatesWindow(config, http, channelService, selection, emojiManager, tokenManager);
         var field = typeof(TemplatesWindow).GetField("_buttonRows", BindingFlags.NonPublic | BindingFlags.Instance);
         field!.SetValue(window, state);
         return window;
@@ -216,7 +216,7 @@ public class TemplateButtonRoundTripTests
             var channelService = new ChannelService(config, http, tokenManager);
             var selection = new ChannelSelectionService(config);
             using var emojiManager = new EmojiManager(http, tokenManager, config);
-            var window = new TemplatesWindow(config, http, channelService, selection, emojiManager);
+            var window = new TemplatesWindow(config, http, channelService, selection, emojiManager, tokenManager);
             var template = new Template { Title = "T", Description = "D" };
 
             var templatesField = typeof(TemplatesWindow).GetField("_templates", BindingFlags.NonPublic | BindingFlags.Instance)!;

--- a/tests/TemplatesWindowPreviewTests.cs
+++ b/tests/TemplatesWindowPreviewTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using DemiCatPlugin;
+using DemiCatPlugin.Emoji;
 using Xunit;
 
 public class TemplatesWindowPreviewTests
@@ -33,9 +34,11 @@ public class TemplatesWindowPreviewTests
     {
         var config = new Config();
         var http = new HttpClient(new StubHandler());
-        var channelService = new ChannelService(config, http, new TokenManager());
+        var tokenManager = new TokenManager();
+        var channelService = new ChannelService(config, http, tokenManager);
         var selection = new ChannelSelectionService(config);
-        var window = new TemplatesWindow(config, http, channelService, selection);
+        using var emojiManager = new EmojiManager(http, tokenManager, config);
+        var window = new TemplatesWindow(config, http, channelService, selection, emojiManager, tokenManager);
 
         var firstTmpl = new Template { Name = "One", Title = "T1", Description = "D1" };
         window.SelectTemplate(0, firstTmpl);


### PR DESCRIPTION
## Summary
- update templates window tests to supply the new TokenManager dependency
- adjust event creation tests for the updated constructor signature
- pass a TokenManager to SyncshellWindow in unit tests to match the new API

## Testing
- dotnet test *(fails: dotnet is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e451c9fde8832887e13eb1f6b35e23