### PR TITLE
Fix layout blocks in Syncshell and Templates windows

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -370,98 +370,101 @@ public class SyncshellWindow : IDisposable
                             SetSyncPreferences(autoSync, _manualSyncAllUsers, _manualSyncCustom);
                         }
 
-        var manualAll = _manualSyncAllUsers;
-        if (ImGui.Checkbox("Manual Sync (All Users)", ref manualAll))
-        {
-            SetSyncPreferences(manualAll ? false : _autoSyncAllUsers, manualAll, _manualSyncCustom);
-        }
+                        var manualAll = _manualSyncAllUsers;
+                        if (ImGui.Checkbox("Manual Sync (All Users)", ref manualAll))
+                        {
+                            SetSyncPreferences(manualAll ? false : _autoSyncAllUsers, manualAll, _manualSyncCustom);
+                        }
 
-        var manualCustom = _manualSyncCustom;
-        if (ImGui.Checkbox("Manual Sync (Custom)", ref manualCustom))
-        {
-            SetSyncPreferences(manualCustom ? false : _autoSyncAllUsers, _manualSyncAllUsers, manualCustom);
-        }
+                        var manualCustom = _manualSyncCustom;
+                        if (ImGui.Checkbox("Manual Sync (Custom)", ref manualCustom))
+                        {
+                            SetSyncPreferences(manualCustom ? false : _autoSyncAllUsers, _manualSyncAllUsers, manualCustom);
+                        }
 
-        var manualModeActive = IsManualModeActive;
-        ImGui.BeginDisabled(!manualModeActive);
-        if (ImGui.Button("Sync now"))
-        {
-            _ = RunManualSyncAsync();
-        }
-        ImGui.EndDisabled();
-        if (!manualModeActive && ImGui.IsItemHovered())
-            ImGui.SetTooltip("Enable a manual sync mode to push pending changes.");
+                        var manualModeActive = IsManualModeActive;
+                        ImGui.BeginDisabled(!manualModeActive);
+                        if (ImGui.Button("Sync now"))
+                        {
+                            _ = RunManualSyncAsync();
+                        }
+                        ImGui.EndDisabled();
+                        if (!manualModeActive && ImGui.IsItemHovered())
+                            ImGui.SetTooltip("Enable a manual sync mode to push pending changes.");
 
-        if (ManualSyncPending)
-        {
-            ImGui.SameLine();
-            ImGui.TextColored(new Vector4(1f, 0.8f, 0.2f, 1f), GetManualPendingLabel());
-        }
-        var limitChanged = ImGui.SliderFloat("File-size limit (MB)", ref _fileSizeLimitMb, 100f, 5120f, "%.0f MB");
-        long sessionBytes;
-        long reservedBytes;
-        long limitBytes;
-        string? budgetStatus;
-        lock (_budgetLock)
-        {
-            sessionBytes = _sessionBytesDownloaded;
-            reservedBytes = _sessionBytesReserved;
-            limitBytes = GetFileSizeLimitBytes();
-            budgetStatus = _budgetStatusMessage;
-        }
+                        if (ManualSyncPending)
+                        {
+                            ImGui.SameLine();
+                            ImGui.TextColored(new Vector4(1f, 0.8f, 0.2f, 1f), GetManualPendingLabel());
+                        }
 
-        var usageLabel = reservedBytes > 0
-            ? $"Session usage: {FormatSize(sessionBytes)} / {FormatSize(limitBytes)} ({FormatSize(reservedBytes)} pending)"
-            : $"Session usage: {FormatSize(sessionBytes)} / {FormatSize(limitBytes)}";
-        ImGui.TextUnformatted(usageLabel);
-        if (!string.IsNullOrEmpty(budgetStatus))
-        {
-            ImGui.TextColored(new Vector4(1f, 0.6f, 0.6f, 1f), budgetStatus);
-        }
+                        var limitChanged = ImGui.SliderFloat("File-size limit (MB)", ref _fileSizeLimitMb, 100f, 5120f, "%.0f MB");
+                        long sessionBytes;
+                        long reservedBytes;
+                        long limitBytes;
+                        string? budgetStatus;
+                        lock (_budgetLock)
+                        {
+                            sessionBytes = _sessionBytesDownloaded;
+                            reservedBytes = _sessionBytesReserved;
+                            limitBytes = GetFileSizeLimitBytes();
+                            budgetStatus = _budgetStatusMessage;
+                        }
 
-        if (limitChanged)
-        {
-            OnFileSizeLimitChanged();
-        }
-        var peerSync = _peerSyncEnabled;
-        if (ImGui.Checkbox("Enable Peer Sync", ref peerSync))
-        {
-            _peerSyncEnabled = peerSync;
-            _config.SyncshellPeerSyncEnabled = peerSync;
-            PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
-            UpdateSyncClientState();
-        }
+                        var usageLabel = reservedBytes > 0
+                            ? $"Session usage: {FormatSize(sessionBytes)} / {FormatSize(limitBytes)} ({FormatSize(reservedBytes)} pending)"
+                            : $"Session usage: {FormatSize(sessionBytes)} / {FormatSize(limitBytes)}";
+                        ImGui.TextUnformatted(usageLabel);
+                        if (!string.IsNullOrEmpty(budgetStatus))
+                        {
+                            ImGui.TextColored(new Vector4(1f, 0.6f, 0.6f, 1f), budgetStatus);
+                        }
 
-        var cacheLimit = _cacheSizeLimitMb;
-        if (ImGui.SliderInt("Cache size limit (MB)", ref cacheLimit, 256, 16384))
-        {
-            cacheLimit = Math.Clamp(cacheLimit, 256, 16384);
-            if (cacheLimit != _cacheSizeLimitMb)
-            {
-                _cacheSizeLimitMb = cacheLimit;
-                _config.SyncshellCacheLimitMb = cacheLimit;
-                PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
-                _ = TrimCacheAsync();
-            }
-        }
-        if (ImGui.Button("Resync All"))
-        {
-            _ = ResyncAll();
-        }
-        ImGui.SameLine();
-        if (ImGui.Button("Clear Cache"))
-        {
-            _ = ClearRemoteCache();
-        }
-        ImGui.SameLine();
-        var pauseLabel = _syncPaused ? "Resume Sync" : "Pause Sync";
-        if (ImGui.Button(pauseLabel))
-        {
-            SetSyncPaused(!_syncPaused);
-        }
-                ImGui.EndTabItem();
-            }
+                        if (limitChanged)
+                        {
+                            OnFileSizeLimitChanged();
+                        }
 
+                        var peerSync = _peerSyncEnabled;
+                        if (ImGui.Checkbox("Enable Peer Sync", ref peerSync))
+                        {
+                            _peerSyncEnabled = peerSync;
+                            _config.SyncshellPeerSyncEnabled = peerSync;
+                            PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
+                            UpdateSyncClientState();
+                        }
+
+                        var cacheLimit = _cacheSizeLimitMb;
+                        if (ImGui.SliderInt("Cache size limit (MB)", ref cacheLimit, 256, 16384))
+                        {
+                            cacheLimit = Math.Clamp(cacheLimit, 256, 16384);
+                            if (cacheLimit != _cacheSizeLimitMb)
+                            {
+                                _cacheSizeLimitMb = cacheLimit;
+                                _config.SyncshellCacheLimitMb = cacheLimit;
+                                PluginServices.Instance?.PluginInterface?.SavePluginConfig(_config);
+                                _ = TrimCacheAsync();
+                            }
+                        }
+
+                        if (ImGui.Button("Resync All"))
+                        {
+                            _ = ResyncAll();
+                        }
+                        ImGui.SameLine();
+                        if (ImGui.Button("Clear Cache"))
+                        {
+                            _ = ClearRemoteCache();
+                        }
+                        ImGui.SameLine();
+                        var pauseLabel = _syncPaused ? "Resume Sync" : "Pause Sync";
+                        if (ImGui.Button(pauseLabel))
+                        {
+                            SetSyncPaused(!_syncPaused);
+                        }
+
+                        ImGui.EndTabItem();
+                    }
                     ImGui.EndTabBar();
                 }
             }
@@ -599,7 +602,9 @@ public class SyncshellWindow : IDisposable
             return MinSyncSettingsHeight;
 
         var membershipSplitterHeight = Math.Max(4f, ImGui.GetStyle().FramePadding.Y);
-        var minRemaining = splitterHeight + MinMembershipPanelHeight * MembershipPanelCount + membershipSplitterHeight * (MembershipPanelCount - 1);
+        var minRemaining = splitterHeight
+            + MinMembershipPanelHeight * MembershipPanelCount
+            + membershipSplitterHeight * (MembershipPanelCount - 1);
         var maxHeight = MathF.Max(MinSyncSettingsHeight, availableHeight - minRemaining);
         maxHeight = MathF.Min(MaxSyncSettingsHeight, maxHeight);
         return MathF.Max(MinSyncSettingsHeight, maxHeight);

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -232,79 +232,83 @@ public class TemplatesWindow
                         if (_roles.Count > 0)
                         {
                             ImGui.Separator();
-                    ImGui.Text("Mention Roles");
-                    {
-                        using var emojiFont = _emojiManager.PushEmojiFont();
-                        foreach (var role in _roles)
-                        {
-                            var roleId = role.Id;
-                            var sel = _mentions.Contains(roleId);
-                            if (ImGui.Checkbox($"{role.Name}##role{role.Id}", ref sel))
+                            ImGui.Text("Mention Roles");
+                            using var emojiFont = _emojiManager.PushEmojiFont();
+                            foreach (var role in _roles)
                             {
-                                if (sel) _mentions.Add(roleId); else _mentions.Remove(roleId);
+                                var roleId = role.Id;
+                                var sel = _mentions.Contains(roleId);
+                                if (ImGui.Checkbox($"{role.Name}##role{role.Id}", ref sel))
+                                {
+                                    if (sel)
+                                        _mentions.Add(roleId);
+                                    else
+                                        _mentions.Remove(roleId);
+                                }
                             }
                         }
+                        else
+                        {
+                            var msg = _config.MentionRoleIds.Count > 0 && RoleCache.LastErrorMessage == null
+                                ? "No mentionable roles configured"
+                                : RoleCache.LastErrorMessage ?? "No roles available";
+                            ImGui.TextUnformatted(msg);
+                        }
+                    }
+
+                    ButtonRowsImGui.Draw(_buttonRows, "template-button-rows");
+                    if (_confirmPost)
+                        ImGui.OpenPopup("Confirm Template Post");
+                    var openConfirm = _confirmPost;
+                    if (_confirmPost && ImGui.BeginPopupModal("Confirm Template Post", ref openConfirm, ImGuiWindowFlags.AlwaysAutoResize))
+                    {
+                        var channelName = _channels.FirstOrDefault(c => c.Id == ChannelId)?.Name ?? ChannelId;
+                        using (var emojiFont = _emojiManager.PushEmojiFont())
+                        {
+                            ImGui.TextUnformatted($"Channel: {channelName}");
+                        }
+
+                        var roleNames = _roles.Where(r => _mentions.Contains(r.Id)).Select(r => r.Name).ToList();
+                        using (var emojiFont = _emojiManager.PushEmojiFont())
+                        {
+                            ImGui.TextUnformatted("Roles: " + (roleNames.Count > 0 ? string.Join(", ", roleNames) : "None"));
+                        }
+
+                        var buttonsCount = _buttonRows.FlattenNonEmpty().Count();
+                        var canConfirm = !string.IsNullOrWhiteSpace(ChannelId)
+                            && DiscordValidation.IsImageUrlAllowed(tmpl.ImageUrl)
+                            && DiscordValidation.IsImageUrlAllowed(tmpl.ThumbnailUrl)
+                            && buttonsCount > 0;
+                        ImGui.BeginDisabled(!canConfirm);
+                        if (ImGui.Button("Confirm"))
+                        {
+                            if (_pendingTemplate != null)
+                                _ = PostTemplate(_pendingTemplate);
+                            _confirmPost = false;
+                            _pendingTemplate = null;
+                            ImGui.CloseCurrentPopup();
+                        }
+                        ImGui.EndDisabled();
+                        ImGui.SameLine();
+                        if (ImGui.Button("Cancel"))
+                        {
+                            _confirmPost = false;
+                            _pendingTemplate = null;
+                            ImGui.CloseCurrentPopup();
+                        }
+                        ImGui.EndPopup();
+                    }
+                    if (!_confirmPost || !openConfirm)
+                    {
+                        _confirmPost = false;
+                        _pendingTemplate = null;
                     }
                 }
                 else
                 {
-                    var msg = _config.MentionRoleIds.Count > 0 && RoleCache.LastErrorMessage == null
-                        ? "No mentionable roles configured"
-                        : RoleCache.LastErrorMessage ?? "No roles available";
-                    ImGui.TextUnformatted(msg);
+                    ImGui.TextUnformatted("Select a template");
                 }
             }
-
-            ButtonRowsImGui.Draw(_buttonRows, "template-button-rows");
-            if (_confirmPost)
-                ImGui.OpenPopup("Confirm Template Post");
-            var openConfirm = _confirmPost;
-            if (_confirmPost && ImGui.BeginPopupModal("Confirm Template Post", ref openConfirm, ImGuiWindowFlags.AlwaysAutoResize))
-            {
-            var channelName = _channels.FirstOrDefault(c => c.Id == ChannelId)?.Name ?? ChannelId;
-                {
-                    using var emojiFont = _emojiManager.PushEmojiFont();
-                    ImGui.TextUnformatted($"Channel: {channelName}");
-                }
-                var roleNames = _roles.Where(r => _mentions.Contains(r.Id)).Select(r => r.Name).ToList();
-                {
-                    using var emojiFont = _emojiManager.PushEmojiFont();
-                    ImGui.TextUnformatted("Roles: " + (roleNames.Count > 0 ? string.Join(", ", roleNames) : "None"));
-                }
-                var buttonsCount = _buttonRows.FlattenNonEmpty().Count();
-                bool canConfirm = !string.IsNullOrWhiteSpace(ChannelId)
-                    && DiscordValidation.IsImageUrlAllowed(tmpl.ImageUrl)
-                    && DiscordValidation.IsImageUrlAllowed(tmpl.ThumbnailUrl)
-                    && buttonsCount > 0;
-                ImGui.BeginDisabled(!canConfirm);
-                if (ImGui.Button("Confirm"))
-                {
-                    if (_pendingTemplate != null)
-                        _ = PostTemplate(_pendingTemplate);
-                    _confirmPost = false;
-                    _pendingTemplate = null;
-                    ImGui.CloseCurrentPopup();
-                }
-                ImGui.EndDisabled();
-                ImGui.SameLine();
-                if (ImGui.Button("Cancel"))
-                {
-                    _confirmPost = false;
-                    _pendingTemplate = null;
-                    ImGui.CloseCurrentPopup();
-                }
-                ImGui.EndPopup();
-            }
-            if (!_confirmPost || !openConfirm)
-            {
-                _confirmPost = false;
-                _pendingTemplate = null;
-            }
-        }
-        else
-        {
-            ImGui.TextUnformatted("Select a template");
-        }
             finally
             {
                 ImGui.EndChild();


### PR DESCRIPTION
## Summary
- restore proper indentation and scoping for the sync settings tab in SyncshellWindow
- clean up the template content panel and confirmation popup logic in TemplatesWindow

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5b78789088328990438a5569b2078