### PR TITLE
Fix missing closing brace in SyncshellWindow.Draw

### DIFF
--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -595,6 +595,8 @@ public class SyncshellWindow : IDisposable
         }
     }
 
+    }
+
     private static float CalculateMaxSyncSettingsHeight(float availableHeight, float splitterHeight)
     {
         if (!float.IsFinite(availableHeight) || availableHeight <= 0f)


### PR DESCRIPTION
## Summary
- add the missing closing brace to the SyncshellWindow.Draw method to balance the try/catch block

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5c3fcb86883289de933665002f278