### PR TITLE
Refine watcher coordination and presence handling

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -656,10 +656,8 @@ public class ChatWindow : IDisposable
     public virtual void StartNetworking()
     {
         MarkNetworkingStarted();
-        _presence?.SetPresenceReady(true);
         _bridge.Start();
         TrySubscribeCurrentChannel(force: true);
-        _presence?.Reset();
     }
 
     public void StopNetworking()
@@ -667,8 +665,6 @@ public class ChatWindow : IDisposable
         _bridge.Stop();
         MarkNetworkingStopped();
         OnSubscriptionStateChanged(false);
-        _presence?.Stop();
-        _presence?.SetPresenceReady(false);
         _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
     }
 

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -25,6 +25,7 @@ public class OfficerChatWindow : ChatWindow
     private bool _subscribed;
     private readonly PresenceSidebar? _presenceSidebar;
     private float _presenceWidth = 200f;
+    private CancellationTokenSource? _cts;
 
     protected override bool MentionsEnabled => true;
 
@@ -82,13 +83,19 @@ public class OfficerChatWindow : ChatWindow
     }
 #endif
 
-    public override void StartNetworking()
+    public bool IsRunning => _cts is { IsCancellationRequested: false };
+
+    public Task StartNetworkingAsync()
     {
+        if (IsRunning)
+        {
+            return Task.CompletedTask;
+        }
+
         if (!OfficerPermissions.HasAccess(_config))
         {
             MarkNetworkingStopped();
             _bridge.Stop();
-            _presence?.SetPresenceReady(false);
 
             var message = NoOfficerAccessMessage;
             var services = PluginServices.Instance;
@@ -112,16 +119,31 @@ public class OfficerChatWindow : ChatWindow
             }
 
             _subscribed = false;
-            return;
+            return Task.CompletedTask;
         }
 
+        _cts = new CancellationTokenSource();
         MarkNetworkingStarted();
-        _presence?.SetPresenceReady(true);
         _bridge.Start();
         Subscribe();
         TryRefreshRoles();
-        _presence?.Reset();
+        return Task.CompletedTask;
     }
+
+    public override void StartNetworking()
+        => StartNetworkingAsync().GetAwaiter().GetResult();
+
+    public Task StopNetworkingAsync()
+    {
+        var cts = Interlocked.Exchange(ref _cts, null);
+        cts?.Cancel();
+        cts?.Dispose();
+        base.StopNetworking();
+        return Task.CompletedTask;
+    }
+
+    public new void StopNetworking()
+        => StopNetworkingAsync().GetAwaiter().GetResult();
 
     public override void Draw()
     {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -65,10 +65,9 @@ public class Plugin : IDalamudPlugin
         ?? throw new InvalidOperationException("HTTP client has not been initialized.");
     private ChannelService _channelService = null!;
     private Action? _openMainUi;
-    private bool _officerWatcherRunning;
     private bool _invalidTokenToastShown;
     private bool? _savedDockVisibilityPreference;
-    private readonly SemaphoreSlim _watcherRestartLock = new(1, 1);
+    private readonly SemaphoreSlim _watchLock = new(1, 1);
     private IEmojiFontHandle? _emojiFontHandle;
     private CommandInfo _mewCommandInfo = null!;
 
@@ -91,6 +90,7 @@ public class Plugin : IDalamudPlugin
         _tokenManager = new TokenManager(pluginInterface);
 
         _settings = new SettingsWindow(pluginInterface, _config, _tokenManager, _log);
+        _settings.Plugin = this;
         _windows.AddWindow(_settings);
 
         _uiBuilder.Draw += OnDraw;
@@ -140,13 +140,8 @@ public class Plugin : IDalamudPlugin
 
             RequestStateService.Load(_config);
 
-            var handler = new SocketsHttpHandler
-            {
-                MaxConnectionsPerServer = 10,
-                PooledConnectionLifetime = TimeSpan.FromMinutes(5),
-                AutomaticDecompression = DecompressionMethods.All
-            };
-            _httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
+            _httpClient = pluginInterface.CreateHttpClient();
+            _httpClient.Timeout = TimeSpan.FromSeconds(10);
 
             WebTextureCache.FetchOverride = FetchWebTexture;
 
@@ -486,6 +481,28 @@ public class Plugin : IDalamudPlugin
         return Task.CompletedTask;
     }
 
+    private Task SetPresenceAsync(bool enabled)
+    {
+        return RunOnFrameworkAsync(() =>
+        {
+            if (_presenceService == null)
+            {
+                return;
+            }
+
+            if (!enabled)
+            {
+                _presenceService.SetPresenceReady(false);
+                _presenceService.Stop();
+                return;
+            }
+
+            _presenceService.Reload();
+            _presenceService.Reset();
+            _presenceService.SetPresenceReady(true);
+        });
+    }
+
     private IEmojiFontHandle? InitializeEmojiFont()
     {
         try
@@ -669,7 +686,7 @@ public class Plugin : IDalamudPlugin
             return buildMethod?.Invoke(builder, Array.Empty<object>());
         }
 
-        object? CreateFontConfig(object baseFont, object glyphRanges)
+        object? CreateFontConfig(object? baseFont, object glyphRanges)
         {
             var config = Activator.CreateInstance(safeFontConfigType);
             if (config == null)
@@ -678,7 +695,10 @@ public class Plugin : IDalamudPlugin
             }
 
             safeFontConfigType.GetProperty("SizePx")?.SetValue(config, fontSize);
-            safeFontConfigType.GetProperty("MergeFont")?.SetValue(config, baseFont);
+            if (baseFont != null)
+            {
+                safeFontConfigType.GetProperty("MergeFont")?.SetValue(config, baseFont);
+            }
             safeFontConfigType.GetProperty("PixelSnapH")?.SetValue(config, true);
             safeFontConfigType.GetProperty("GlyphRanges")?.SetValue(config, glyphRanges);
 
@@ -700,6 +720,37 @@ public class Plugin : IDalamudPlugin
 
         try
         {
+            var atlasType = atlas.GetType();
+            var addFontMethod = atlasType.GetMethod("AddFontFromFile", new[] { typeof(string), safeFontConfigType });
+            if (addFontMethod != null)
+            {
+                object? baseFont = null;
+                try
+                {
+                    baseFont = atlasType.GetProperty("DefaultFont")?.GetValue(atlas);
+                    var sizeProperty = baseFont?.GetType().GetProperty("SizePx");
+                    sizeProperty?.SetValue(baseFont, fontSize);
+                }
+                catch
+                {
+                    baseFont = null;
+                }
+
+                var glyphRanges = CreateGlyphRanges();
+                if (glyphRanges != null)
+                {
+                    var config = CreateFontConfig(baseFont, glyphRanges);
+                    if (config != null)
+                    {
+                        var handle = addFontMethod.Invoke(atlas, new[] { fontPath, config });
+                        if (handle != null)
+                        {
+                            return handle;
+                        }
+                    }
+                }
+            }
+
             return dynamicAtlas.NewDelegateFontHandle((Action<dynamic>)(toolkit =>
             {
                 toolkit.OnPreBuild((Action<dynamic>)(pre =>
@@ -919,19 +970,27 @@ public class Plugin : IDalamudPlugin
         }
     }
 
-    private async Task RestartWatchersAsync()
+    internal Task WithWatchLock(Func<Task> action) => WithWatchLockAsync(action);
+
+    private async Task WithWatchLockAsync(Func<Task> action)
     {
-        await _watcherRestartLock.WaitAsync().ConfigureAwait(false);
+        await _watchLock.WaitAsync().ConfigureAwait(false);
         try
         {
-            StopWatchers();
-            await StartWatchersAsync().ConfigureAwait(false);
+            await action().ConfigureAwait(false);
         }
         finally
         {
-            _watcherRestartLock.Release();
+            _watchLock.Release();
         }
     }
+
+    internal Task RestartWatchersAsync() =>
+        WithWatchLock(async () =>
+        {
+            await StopWatchersAsync().ConfigureAwait(false);
+            await StartWatchersAsync().ConfigureAwait(false);
+        });
 
     private void StartWatchers()
     {
@@ -954,9 +1013,9 @@ public class Plugin : IDalamudPlugin
 
     private void HandleTokenUnlinked(string? reason)
     {
-        void Execute()
+        async Task ExecuteAsync()
         {
-            StopWatchers();
+            await WithWatchLock(StopWatchersAsync).ConfigureAwait(false);
             _mainWindow.SetNotePadReadOnly(true);
 
             var savedDockVisibility = _config.DockVisible;
@@ -990,7 +1049,7 @@ public class Plugin : IDalamudPlugin
         {
             try
             {
-                framework.RunOnTick(Execute);
+                framework.RunOnTick(ExecuteAsync);
                 return;
             }
             catch (Exception ex)
@@ -1000,10 +1059,10 @@ public class Plugin : IDalamudPlugin
             }
         }
 
-        Execute();
+        ExecuteAsync().GetAwaiter().GetResult();
     }
 
-    private async Task StartWatchersAsync()
+    internal async Task StartWatchersAsync()
     {
         if (!_tokenManager.IsReady() || !ApiHelpers.ValidateApiBaseUrl(_config))
             return;
@@ -1012,7 +1071,7 @@ public class Plugin : IDalamudPlugin
         HttpResponseMessage? response = null;
         try
         {
-            response = await pingService.PingAsync(CancellationToken.None);
+            response = await pingService.PingAsync(CancellationToken.None).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -1021,6 +1080,7 @@ public class Plugin : IDalamudPlugin
 
         if (response == null)
         {
+            await SetPresenceAsync(false).ConfigureAwait(false);
             HandleWatcherStartupFailure(string.Empty);
             return;
         }
@@ -1029,12 +1089,14 @@ public class Plugin : IDalamudPlugin
         {
             Services.Log.Warning($"Ping returned {(int)response.StatusCode} {response.StatusCode}; clearing token");
             _tokenManager.Clear("Invalid API key");
+            await SetPresenceAsync(false).ConfigureAwait(false);
             return;
         }
 
         if (!response.IsSuccessStatusCode)
         {
             var statusText = $" ({(int)response.StatusCode} {response.StatusCode})";
+            await SetPresenceAsync(false).ConfigureAwait(false);
             HandleWatcherStartupFailure(statusText);
             return;
         }
@@ -1049,7 +1111,7 @@ public class Plugin : IDalamudPlugin
         if (_config.Events || _config.SyncedChat || hasOfficerAccess)
         {
             Services.Log.Info("Starting channel watcher");
-            _ = _channelWatcher.Start();
+            await _channelWatcher.Start().ConfigureAwait(false);
         }
 
         if (_config.NotePadEnabled)
@@ -1058,33 +1120,37 @@ public class Plugin : IDalamudPlugin
             _notePadService.Start();
         }
 
-        if (_config.SyncedChat && _config.EnableFcChat)
+        var enableFcChat = _config.SyncedChat && _config.EnableFcChat;
+        if (enableFcChat)
         {
             Services.Log.Info("Starting chat window networking");
             _chatWindow.StartNetworking();
         }
+        else
+        {
+            _chatWindow.StopNetworking();
+        }
 
         if (hasOfficerAccess)
         {
-            if (!_officerWatcherRunning)
-            {
-                Services.Log.Info("Starting officer chat window networking");
-                _officerChatWindow.StartNetworking();
-                _officerWatcherRunning = true;
-            }
+            Services.Log.Info("Starting officer chat window networking");
+            await _officerChatWindow.StartNetworkingAsync().ConfigureAwait(false);
         }
         else
         {
-            _officerWatcherRunning = false;
+            await _officerChatWindow.StopNetworkingAsync().ConfigureAwait(false);
         }
 
         if (_config.Events)
         {
             Services.Log.Info("Starting event watchers");
-            _ = _ui.StartNetworking();
+            await _ui.StartNetworking().ConfigureAwait(false);
             _mainWindow.EventCreateWindow.StartNetworking();
             _mainWindow.TemplatesWindow.StartNetworking();
         }
+
+        var shouldEnablePresence = enableFcChat || hasOfficerAccess;
+        await SetPresenceAsync(shouldEnablePresence).ConfigureAwait(false);
 
         Services.Log.Info("Watchers started");
     }
@@ -1164,20 +1230,26 @@ public class Plugin : IDalamudPlugin
         PluginServices.Instance?.ToastGui.ShowError(message);
     }
 
-    private void StopWatchers()
+    internal async Task StopWatchersAsync()
     {
+        if (!_initialized)
+        {
+            return;
+        }
+
         Services.Log.Info("Stopping watchers");
+
+        await SetPresenceAsync(false).ConfigureAwait(false);
+
         _requestWatcher.Stop();
         _channelWatcher.Stop();
         _notePadService.Stop();
         _chatWindow.StopNetworking();
-        _officerChatWindow.StopNetworking();
-        _officerWatcherRunning = false;
-        _presenceService?.SetPresenceReady(false);
-        _presenceService?.Stop();
+        await _officerChatWindow.StopNetworkingAsync().ConfigureAwait(false);
         _ui.StopNetworking();
         _mainWindow.TemplatesWindow.StopNetworking();
         MembershipCache.Reset();
+
         Services.Log.Info("Watchers stopped");
     }
 
@@ -1276,7 +1348,7 @@ public class Plugin : IDalamudPlugin
 
             _ = Services.Framework.RunOnTick(() =>
             {
-                var officerWatcherWasRunning = _officerWatcherRunning;
+                var officerWatcherWasRunning = _officerChatWindow.IsRunning;
                 var channelWatcherWasRunning = _channelWatcher.IsRunning;
                 var requestWatcherWasRunning = _requestWatcher.IsRunning;
                 var chatWasActive = _config.SyncedChat && _config.EnableFcChat;
@@ -1328,60 +1400,62 @@ public class Plugin : IDalamudPlugin
 
                 _ = Task.Run(async () =>
                 {
-                    await _watcherRestartLock.WaitAsync().ConfigureAwait(false);
                     try
                     {
-                        if (stopRequestWatcher)
+                        await WithWatchLock(async () =>
                         {
-                            Services.Log.Info("Stopping request watcher");
-                            _requestWatcher.Stop();
-                        }
+                            if (stopRequestWatcher)
+                            {
+                                Services.Log.Info("Stopping request watcher");
+                                _requestWatcher.Stop();
+                            }
 
-                        if (stopChannelWatcher)
-                        {
-                            Services.Log.Info("Stopping channel watcher");
-                            _channelWatcher.Stop();
-                        }
+                            if (stopChannelWatcher)
+                            {
+                                Services.Log.Info("Stopping channel watcher");
+                                _channelWatcher.Stop();
+                            }
 
-                        if (stopOfficer)
-                        {
-                            Services.Log.Info("Stopping officer chat window networking");
-                            _officerChatWindow.StopNetworking();
-                            _officerWatcherRunning = false;
-                        }
+                            if (stopOfficer)
+                            {
+                                Services.Log.Info("Stopping officer chat window networking");
+                                await _officerChatWindow.StopNetworkingAsync().ConfigureAwait(false);
+                            }
 
-                        if (stopChat)
-                        {
-                            Services.Log.Info("Stopping chat window networking");
-                            _chatWindow.StopNetworking();
-                            _presenceService?.SetPresenceReady(false);
-                            _presenceService?.Stop();
-                        }
+                            if (stopChat)
+                            {
+                                Services.Log.Info("Stopping chat window networking");
+                                _chatWindow.StopNetworking();
+                            }
 
-                        if (startChannelWatcher)
-                        {
-                            Services.Log.Info("Starting channel watcher");
-                            await _channelWatcher.Start().ConfigureAwait(false);
-                        }
+                            if (startChannelWatcher)
+                            {
+                                Services.Log.Info("Starting channel watcher");
+                                await _channelWatcher.Start().ConfigureAwait(false);
+                            }
 
-                        if (startRequestWatcher)
-                        {
-                            Services.Log.Info("Starting request watcher");
-                            _requestWatcher.Start();
-                        }
+                            if (startRequestWatcher)
+                            {
+                                Services.Log.Info("Starting request watcher");
+                                _requestWatcher.Start();
+                            }
 
-                        if (startChat)
-                        {
-                            Services.Log.Info("Starting chat window networking");
-                            _chatWindow.StartNetworking();
-                        }
+                            if (startChat)
+                            {
+                                Services.Log.Info("Starting chat window networking");
+                                _chatWindow.StartNetworking();
+                            }
 
-                        if (startOfficer)
-                        {
-                            Services.Log.Info("Starting officer chat window networking");
-                            _officerChatWindow.StartNetworking();
-                            _officerWatcherRunning = true;
-                        }
+                            if (startOfficer)
+                            {
+                                Services.Log.Info("Starting officer chat window networking");
+                                await _officerChatWindow.StartNetworkingAsync().ConfigureAwait(false);
+                            }
+
+                            var presenceEnabled = (_config.SyncedChat && _config.EnableFcChat)
+                                || OfficerPermissions.HasAccess(_config);
+                            await SetPresenceAsync(presenceEnabled).ConfigureAwait(false);
+                        }).ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
@@ -1389,7 +1463,6 @@ public class Plugin : IDalamudPlugin
                     }
                     finally
                     {
-                        _watcherRestartLock.Release();
                         _ = Services.Framework.RunOnTick(() =>
                         {
                             _mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -57,6 +57,7 @@ public class SettingsWindow : Window, IDisposable
     public RequestWatcher? RequestWatcher { get; set; }
     public NotePadService? NotePadService { get; set; }
     public DeveloperWindow? DeveloperWindow => _devWindow;
+    internal Plugin? Plugin { get; set; }
 
     public SettingsWindow(IDalamudPluginInterface pluginInterface, Config config, TokenManager tokenManager, IPluginLog log)
         : base("DemiCat Settings")
@@ -1030,6 +1031,12 @@ public class SettingsWindow : Window, IDisposable
 
     private void StopAllWatchersAndPresence()
     {
+        if (Plugin != null)
+        {
+            _ = Plugin.WithWatchLock(Plugin.StopWatchersAsync);
+            return;
+        }
+
         void SafeInvoke(Action action, string context)
         {
             try
@@ -1182,9 +1189,6 @@ public class SettingsWindow : Window, IDisposable
     private async Task HardReloadIdentityAndStartInternalAsync()
     {
         var framework = PluginServices.Instance?.Framework;
-        var presence = ChatWindow?.Presence ?? OfficerChatWindow?.Presence;
-        var presenceRestarted = false;
-
         void UpdateStatus(string status)
         {
             if (framework == null)
@@ -1204,249 +1208,162 @@ public class SettingsWindow : Window, IDisposable
             }
         }
 
-        presence?.SetPresenceReady(false);
-
         try
         {
-            try
-            {
-                MainWindow?.ReloadSignupPresets();
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to reload signup presets during hard reload.");
-            }
-
-            if (_httpClient == null)
+            var plugin = Plugin;
+            if (plugin == null)
             {
                 UpdateStatus("Service not ready");
                 return;
             }
 
-            HttpResponseMessage? pingResponse = null;
-            try
+            await plugin.WithWatchLock(async () =>
             {
-                var pingService = PingService.Instance ?? new PingService(_httpClient, _config, _tokenManager);
-                pingResponse = await pingService.PingAsync(CancellationToken.None);
-            }
-            catch (Exception ex)
-            {
-                _log.Warning(ex, "Failed to ping DemiCat backend during hard reload.");
-            }
+                await plugin.StopWatchersAsync().ConfigureAwait(false);
 
-            if (pingResponse == null)
-            {
-                UpdateStatus("Network error");
-                return;
-            }
-
-            if (pingResponse.StatusCode == HttpStatusCode.Unauthorized || pingResponse.StatusCode == HttpStatusCode.Forbidden)
-            {
-                _tokenManager.Clear("Invalid API key");
-                UpdateStatus("Authentication failed");
-                return;
-            }
-
-            if (!pingResponse.IsSuccessStatusCode)
-            {
-                UpdateStatus("Network error");
-                return;
-            }
-
-            await UpdateIdentityAsync(framework);
-
-            if (_refreshRoles != null)
-            {
                 try
                 {
-                    var rolesRefreshed = await _refreshRoles();
-                    if (!rolesRefreshed)
-                    {
-                        _log.Warning("Role refresh after key validation reported failure.");
-                    }
+                    MainWindow?.ReloadSignupPresets();
                 }
                 catch (Exception ex)
                 {
-                    _log.Error(ex, "Failed to refresh roles during hard reload.");
+                    _log.Error(ex, "Failed to reload signup presets during hard reload.");
                 }
-            }
-            else
-            {
-                _log.Warning("RefreshRoles delegate is not set; roles will not be refreshed.");
-            }
 
-            if (_startNetworking != null)
-            {
+                if (_httpClient == null)
+                {
+                    UpdateStatus("Service not ready");
+                    return;
+                }
+
+                HttpResponseMessage? pingResponse = null;
                 try
                 {
-                    await _startNetworking();
+                    var pingService = PingService.Instance ?? new PingService(_httpClient, _config, _tokenManager);
+                    pingResponse = await pingService.PingAsync(CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
-                    _log.Error(ex, "Failed to start UI networking during hard reload.");
+                    _log.Warning(ex, "Failed to ping DemiCat backend during hard reload.");
                 }
-            }
-            else
-            {
-                _log.Warning("StartNetworking delegate is not set; skipping UI renderer start.");
-            }
 
-            try
-            {
-                if (_config.Events)
+                if (pingResponse == null)
                 {
-                    MainWindow?.EventCreateWindow.StartNetworking();
-                    MainWindow?.TemplatesWindow.StartNetworking();
+                    UpdateStatus("Network error");
+                    return;
                 }
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to start event or template networking during hard reload.");
-            }
 
-            try
-            {
-                if (ChannelWatcher != null)
+                if (pingResponse.StatusCode == HttpStatusCode.Unauthorized || pingResponse.StatusCode == HttpStatusCode.Forbidden)
                 {
-                    await ChannelWatcher.Start();
+                    _tokenManager.Clear("Invalid API key");
+                    UpdateStatus("Authentication failed");
+                    return;
                 }
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to start ChannelWatcher during hard reload.");
-            }
 
-            try
-            {
-                RequestWatcher?.Start();
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to start RequestWatcher during hard reload.");
-            }
-
-            try
-            {
-                if (_config.NotePadEnabled)
+                if (!pingResponse.IsSuccessStatusCode)
                 {
-                    NotePadService?.Start();
+                    UpdateStatus("Network error");
+                    return;
                 }
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to start NotePad service during hard reload.");
-            }
 
-            try
-            {
-                if (_config.EnableFcChat)
-                {
-                    ChatWindow?.StartNetworking();
-                }
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to start ChatWindow networking during hard reload.");
-            }
+                await UpdateIdentityAsync(framework).ConfigureAwait(false);
 
-            try
-            {
-                if (OfficerPermissions.HasAccess(_config))
-                {
-                    OfficerChatWindow?.StartNetworking();
-                }
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to start OfficerChatWindow networking during hard reload.");
-            }
-
-            try
-            {
-                if (_config.EnableFcChat)
-                {
-                    _ = ChatWindow?.RefreshChannels();
-                }
-                if (OfficerPermissions.HasAccess(_config))
-                {
-                    _ = OfficerChatWindow?.RefreshChannels();
-                }
-                _ = MainWindow?.EventCreateWindow.RefreshChannels();
-                _ = MainWindow?.TemplatesWindow.RefreshChannels();
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to refresh channels during hard reload.");
-            }
-
-            try
-            {
-                if (_config.EnableFcChat)
-                {
-                    _ = ChatWindow?.RequestRefreshMessagesAsync();
-                }
-                if (OfficerPermissions.HasAccess(_config))
-                {
-                    _ = OfficerChatWindow?.RequestRefreshMessagesAsync();
-                }
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to refresh messages during hard reload.");
-            }
-
-            try
-            {
-                MainWindow?.Ui.ResetChannels();
-                MainWindow?.ResetEventCreateRoles();
-                MainWindow?.TemplatesWindow.ResetRoles();
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to reset UI or roles during hard reload.");
-            }
-
-            try
-            {
-                presence?.Reset();
-                presence?.Reload();
-                presenceRestarted = presence != null;
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, "Failed to reset or reload presence during hard reload.");
-            }
-
-            bool shouldOpenWindow;
-            lock (_hardReloadLock)
-            {
-                shouldOpenWindow = _requestMainWindowOpen;
-                _requestMainWindowOpen = false;
-            }
-
-            if (shouldOpenWindow && MainWindow != null)
-            {
-                if (framework != null)
+                if (_refreshRoles != null)
                 {
                     try
                     {
-                        _ = framework.RunOnTick(() => MainWindow.IsOpen = true);
+                        var rolesRefreshed = await _refreshRoles().ConfigureAwait(false);
+                        if (!rolesRefreshed)
+                        {
+                            _log.Warning("Role refresh after key validation reported failure.");
+                        }
                     }
                     catch (Exception ex)
                     {
-                        _log.Warning(ex, "Failed to open main window on framework thread during hard reload.");
-                        MainWindow.IsOpen = true;
+                        _log.Error(ex, "Failed to refresh roles during hard reload.");
                     }
                 }
                 else
                 {
-                    MainWindow.IsOpen = true;
+                    _log.Warning("RefreshRoles delegate is not set; roles will not be refreshed.");
                 }
-            }
+
+                try
+                {
+                    await plugin.StartWatchersAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _log.Error(ex, "Failed to start watchers during hard reload.");
+                    UpdateStatus("Failed to start watchers");
+                    return;
+                }
+
+                try
+                {
+                    if (_config.EnableFcChat)
+                    {
+                        _ = ChatWindow?.RefreshChannels();
+                        _ = ChatWindow?.RequestRefreshMessagesAsync();
+                    }
+
+                    if (OfficerPermissions.HasAccess(_config))
+                    {
+                        _ = OfficerChatWindow?.RefreshChannels();
+                        _ = OfficerChatWindow?.RequestRefreshMessagesAsync();
+                    }
+
+                    _ = MainWindow?.EventCreateWindow.RefreshChannels();
+                    _ = MainWindow?.TemplatesWindow.RefreshChannels();
+                }
+                catch (Exception ex)
+                {
+                    _log.Error(ex, "Failed to refresh channels during hard reload.");
+                }
+
+                try
+                {
+                    MainWindow?.Ui.ResetChannels();
+                    MainWindow?.ResetEventCreateRoles();
+                    MainWindow?.TemplatesWindow.ResetRoles();
+                }
+                catch (Exception ex)
+                {
+                    _log.Error(ex, "Failed to reset UI or roles during hard reload.");
+                }
+
+                bool shouldOpenWindow;
+                lock (_hardReloadLock)
+                {
+                    shouldOpenWindow = _requestMainWindowOpen;
+                    _requestMainWindowOpen = false;
+                }
+
+                if (shouldOpenWindow && MainWindow != null)
+                {
+                    if (framework != null)
+                    {
+                        try
+                        {
+                            await framework.RunOnTick(() => MainWindow.IsOpen = true).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            _log.Warning(ex, "Failed to open main window on framework thread during hard reload.");
+                            MainWindow.IsOpen = true;
+                        }
+                    }
+                    else
+                    {
+                        MainWindow.IsOpen = true;
+                    }
+                }
+
+                UpdateStatus(string.Empty);
+            }).ConfigureAwait(false);
         }
         finally
         {
-            presence?.SetPresenceReady(presenceRestarted);
             lock (_hardReloadLock)
             {
                 _hardReloadTask = null;

--- a/docs/plugin-runtime-audit.md
+++ b/docs/plugin-runtime-audit.md
@@ -1,0 +1,23 @@
+# Plugin runtime audit
+
+## Potential runtime conflicts
+
+### Hard reload vs watcher restarts
+- `Plugin.WithWatchLock` now provides a single coordination point for every watcher restart, and `SettingsWindow.HardReloadIdentityAndStartInternalAsync` executes entirely within that scope so hard reloads and guild updates no longer race each other.【F:DemiCatPlugin/Plugin.cs†L914-L930】【F:DemiCatPlugin/SettingsWindow.cs†L1210-L1333】
+- Follow-up: continue to audit individual watcher implementations to ensure they respect cancellation tokens while the lock is held so long-running network calls cannot stall unrelated restarts.
+
+### Officer chat networking state
+- Officer networking state is tracked inside `OfficerChatWindow` through an internal cancellation token so the plugin no longer maintains a duplicate `_officerWatcherRunning` flag. All officer start/stop calls now flow through the shared watch coordinator.【F:DemiCatPlugin/OfficerChatWindow.cs†L37-L91】【F:DemiCatPlugin/Plugin.cs†L1087-L1135】
+
+### Presence lifecycle
+- Presence readiness toggles have been centralized into `Plugin.SetPresenceAsync`, which marshals the updates onto the framework thread and is only invoked from within watch-locked flows.【F:DemiCatPlugin/Plugin.cs†L468-L487】【F:DemiCatPlugin/SettingsWindow.cs†L1210-L1333】
+- Individual windows no longer call `SetPresenceReady` during their start/stop routines, reducing the risk of out-of-order updates when multiple restart paths overlap.【F:DemiCatPlugin/ChatWindow.cs†L658-L676】【F:DemiCatPlugin/OfficerChatWindow.cs†L41-L91】
+
+## Alignment with Dalamud platform APIs
+- `Plugin.Initialize` now calls `IDalamudPluginInterface.CreateHttpClient()`, so proxy, retry, and telemetry behavior stay aligned with Dalamud without custom handler maintenance.【F:DemiCatPlugin/Plugin.cs†L115-L162】
+- Emoji font initialization first attempts to use the modern `AddFontFromFile` API exposed by the managed atlas facade and gracefully falls back to the legacy reflection pipeline when the interface is unavailable.【F:DemiCatPlugin/Plugin.cs†L520-L613】
+
+## Tooling to stay on .NET 9.0.3 and Dalamud 13
+- `global.json` already pins the .NET SDK to `9.0.300`, matching Dalamud 9.0.3 expectations.【F:global.json†L1-L6】
+- Added `scripts/verify-sdk.sh` to surface the active SDK, ensure `9.0.300` is installed, and perform a scoped restore for the plugin project. Running this script after SDK updates catches drift early.
+- Future improvements could add CI automation that runs `dotnet format` and the Dalamud packager in `--dry-run` mode to confirm compatibility before distributing builds.

--- a/scripts/verify-sdk.sh
+++ b/scripts/verify-sdk.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "dotnet CLI is not available" >&2
+  exit 1
+fi
+
+echo "Active dotnet SDKs:" >&2
+dotnet --list-sdks >&2
+
+if ! dotnet --list-sdks | grep -q "9\.0\.300"; then
+  echo "Required SDK 9.0.300 is missing" >&2
+  exit 1
+fi
+
+echo "Restoring DemiCatPlugin with SDK $(dotnet --version)" >&2
+dotnet restore DemiCatPlugin/DemiCatPlugin.csproj >/dev/null
+
+echo "SDK verification succeeded" >&2

--- a/tests/PresenceServiceLifecycleTests.cs
+++ b/tests/PresenceServiceLifecycleTests.cs
@@ -61,7 +61,7 @@ public class PresenceServiceLifecycleTests : IDisposable
     }
 
     [Fact]
-    public void ChatWindow_StartAndStopTogglePresenceReady()
+    public void ChatWindow_StartAndStopDoNotTogglePresenceReady()
     {
         var config = new Config { ApiBaseUrl = "https://example.invalid" };
         using var httpClient = new HttpClient(new StubPresenceHandler());
@@ -71,14 +71,15 @@ public class PresenceServiceLifecycleTests : IDisposable
 
         PingService.Instance = new PingService(httpClient, config, tokenManager);
 
-        presence.SetPresenceReady(false);
         var window = new ChatWindow(config, httpClient, presence, tokenManager, channelService);
 
+        presence.SetPresenceReady(false);
         window.StartNetworking();
-        Assert.True(presence.IsPresenceReady);
-
-        window.StopNetworking();
         Assert.False(presence.IsPresenceReady);
+
+        presence.SetPresenceReady(true);
+        window.StopNetworking();
+        Assert.True(presence.IsPresenceReady);
     }
 
     public void Dispose()

--- a/tests/RefreshRolesTests.cs
+++ b/tests/RefreshRolesTests.cs
@@ -79,8 +79,6 @@ public class RefreshRolesTests
         SetPrivateField(plugin, "_channelWatcher", channelWatcher);
         SetPrivateField(plugin, "_requestWatcher", requestWatcher);
         SetPrivateField(plugin, "_mainWindow", mainWindow);
-        SetPrivateField(plugin, "_watcherRestartLock", new SemaphoreSlim(1, 1));
-        SetPrivateField(plugin, "_officerWatcherRunning", false);
         SetPrivateField(plugin, "_presenceService", null);
 
         try


### PR DESCRIPTION
## Summary
- coordinate watcher start and stop flows through `Plugin.WithWatchLock` and drive presence updates via the new `SetPresenceAsync` helper used by hard reload, token unlink, and role refresh paths
- move officer networking state into `OfficerChatWindow` with async start/stop helpers, switch to Dalamud's `CreateHttpClient`, and add a managed-atlas fast path when loading the emoji font
- refresh the runtime audit and tests to document the new coordination model and the centralized presence lifecycle

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e505f2e17083289f124edbfcb5295d