### PR TITLE
Fix SettingsWindow ImGui context guards

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -120,6 +120,11 @@ public class SettingsWindow : Window, IDisposable
 
     public override void PreDraw()
     {
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
+        {
+            return;
+        }
+
         _colorPushCount = 0;
 
         var primaryColor = Config.SanitizeColor(_config.PrimaryWindowColor, Config.DefaultPrimaryWindowColor);
@@ -131,6 +136,11 @@ public class SettingsWindow : Window, IDisposable
 
     public override void Draw()
     {
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
+        {
+            return;
+        }
+
         if (ImGui.BeginTabBar("SettingsTabs"))
         {
             if (!ServicesReady)


### PR DESCRIPTION
## Summary
- ensure SettingsWindow only guards against a missing ImGui context in PreDraw and Draw

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e58024138c832899b17f8c07c60e51