### PR TITLE
Update ImGui BeginChild usage for ImGui 1.90

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -803,7 +803,7 @@ public class ChatWindow : IDisposable
         }
         composeRatio = actualRatio;
         const float ScrollTolerance = 1f;
-        ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), true, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
 
         var fontScale = GetFontScale();
         var chatFontScope = PushWindowFontScale(fontScale);
@@ -1231,7 +1231,7 @@ public class ChatWindow : IDisposable
                 var desiredPreviewHeight = _previewContentHeight > 0f ? _previewContentHeight : fallbackHeight;
                 var previewHeight = Math.Clamp(desiredPreviewHeight, minPreviewHeight, maxPreviewHeight);
 
-                ImGui.BeginChild("##inputPreview", new Vector2(0, previewHeight), true, ImGuiWindowFlags.None);
+                ImGui.BeginChild("##inputPreview", new Vector2(0, previewHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
                 var childStartCursor = ImGui.GetCursorPosY();
                 if (!string.IsNullOrEmpty(plainTextPreview))
                 {
@@ -1563,7 +1563,7 @@ public class ChatWindow : IDisposable
         var codeBlock = Regex.Match(text, "^\\[CODEBLOCK\\](.+?)\\[/CODEBLOCK\\]$", RegexOptions.Singleline);
         if (codeBlock.Success)
         {
-            ImGui.BeginChild($"codeblock{GetHashCode()}{text.GetHashCode()}", new Vector2(0, 0), true, ImGuiWindowFlags.None);
+            ImGui.BeginChild($"codeblock{GetHashCode()}{text.GetHashCode()}", new Vector2(0, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             ImGui.TextUnformatted(codeBlock.Groups[1].Value);
             ImGui.EndChild();
             return;
@@ -2750,7 +2750,7 @@ public class ChatWindow : IDisposable
             ImGuiWindowFlags.AlwaysAutoResize |
             ImGuiWindowFlags.NoScrollbar |
             ImGuiWindowFlags.NoScrollWithMouse;
-        if (ImGui.BeginChild("##attachmentChip", new Vector2(0, 0), true, childFlags))
+        if (ImGui.BeginChild("##attachmentChip", new Vector2(0, 0), ImGuiChildFlags.Borders, childFlags))
         {
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(6f * scale, style.ItemSpacing.Y));
 

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -42,7 +42,7 @@ public static class EmbedPreviewRenderer
             avail = 400;
         }
 
-        ImGui.BeginChild($"embedprev{dto.Id}", new Vector2(avail, 0), true, ImGuiWindowFlags.None);
+        ImGui.BeginChild($"embedprev{dto.Id}", new Vector2(avail, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
 
         ImGui.Indent(indent);
         ImGui.Dummy(new Vector2(0f, verticalPadding));

--- a/DemiCatPlugin/EmbedStyleControls.cs
+++ b/DemiCatPlugin/EmbedStyleControls.cs
@@ -281,7 +281,7 @@ public static class EmbedStyleControls
             {
                 var tileSize = Math.Clamp(context.EmojiTileSize, Config.MinEmojiTileSize, Config.MaxEmojiTileSize);
                 var childSize = context.EmojiGridHeight > 0f ? new Vector2(0f, context.EmojiGridHeight) : Vector2.Zero;
-                ImGui.BeginChild($"##borderEmojiGrid_{searchKey}", childSize, false, ImGuiWindowFlags.None);
+                ImGui.BeginChild($"##borderEmojiGrid_{searchKey}", childSize, ImGuiChildFlags.None, ImGuiWindowFlags.None);
 
                 var avail = Math.Max(1f, ImGui.GetContentRegionAvail().X);
                 var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (tileSize + 4f)));

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -139,7 +139,7 @@ public sealed class EmojiPicker
         }
 
         var childSize = _gridHeight > 0f ? new Vector2(0, _gridHeight) : Vector2.Zero;
-        ImGui.BeginChild("##emoji_std_grid", childSize, false, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##emoji_std_grid", childSize, ImGuiChildFlags.None, ImGuiWindowFlags.None);
         var avail = ImGui.GetContentRegionAvail().X;
         var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (_tileSize + 4f)));
         var column = 0;
@@ -155,7 +155,7 @@ public sealed class EmojiPicker
 
             var emoji = filtered[i];
             ImGui.PushID(i);
-            using var _ = _manager.PushEmojiFont();
+            using var emojiFontScope = _manager.PushEmojiFont();
             if (ImGui.Button(emoji.Emoji, new Vector2(_tileSize, _tileSize)))
             {
                 selected = EmojiFormatter.CreateUnicodeToken(emoji);
@@ -238,7 +238,7 @@ public sealed class EmojiPicker
         }
 
         var childSize = _gridHeight > 0f ? new Vector2(0, _gridHeight) : Vector2.Zero;
-        ImGui.BeginChild("##emoji_custom_grid", childSize, false, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##emoji_custom_grid", childSize, ImGuiChildFlags.None, ImGuiWindowFlags.None);
         var avail = ImGui.GetContentRegionAvail().X;
         var columns = Math.Max(1, (int)Math.Floor((avail + 6f) / (_tileSize + 6f)));
         var column = 0;

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -154,7 +154,7 @@ public class EventCreateWindow
 
             var footer = ImGui.GetFrameHeightWithSpacing() * 2;
             var avail = ImGui.GetContentRegionAvail();
-            ImGui.BeginChild("eventCreateScroll", new Vector2(avail.X, avail.Y - footer), true, ImGuiWindowFlags.None);
+            ImGui.BeginChild("eventCreateScroll", new Vector2(avail.X, avail.Y - footer), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             try
             {
                 if (!_channelsLoaded)

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -244,7 +244,7 @@ public class EventView : IDisposable
             childHeight = 0f;
         }
 
-        ImGui.BeginChild($"eventEmbed{dto.Id}", new Vector2(availWidth, childHeight), false, ImGuiWindowFlags.None);
+        ImGui.BeginChild($"eventEmbed{dto.Id}", new Vector2(availWidth, childHeight), ImGuiChildFlags.None, ImGuiWindowFlags.None);
 
         ImGui.Indent(indent);
         ImGui.Dummy(new Vector2(0f, verticalPadding));
@@ -734,7 +734,8 @@ internal static class EventViewImGuiHelpers
         }
 
         var size = new Vector2(width, height);
-        ImGui.BeginChild(childId, size, border, windowFlags);
+        var childFlags = border ? ImGuiChildFlags.Borders : ImGuiChildFlags.None;
+        ImGui.BeginChild(childId, size, childFlags, windowFlags);
         return size.Y;
     }
 }

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -80,7 +80,7 @@ public class FcChatWindow : ChatWindow
                 ImGui.SameLine();
             }
 
-            ImGui.BeginChild("##fcChat", ImGui.GetContentRegionAvail(), false, ImGuiWindowFlags.None);
+            ImGui.BeginChild("##fcChat", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.None);
             try
             {
                 base.Draw();

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -101,7 +101,7 @@ public sealed class NotePadWindow : IDisposable
         var pageListWidth = Math.Clamp(region.X * ratio, 160f, Math.Max(160f, region.X - 200f));
         var editorWidth = Math.Max(200f, region.X - pageListWidth - splitterWidth);
 
-        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), true, ImGuiWindowFlags.None);
+        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
         try
         {
             DrawPageList(selectedSection, selectedPage);
@@ -133,7 +133,7 @@ public sealed class NotePadWindow : IDisposable
         }
 
         ImGui.SameLine();
-        ImGui.BeginChild("NotePadEditor", new Vector2(editorWidth, region.Y), false, ImGuiWindowFlags.None);
+        ImGui.BeginChild("NotePadEditor", new Vector2(editorWidth, region.Y), ImGuiChildFlags.None, ImGuiWindowFlags.None);
         try
         {
             DrawEditor(selectedSection, selectedPage);

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -188,7 +188,7 @@ public class OfficerChatWindow : ChatWindow
                 _ = RoleCache.EnsureLoaded(_httpClient, _config, _tokenManager);
                 _presenceSidebar!.Draw(ref _presenceWidth);
                 ImGui.SameLine();
-                ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), false, ImGuiWindowFlags.None);
+                ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.None);
                 childOpened = true;
             }
 

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -65,7 +65,7 @@ public class PresenceSidebar : IDisposable
             shouldReturn = true;
         }
 
-        ImGui.BeginChild("##presence", new Vector2(width, 0), true, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##presence", new Vector2(width, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
 
         try
         {

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -99,7 +99,7 @@ public class RequestBoardWindow
                     {
                         ImGui.PushID(req.Id);
                         ImGui.PushStyleColor(ImGuiCol.ChildBg, UrgencyColor(req.Urgency));
-                        ImGui.BeginChild("card", new Vector2(-1, 0), true, ImGuiWindowFlags.None);
+                        ImGui.BeginChild("card", new Vector2(-1, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
                         try
                         {
                             ImGui.TextUnformatted(req.Title);

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -22,7 +22,6 @@ using Penumbra.Api.Enums;
 using Serilog;
 using Serilog.Events;
 using Dalamud.Interface.Utility;
-using Dalamud.Plugin.Services;
 using ImGuiInputTextCallbackData = ImGuiNET.ImGuiInputTextCallbackData;
 using ImGuiMouseCursor = ImGuiNET.ImGuiMouseCursor;
 
@@ -356,7 +355,7 @@ public class SyncshellWindow : IDisposable
                 _syncSettingsHeight = DefaultSyncSettingsHeight;
             maxSettingsHeight = MathF.Max(MinSyncSettingsHeight, maxSettingsHeight);
             _syncSettingsHeight = Math.Clamp(_syncSettingsHeight, MinSyncSettingsHeight, maxSettingsHeight);
-            ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), true, ImGuiWindowFlags.None);
+            ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             try
             {
                 if (ImGui.BeginTabBar("syncshell-settings-tabs"))
@@ -525,7 +524,7 @@ public class SyncshellWindow : IDisposable
             var childHeight = 70f;
             if (asset.Kind == "BUNDLE" && asset.Items != null)
                 childHeight += ImGui.GetTextLineHeightWithSpacing() * asset.Items.Count;
-            ImGui.BeginChild("card", new Vector2(-1, childHeight), true, ImGuiWindowFlags.None);
+            ImGui.BeginChild("card", new Vector2(-1, childHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             ImGui.TextUnformatted(asset.Name);
             if (!_seenAssetIds.Contains(asset.Id))
             {
@@ -878,7 +877,7 @@ public class SyncshellWindow : IDisposable
     {
         var id = $"syncshell-panel-{label.Replace(' ', '-').ToLowerInvariant()}";
         var size = fillRemaining ? new Vector2(-1, 0f) : new Vector2(-1, height);
-        ImGui.BeginChild(id, size, true, ImGuiWindowFlags.None);
+        ImGui.BeginChild(id, size, ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
         ImGui.TextUnformatted(label);
         ImGui.Separator();
         content();
@@ -2882,7 +2881,7 @@ public class SyncshellWindow : IDisposable
                 }
                 catch (Exception ex)
                 {
-                    PluginServices.Instance?.Log.Warning("Failed to refresh SyncShell installations", ex);
+                    PluginServices.Instance?.Log.Warning(ex, "Failed to refresh SyncShell installations");
                 }
             }
             while (Interlocked.CompareExchange(ref _installationsRefreshRequested, 0, 1) == 1);
@@ -4580,7 +4579,7 @@ public class SyncshellWindow : IDisposable
         }
         catch (Exception ex)
         {
-            PluginServices.Instance?.Log.Warning("Failed to push SyncShell manifest", ex);
+            PluginServices.Instance?.Log.Warning(ex, "Failed to push SyncShell manifest");
             return false;
         }
     }
@@ -4677,7 +4676,7 @@ public class SyncshellWindow : IDisposable
         }
         catch (Exception ex)
         {
-            PluginServices.Instance?.Log.Warning("Failed to trim SyncShell cache", ex);
+            PluginServices.Instance?.Log.Warning(ex, "Failed to trim SyncShell cache");
         }
     }
 
@@ -4828,7 +4827,7 @@ public class SyncshellWindow : IDisposable
         }
         catch (Exception ex)
         {
-            PluginServices.Instance?.Log.Warning("Failed to stop SyncShell client", ex);
+            PluginServices.Instance?.Log.Warning(ex, "Failed to stop SyncShell client");
         }
         _syncClient.Dispose();
         if (PluginServices.Instance?.ProgressOverlay == _progressOverlay)

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -177,7 +177,7 @@ public class TemplatesWindow
                 ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
             }
 
-            ImGui.BeginChild("TemplateList", new Vector2(150, 0), true, ImGuiWindowFlags.None);
+            ImGui.BeginChild("TemplateList", new Vector2(150, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             try
             {
                 using var emojiFont = _emojiManager.PushEmojiFont();
@@ -198,7 +198,7 @@ public class TemplatesWindow
 
             ImGui.SameLine();
 
-            ImGui.BeginChild("TemplateContent", ImGui.GetContentRegionAvail(), false, ImGuiWindowFlags.None);
+            ImGui.BeginChild("TemplateContent", ImGui.GetContentRegionAvail(), ImGuiChildFlags.None, ImGuiWindowFlags.None);
             try
             {
                 if (_selectedIndex >= 0 && _selectedIndex < _templates.Count)

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -933,7 +933,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             }
 
             {
-                using var _ = _emojiManager.PushEmojiFont();
+                using var emojiFontScope = _emojiManager.PushEmojiFont();
                 if (ImGui.Combo("Channel", ref comboIndex, channelNames, channelNames.Length))
                 {
                     if (comboIndex >= 0 && comboIndex < _channels.Count)
@@ -1005,7 +1005,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
             _embedWarningShown = false;
 
-            ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), true, ImGuiWindowFlags.None);
+            ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             foreach (var view in embeds)
             {
                 view?.Draw();


### PR DESCRIPTION
## Summary
- update all DemiCatPlugin ImGui.BeginChild calls to use ImGuiChildFlags instead of the removed bool overloads
- rename discard-based emoji font scopes, remove the duplicate Dalamud.Plugin.Services import, and keep helper logic compatible with the new API
- switch SyncshellWindow Serilog warning calls to the exception-first overload

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5bc6b5f688328a584da615cc4186d