### PR TITLE
Fix blank plugin windows on Dalamud update

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -715,7 +715,7 @@ public class ChatWindow : IDisposable
 
     public virtual void Draw()
     {
-        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -241,7 +241,7 @@ public class MainWindow : Window, IDisposable
 
     public override void Draw()
     {
-        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }
@@ -257,7 +257,7 @@ public class MainWindow : Window, IDisposable
 
     internal void DrawFeatures()
     {
-        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -147,7 +147,7 @@ public class OfficerChatWindow : ChatWindow
 
     public override void Draw()
     {
-        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }

--- a/DemiCatPlugin/ProgressOverlay.cs
+++ b/DemiCatPlugin/ProgressOverlay.cs
@@ -86,7 +86,7 @@ public sealed class ProgressOverlay
             return;
         }
 
-        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -122,7 +122,7 @@ public class SettingsWindow : Window, IDisposable
     {
         _colorPushCount = 0;
 
-        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }
@@ -136,7 +136,7 @@ public class SettingsWindow : Window, IDisposable
 
     public override void Draw()
     {
-        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -287,7 +287,7 @@ public class SyncshellWindow : IDisposable
     {
         PumpClientEvents();
 
-        if (!ImGuiHelpers.IsImGuiInitialized || ImGui.GetCurrentContext() == IntPtr.Zero)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- stop returning early from plugin windows when ImGuiHelpers reports ImGui is not initialized
- ensure settings, chat, and other plugin windows continue to render after the latest Dalamud changes

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e578bb8cc48328bd4e553e121752a1