### PR TITLE
Remove redundant ImGui initialization guards in settings window

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -122,11 +122,6 @@ public class SettingsWindow : Window, IDisposable
     {
         _colorPushCount = 0;
 
-        if (ImGui.GetCurrentContext() == IntPtr.Zero)
-        {
-            return;
-        }
-
         var primaryColor = Config.SanitizeColor(_config.PrimaryWindowColor, Config.DefaultPrimaryWindowColor);
         primaryColor.W = 1f;
         ImGui.PushStyleColor(ImGuiCol.WindowBg, primaryColor);
@@ -136,11 +131,6 @@ public class SettingsWindow : Window, IDisposable
 
     public override void Draw()
     {
-        if (ImGui.GetCurrentContext() == IntPtr.Zero)
-        {
-            return;
-        }
-
         if (ImGui.BeginTabBar("SettingsTabs"))
         {
             if (!ServicesReady)


### PR DESCRIPTION
## Summary
- allow the settings window to render before the ImGui helper reports initialization by removing unnecessary context guards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e57c71db888328bf6a31809da941ca