### PR TITLE
Defer token loading to plugin initialization

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -151,6 +151,9 @@ public class Plugin : IDalamudPlugin
             if (Services.PluginInterface == null || Services.Log == null)
                 throw new InvalidOperationException("Failed to initialize plugin services.");
 
+            _tokenManager.Load();
+            _settings.SynchronizeTokenState();
+
             var oldVersion = _config.Version;
             var originalApiBaseUrl = _config.ApiBaseUrl;
             _config.Migrate();

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -59,18 +59,23 @@ public class SettingsWindow : Window, IDisposable
     public DeveloperWindow? DeveloperWindow => _devWindow;
     internal Plugin? Plugin { get; set; }
 
+    internal void SynchronizeTokenState()
+    {
+        _apiKey = _tokenManager.Token ?? string.Empty;
+        _isLinked = _tokenManager.State == LinkState.Linked;
+    }
+
     public SettingsWindow(IDalamudPluginInterface pluginInterface, Config config, TokenManager tokenManager, IPluginLog log)
         : base("DemiCat Settings")
     {
         _pluginInterface = pluginInterface;
         _config = config;
         _tokenManager = tokenManager;
-        _apiKey = tokenManager.Token ?? string.Empty;
+        SynchronizeTokenState();
         _penumbraModsDirectory = config.PenumbraModsDirectory ?? string.Empty;
         _penumbraConfigDirectory = config.PenumbraConfigDirectory ?? string.Empty;
         _penumbraCollectionOverride = config.PenumbraCollectionOverride ?? string.Empty;
         _log = log;
-        _isLinked = _tokenManager.State == LinkState.Linked;
         _tokenManager.OnLinked += OnLinked;
         _tokenManager.OnUnlinked += OnUnlinked;
 
@@ -104,7 +109,7 @@ public class SettingsWindow : Window, IDisposable
     {
         base.OnOpen();
 
-        _isLinked = _tokenManager.State == LinkState.Linked;
+        SynchronizeTokenState();
 
         if (!_settingsLoaded)
         {
@@ -830,11 +835,14 @@ public class SettingsWindow : Window, IDisposable
         }
     }
 
-    private void OnLinked() => _isLinked = true;
+    private void OnLinked()
+    {
+        SynchronizeTokenState();
+    }
 
     private void OnUnlinked(string? reason)
     {
-        _isLinked = false;
+        SynchronizeTokenState();
         _syncStatus = reason ?? string.Empty;
     }
 

--- a/DemiCatPlugin/TokenManager.cs
+++ b/DemiCatPlugin/TokenManager.cs
@@ -44,7 +44,6 @@ public class TokenManager
     {
         _pluginInterface = pluginInterface;
         Instance = this;
-        Load();
     }
 
     public bool IsReady() => State == LinkState.Linked;


### PR DESCRIPTION
## Summary
- load the token manager from storage during Initialize so the plugin constructor stays cold
- synchronize the settings window token state after deferred loading and when link status changes

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e56d26027883288b647f0f17aa45a9