### PR TITLE
Fix ImGui child border flag usage

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -803,7 +803,7 @@ public class ChatWindow : IDisposable
         }
         composeRatio = actualRatio;
         const float ScrollTolerance = 1f;
-        ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
 
         var fontScale = GetFontScale();
         var chatFontScope = PushWindowFontScale(fontScale);
@@ -1231,7 +1231,7 @@ public class ChatWindow : IDisposable
                 var desiredPreviewHeight = _previewContentHeight > 0f ? _previewContentHeight : fallbackHeight;
                 var previewHeight = Math.Clamp(desiredPreviewHeight, minPreviewHeight, maxPreviewHeight);
 
-                ImGui.BeginChild("##inputPreview", new Vector2(0, previewHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+                ImGui.BeginChild("##inputPreview", new Vector2(0, previewHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
                 var childStartCursor = ImGui.GetCursorPosY();
                 if (!string.IsNullOrEmpty(plainTextPreview))
                 {
@@ -1563,7 +1563,7 @@ public class ChatWindow : IDisposable
         var codeBlock = Regex.Match(text, "^\\[CODEBLOCK\\](.+?)\\[/CODEBLOCK\\]$", RegexOptions.Singleline);
         if (codeBlock.Success)
         {
-            ImGui.BeginChild($"codeblock{GetHashCode()}{text.GetHashCode()}", new Vector2(0, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+            ImGui.BeginChild($"codeblock{GetHashCode()}{text.GetHashCode()}", new Vector2(0, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
             ImGui.TextUnformatted(codeBlock.Groups[1].Value);
             ImGui.EndChild();
             return;
@@ -2750,7 +2750,7 @@ public class ChatWindow : IDisposable
             ImGuiWindowFlags.AlwaysAutoResize |
             ImGuiWindowFlags.NoScrollbar |
             ImGuiWindowFlags.NoScrollWithMouse;
-        if (ImGui.BeginChild("##attachmentChip", new Vector2(0, 0), ImGuiChildFlags.Borders, childFlags))
+        if (ImGui.BeginChild("##attachmentChip", new Vector2(0, 0), ImGuiChildFlags.Border, childFlags))
         {
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(6f * scale, style.ItemSpacing.Y));
 

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -42,7 +42,7 @@ public static class EmbedPreviewRenderer
             avail = 400;
         }
 
-        ImGui.BeginChild($"embedprev{dto.Id}", new Vector2(avail, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+        ImGui.BeginChild($"embedprev{dto.Id}", new Vector2(avail, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
 
         ImGui.Indent(indent);
         ImGui.Dummy(new Vector2(0f, verticalPadding));

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -154,7 +154,7 @@ public class EventCreateWindow
 
             var footer = ImGui.GetFrameHeightWithSpacing() * 2;
             var avail = ImGui.GetContentRegionAvail();
-            ImGui.BeginChild("eventCreateScroll", new Vector2(avail.X, avail.Y - footer), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+            ImGui.BeginChild("eventCreateScroll", new Vector2(avail.X, avail.Y - footer), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
             try
             {
                 if (!_channelsLoaded)

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -734,7 +734,7 @@ internal static class EventViewImGuiHelpers
         }
 
         var size = new Vector2(width, height);
-        var childFlags = border ? ImGuiChildFlags.Borders : ImGuiChildFlags.None;
+        var childFlags = border ? ImGuiChildFlags.Border : ImGuiChildFlags.None;
         ImGui.BeginChild(childId, size, childFlags, windowFlags);
         return size.Y;
     }

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -101,7 +101,7 @@ public sealed class NotePadWindow : IDisposable
         var pageListWidth = Math.Clamp(region.X * ratio, 160f, Math.Max(160f, region.X - 200f));
         var editorWidth = Math.Max(200f, region.X - pageListWidth - splitterWidth);
 
-        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
         try
         {
             DrawPageList(selectedSection, selectedPage);

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -65,7 +65,7 @@ public class PresenceSidebar : IDisposable
             shouldReturn = true;
         }
 
-        ImGui.BeginChild("##presence", new Vector2(width, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##presence", new Vector2(width, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
 
         try
         {

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -99,7 +99,7 @@ public class RequestBoardWindow
                     {
                         ImGui.PushID(req.Id);
                         ImGui.PushStyleColor(ImGuiCol.ChildBg, UrgencyColor(req.Urgency));
-                        ImGui.BeginChild("card", new Vector2(-1, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+                        ImGui.BeginChild("card", new Vector2(-1, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
                         try
                         {
                             ImGui.TextUnformatted(req.Title);

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -355,7 +355,7 @@ public class SyncshellWindow : IDisposable
                 _syncSettingsHeight = DefaultSyncSettingsHeight;
             maxSettingsHeight = MathF.Max(MinSyncSettingsHeight, maxSettingsHeight);
             _syncSettingsHeight = Math.Clamp(_syncSettingsHeight, MinSyncSettingsHeight, maxSettingsHeight);
-            ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+            ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
             try
             {
                 if (ImGui.BeginTabBar("syncshell-settings-tabs"))
@@ -524,7 +524,7 @@ public class SyncshellWindow : IDisposable
             var childHeight = 70f;
             if (asset.Kind == "BUNDLE" && asset.Items != null)
                 childHeight += ImGui.GetTextLineHeightWithSpacing() * asset.Items.Count;
-            ImGui.BeginChild("card", new Vector2(-1, childHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+            ImGui.BeginChild("card", new Vector2(-1, childHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
             ImGui.TextUnformatted(asset.Name);
             if (!_seenAssetIds.Contains(asset.Id))
             {
@@ -879,7 +879,7 @@ public class SyncshellWindow : IDisposable
     {
         var id = $"syncshell-panel-{label.Replace(' ', '-').ToLowerInvariant()}";
         var size = fillRemaining ? new Vector2(-1, 0f) : new Vector2(-1, height);
-        ImGui.BeginChild(id, size, ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+        ImGui.BeginChild(id, size, ImGuiChildFlags.Border, ImGuiWindowFlags.None);
         ImGui.TextUnformatted(label);
         ImGui.Separator();
         content();

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -177,7 +177,7 @@ public class TemplatesWindow
                 ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
             }
 
-            ImGui.BeginChild("TemplateList", new Vector2(150, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+            ImGui.BeginChild("TemplateList", new Vector2(150, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
             try
             {
                 using var emojiFont = _emojiManager.PushEmojiFont();

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -1005,7 +1005,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
             _embedWarningShown = false;
 
-            ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
+            ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
             foreach (var view in embeds)
             {
                 view?.Draw();


### PR DESCRIPTION
## Summary
- replace usage of the removed `ImGuiChildFlags.Borders` flag with `ImGuiChildFlags.Border` across child window renders
- align the plugin with the current ImGui.NET 1.90 bindings so it compiles successfully

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c4dcacb48328bcf1af1a7bce4eb0