### PR TITLE
Initialize plugin services in constructor

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -45,7 +45,7 @@ public class Plugin : IDalamudPlugin
     private const string MewCommandHelpMessage = "Open the DemiCat main window.";
 
     private PluginServices? _services;
-    private PluginServices Services => _services ?? PluginServices.Instance
+    private PluginServices Services => _services
         ?? throw new InvalidOperationException("Plugin services are not initialized.");
     private UiRenderer _ui = null!;
     private AvatarCache _avatarCache = null!;
@@ -87,6 +87,11 @@ public class Plugin : IDalamudPlugin
         _uiBuilder = pluginInterface.UiBuilder ?? throw new ArgumentNullException(nameof(pluginInterface.UiBuilder));
         _log = pluginInterface.Create<IPluginLog>() ?? throw new InvalidOperationException("Failed to acquire plugin log.");
 
+        _services = pluginInterface.Create<PluginServices>()
+            ?? throw new InvalidOperationException("Failed to initialize plugin services.");
+        if (_services.PluginInterface == null || _services.Log == null)
+            throw new InvalidOperationException("Failed to initialize plugin services.");
+
         _config = pluginInterface.GetPluginConfig() as Config ?? new Config();
         _tokenManager = new TokenManager(pluginInterface);
 
@@ -123,7 +128,7 @@ public class Plugin : IDalamudPlugin
 
         try
         {
-            _services = pluginInterface.Create<PluginServices>()
+            _services ??= pluginInterface.Create<PluginServices>()
                 ?? throw new InvalidOperationException("Failed to initialize plugin services.");
             if (Services.PluginInterface == null || Services.Log == null)
                 throw new InvalidOperationException("Failed to initialize plugin services.");


### PR DESCRIPTION
## Summary
- create the PluginServices instance via Dalamud's service factory when the plugin is constructed
- require PluginServices to be set directly on the plugin instead of falling back to the static Instance accessor

## Testing
- not run (environment does not provide dotnet)


------
https://chatgpt.com/codex/tasks/task_e_68e470cab08c8328a94baa27527012fb