### PR TITLE
Harden ImGui usage and remove unsupported APIs

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -803,7 +803,7 @@ public class ChatWindow : IDisposable
         }
         composeRatio = actualRatio;
         const float ScrollTolerance = 1f;
-        ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), true, ImGuiWindowFlags.None);
 
         var fontScale = GetFontScale();
         var chatFontScope = PushWindowFontScale(fontScale);
@@ -1231,7 +1231,7 @@ public class ChatWindow : IDisposable
                 var desiredPreviewHeight = _previewContentHeight > 0f ? _previewContentHeight : fallbackHeight;
                 var previewHeight = Math.Clamp(desiredPreviewHeight, minPreviewHeight, maxPreviewHeight);
 
-                ImGui.BeginChild("##inputPreview", new Vector2(0, previewHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+                ImGui.BeginChild("##inputPreview", new Vector2(0, previewHeight), true, ImGuiWindowFlags.None);
                 var childStartCursor = ImGui.GetCursorPosY();
                 if (!string.IsNullOrEmpty(plainTextPreview))
                 {
@@ -1563,7 +1563,7 @@ public class ChatWindow : IDisposable
         var codeBlock = Regex.Match(text, "^\\[CODEBLOCK\\](.+?)\\[/CODEBLOCK\\]$", RegexOptions.Singleline);
         if (codeBlock.Success)
         {
-            ImGui.BeginChild($"codeblock{GetHashCode()}{text.GetHashCode()}", new Vector2(0, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+            ImGui.BeginChild($"codeblock{GetHashCode()}{text.GetHashCode()}", new Vector2(0, 0), true, ImGuiWindowFlags.None);
             ImGui.TextUnformatted(codeBlock.Groups[1].Value);
             ImGui.EndChild();
             return;
@@ -2750,7 +2750,7 @@ public class ChatWindow : IDisposable
             ImGuiWindowFlags.AlwaysAutoResize |
             ImGuiWindowFlags.NoScrollbar |
             ImGuiWindowFlags.NoScrollWithMouse;
-        if (ImGui.BeginChild("##attachmentChip", new Vector2(0, 0), ImGuiChildFlags.Border, childFlags))
+        if (ImGui.BeginChild("##attachmentChip", new Vector2(0, 0), true, childFlags))
         {
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(6f * scale, style.ItemSpacing.Y));
 

--- a/DemiCatPlugin/DeveloperWindow.cs
+++ b/DemiCatPlugin/DeveloperWindow.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using System.Threading.Tasks;
 using Dalamud.Interface.Windowing;
 using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
 using ImGuiNET;
 
 namespace DemiCatPlugin;
@@ -45,19 +46,38 @@ public class DeveloperWindow : Window
 
     public override void Draw()
     {
-        ImGui.InputText("API Base URL", ref _apiBaseUrl, 256);
-        ImGui.InputText("WebSocket Path", ref _wsPath, 64);
-
-        if (ImGui.Button("Apply"))
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
-            ApplyApiBaseUrlChange(_apiBaseUrl);
+            return;
         }
 
-        ImGui.SameLine();
-
-        if (ImGui.Button("Reset to default"))
+        try
         {
-            ApplyApiBaseUrlChange(Config.DefaultApiBaseUrl);
+            ImGui.InputText("API Base URL", ref _apiBaseUrl, 256);
+            ImGui.InputText("WebSocket Path", ref _wsPath, 64);
+
+            if (ImGui.Button("Apply"))
+            {
+                ApplyApiBaseUrlChange(_apiBaseUrl);
+            }
+
+            ImGui.SameLine();
+
+            if (ImGui.Button("Reset to default"))
+            {
+                ApplyApiBaseUrlChange(Config.DefaultApiBaseUrl);
+            }
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                PluginServices.Instance?.Log.Error(ex, "DeveloperWindow.Draw()");
+            }
+            catch
+            {
+                // ignored
+            }
         }
     }
 

--- a/DemiCatPlugin/DockableWindow.cs
+++ b/DemiCatPlugin/DockableWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Numerics;
 using ImGuiNET;
+using Dalamud.Plugin.Services;
 
 namespace DemiCatPlugin;
 
@@ -65,6 +66,9 @@ public abstract class DockableWindow
         if (!IsOpen)
             return;
 
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
+            return;
+
         if (InitialSize is { } initialSize)
         {
             var sanitizedSize = new Vector2(
@@ -75,47 +79,78 @@ public abstract class DockableWindow
 
         var open = IsOpen;
         var colorsPushed = 0;
-        _hasDrawnHeaderThisFrame = false;
-        if (UseThemedColors)
+        var pushedCornerRadius = false;
+        var pushedAlpha = false;
+        var beginCalled = false;
+        try
         {
-            colorsPushed = PushWindowThemeColors();
-        }
-
-        var pushedCornerRadius = TryPushWindowCornerRadius();
-        var pushedAlpha = TryPushWindowOpacityOverride(ComputeEffectiveOpacity());
-
-        if (ImGui.Begin(WindowTitle, ref open, WindowFlags))
-        {
-            if (SupportsFade && (ImGui.IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows)
-                || ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows)
-                || ImGui.IsAnyItemActive()))
+            _hasDrawnHeaderThisFrame = false;
+            if (UseThemedColors)
             {
-                ResetFadeTimer();
+                colorsPushed = PushWindowThemeColors();
             }
 
-            DrawHeaderWithSettingsButton();
-            DrawContents();
-        }
-        ImGui.End();
+            pushedCornerRadius = TryPushWindowCornerRadius();
+            pushedAlpha = TryPushWindowOpacityOverride(ComputeEffectiveOpacity());
 
-        if (pushedAlpha)
-        {
-            ImGui.PopStyleVar();
-        }
+            var beginOpen = ImGui.Begin(WindowTitle, ref open, WindowFlags);
+            beginCalled = true;
+            try
+            {
+                if (beginOpen)
+                {
+                    if (SupportsFade && (ImGui.IsWindowHovered(ImGuiHoveredFlags.RootAndChildWindows)
+                        || ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows)
+                        || ImGui.IsAnyItemActive()))
+                    {
+                        ResetFadeTimer();
+                    }
 
-        if (pushedCornerRadius)
-        {
-            ImGui.PopStyleVar();
+                    DrawHeaderWithSettingsButton();
+                    DrawContents();
+                }
+            }
+            finally
+            {
+                if (beginCalled)
+                {
+                    ImGui.End();
+                }
+            }
         }
-
-        if (UseThemedColors)
+        catch (Exception ex)
         {
-            ImGui.PopStyleColor(colorsPushed);
+            try
+            {
+                var typeName = GetType().Name;
+                PluginServices.Instance?.Log.Error(ex, $"{typeName}.Draw()");
+            }
+            catch
+            {
+                // ignored
+            }
         }
-
-        if (open != IsOpen)
+        finally
         {
-            IsOpen = open;
+            if (pushedAlpha)
+            {
+                ImGui.PopStyleVar();
+            }
+
+            if (pushedCornerRadius)
+            {
+                ImGui.PopStyleVar();
+            }
+
+            if (UseThemedColors && colorsPushed > 0)
+            {
+                ImGui.PopStyleColor(colorsPushed);
+            }
+
+            if (open != IsOpen)
+            {
+                IsOpen = open;
+            }
         }
     }
 

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -42,7 +42,7 @@ public static class EmbedPreviewRenderer
             avail = 400;
         }
 
-        ImGui.BeginChild($"embedprev{dto.Id}", new Vector2(avail, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+        ImGui.BeginChild($"embedprev{dto.Id}", new Vector2(avail, 0), true, ImGuiWindowFlags.None);
 
         ImGui.Indent(indent);
         ImGui.Dummy(new Vector2(0f, verticalPadding));

--- a/DemiCatPlugin/EmbedStyleControls.cs
+++ b/DemiCatPlugin/EmbedStyleControls.cs
@@ -281,7 +281,7 @@ public static class EmbedStyleControls
             {
                 var tileSize = Math.Clamp(context.EmojiTileSize, Config.MinEmojiTileSize, Config.MaxEmojiTileSize);
                 var childSize = context.EmojiGridHeight > 0f ? new Vector2(0f, context.EmojiGridHeight) : Vector2.Zero;
-                ImGui.BeginChild($"##borderEmojiGrid_{searchKey}", childSize, ImGuiChildFlags.None, ImGuiWindowFlags.None);
+                ImGui.BeginChild($"##borderEmojiGrid_{searchKey}", childSize, false, ImGuiWindowFlags.None);
 
                 var avail = Math.Max(1f, ImGui.GetContentRegionAvail().X);
                 var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (tileSize + 4f)));

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -139,7 +139,7 @@ public sealed class EmojiPicker
         }
 
         var childSize = _gridHeight > 0f ? new Vector2(0, _gridHeight) : Vector2.Zero;
-        ImGui.BeginChild("##emoji_std_grid", childSize, ImGuiChildFlags.None, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##emoji_std_grid", childSize, false, ImGuiWindowFlags.None);
         var avail = ImGui.GetContentRegionAvail().X;
         var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (_tileSize + 4f)));
         var column = 0;
@@ -238,7 +238,7 @@ public sealed class EmojiPicker
         }
 
         var childSize = _gridHeight > 0f ? new Vector2(0, _gridHeight) : Vector2.Zero;
-        ImGui.BeginChild("##emoji_custom_grid", childSize, ImGuiChildFlags.None, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##emoji_custom_grid", childSize, false, ImGuiWindowFlags.None);
         var avail = ImGui.GetContentRegionAvail().X;
         var columns = Math.Max(1, (int)Math.Floor((avail + 6f) / (_tileSize + 6f)));
         var column = 0;

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ImGuiNET;
 using Dalamud.Interface.ImGuiFileDialog;
+using Dalamud.Plugin.Services;
 using DiscordHelper;
 using DemiCat.UI;
 using DemiCatPlugin.Emoji;
@@ -129,57 +130,65 @@ public class EventCreateWindow
 
     public void Draw()
     {
-        if (!_tokenManager.IsReady())
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
-            ImGui.TextUnformatted("Link DemiCat to create events");
             return;
         }
 
-        if (!_config.Events)
+        try
         {
-            ImGui.TextUnformatted("Feature disabled");
-            return;
-        }
-
-        _imageFileDialog.Draw();
-        _thumbnailFileDialog.Draw();
-
-        var footer = ImGui.GetFrameHeightWithSpacing() * 2;
-        var avail = ImGui.GetContentRegionAvail();
-        ImGui.BeginChild("eventCreateScroll", new Vector2(avail.X, avail.Y - footer), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
-
-        if (!_channelsLoaded)
-        {
-            _ = RefreshChannels();
-        }
-        if (_channels.Count > 0)
-        {
-            var channelNames = _channelDisplayNames;
+            if (!_tokenManager.IsReady())
             {
-                using var emojiFont = _emojiManager.PushEmojiFont();
-                if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
-                {
-                    var newId = _channels[_selectedIndex].Id;
-                    _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, newId);
-                }
+                ImGui.TextUnformatted("Link DemiCat to create events");
+                return;
             }
-        }
-        else
-        {
-            ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
-        }
 
-        var style = ImGui.GetStyle();
-        var labelColumnWidth = ImGui.CalcTextSize("Thumbnail URL").X + style.ItemInnerSpacing.X * 2f;
-        if (!_rolesLoaded)
-        {
-            _ = LoadRoles();
-        }
+            if (!_config.Events)
+            {
+                ImGui.TextUnformatted("Feature disabled");
+                return;
+            }
 
-        if (ImGui.BeginTable("eventCreateForm", 2, ImGuiTableFlags.SizingStretchSame))
-        {
-            ImGui.TableSetupColumn("Label", ImGuiTableColumnFlags.WidthFixed, labelColumnWidth);
-            ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch);
+            _imageFileDialog.Draw();
+            _thumbnailFileDialog.Draw();
+
+            var footer = ImGui.GetFrameHeightWithSpacing() * 2;
+            var avail = ImGui.GetContentRegionAvail();
+            ImGui.BeginChild("eventCreateScroll", new Vector2(avail.X, avail.Y - footer), true, ImGuiWindowFlags.None);
+            try
+            {
+                if (!_channelsLoaded)
+                {
+                    _ = RefreshChannels();
+                }
+                if (_channels.Count > 0)
+                {
+                    var channelNames = _channelDisplayNames;
+                    {
+                        using var emojiFont = _emojiManager.PushEmojiFont();
+                        if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
+                        {
+                            var newId = _channels[_selectedIndex].Id;
+                            _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, newId);
+                        }
+                    }
+                }
+                else
+                {
+                    ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
+                }
+
+                var style = ImGui.GetStyle();
+                var labelColumnWidth = ImGui.CalcTextSize("Thumbnail URL").X + style.ItemInnerSpacing.X * 2f;
+                if (!_rolesLoaded)
+                {
+                    _ = LoadRoles();
+                }
+
+                if (ImGui.BeginTable("eventCreateForm", 2, ImGuiTableFlags.SizingStretchSame))
+                {
+                    ImGui.TableSetupColumn("Label", ImGuiTableColumnFlags.WidthFixed, labelColumnWidth);
+                    ImGui.TableSetupColumn("Value", ImGuiTableColumnFlags.WidthStretch);
 
             void DrawFormRow(string label, Action drawControl, bool alignLabel = true, bool setFullWidth = true)
             {
@@ -541,8 +550,11 @@ public class EventCreateWindow
         {
             ImGui.TextUnformatted(_lastResult);
         }
-
-        ImGui.EndChild();
+            }
+            finally
+            {
+                ImGui.EndChild();
+            }
 
         if (ImGui.Button("Create"))
         {
@@ -584,6 +596,18 @@ public class EventCreateWindow
             ImGui.EndPopup();
         }
         if (!_confirmCreate || !openConfirm) _confirmCreate = false;
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                PluginServices.Instance?.Log.Error(ex, "EventCreateWindow.Draw()");
+            }
+            catch
+            {
+                // ignored
+            }
+        }
     }
 
     private async Task LoadRoles()

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -244,7 +244,7 @@ public class EventView : IDisposable
             childHeight = 0f;
         }
 
-        ImGui.BeginChild($"eventEmbed{dto.Id}", new Vector2(availWidth, childHeight), ImGuiChildFlags.None, ImGuiWindowFlags.None);
+        ImGui.BeginChild($"eventEmbed{dto.Id}", new Vector2(availWidth, childHeight), false, ImGuiWindowFlags.None);
 
         ImGui.Indent(indent);
         ImGui.Dummy(new Vector2(0f, verticalPadding));
@@ -722,7 +722,7 @@ public class EventView : IDisposable
 
 internal static class EventViewImGuiHelpers
 {
-    public static float BeginPreviewChild(string childId, ImGuiChildFlags childFlags = ImGuiChildFlags.None, float minHeight = 0f, ImGuiWindowFlags windowFlags = ImGuiWindowFlags.None)
+    public static float BeginPreviewChild(string childId, bool border = false, float minHeight = 0f, ImGuiWindowFlags windowFlags = ImGuiWindowFlags.None)
     {
         var avail = ImGui.GetContentRegionAvail();
         var width = float.IsFinite(avail.X) ? Math.Max(avail.X, 0f) : 0f;
@@ -734,7 +734,7 @@ internal static class EventViewImGuiHelpers
         }
 
         var size = new Vector2(width, height);
-        ImGui.BeginChild(childId, size, childFlags, windowFlags);
+        ImGui.BeginChild(childId, size, border, windowFlags);
         return size.Y;
     }
 }

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -5,6 +5,7 @@ using ImGuiNET;
 using System.Numerics;
 using DemiCatPlugin.Avatars;
 using DemiCatPlugin.Emoji;
+using Dalamud.Plugin.Services;
 
 namespace DemiCatPlugin;
 
@@ -52,29 +53,54 @@ public class FcChatWindow : ChatWindow
 
     public override void Draw()
     {
-        if (!_config.SyncedChat || !_config.EnableFcChat)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
-            ImGui.TextUnformatted("Feature disabled");
             return;
         }
 
-        if (!_tokenManager.IsReady())
+        try
         {
-            base.Draw();
-            return;
+            if (!_config.SyncedChat || !_config.EnableFcChat)
+            {
+                ImGui.TextUnformatted("Feature disabled");
+                return;
+            }
+
+            if (!_tokenManager.IsReady())
+            {
+                base.Draw();
+                return;
+            }
+
+            _ = RoleCache.EnsureLoaded(_httpClient, _config, _tokenManager);
+
+            if (_presenceSidebar != null)
+            {
+                _presenceSidebar.Draw(ref _presenceWidth);
+                ImGui.SameLine();
+            }
+
+            ImGui.BeginChild("##fcChat", ImGui.GetContentRegionAvail(), false, ImGuiWindowFlags.None);
+            try
+            {
+                base.Draw();
+            }
+            finally
+            {
+                ImGui.EndChild();
+            }
         }
-
-        _ = RoleCache.EnsureLoaded(_httpClient, _config, _tokenManager);
-
-        if (_presenceSidebar != null)
+        catch (Exception ex)
         {
-            _presenceSidebar.Draw(ref _presenceWidth);
-            ImGui.SameLine();
+            try
+            {
+                PluginServices.Instance?.Log.Error(ex, "FcChatWindow.Draw()");
+            }
+            catch
+            {
+                // ignored
+            }
         }
-
-        ImGui.BeginChild("##fcChat", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.None);
-        base.Draw();
-        ImGui.EndChild();
     }
 
     public override Task RefreshMessages()

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -241,13 +241,36 @@ public class MainWindow : Window, IDisposable
 
     public override void Draw()
     {
-        if (!_isTokenReady())
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
-            HandleUnlinkedState();
+            if (!_isTokenReady())
+            {
+                HandleUnlinkedState();
+            }
             return;
         }
 
-        DrawFeatures();
+        try
+        {
+            if (!_isTokenReady())
+            {
+                HandleUnlinkedState();
+                return;
+            }
+
+            DrawFeatures();
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                PluginServices.Instance?.Log.Error(ex, "MainWindow.Draw()");
+            }
+            catch
+            {
+                // ignored
+            }
+        }
     }
 
     internal void DrawFeatures()
@@ -314,16 +337,30 @@ public class MainWindow : Window, IDisposable
             ImGui.PushStyleColor(ImGuiCol.Border, Vector4.Zero);
 
             var open = true;
-            if (ImGui.Begin(DockWindowTitle, ref open, windowFlags))
+            var windowPos = Vector2.Zero;
+            try
             {
-                _ = DrawDockStrip(visibleFeatures, settingsItem, iconSize, spacing, separatorThickness, indicatorHeight, accentColor, dockBgColor);
-                DrawDockContextMenu();
-            }
-            var windowPos = ImGui.GetWindowPos();
-            ImGui.End();
+                var beginOpen = ImGui.Begin(DockWindowTitle, ref open, windowFlags);
+                try
+                {
+                    if (beginOpen)
+                    {
+                        _ = DrawDockStrip(visibleFeatures, settingsItem, iconSize, spacing, separatorThickness, indicatorHeight, accentColor, dockBgColor);
+                        DrawDockContextMenu();
+                    }
 
-            ImGui.PopStyleColor(2);
-            ImGui.PopStyleVar(2);
+                    windowPos = ImGui.GetWindowPos();
+                }
+                finally
+                {
+                    ImGui.End();
+                }
+            }
+            finally
+            {
+                ImGui.PopStyleColor(2);
+                ImGui.PopStyleVar(2);
+            }
 
             if (!open)
             {

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using ImGuiNET;
+using Dalamud.Plugin.Services;
 
 namespace DemiCatPlugin;
 
@@ -67,6 +68,13 @@ public sealed class NotePadWindow : IDisposable
 
     public void Draw()
     {
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
+        {
+            return;
+        }
+
+        try
+        {
         HandleKeyboardShortcuts();
         HandleAutosave();
 
@@ -93,9 +101,15 @@ public sealed class NotePadWindow : IDisposable
         var pageListWidth = Math.Clamp(region.X * ratio, 160f, Math.Max(160f, region.X - 200f));
         var editorWidth = Math.Max(200f, region.X - pageListWidth - splitterWidth);
 
-        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
-        DrawPageList(selectedSection, selectedPage);
-        ImGui.EndChild();
+        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), true, ImGuiWindowFlags.None);
+        try
+        {
+            DrawPageList(selectedSection, selectedPage);
+        }
+        finally
+        {
+            ImGui.EndChild();
+        }
 
         ImGui.SameLine();
         ImGui.InvisibleButton("NotePadSplitter", new Vector2(splitterWidth, region.Y));
@@ -119,9 +133,15 @@ public sealed class NotePadWindow : IDisposable
         }
 
         ImGui.SameLine();
-        ImGui.BeginChild("NotePadEditor", new Vector2(editorWidth, region.Y), ImGuiChildFlags.None, ImGuiWindowFlags.None);
-        DrawEditor(selectedSection, selectedPage);
-        ImGui.EndChild();
+        ImGui.BeginChild("NotePadEditor", new Vector2(editorWidth, region.Y), false, ImGuiWindowFlags.None);
+        try
+        {
+            DrawEditor(selectedSection, selectedPage);
+        }
+        finally
+        {
+            ImGui.EndChild();
+        }
 
         if (_sectionOrderDirty)
         {
@@ -134,6 +154,18 @@ public sealed class NotePadWindow : IDisposable
             _pageOrderDirty = false;
             var order = selectedSection.Pages.Select(p => p.Id).ToList();
             _ = Task.Run(() => _service.ReorderPagesAsync(selectedSection.Id, order, CancellationToken.None));
+        }
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                PluginServices.Instance?.Log.Error(ex, "NotePadWindow.Draw()");
+            }
+            catch
+            {
+                // ignored
+            }
         }
     }
 

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -152,50 +152,71 @@ public class OfficerChatWindow : ChatWindow
             return;
         }
 
-        if (!OfficerPermissions.HasAccess(_config))
+        try
         {
-            var message = string.IsNullOrEmpty(_statusMessage)
-                ? NoOfficerAccessMessage
-                : _statusMessage;
-            ImGui.TextUnformatted(message);
-            return;
-        }
-
-        if (!_bridge.IsReady())
-        {
-            if (!string.IsNullOrEmpty(_statusMessage))
+            if (!OfficerPermissions.HasAccess(_config))
             {
-                ImGui.TextUnformatted(_statusMessage);
+                var message = string.IsNullOrEmpty(_statusMessage)
+                    ? NoOfficerAccessMessage
+                    : _statusMessage;
+                ImGui.TextUnformatted(message);
+                return;
             }
-            else
+
+            if (!_bridge.IsReady())
             {
-                ImGui.TextUnformatted("Link DemiCat…");
+                if (!string.IsNullOrEmpty(_statusMessage))
+                {
+                    ImGui.TextUnformatted(_statusMessage);
+                }
+                else
+                {
+                    ImGui.TextUnformatted("Link DemiCat…");
+                }
+                return;
             }
-            return;
+
+            if (!_subscribed)
+            {
+                Subscribe();
+            }
+
+            var showPresence = _presenceSidebar != null && _tokenManager.IsReady();
+            var childOpened = false;
+            if (showPresence)
+            {
+                _ = RoleCache.EnsureLoaded(_httpClient, _config, _tokenManager);
+                _presenceSidebar!.Draw(ref _presenceWidth);
+                ImGui.SameLine();
+                ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), false, ImGuiWindowFlags.None);
+                childOpened = true;
+            }
+
+            try
+            {
+                base.Draw();
+
+                // Reserved padded area beneath the standard chat input for upcoming officer tools.
+                ImGui.Dummy(new Vector2(0, ImGui.GetFrameHeightWithSpacing()));
+            }
+            finally
+            {
+                if (childOpened)
+                {
+                    ImGui.EndChild();
+                }
+            }
         }
-
-        if (!_subscribed)
+        catch (Exception ex)
         {
-            Subscribe();
-        }
-
-        var showPresence = _presenceSidebar != null && _tokenManager.IsReady();
-        if (showPresence)
-        {
-        _ = RoleCache.EnsureLoaded(_httpClient, _config, _tokenManager);
-            _presenceSidebar!.Draw(ref _presenceWidth);
-            ImGui.SameLine();
-            ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.None);
-        }
-
-        base.Draw();
-
-        // Reserved padded area beneath the standard chat input for upcoming officer tools.
-        ImGui.Dummy(new Vector2(0, ImGui.GetFrameHeightWithSpacing()));
-
-        if (showPresence)
-        {
-            ImGui.EndChild();
+            try
+            {
+                PluginServices.Instance?.Log.Error(ex, "OfficerChatWindow.Draw()");
+            }
+            catch
+            {
+                // ignored
+            }
         }
     }
 

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -65,7 +65,7 @@ public class PresenceSidebar : IDisposable
             shouldReturn = true;
         }
 
-        ImGui.BeginChild("##presence", new Vector2(width, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##presence", new Vector2(width, 0), true, ImGuiWindowFlags.None);
 
         try
         {

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using ImGuiNET;
 using System.Numerics;
+using Dalamud.Plugin.Services;
 
 namespace DemiCatPlugin;
 
@@ -50,115 +51,154 @@ public class RequestBoardWindow
 
     public void Draw()
     {
-        if (!_config.Requests)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
-            ImGui.TextUnformatted("Feature disabled");
             return;
         }
-        if (!_tokenManager.IsReady())
-        {
-            ImGui.TextUnformatted("Link DemiCat to view requests");
-            return;
-        }
-        if (ImGui.Button("Create Request"))
-            ImGui.OpenPopup("createRequest");
 
-        var mode = (int)_sortMode;
-        if (ImGui.Combo("Sort By", ref mode, SortLabels, SortLabels.Length))
-            _sortMode = (SortMode)mode;
-
-        var requests = RequestStateService.All;
-        requests = _sortMode switch
+        try
         {
-            SortMode.Type => requests.OrderBy(r => r.Type),
-            SortMode.Name => requests.OrderBy(r => r.Title),
-            _ => requests.OrderByDescending(r => r.CreatedAt)
-        };
-        var requestList = requests.ToList();
-
-        if (requestList.Count == 0)
-        {
-            ImGui.TextUnformatted("No requests available.");
-        }
-        else
-        {
-            ImGui.PushStyleVar(ImGuiStyleVar.ChildRounding, 8f);
-            ImGui.PushStyleVar(ImGuiStyleVar.ChildBorderSize, 1f);
-            ImGui.PushStyleColor(ImGuiCol.Border, new Vector4(0.35f, 0.45f, 0.55f, 0.5f));
-
-            foreach (var req in requestList)
+            if (!_config.Requests)
             {
-                ImGui.PushID(req.Id);
-                ImGui.PushStyleColor(ImGuiCol.ChildBg, UrgencyColor(req.Urgency));
-                ImGui.BeginChild("card", new Vector2(-1, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+                ImGui.TextUnformatted("Feature disabled");
+                return;
+            }
+            if (!_tokenManager.IsReady())
+            {
+                ImGui.TextUnformatted("Link DemiCat to view requests");
+                return;
+            }
+            if (ImGui.Button("Create Request"))
+                ImGui.OpenPopup("createRequest");
 
-                ImGui.TextUnformatted(req.Title);
-                ImGui.Spacing();
-                ImGui.TextUnformatted($"Status: {req.Status}   Type: {req.Type}   Urgency: {req.Urgency}");
-                if (!string.IsNullOrWhiteSpace(req.CreatedBy))
-                    ImGui.TextUnformatted($"Created by {req.CreatedBy}");
-                if (req.CreatedAt != DateTime.MinValue)
-                    ImGui.TextUnformatted($"Created at {req.CreatedAt:u}");
+            var mode = (int)_sortMode;
+            if (ImGui.Combo("Sort By", ref mode, SortLabels, SortLabels.Length))
+                _sortMode = (SortMode)mode;
 
-                ImGui.Separator();
-                var desc = string.IsNullOrWhiteSpace(req.Description) ? "No description provided." : req.Description;
-                ImGui.TextWrapped(desc);
+            var requests = RequestStateService.All;
+            requests = _sortMode switch
+            {
+                SortMode.Type => requests.OrderBy(r => r.Type),
+                SortMode.Name => requests.OrderBy(r => r.Title),
+                _ => requests.OrderByDescending(r => r.CreatedAt)
+            };
+            var requestList = requests.ToList();
 
-                if (_conflicts.TryGetValue(req.Id, out var conflicted) && conflicted)
+            if (requestList.Count == 0)
+            {
+                ImGui.TextUnformatted("No requests available.");
+            }
+            else
+            {
+                ImGui.PushStyleVar(ImGuiStyleVar.ChildRounding, 8f);
+                ImGui.PushStyleVar(ImGuiStyleVar.ChildBorderSize, 1f);
+                ImGui.PushStyleColor(ImGuiCol.Border, new Vector4(0.35f, 0.45f, 0.55f, 0.5f));
+                try
                 {
-                    ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(1f, 0.4f, 0.4f, 1f));
-                    ImGui.TextWrapped("Unable to update request because it was modified elsewhere. Refresh and try again.");
+                    foreach (var req in requestList)
+                    {
+                        ImGui.PushID(req.Id);
+                        ImGui.PushStyleColor(ImGuiCol.ChildBg, UrgencyColor(req.Urgency));
+                        ImGui.BeginChild("card", new Vector2(-1, 0), true, ImGuiWindowFlags.None);
+                        try
+                        {
+                            ImGui.TextUnformatted(req.Title);
+                            ImGui.Spacing();
+                            ImGui.TextUnformatted($"Status: {req.Status}   Type: {req.Type}   Urgency: {req.Urgency}");
+                            if (!string.IsNullOrWhiteSpace(req.CreatedBy))
+                                ImGui.TextUnformatted($"Created by {req.CreatedBy}");
+                            if (req.CreatedAt != DateTime.MinValue)
+                                ImGui.TextUnformatted($"Created at {req.CreatedAt:u}");
+
+                            ImGui.Separator();
+                            var desc = string.IsNullOrWhiteSpace(req.Description) ? "No description provided." : req.Description;
+                            ImGui.TextWrapped(desc);
+
+                            if (_conflicts.TryGetValue(req.Id, out var conflicted) && conflicted)
+                            {
+                                ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(1f, 0.4f, 0.4f, 1f));
+                                try
+                                {
+                                    ImGui.TextWrapped("Unable to update request because it was modified elsewhere. Refresh and try again.");
+                                }
+                                finally
+                                {
+                                    ImGui.PopStyleColor();
+                                }
+                            }
+
+                            ImGui.Spacing();
+                            DrawActionButtons(req);
+
+                            ImGui.Separator();
+                            DrawRequirements(req);
+                        }
+                        finally
+                        {
+                            ImGui.EndChild();
+                        }
+                        ImGui.PopStyleColor();
+                        ImGui.PopID();
+                        ImGui.Spacing();
+                    }
+                }
+                finally
+                {
                     ImGui.PopStyleColor();
+                    ImGui.PopStyleVar();
+                    ImGui.PopStyleVar();
                 }
-
-                ImGui.Spacing();
-                DrawActionButtons(req);
-
-                ImGui.Separator();
-                DrawRequirements(req);
-
-                ImGui.EndChild();
-                ImGui.PopStyleColor();
-                ImGui.PopID();
-                ImGui.Spacing();
             }
 
-            ImGui.PopStyleColor();
-            ImGui.PopStyleVar();
-            ImGui.PopStyleVar();
-        }
+            DrawMessagePopup();
 
-        DrawMessagePopup();
-
-        if (ImGui.BeginPopup("createRequest"))
-        {
-            ImGui.InputText("Title", ref _newTitle, 100);
-            ImGui.InputTextMultiline("Description", ref _newDescription, 1000, new Vector2(300, 80));
-            var typeIdx = (int)_newType;
-            var typeLabels = Enum.GetNames<RequestType>();
-            if (ImGui.Combo("Type", ref typeIdx, typeLabels, typeLabels.Length))
-                _newType = (RequestType)typeIdx;
-            var urgIdx = (int)_newUrgency;
-            var urgLabels = Enum.GetNames<RequestUrgency>();
-            if (ImGui.Combo("Urgency", ref urgIdx, urgLabels, urgLabels.Length))
-                _newUrgency = (RequestUrgency)urgIdx;
-            if (!string.IsNullOrEmpty(_createStatus))
-                ImGui.TextUnformatted(_createStatus);
-            if (ImGui.Button("Create"))
+            if (ImGui.BeginPopup("createRequest"))
             {
-                if (ValidateNewRequest())
+                try
                 {
-                    _ = CreateRequest();
-                    _createStatus = string.Empty;
-                    ImGui.CloseCurrentPopup();
+                    ImGui.InputText("Title", ref _newTitle, 100);
+                    ImGui.InputTextMultiline("Description", ref _newDescription, 1000, new Vector2(300, 80));
+                    var typeIdx = (int)_newType;
+                    var typeLabels = Enum.GetNames<RequestType>();
+                    if (ImGui.Combo("Type", ref typeIdx, typeLabels, typeLabels.Length))
+                        _newType = (RequestType)typeIdx;
+                    var urgIdx = (int)_newUrgency;
+                    var urgLabels = Enum.GetNames<RequestUrgency>();
+                    if (ImGui.Combo("Urgency", ref urgIdx, urgLabels, urgLabels.Length))
+                        _newUrgency = (RequestUrgency)urgIdx;
+                    if (!string.IsNullOrEmpty(_createStatus))
+                        ImGui.TextUnformatted(_createStatus);
+                    if (ImGui.Button("Create"))
+                    {
+                        if (ValidateNewRequest())
+                        {
+                            _ = CreateRequest();
+                            _createStatus = string.Empty;
+                            ImGui.CloseCurrentPopup();
+                        }
+                    }
+                    ImGui.SameLine();
+                    if (ImGui.Button("Cancel"))
+                    {
+                        ImGui.CloseCurrentPopup();
+                    }
+                }
+                finally
+                {
+                    ImGui.EndPopup();
                 }
             }
-            ImGui.SameLine();
-            if (ImGui.Button("Cancel"))
+        }
+        catch (Exception ex)
+        {
+            try
             {
-                ImGui.CloseCurrentPopup();
+                PluginServices.Instance?.Log.Error(ex, "RequestBoardWindow.Draw()");
             }
-            ImGui.EndPopup();
+            catch
+            {
+                // ignored
+            }
         }
     }
 
@@ -255,37 +295,41 @@ public class RequestBoardWindow
         if (!ImGui.BeginPopup("requestMessage"))
             return;
 
-        if (_messagePopupRequestId == null || !RequestStateService.TryGet(_messagePopupRequestId, out var req))
+        try
         {
-            ImGui.TextUnformatted("No request selected.");
-            if (ImGui.Button("Close"))
+            if (_messagePopupRequestId == null || !RequestStateService.TryGet(_messagePopupRequestId, out var req))
+            {
+                ImGui.TextUnformatted("No request selected.");
+                if (ImGui.Button("Close"))
+                {
+                    ImGui.CloseCurrentPopup();
+                    _messagePopupRequestId = null;
+                }
+                return;
+            }
+
+            var draft = _messageDrafts.TryGetValue(req.Id, out var existing) ? existing : string.Empty;
+            ImGui.InputTextMultiline("##message", ref draft, 1000, new Vector2(320, 120));
+            _messageDrafts[req.Id] = draft;
+
+            if (ImGui.Button("Send") && !string.IsNullOrWhiteSpace(draft))
+            {
+                _ = CommentAndRefresh(req, draft);
+                _messageDrafts[req.Id] = string.Empty;
+                ImGui.CloseCurrentPopup();
+                _messagePopupRequestId = null;
+            }
+            ImGui.SameLine();
+            if (ImGui.Button("Cancel"))
             {
                 ImGui.CloseCurrentPopup();
                 _messagePopupRequestId = null;
             }
+        }
+        finally
+        {
             ImGui.EndPopup();
-            return;
         }
-
-        var draft = _messageDrafts.TryGetValue(req.Id, out var existing) ? existing : string.Empty;
-        ImGui.InputTextMultiline("##message", ref draft, 1000, new Vector2(320, 120));
-        _messageDrafts[req.Id] = draft;
-
-        if (ImGui.Button("Send") && !string.IsNullOrWhiteSpace(draft))
-        {
-            _ = CommentAndRefresh(req, draft);
-            _messageDrafts[req.Id] = string.Empty;
-            ImGui.CloseCurrentPopup();
-            _messagePopupRequestId = null;
-        }
-        ImGui.SameLine();
-        if (ImGui.Button("Cancel"))
-        {
-            ImGui.CloseCurrentPopup();
-            _messagePopupRequestId = null;
-        }
-
-        ImGui.EndPopup();
     }
 
     private async Task UpdateAndRefresh(RequestState req, RequestStatus newStatus)

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -129,34 +129,23 @@ public class SettingsWindow : Window, IDisposable
 
         try
         {
-            if (ImGui.BeginTabBar("SettingsTabs"))
+            if (!ServicesReady)
             {
-                if (!ServicesReady)
-                {
-                    ImGui.TextColored(new Vector4(1f, 0.85f, 0f, 1f), "Some services are still starting; features that depend on them are temporarily disabled.");
-                    ImGui.Separator();
-                }
-
-                if (ImGui.BeginTabItem("General"))
-                {
-                    DrawGeneralTab();
-                    ImGui.EndTabItem();
-                }
-
-                if (ImGui.BeginTabItem("Appearance"))
-                {
-                    DrawAppearanceTab();
-                    ImGui.EndTabItem();
-                }
-
-                if (ImGui.BeginTabItem("SyncShell Settings"))
-                {
-                    DrawSyncshellTab();
-                    ImGui.EndTabItem();
-                }
-
-                ImGui.EndTabBar();
+                ImGui.TextColored(new Vector4(1f, 0.85f, 0f, 1f), "Some services are still starting; features that depend on them are temporarily disabled.");
+                ImGui.Separator();
             }
+
+            DrawGeneralTab();
+
+            ImGui.Separator();
+            ImGui.Spacing();
+
+            DrawAppearanceTab();
+
+            ImGui.Separator();
+            ImGui.Spacing();
+
+            DrawSyncshellTab();
         }
         catch (Exception ex)
         {

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -22,6 +22,7 @@ using Penumbra.Api.Enums;
 using Serilog;
 using Serilog.Events;
 using Dalamud.Interface.Utility;
+using Dalamud.Plugin.Services;
 using ImGuiInputTextCallbackData = ImGuiNET.ImGuiInputTextCallbackData;
 using ImGuiMouseCursor = ImGuiNET.ImGuiMouseCursor;
 
@@ -292,78 +293,82 @@ public class SyncshellWindow : IDisposable
             return;
         }
 
-        if (!_config.FCSyncShell)
+        try
         {
-            const string message = "SyncShell is under development";
-            var size = ImGui.CalcTextSize(message);
-            var avail = ImGui.GetContentRegionAvail();
-            ImGui.SetCursorPos(new Vector2((avail.X - size.X) / 2, (avail.Y - size.Y) / 2));
-            ImGui.TextUnformatted(message);
-            return;
-        }
-
-        if (!_loading && (Volatile.Read(ref _needsRefresh) || DateTimeOffset.UtcNow - _lastRefresh > TimeSpan.FromMinutes(5)))
-            _ = Refresh();
-
-        if (Volatile.Read(ref _membershipRefreshInProgress) == 0)
-        {
-            var refreshAge = DateTimeOffset.UtcNow - _lastMembershipFetch;
-            if (Volatile.Read(ref _membershipNeedsRefresh) || refreshAge > TimeSpan.FromSeconds(45))
+            if (!_config.FCSyncShell)
             {
-                RequestMembershipRefresh();
+                const string message = "SyncShell is under development";
+                var size = ImGui.CalcTextSize(message);
+                var avail = ImGui.GetContentRegionAvail();
+                ImGui.SetCursorPos(new Vector2((avail.X - size.X) / 2, (avail.Y - size.Y) / 2));
+                ImGui.TextUnformatted(message);
+                return;
             }
-        }
 
-        if (_loading)
-        {
-            ImGui.TextUnformatted("Loading...");
-            return;
-        }
+            if (!_loading && (Volatile.Read(ref _needsRefresh) || DateTimeOffset.UtcNow - _lastRefresh > TimeSpan.FromMinutes(5)))
+                _ = Refresh();
 
-        if (_penumbraConflict != null)
-            ImGui.OpenPopup("Penumbra Conflict");
-        var openConflict = true;
-        if (_penumbraConflict != null && ImGui.BeginPopupModal("Penumbra Conflict", ref openConflict, ImGuiWindowFlags.AlwaysAutoResize))
-        {
-            ImGui.TextUnformatted($"Mod {_penumbraConflict.ModName} already exists. Use vault version or keep mine?");
-            if (ImGui.Button("Use vault version"))
+            if (Volatile.Read(ref _membershipRefreshInProgress) == 0)
             {
-                _penumbraConflict?.Tcs.TrySetResult(true);
-                _penumbraConflict = null;
+                var refreshAge = DateTimeOffset.UtcNow - _lastMembershipFetch;
+                if (Volatile.Read(ref _membershipNeedsRefresh) || refreshAge > TimeSpan.FromSeconds(45))
+                {
+                    RequestMembershipRefresh();
+                }
             }
-            ImGui.SameLine();
-            if (ImGui.Button("Keep mine"))
+
+            if (_loading)
+            {
+                ImGui.TextUnformatted("Loading...");
+                return;
+            }
+
+            if (_penumbraConflict != null)
+                ImGui.OpenPopup("Penumbra Conflict");
+            var openConflict = true;
+            if (_penumbraConflict != null && ImGui.BeginPopupModal("Penumbra Conflict", ref openConflict, ImGuiWindowFlags.AlwaysAutoResize))
+            {
+                ImGui.TextUnformatted($"Mod {_penumbraConflict.ModName} already exists. Use vault version or keep mine?");
+                if (ImGui.Button("Use vault version"))
+                {
+                    _penumbraConflict?.Tcs.TrySetResult(true);
+                    _penumbraConflict = null;
+                }
+                ImGui.SameLine();
+                if (ImGui.Button("Keep mine"))
+                {
+                    _penumbraConflict?.Tcs.TrySetResult(false);
+                    _penumbraConflict = null;
+                }
+                ImGui.EndPopup();
+            }
+            else if (_penumbraConflict != null && !openConflict)
             {
                 _penumbraConflict?.Tcs.TrySetResult(false);
                 _penumbraConflict = null;
             }
-            ImGui.EndPopup();
-        }
-        else if (_penumbraConflict != null && !openConflict)
-        {
-            _penumbraConflict?.Tcs.TrySetResult(false);
-            _penumbraConflict = null;
-        }
 
-        var style = ImGui.GetStyle();
-        var settingsSplitterHeight = Math.Max(4f, style.FramePadding.Y);
-        var totalAvailableHeight = ImGui.GetContentRegionAvail().Y;
-        var maxSettingsHeight = CalculateMaxSyncSettingsHeight(totalAvailableHeight, settingsSplitterHeight);
-        if (!float.IsFinite(_syncSettingsHeight) || _syncSettingsHeight <= 0f)
-            _syncSettingsHeight = DefaultSyncSettingsHeight;
-        maxSettingsHeight = MathF.Max(MinSyncSettingsHeight, maxSettingsHeight);
-        _syncSettingsHeight = Math.Clamp(_syncSettingsHeight, MinSyncSettingsHeight, maxSettingsHeight);
-        ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
-        if (ImGui.BeginTabBar("syncshell-settings-tabs"))
-        {
-            if (ImGui.BeginTabItem("Sync"))
+            var style = ImGui.GetStyle();
+            var settingsSplitterHeight = Math.Max(4f, style.FramePadding.Y);
+            var totalAvailableHeight = ImGui.GetContentRegionAvail().Y;
+            var maxSettingsHeight = CalculateMaxSyncSettingsHeight(totalAvailableHeight, settingsSplitterHeight);
+            if (!float.IsFinite(_syncSettingsHeight) || _syncSettingsHeight <= 0f)
+                _syncSettingsHeight = DefaultSyncSettingsHeight;
+            maxSettingsHeight = MathF.Max(MinSyncSettingsHeight, maxSettingsHeight);
+            _syncSettingsHeight = Math.Clamp(_syncSettingsHeight, MinSyncSettingsHeight, maxSettingsHeight);
+            ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), true, ImGuiWindowFlags.None);
+            try
             {
-                ImGui.TextUnformatted("Sync Settings");
-                var autoSync = _autoSyncAllUsers;
-                if (ImGui.Checkbox("Auto Sync to all Connected Users", ref autoSync))
+                if (ImGui.BeginTabBar("syncshell-settings-tabs"))
                 {
-                    SetSyncPreferences(autoSync, _manualSyncAllUsers, _manualSyncCustom);
-                }
+                    if (ImGui.BeginTabItem("Sync"))
+                    {
+                        ImGui.TextUnformatted("Sync Settings");
+                        var autoSync = _autoSyncAllUsers;
+                        if (ImGui.Checkbox("Auto Sync to all Connected Users", ref autoSync))
+                        {
+                            SetSyncPreferences(autoSync, _manualSyncAllUsers, _manualSyncCustom);
+                        }
 
         var manualAll = _manualSyncAllUsers;
         if (ImGui.Checkbox("Manual Sync (All Users)", ref manualAll))
@@ -457,10 +462,13 @@ public class SyncshellWindow : IDisposable
                 ImGui.EndTabItem();
             }
 
-            ImGui.EndTabBar();
-        }
-        ImGui.EndChild();
-
+                    ImGui.EndTabBar();
+                }
+            }
+            finally
+            {
+                ImGui.EndChild();
+            }
         var splitterWidth = ImGui.GetContentRegionAvail().X;
         if (splitterWidth <= 0f)
         {
@@ -514,7 +522,7 @@ public class SyncshellWindow : IDisposable
             var childHeight = 70f;
             if (asset.Kind == "BUNDLE" && asset.Items != null)
                 childHeight += ImGui.GetTextLineHeightWithSpacing() * asset.Items.Count;
-            ImGui.BeginChild("card", new Vector2(-1, childHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+            ImGui.BeginChild("card", new Vector2(-1, childHeight), true, ImGuiWindowFlags.None);
             ImGui.TextUnformatted(asset.Name);
             if (!_seenAssetIds.Contains(asset.Id))
             {
@@ -572,6 +580,17 @@ public class SyncshellWindow : IDisposable
 
         if (saveSeen)
             PluginServices.Instance?.PluginInterface.SavePluginConfig(_config);
+    }
+    catch (Exception ex)
+    {
+        try
+        {
+            PluginServices.Instance?.Log.Error(ex, "SyncshellWindow.Draw()");
+        }
+        catch
+        {
+            // ignored
+        }
     }
 
     private static float CalculateMaxSyncSettingsHeight(float availableHeight, float splitterHeight)
@@ -854,7 +873,7 @@ public class SyncshellWindow : IDisposable
     {
         var id = $"syncshell-panel-{label.Replace(' ', '-').ToLowerInvariant()}";
         var size = fillRemaining ? new Vector2(-1, 0f) : new Vector2(-1, height);
-        ImGui.BeginChild(id, size, ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+        ImGui.BeginChild(id, size, true, ImGuiWindowFlags.None);
         ImGui.TextUnformatted(label);
         ImGui.Separator();
         content();

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Globalization;
 using ImGuiNET;
+using Dalamud.Plugin.Services;
 using DiscordHelper;
 using DemiCat.UI;
 using DemiCatPlugin.Emoji;
@@ -127,97 +128,110 @@ public class TemplatesWindow
 
     public void Draw()
     {
-        if (!_config.Templates)
+        if (ImGui.GetCurrentContext() == IntPtr.Zero)
         {
-            ImGui.TextUnformatted("Feature disabled");
             return;
         }
 
-        if (!_tokenManager.IsReady())
+        try
         {
-            ImGui.TextUnformatted("Link DemiCat to manage templates");
-            return;
-        }
+            if (!_config.Templates)
+            {
+                ImGui.TextUnformatted("Feature disabled");
+                return;
+            }
 
-        if (!_rolesLoaded && !_rolesLoading)
-        {
-            _ = LoadRoles();
-        }
+            if (!_tokenManager.IsReady())
+            {
+                ImGui.TextUnformatted("Link DemiCat to manage templates");
+                return;
+            }
 
-        if (!_channelsLoaded && !_channelsLoading)
-        {
-            _ = FetchChannels();
-        }
-        if (!_templatesLoaded && !_templatesLoading)
-        {
-            _ = LoadTemplates();
-        }
-        if (_channels.Count > 0)
-        {
-            var channelNames = _channelDisplayNames;
+            if (!_rolesLoaded && !_rolesLoading)
+            {
+                _ = LoadRoles();
+            }
+
+            if (!_channelsLoaded && !_channelsLoading)
+            {
+                _ = FetchChannels();
+            }
+            if (!_templatesLoaded && !_templatesLoading)
+            {
+                _ = LoadTemplates();
+            }
+            if (_channels.Count > 0)
+            {
+                var channelNames = _channelDisplayNames;
+                {
+                    using var emojiFont = _emojiManager.PushEmojiFont();
+                    if (ImGui.Combo("Channel", ref _channelIndex, channelNames, channelNames.Length))
+                    {
+                        var newId = _channels[_channelIndex].Id;
+                        _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, newId);
+                    }
+                }
+            }
+            else
+            {
+                ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
+            }
+
+            ImGui.BeginChild("TemplateList", new Vector2(150, 0), true, ImGuiWindowFlags.None);
+            try
             {
                 using var emojiFont = _emojiManager.PushEmojiFont();
-                if (ImGui.Combo("Channel", ref _channelIndex, channelNames, channelNames.Length))
+                for (var i = 0; i < _templates.Count; i++)
                 {
-                    var newId = _channels[_channelIndex].Id;
-                    _channelSelection.SetChannel(ChannelKind.Event, _config.GuildId, newId);
+                    var tmplItem = _templates[i];
+                    var name = tmplItem.Template.Name;
+                    if (ImGui.Selectable(name, _selectedIndex == i))
+                    {
+                        SelectTemplate(i, tmplItem.Template);
+                    }
                 }
             }
-        }
-        else
-        {
-            ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
-        }
-
-        ImGui.BeginChild("TemplateList", new Vector2(150, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
-        {
-            using var emojiFont = _emojiManager.PushEmojiFont();
-            for (var i = 0; i < _templates.Count; i++)
+            finally
             {
-                var tmplItem = _templates[i];
-                var name = tmplItem.Template.Name;
-                if (ImGui.Selectable(name, _selectedIndex == i))
-                {
-                    SelectTemplate(i, tmplItem.Template);
-                }
+                ImGui.EndChild();
             }
-        }
-        ImGui.EndChild();
 
-        ImGui.SameLine();
-
-        ImGui.BeginChild("TemplateContent", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.None);
-        if (_selectedIndex >= 0 && _selectedIndex < _templates.Count)
-        {
-            var tmpl = _templates[_selectedIndex].Template;
-            ImGui.TextUnformatted("Event Time");
-            if (_timePicker.Draw("TemplateTime", out var selectedTime))
-            {
-                ApplyTime(tmpl, selectedTime);
-            }
-            ImGui.Spacing();
-            if (ImGui.Button("Preview"))
-            {
-                OpenPreview(tmpl);
-            }
             ImGui.SameLine();
-            if (ImGui.Button("Post"))
-            {
-                _pendingTemplate = tmpl;
-                _confirmPost = true;
-            }
-            ImGui.SameLine();
-            if (ImGui.Button("Delete"))
-            {
-                var id = _templates[_selectedIndex].Id;
-                _ = DeleteTemplate(id);
-            }
 
-            if (_rolesLoaded)
+            ImGui.BeginChild("TemplateContent", ImGui.GetContentRegionAvail(), false, ImGuiWindowFlags.None);
+            try
             {
-                if (_roles.Count > 0)
+                if (_selectedIndex >= 0 && _selectedIndex < _templates.Count)
                 {
-                    ImGui.Separator();
+                    var tmpl = _templates[_selectedIndex].Template;
+                    ImGui.TextUnformatted("Event Time");
+                    if (_timePicker.Draw("TemplateTime", out var selectedTime))
+                    {
+                        ApplyTime(tmpl, selectedTime);
+                    }
+                    ImGui.Spacing();
+                    if (ImGui.Button("Preview"))
+                    {
+                        OpenPreview(tmpl);
+                    }
+                    ImGui.SameLine();
+                    if (ImGui.Button("Post"))
+                    {
+                        _pendingTemplate = tmpl;
+                        _confirmPost = true;
+                    }
+                    ImGui.SameLine();
+                    if (ImGui.Button("Delete"))
+                    {
+                        var id = _templates[_selectedIndex].Id;
+                        _ = DeleteTemplate(id);
+                    }
+
+                    if (_rolesLoaded)
+                    {
+                        if (_roles.Count > 0)
+                        {
+                            ImGui.Separator();
                     ImGui.Text("Mention Roles");
                     {
                         using var emojiFont = _emojiManager.PushEmojiFont();
@@ -291,7 +305,10 @@ public class TemplatesWindow
         {
             ImGui.TextUnformatted("Select a template");
         }
-        ImGui.EndChild();
+            finally
+            {
+                ImGui.EndChild();
+            }
 
         if (!string.IsNullOrEmpty(_lastResult))
         {
@@ -315,6 +332,18 @@ public class TemplatesWindow
                 ImGui.EndChild();
             }
             ImGui.End();
+        }
+        }
+        catch (Exception ex)
+        {
+            try
+            {
+                PluginServices.Instance?.Log.Error(ex, "TemplatesWindow.Draw()");
+            }
+            catch
+            {
+                // ignored
+            }
         }
     }
 

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -33,6 +33,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
     private readonly List<ChannelDto> _channels = new();
     private string[] _channelDisplayNames = Array.Empty<string>();
     private bool _channelsLoaded;
+    private bool _channelsFetchInFlight;
     private bool _channelFetchFailed;
     private string _channelErrorMessage = string.Empty;
     private int _selectedIndex;
@@ -900,7 +901,11 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
             if (!_channelsLoaded)
             {
-                _ = FetchChannels();
+                if (!_channelsFetchInFlight)
+                {
+                    _channelsFetchInFlight = true;
+                    _ = FetchChannels();
+                }
                 ImGui.TextUnformatted("Loading channels...");
                 return;
             }
@@ -1000,7 +1005,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
             _embedWarningShown = false;
 
-            ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+            ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), true, ImGuiWindowFlags.None);
             foreach (var view in embeds)
             {
                 view?.Draw();
@@ -1206,37 +1211,102 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
     private async Task FetchChannels(bool refreshed = false)
     {
-        if (!_tokenManager.IsReady()) return;
-        if (!ApiHelpers.ValidateApiBaseUrl(_config))
-        {
-            PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
-            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
-            {
-                _channelFetchFailed = true;
-                _channelErrorMessage = "Invalid API URL";
-                _channelsLoaded = true;
-            });
-            return;
-        }
-
+        var resetFetchFlag = false;
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
-            ApiHelpers.AddAuthHeader(request, _tokenManager);
-            var response = await _httpClient.SendAsync(request);
-            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            _channelsFetchInFlight = true;
+            resetFetchFlag = true;
+
+            if (!_tokenManager.IsReady()) return;
+            if (!ApiHelpers.ValidateApiBaseUrl(_config))
             {
-                var responseBody = await response.Content.ReadAsStringAsync();
+                PluginServices.Instance!.Log.Warning("Cannot fetch channels: API base URL is not configured.");
+                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Invalid API URL";
+                    _channelsLoaded = true;
+                });
+                return;
+            }
+
+            try
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels");
+                ApiHelpers.AddAuthHeader(request, _tokenManager);
+                var response = await _httpClient.SendAsync(request);
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    var responseBody = await response.Content.ReadAsStringAsync();
+                    PluginServices.Instance!.Log.Warning(
+                        $"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}. Clearing token");
+                    _tokenManager.Clear("Invalid API key");
+                    return;
+                }
+                if (response.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    var responseBody = await response.Content.ReadAsStringAsync();
+                    PluginServices.Instance!.Log.Warning(
+                        $"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}.");
+                    ShowPermissionToast();
+                    _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                    {
+                        _channelFetchFailed = true;
+                        _channelErrorMessage = ForbiddenMessage;
+                        _channelsLoaded = true;
+                    });
+                    return;
+                }
+                if (!response.IsSuccessStatusCode)
+                {
+                    var responseBody = await response.Content.ReadAsStringAsync();
+                    PluginServices.Instance!.Log.Warning($"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}");
+                    _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                    {
+                        _channelFetchFailed = true;
+                        _channelErrorMessage = "Failed to load channels";
+                        _channelsLoaded = true;
+                    });
+                    return;
+                }
+                var stream = await response.Content.ReadAsStreamAsync();
+                var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
+                var eventChannels = (dto.Event ?? new List<ChannelDto>())
+                    .Where(c => c != null)
+                    .ToList();
+                foreach (var channel in eventChannels)
+                {
+                    channel.EnsureKind(ChannelKind.Event);
+                }
+                if (await ChannelNameResolver.Resolve(
+                        eventChannels,
+                        _httpClient,
+                        _config,
+                        refreshed,
+                        () => FetchChannels(true),
+                        _tokenManager))
+                {
+                    return;
+                }
+                ResetPermissionToast();
+                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    ApplyEventChannels(eventChannels);
+                });
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
+            {
                 PluginServices.Instance!.Log.Warning(
-                    $"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}. Clearing token");
+                    ex,
+                    "Failed to fetch channels due to authorization failure; clearing token");
                 _tokenManager.Clear("Invalid API key");
                 return;
             }
-            if (response.StatusCode == HttpStatusCode.Forbidden)
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
             {
-                var responseBody = await response.Content.ReadAsStringAsync();
                 PluginServices.Instance!.Log.Warning(
-                    $"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}.");
+                    ex,
+                    "Failed to fetch channels due to forbidden response");
                 ShowPermissionToast();
                 _ = PluginServices.Instance!.Framework.RunOnTick(() =>
                 {
@@ -1244,85 +1314,34 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                     _channelErrorMessage = ForbiddenMessage;
                     _channelsLoaded = true;
                 });
-                return;
             }
-            if (!response.IsSuccessStatusCode)
+            catch (HttpRequestException ex)
             {
-                var responseBody = await response.Content.ReadAsStringAsync();
-                PluginServices.Instance!.Log.Warning($"Failed to fetch channels. Status: {response.StatusCode}. Response Body: {responseBody}");
+                PluginServices.Instance!.Log.Warning($"Failed to fetch channels. Status: {ex.StatusCode}");
                 _ = PluginServices.Instance!.Framework.RunOnTick(() =>
                 {
                     _channelFetchFailed = true;
                     _channelErrorMessage = "Failed to load channels";
                     _channelsLoaded = true;
                 });
-                return;
             }
-            var stream = await response.Content.ReadAsStreamAsync();
-            var dto = await JsonSerializer.DeserializeAsync<ChannelListDto>(stream) ?? new ChannelListDto();
-            var eventChannels = (dto.Event ?? new List<ChannelDto>())
-                .Where(c => c != null)
-                .ToList();
-            foreach (var channel in eventChannels)
+            catch (Exception ex)
             {
-                channel.EnsureKind(ChannelKind.Event);
+                PluginServices.Instance!.Log.Error(ex, "Error fetching channels");
+                _ = PluginServices.Instance!.Framework.RunOnTick(() =>
+                {
+                    _channelFetchFailed = true;
+                    _channelErrorMessage = "Failed to load channels";
+                    _channelsLoaded = true;
+                });
             }
-            if (await ChannelNameResolver.Resolve(
-                    eventChannels,
-                    _httpClient,
-                    _config,
-                    refreshed,
-                    () => FetchChannels(true),
-                    _tokenManager))
+        }
+        finally
+        {
+            if (resetFetchFlag)
             {
-                return;
+                _channelsFetchInFlight = false;
             }
-            ResetPermissionToast();
-            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
-            {
-                ApplyEventChannels(eventChannels);
-            });
-        }
-        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized)
-        {
-            PluginServices.Instance!.Log.Warning(
-                ex,
-                "Failed to fetch channels due to authorization failure; clearing token");
-            _tokenManager.Clear("Invalid API key");
-            return;
-        }
-        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.Forbidden)
-        {
-            PluginServices.Instance!.Log.Warning(
-                ex,
-                "Failed to fetch channels due to forbidden response");
-            ShowPermissionToast();
-            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
-            {
-                _channelFetchFailed = true;
-                _channelErrorMessage = ForbiddenMessage;
-                _channelsLoaded = true;
-            });
-        }
-        catch (HttpRequestException ex)
-        {
-            PluginServices.Instance!.Log.Warning($"Failed to fetch channels. Status: {ex.StatusCode}");
-            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
-            {
-                _channelFetchFailed = true;
-                _channelErrorMessage = "Failed to load channels";
-                _channelsLoaded = true;
-            });
-        }
-        catch (Exception ex)
-        {
-            PluginServices.Instance!.Log.Error(ex, "Error fetching channels");
-            _ = PluginServices.Instance!.Framework.RunOnTick(() =>
-            {
-                _channelFetchFailed = true;
-                _channelErrorMessage = "Failed to load channels";
-                _channelsLoaded = true;
-            });
         }
     }
 


### PR DESCRIPTION
## Summary
- add context guards, exception handling, and RAII cleanup to dockable and child windows to avoid ImGui stack imbalance
- simplify the settings window to a single-flow layout without tabs while keeping color management localized
- guard event channel fetches and swap ImGuiChildFlags usage for bool-based overloads to stay compatible with Dalamud ImGui

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b3b890648328a5b84efd1e66bccc