### PR TITLE
Ensure ImGui references and UI draws are context-safe

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -25,6 +25,18 @@
     <PackageReference Include="Penumbra.Api" Version="5.12.0" />
     <PackageReference Include="Glamourer.Api" Version="2.6.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+
+  <!-- Prefer Dalamud's ImGui.NET if available -->
+  <ItemGroup Condition="Exists('$(DalamudLibPath)/ImGui.NET.dll')">
+    <Reference Include="ImGui.NET">
+      <HintPath>$(DalamudLibPath)/ImGui.NET.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <!-- Cross-OS fallback: compiler sees ImGui types, nothing gets shipped -->
+  <ItemGroup Condition="!Exists('$(DalamudLibPath)/ImGui.NET.dll')">
     <PackageReference Include="ImGui.NET" Version="1.90.8.1">
       <IncludeAssets>compile</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -319,6 +319,11 @@ public class Plugin : IDalamudPlugin
     {
         EnsureInitializationAttempted();
         _log?.Info("Config open requested");
+        RequestSettingsOpen();
+    }
+
+    private void RequestSettingsOpen()
+    {
         if (_settings == null)
             return;
 
@@ -326,11 +331,10 @@ public class Plugin : IDalamudPlugin
         if (framework != null)
         {
             framework.RunOnTick(() => _settings!.IsOpen = true);
+            return;
         }
-        else
-        {
-            _settings.IsOpen = true;
-        }
+
+        _settings.IsOpen = true;
     }
 
     private void RegisterDeveloperWindow()
@@ -428,19 +432,13 @@ public class Plugin : IDalamudPlugin
 
         if (!_initialized)
         {
-            if (_settings != null)
-            {
-                _settings.IsOpen = true;
-            }
+            RequestSettingsOpen();
             return;
         }
 
         if (!_tokenManager.IsReady())
         {
-            if (_settings != null)
-            {
-                _settings.IsOpen = true;
-            }
+            RequestSettingsOpen();
             return;
         }
 

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -881,60 +881,71 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     public void Draw()
     {
-        if (!_tokenManager.IsReady())
-        {
-            ImGui.TextUnformatted("Link DemiCat to view events");
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
             return;
-        }
 
-        if (!_config.Events)
+        try
         {
-            ImGui.TextUnformatted("Feature disabled");
-            return;
-        }
-
-        if (!_channelsLoaded)
-        {
-            _ = FetchChannels();
-            ImGui.TextUnformatted("Loading channels...");
-            return;
-        }
-
-        if (_channels.Count == 0)
-        {
-            ShowWarningOrToast(_channelFetchFailed ? _channelErrorMessage : "No channels available", ref _channelWarningShown);
-            return;
-        }
-
-        var channelNames = _channelDisplayNames;
-
-        if (channelNames.Length == 0)
-        {
-            ShowWarningOrToast(_channelFetchFailed ? _channelErrorMessage : "No channels available", ref _channelWarningShown);
-            return;
-        }
-
-        _channelWarningShown = false;
-
-        var comboIndex = _selectedIndex;
-        if (comboIndex < 0 || comboIndex >= channelNames.Length)
-        {
-            comboIndex = Math.Clamp(comboIndex, 0, channelNames.Length - 1);
-        }
-
-        {
-            using var emojiFont = _emojiManager.PushEmojiFont();
-            if (ImGui.Combo("Channel", ref comboIndex, channelNames, channelNames.Length))
+            if (!_tokenManager.IsReady())
             {
-                if (comboIndex >= 0 && comboIndex < _channels.Count)
+                ImGui.TextUnformatted("Link DemiCat to view events");
+                return;
+            }
+
+            if (!_config.Events)
+            {
+                ImGui.TextUnformatted("Feature disabled");
+                return;
+            }
+
+            if (!_channelsLoaded)
+            {
+                _ = FetchChannels();
+                ImGui.TextUnformatted("Loading channels...");
+                return;
+            }
+
+            if (_channels.Count == 0)
+            {
+                ShowWarningOrToast(_channelFetchFailed ? _channelErrorMessage : "No channels available", ref _channelWarningShown);
+                return;
+            }
+
+            var channelNames = _channelDisplayNames;
+
+            if (channelNames.Length == 0)
+            {
+                ShowWarningOrToast(_channelFetchFailed ? _channelErrorMessage : "No channels available", ref _channelWarningShown);
+                return;
+            }
+
+            _channelWarningShown = false;
+
+            var comboIndex = _selectedIndex;
+            if (comboIndex < 0 || comboIndex >= channelNames.Length)
+            {
+                comboIndex = Math.Clamp(comboIndex, 0, channelNames.Length - 1);
+            }
+
+            {
+                using var _ = _emojiManager.PushEmojiFont();
+                if (ImGui.Combo("Channel", ref comboIndex, channelNames, channelNames.Length))
                 {
-                    var selectedChannel = _channels[comboIndex];
-                    if (!string.IsNullOrEmpty(selectedChannel?.Id))
+                    if (comboIndex >= 0 && comboIndex < _channels.Count)
                     {
-                        _selectedIndex = comboIndex;
-                        _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, selectedChannel.Id);
-                        _ = RefreshChannels();
-                        _ = RefreshEmbeds();
+                        var selectedChannel = _channels[comboIndex];
+                        if (!string.IsNullOrEmpty(selectedChannel?.Id))
+                        {
+                            _selectedIndex = comboIndex;
+                            _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, selectedChannel.Id);
+                            _ = RefreshChannels();
+                            _ = RefreshEmbeds();
+                        }
+                        else
+                        {
+                            ShowWarningOrToast("Select a valid channel to view events.", ref _channelSelectionWarningShown);
+                            return;
+                        }
                     }
                     else
                     {
@@ -944,64 +955,70 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 }
                 else
                 {
-                    ShowWarningOrToast("Select a valid channel to view events.", ref _channelSelectionWarningShown);
-                    return;
+                    _selectedIndex = comboIndex;
                 }
             }
-            else
+
+            if (_selectedIndex < 0 || _selectedIndex >= _channels.Count)
             {
-                _selectedIndex = comboIndex;
+                ShowWarningOrToast("Select a channel to view events.", ref _channelSelectionWarningShown);
+                return;
+            }
+
+            var selected = _channels[_selectedIndex];
+            if (selected == null || string.IsNullOrEmpty(selected.Id))
+            {
+                ShowWarningOrToast("Select a channel to view events.", ref _channelSelectionWarningShown);
+                return;
+            }
+
+            var channelId = ChannelId;
+            var currentGuildId = ChannelKeyHelper.NormalizeGuildId(_config.GuildId);
+            if (string.IsNullOrWhiteSpace(channelId))
+            {
+                ShowWarningOrToast("Select a channel to view events.", ref _channelSelectionWarningShown);
+                return;
+            }
+
+            _channelSelectionWarningShown = false;
+
+            List<EventView> embeds;
+            lock (_embedLock)
+            {
+                embeds = _embeds.Values
+                    .Where(v => v != null
+                        && v.ChannelId == channelId
+                        && string.Equals(ChannelKeyHelper.NormalizeGuildId(v.GuildId), currentGuildId, StringComparison.Ordinal))
+                    .ToList();
+            }
+
+            if (_embedDtos.Count == 0 || embeds.Count == 0)
+            {
+                ShowWarningOrToast("No events to display.", ref _embedWarningShown);
+                return;
+            }
+
+            _embedWarningShown = false;
+
+            ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+            foreach (var view in embeds)
+            {
+                view?.Draw();
+            }
+
+            ImGui.EndChild();
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                PluginServices.Instance?.Log.Error(ex, "UiRenderer.Draw()");
+            }
+            catch
+            {
+                // ignored
             }
         }
-
-        if (_selectedIndex < 0 || _selectedIndex >= _channels.Count)
-        {
-            ShowWarningOrToast("Select a channel to view events.", ref _channelSelectionWarningShown);
-            return;
-        }
-
-        var selected = _channels[_selectedIndex];
-        if (selected == null || string.IsNullOrEmpty(selected.Id))
-        {
-            ShowWarningOrToast("Select a channel to view events.", ref _channelSelectionWarningShown);
-            return;
-        }
-
-        var channelId = ChannelId;
-        var currentGuildId = ChannelKeyHelper.NormalizeGuildId(_config.GuildId);
-        if (string.IsNullOrWhiteSpace(channelId))
-        {
-            ShowWarningOrToast("Select a channel to view events.", ref _channelSelectionWarningShown);
-            return;
-        }
-
-        _channelSelectionWarningShown = false;
-
-        List<EventView> embeds;
-        lock (_embedLock)
-        {
-            embeds = _embeds.Values
-                .Where(v => v != null
-                    && v.ChannelId == channelId
-                    && string.Equals(ChannelKeyHelper.NormalizeGuildId(v.GuildId), currentGuildId, StringComparison.Ordinal))
-                .ToList();
-        }
-
-        if (_embedDtos.Count == 0 || embeds.Count == 0)
-        {
-            ShowWarningOrToast("No events to display.", ref _embedWarningShown);
-            return;
-        }
-
-        _embedWarningShown = false;
-
-        ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
-        foreach (var view in embeds)
-        {
-            view?.Draw();
-        }
-
-        ImGui.EndChild();
     }
 
     private void ShowWarningOrToast(string message, ref bool toastShown)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,11 @@
 <Project>
   <PropertyGroup>
+    <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
+    <EnableWindowsTargeting Condition="'$(OS)' != 'Windows_NT'">true</EnableWindowsTargeting>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <PropertyGroup>
     <DalamudLibPath>/root/.xlcore/dalamud/Hooks/dev</DalamudLibPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add repo-wide net9 targeting defaults so builds pick Windows targeting when needed without copying plugin dependencies
- prefer Dalamud's bundled ImGui.NET at build time with a compile-only NuGet fallback to avoid shipping the DLL
- open the settings window via Framework.RunOnTick and guard the UI renderer draw loop against missing ImGui contexts

## Testing
- `dotnet clean` *(fails: command not found)*
- `git clean -xfd`


------
https://chatgpt.com/codex/tasks/task_e_68e5b1c02c608328b2f4c27c0a45902e