### PR TITLE
Align ImGui child usage with Dalamud runtime

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -803,7 +803,7 @@ public class ChatWindow : IDisposable
         }
         composeRatio = actualRatio;
         const float ScrollTolerance = 1f;
-        ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##chatScroll", new Vector2(-1, scrollRegionHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
 
         var fontScale = GetFontScale();
         var chatFontScope = PushWindowFontScale(fontScale);
@@ -1231,7 +1231,7 @@ public class ChatWindow : IDisposable
                 var desiredPreviewHeight = _previewContentHeight > 0f ? _previewContentHeight : fallbackHeight;
                 var previewHeight = Math.Clamp(desiredPreviewHeight, minPreviewHeight, maxPreviewHeight);
 
-                ImGui.BeginChild("##inputPreview", new Vector2(0, previewHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+                ImGui.BeginChild("##inputPreview", new Vector2(0, previewHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
                 var childStartCursor = ImGui.GetCursorPosY();
                 if (!string.IsNullOrEmpty(plainTextPreview))
                 {
@@ -1563,7 +1563,7 @@ public class ChatWindow : IDisposable
         var codeBlock = Regex.Match(text, "^\\[CODEBLOCK\\](.+?)\\[/CODEBLOCK\\]$", RegexOptions.Singleline);
         if (codeBlock.Success)
         {
-            ImGui.BeginChild($"codeblock{GetHashCode()}{text.GetHashCode()}", new Vector2(0, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+            ImGui.BeginChild($"codeblock{GetHashCode()}{text.GetHashCode()}", new Vector2(0, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             ImGui.TextUnformatted(codeBlock.Groups[1].Value);
             ImGui.EndChild();
             return;
@@ -2750,7 +2750,7 @@ public class ChatWindow : IDisposable
             ImGuiWindowFlags.AlwaysAutoResize |
             ImGuiWindowFlags.NoScrollbar |
             ImGuiWindowFlags.NoScrollWithMouse;
-        if (ImGui.BeginChild("##attachmentChip", new Vector2(0, 0), ImGuiChildFlags.Border, childFlags))
+        if (ImGui.BeginChild("##attachmentChip", new Vector2(0, 0), ImGuiChildFlags.Borders, childFlags))
         {
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(6f * scale, style.ItemSpacing.Y));
 

--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -27,20 +27,12 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
-  <!-- Prefer Dalamud's ImGui.NET if available -->
-  <ItemGroup Condition="Exists('$(DalamudLibPath)/ImGui.NET.dll')">
+  <!-- Always build against Dalamud's ImGui.NET to match the runtime -->
+  <ItemGroup>
     <Reference Include="ImGui.NET">
       <HintPath>$(DalamudLibPath)/ImGui.NET.dll</HintPath>
       <Private>false</Private>
     </Reference>
-  </ItemGroup>
-
-  <!-- Cross-OS fallback: compiler sees ImGui types, nothing gets shipped -->
-  <ItemGroup Condition="!Exists('$(DalamudLibPath)/ImGui.NET.dll')">
-    <PackageReference Include="ImGui.NET" Version="1.90.8.1">
-      <IncludeAssets>compile</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -42,7 +42,7 @@ public static class EmbedPreviewRenderer
             avail = 400;
         }
 
-        ImGui.BeginChild($"embedprev{dto.Id}", new Vector2(avail, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+        ImGui.BeginChild($"embedprev{dto.Id}", new Vector2(avail, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
 
         ImGui.Indent(indent);
         ImGui.Dummy(new Vector2(0f, verticalPadding));

--- a/DemiCatPlugin/EmbedStyleControls.cs
+++ b/DemiCatPlugin/EmbedStyleControls.cs
@@ -281,7 +281,7 @@ public static class EmbedStyleControls
             {
                 var tileSize = Math.Clamp(context.EmojiTileSize, Config.MinEmojiTileSize, Config.MaxEmojiTileSize);
                 var childSize = context.EmojiGridHeight > 0f ? new Vector2(0f, context.EmojiGridHeight) : Vector2.Zero;
-                ImGui.BeginChild($"##borderEmojiGrid_{searchKey}", childSize, ImGuiChildFlags.None, ImGuiWindowFlags.None);
+                ImGui.BeginChild($"##borderEmojiGrid_{searchKey}", childSize, ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
 
                 var avail = Math.Max(1f, ImGui.GetContentRegionAvail().X);
                 var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (tileSize + 4f)));

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -154,7 +154,7 @@ public class EventCreateWindow
 
             var footer = ImGui.GetFrameHeightWithSpacing() * 2;
             var avail = ImGui.GetContentRegionAvail();
-            ImGui.BeginChild("eventCreateScroll", new Vector2(avail.X, avail.Y - footer), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+            ImGui.BeginChild("eventCreateScroll", new Vector2(avail.X, avail.Y - footer), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             try
             {
                 if (!_channelsLoaded)

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -244,7 +244,7 @@ public class EventView : IDisposable
             childHeight = 0f;
         }
 
-        ImGui.BeginChild($"eventEmbed{dto.Id}", new Vector2(availWidth, childHeight), ImGuiChildFlags.None, ImGuiWindowFlags.None);
+        ImGui.BeginChild($"eventEmbed{dto.Id}", new Vector2(availWidth, childHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
 
         ImGui.Indent(indent);
         ImGui.Dummy(new Vector2(0f, verticalPadding));
@@ -734,7 +734,7 @@ internal static class EventViewImGuiHelpers
         }
 
         var size = new Vector2(width, height);
-        var childFlags = border ? ImGuiChildFlags.Border : ImGuiChildFlags.None;
+        var childFlags = border ? ImGuiChildFlags.Borders : ImGuiChildFlags.None;
         ImGui.BeginChild(childId, size, childFlags, windowFlags);
         return size.Y;
     }

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -101,7 +101,7 @@ public sealed class NotePadWindow : IDisposable
         var pageListWidth = Math.Clamp(region.X * ratio, 160f, Math.Max(160f, region.X - 200f));
         var editorWidth = Math.Max(200f, region.X - pageListWidth - splitterWidth);
 
-        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+        ImGui.BeginChild("NotePadPageList", new Vector2(pageListWidth, region.Y), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
         try
         {
             DrawPageList(selectedSection, selectedPage);

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -65,7 +65,7 @@ public class PresenceSidebar : IDisposable
             shouldReturn = true;
         }
 
-        ImGui.BeginChild("##presence", new Vector2(width, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+        ImGui.BeginChild("##presence", new Vector2(width, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
 
         try
         {

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -99,7 +99,7 @@ public class RequestBoardWindow
                     {
                         ImGui.PushID(req.Id);
                         ImGui.PushStyleColor(ImGuiCol.ChildBg, UrgencyColor(req.Urgency));
-                        ImGui.BeginChild("card", new Vector2(-1, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+                        ImGui.BeginChild("card", new Vector2(-1, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
                         try
                         {
                             ImGui.TextUnformatted(req.Title);

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -355,7 +355,7 @@ public class SyncshellWindow : IDisposable
                 _syncSettingsHeight = DefaultSyncSettingsHeight;
             maxSettingsHeight = MathF.Max(MinSyncSettingsHeight, maxSettingsHeight);
             _syncSettingsHeight = Math.Clamp(_syncSettingsHeight, MinSyncSettingsHeight, maxSettingsHeight);
-            ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+            ImGui.BeginChild("sync-settings", new Vector2(-1, _syncSettingsHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             try
             {
                 if (ImGui.BeginTabBar("syncshell-settings-tabs"))
@@ -524,7 +524,7 @@ public class SyncshellWindow : IDisposable
             var childHeight = 70f;
             if (asset.Kind == "BUNDLE" && asset.Items != null)
                 childHeight += ImGui.GetTextLineHeightWithSpacing() * asset.Items.Count;
-            ImGui.BeginChild("card", new Vector2(-1, childHeight), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+            ImGui.BeginChild("card", new Vector2(-1, childHeight), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             ImGui.TextUnformatted(asset.Name);
             if (!_seenAssetIds.Contains(asset.Id))
             {
@@ -879,7 +879,7 @@ public class SyncshellWindow : IDisposable
     {
         var id = $"syncshell-panel-{label.Replace(' ', '-').ToLowerInvariant()}";
         var size = fillRemaining ? new Vector2(-1, 0f) : new Vector2(-1, height);
-        ImGui.BeginChild(id, size, ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+        ImGui.BeginChild(id, size, ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
         ImGui.TextUnformatted(label);
         ImGui.Separator();
         content();

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -177,7 +177,7 @@ public class TemplatesWindow
                 ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
             }
 
-            ImGui.BeginChild("TemplateList", new Vector2(150, 0), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+            ImGui.BeginChild("TemplateList", new Vector2(150, 0), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             try
             {
                 using var emojiFont = _emojiManager.PushEmojiFont();

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -933,7 +933,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             }
 
             {
-                using var emojiFontScope = _emojiManager.PushEmojiFont();
+                using var emojiFont = _emojiManager.PushEmojiFont();
                 if (ImGui.Combo("Channel", ref comboIndex, channelNames, channelNames.Length))
                 {
                     if (comboIndex >= 0 && comboIndex < _channels.Count)
@@ -1005,7 +1005,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
 
             _embedWarningShown = false;
 
-            ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), ImGuiChildFlags.Border, ImGuiWindowFlags.None);
+            ImGui.BeginChild("##eventScroll", ImGui.GetContentRegionAvail(), ImGuiChildFlags.Borders, ImGuiWindowFlags.None);
             foreach (var view in embeds)
             {
                 view?.Draw();

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,11 +1,23 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net9.0-windows10.0.19041</TargetFramework>
-    <EnableWindowsTargeting Condition="'$(OS)' != 'Windows_NT'">true</EnableWindowsTargeting>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+    <!-- Resolve Dalamud dev hooks automatically if not provided -->
+    <DalamudLibPath Condition="'$(DalamudLibPath)'=='' and '$(OS)'=='Windows_NT'">
+      $(LOCALAPPDATA)\XIVLauncher\addon\Hooks\dev
+    </DalamudLibPath>
+    <!-- XIV on Mac / Linux -->
+    <DalamudLibPath Condition="'$(DalamudLibPath)'=='' and '$(OS)'!='Windows_NT'">
+      $(HOME)/.xlcore/dalamud/Hooks/dev
+    </DalamudLibPath>
   </PropertyGroup>
-  <PropertyGroup>
-    <DalamudLibPath>/root/.xlcore/dalamud/Hooks/dev</DalamudLibPath>
-  </PropertyGroup>
+
+  <!-- Fail fast if we can't find Dalamud's ImGui.NET -->
+  <Target Name="CheckDalamudLibs" BeforeTargets="Build"
+          Condition="!Exists('$(DalamudLibPath)/ImGui.NET.dll')">
+    <Error Text="ImGui.NET.dll not found in $(DalamudLibPath).
+Launch the game once and run Dalamud → Dev Tools → Scan Dev Plugins so Hooks/dev is populated, then rebuild." />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- update Directory.Build.props to autodetect Dalamud hook paths and fail fast when ImGui.NET is missing
- reference Dalamud's bundled ImGui.NET assembly directly in the plugin project
- migrate BeginChild calls to ImGuiChildFlags and fix the emoji font scope discard naming

## Testing
- not run (requires Dalamud-provided ImGui.NET assemblies)

------
https://chatgpt.com/codex/tasks/task_e_68e5c8f619b48328a28dd558b31e8730