### PR TITLE
Handle Dalamud managed font atlas rename

### DIFF
--- a/DemiCat.UI/DemiCat.UI.csproj
+++ b/DemiCat.UI/DemiCat.UI.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -608,7 +608,7 @@ public class Plugin : IDalamudPlugin
             }
 
             var fontSize = TryGetDefaultFontSize();
-            var managedFontAtlasAssembly = TryLoadManagedFontAtlasAssembly();
+            var managedFontAtlasAssembly = TryLoadManagedFontAtlasAssembly(atlas);
             if (managedFontAtlasAssembly == null)
             {
                 return null;
@@ -684,8 +684,18 @@ public class Plugin : IDalamudPlugin
 
     private object? TryGetManagedFontAtlas()
     {
-        var property = _uiBuilder.GetType().GetProperty("FontAtlas");
-        var atlas = property?.GetValue(_uiBuilder);
+        var builderType = _uiBuilder.GetType();
+        var property = builderType.GetProperty("FontAtlas")
+                       ?? builderType.GetProperty("ManagedFontAtlas");
+
+        if (property == null)
+        {
+            Services.Log.Info(
+                "Managed font atlas property not found on UiBuilder; skipping emoji font initialization.");
+            return null;
+        }
+
+        var atlas = property.GetValue(_uiBuilder);
         if (atlas == null)
         {
             Services.Log.Info("Managed font atlas not available; skipping emoji font initialization.");
@@ -696,7 +706,9 @@ public class Plugin : IDalamudPlugin
 
     private float TryGetDefaultFontSize()
     {
-        var property = _uiBuilder.GetType().GetProperty("FontDefaultSizePx");
+        var builderType = _uiBuilder.GetType();
+        var property = builderType.GetProperty("FontDefaultSizePx")
+                       ?? builderType.GetProperty("DefaultFontSizePx");
         var value = property?.GetValue(_uiBuilder);
         return value switch
         {
@@ -706,8 +718,21 @@ public class Plugin : IDalamudPlugin
         };
     }
 
-    private Assembly? TryLoadManagedFontAtlasAssembly()
+    private Assembly? TryLoadManagedFontAtlasAssembly(object atlas)
     {
+        try
+        {
+            var assembly = atlas.GetType().Assembly;
+            if (assembly != null)
+            {
+                return assembly;
+            }
+        }
+        catch (Exception ex)
+        {
+            Services.Log.Debug(ex, "Failed to resolve managed font atlas assembly from atlas instance.");
+        }
+
         var existing = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(
             asm => string.Equals(asm.GetName().Name, ManagedFontAtlasAssemblyName, StringComparison.Ordinal));
         if (existing != null)

--- a/docs/plugin-runtime-audit.md
+++ b/docs/plugin-runtime-audit.md
@@ -18,7 +18,7 @@
 
 ## Alignment with Dalamud platform APIs
 - Dalamud v9 removed `IDalamudPluginInterface.CreateHttpClient()`, so the plugin now constructs a singleton `HttpClient` with a `SocketsHttpHandler` that opts into `HappyEyeballsCallback.ConnectAsync` for dual-stack connection attempts while keeping decompression, pooling, and timeout behavior consistent.【F:DemiCatPlugin/Plugin.cs†L115-L177】
-- Emoji font integration currently reflects into `Dalamud.Interface.ManagedFontAtlas`. Dalamud 9 introduced helper extensions through `IManagedFontAtlas`. Investigate whether those cover the current reflection usage to simplify upgrades when the managed atlas API changes.【F:DemiCatPlugin/Plugin.cs†L181-L352】
+- Emoji font integration previously reflected into `Dalamud.Interface.ManagedFontAtlas`. The plugin now probes both `FontAtlas` and `ManagedFontAtlas` properties on `IUiBuilder` and resolves the backing assembly from the atlas instance to remain compatible with Dalamud 13’s renamed APIs.【F:DemiCatPlugin/Plugin.cs†L585-L737】
 
 
 ## Tooling to stay on .NET 9.0.3 and Dalamud 13


### PR DESCRIPTION
## Summary
- teach the emoji font loader to look for both `FontAtlas` and `ManagedFontAtlas` on the UiBuilder so it remains compatible with Dalamud 13
- resolve the managed font atlas assembly from the atlas instance and note the change in the runtime audit

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e64823f4b08328b701ef6e549d2306