### PR TITLE
Scope Dalamud ImGui check to plugin

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -16,6 +16,7 @@
     <FileVersion>13.0.0.9</FileVersion>
 
     <NoWarn>CA1416</NoWarn>
+    <RequiresDalamudImGui>true</RequiresDalamudImGui>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StbImageSharp" Version="2.30.15" />
@@ -27,7 +28,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
-  <!-- Always build against Dalamud's ImGui.NET to match the runtime -->
+  <!-- Always build the plugin against Dalamud's ImGui.NET to match the runtime -->
   <ItemGroup>
     <Reference Include="ImGui.NET">
       <HintPath>$(DalamudLibPath)/ImGui.NET.dll</HintPath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,11 +12,13 @@
     <DalamudLibPath Condition="'$(DalamudLibPath)'=='' and '$(OS)'!='Windows_NT'">
       $(HOME)/.xlcore/dalamud/Hooks/dev
     </DalamudLibPath>
+    <!-- Only projects that set this to true will enforce/check ImGui.NET -->
+    <RequiresDalamudImGui>false</RequiresDalamudImGui>
   </PropertyGroup>
 
-  <!-- Fail fast if we can't find Dalamud's ImGui.NET -->
+  <!-- Fail fast ONLY for projects that opt in -->
   <Target Name="CheckDalamudLibs" BeforeTargets="Build"
-          Condition="!Exists('$(DalamudLibPath)/ImGui.NET.dll')">
+          Condition="'$(RequiresDalamudImGui)'=='true' and !Exists('$(DalamudLibPath)/ImGui.NET.dll')">
     <Error Text="ImGui.NET.dll not found in $(DalamudLibPath).
 Launch the game once and run Dalamud → Dev Tools → Scan Dev Plugins so Hooks/dev is populated, then rebuild." />
   </Target>


### PR DESCRIPTION
## Summary
- add an opt-in flag in the shared build props to control Dalamud ImGui validation
- enable the opt-in for the plugin so only it enforces the ImGui.NET dependency

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5cc9e3e4c8328b5e360eded5e210b