### PR TITLE
Guard settings window color push when ImGui not ready

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -122,6 +122,10 @@ public class SettingsWindow : Window, IDisposable
     {
         _colorPushCount = 0;
 
+        // On XIV on Mac there can be a frame where the ImGui context isn't ready yet.
+        if (!Dalamud.Interface.Utility.ImGuiHelpers.IsImGuiReady)
+            return;
+
         var primaryColor = Config.SanitizeColor(_config.PrimaryWindowColor, Config.DefaultPrimaryWindowColor);
         primaryColor.W = 1f;
         ImGui.PushStyleColor(ImGuiCol.WindowBg, primaryColor);


### PR DESCRIPTION
## Summary
- guard SettingsWindow.PreDraw from pushing ImGui style colors when the ImGui context is not yet ready
- leave style stack untouched when ImGui is unavailable to avoid crashing on configuration open

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5957b24188328a7c2f55c8d9b690e