### PR TITLE
Remove NuGet ImGui.NET fallback

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -27,10 +27,6 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="!Exists('$(DalamudLibPath)/ImGui.NET.dll')">
-    <PackageReference Include="ImGui.NET" Version="1.90.8.1" />
-  </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Lumina.Excel">
       <HintPath>$(DalamudLibPath)/Lumina.Excel.dll</HintPath>
@@ -70,6 +66,9 @@
   </ItemGroup>
   <PropertyGroup>
     <DalamudIcon>icon.png</DalamudIcon>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <!-- DO NOT import a custom DalamudPackager.targets for v13 -->


### PR DESCRIPTION
## Summary
- remove the conditional NuGet ImGui.NET package reference so the project always links against Dalamud's ImGui.NET
- disable CopyLocalLockFileAssemblies to avoid copying ImGui.NET into the plugin output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5a04dbc608328bf0caea1f19e5e55