### PR TITLE
Guard settings window ImGui style pushes

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -319,8 +319,18 @@ public class Plugin : IDalamudPlugin
     {
         EnsureInitializationAttempted();
         _log?.Info("Config open requested");
-        if (_settings != null)
+        if (_settings == null)
+            return;
+
+        var framework = PluginServices.Instance?.Framework;
+        if (framework != null)
+        {
+            framework.RunOnTick(() => _settings!.IsOpen = true);
+        }
+        else
+        {
             _settings.IsOpen = true;
+        }
     }
 
     private void RegisterDeveloperWindow()

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using System.Linq;
 using System.IO;
 using ImGuiNET;
-using Dalamud.Interface.Utility;
 using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Interface.Windowing;
 using Dalamud.Plugin;
@@ -45,8 +44,6 @@ public class SettingsWindow : Window, IDisposable
     private readonly FileDialogManager _penumbraModsDialog = new();
     private readonly FileDialogManager _penumbraConfigDialog = new();
     private string _penumbraCollectionOverride = string.Empty;
-
-    private int _colorPushCount;
 
     private bool ServicesReady => _httpClient != null && _refreshRoles != null && _startNetworking != null;
 
@@ -118,23 +115,18 @@ public class SettingsWindow : Window, IDisposable
         }
     }
 
-    public override void PreDraw()
+    public override void Draw()
     {
-        _colorPushCount = 0;
-
         // On XIV on Mac/Wine the first frame after opening can lack a valid ImGui context.
         if (ImGui.GetCurrentContext() == IntPtr.Zero)
             return;
 
         var primaryColor = Config.SanitizeColor(_config.PrimaryWindowColor, Config.DefaultPrimaryWindowColor);
         primaryColor.W = 1f;
+
         ImGui.PushStyleColor(ImGuiCol.WindowBg, primaryColor);
         ImGui.PushStyleColor(ImGuiCol.ChildBg, primaryColor);
-        _colorPushCount = 2;
-    }
 
-    public override void Draw()
-    {
         try
         {
             if (ImGui.BeginTabBar("SettingsTabs"))
@@ -170,14 +162,9 @@ public class SettingsWindow : Window, IDisposable
         {
             _log.Error(ex, "SettingsWindow.Draw() crashed");
         }
-    }
-
-    public override void PostDraw()
-    {
-        if (_colorPushCount > 0)
+        finally
         {
-            ImGui.PopStyleColor(_colorPushCount);
-            _colorPushCount = 0;
+            ImGui.PopStyleColor(2);
         }
     }
 


### PR DESCRIPTION
## Summary
- guard the settings window draw routine so ImGui style colors are only pushed when a context exists
- wrap the style pushes in a try/finally block to ensure pops always occur
- schedule config window opening on the framework tick to avoid first-frame context races

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e59b0e7d30832895f1afbaf72cdf8c