### PR TITLE
Add compile-only ImGui.NET reference

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -25,6 +25,10 @@
     <PackageReference Include="Penumbra.Api" Version="5.12.0" />
     <PackageReference Include="Glamourer.Api" Version="2.6.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="ImGui.NET" Version="1.90.8.1">
+      <IncludeAssets>compile</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -33,9 +37,6 @@
     </Reference>
     <Reference Include="Lumina.Excel.GeneratedSheets" Condition="Exists('$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll')">
       <HintPath>$(DalamudLibPath)/Lumina.Excel.GeneratedSheets.dll</HintPath>
-    </Reference>
-    <Reference Include="ImGui.NET" Condition="Exists('$(DalamudLibPath)/ImGui.NET.dll')">
-      <HintPath>$(DalamudLibPath)/ImGui.NET.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add a compile-only PackageReference for ImGui.NET so the plugin can build without relying on Dalamud library paths
- remove the old direct reference to the Dalamud-provided ImGui.NET DLL

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release` *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a4c3d5448328afd84a73140aa8fa