### PR TITLE
Hide DemiCat host window

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -140,8 +140,11 @@ public class MainWindow : Window, IDisposable
         _syncshell = _syncshellEnabled ? new SyncshellWindow(config, httpClient, tokenManager) : null;
         RespectCloseHotkey = false;
         Flags = ImGuiWindowFlags.NoDecoration
+            | ImGuiWindowFlags.NoInputs
+            | ImGuiWindowFlags.NoBackground
             | ImGuiWindowFlags.NoSavedSettings
-            | ImGuiWindowFlags.NoFocusOnAppearing;
+            | ImGuiWindowFlags.NoFocusOnAppearing
+            | ImGuiWindowFlags.NoBringToFrontOnFocus;
 
         _eventsWindowHost = new EventsDockableWindow(config, ui, IsLinked);
         _eventCreateWindowHost = new EventCreateDockableWindow(config, _create, IsLinked);


### PR DESCRIPTION
## Summary
- make the MainWindow host invisible and non-interactive to prevent the extra DemiCat Host window from appearing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4576cd268832899ea37b12e7fedae