### PR TITLE
Guard SettingsWindow PreDraw from null ImGui context

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -122,8 +122,8 @@ public class SettingsWindow : Window, IDisposable
     {
         _colorPushCount = 0;
 
-        // On XIV on Mac there can be a frame where the ImGui context isn't ready yet.
-        if (!Dalamud.Interface.Utility.ImGuiHelpers.IsImGuiReady)
+        // On XIV on Mac/Wine the first frame after opening can lack a valid ImGui context.
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
             return;
 
         var primaryColor = Config.SanitizeColor(_config.PrimaryWindowColor, Config.DefaultPrimaryWindowColor);


### PR DESCRIPTION
## Summary
- skip style color pushes in `SettingsWindow.PreDraw` when no ImGui context is active to avoid crashes on the first frame on macOS/Wine

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5992942e083289d32fd5ac618e638