### PR TITLE
Remove invalid ImGui context guards

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -241,11 +241,6 @@ public class MainWindow : Window, IDisposable
 
     public override void Draw()
     {
-        if (ImGui.GetCurrentContext() == IntPtr.Zero)
-        {
-            return;
-        }
-
         if (!_isTokenReady())
         {
             HandleUnlinkedState();

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -136,11 +136,6 @@ public class SettingsWindow : Window, IDisposable
 
     public override void Draw()
     {
-        if (ImGui.GetCurrentContext() == IntPtr.Zero)
-        {
-            return;
-        }
-
         if (ImGui.BeginTabBar("SettingsTabs"))
         {
             if (!ServicesReady)


### PR DESCRIPTION
## Summary
- remove the ImGui context guard from `SettingsWindow.Draw` so the settings tabs render
- remove the redundant guard from `MainWindow.Draw` so feature content can render during valid frames

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e58a2acc7c8328b07c1e30dc263b24