### PR TITLE
Fix settings window toggling for older C# version

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -418,13 +418,19 @@ public class Plugin : IDalamudPlugin
 
         if (!_initialized)
         {
-            _settings?.IsOpen = true;
+            if (_settings != null)
+            {
+                _settings.IsOpen = true;
+            }
             return;
         }
 
         if (!_tokenManager.IsReady())
         {
-            _settings?.IsOpen = true;
+            if (_settings != null)
+            {
+                _settings.IsOpen = true;
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary
- replace null-conditional assignments with explicit null checks when toggling the settings window

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e577121c508328895c3e5c8e066d6e