### PR TITLE
Fix ImGui BeginChild bool overload

### DIFF
--- a/DemiCatPlugin/ImGuiCompat.BeginChild.cs
+++ b/DemiCatPlugin/ImGuiCompat.BeginChild.cs
@@ -8,7 +8,7 @@ namespace ImGuiNET
     {
         public static bool BeginChild(string str_id, Vector2 size, bool border, ImGuiWindowFlags flags = ImGuiWindowFlags.None)
         {
-            var childFlags = border ? ImGuiChildFlags.Border : ImGuiChildFlags.None;
+            var childFlags = border ? ImGuiChildFlags.Borders : ImGuiChildFlags.None;
             return BeginChild(str_id, size, childFlags, flags);
         }
     }


### PR DESCRIPTION
## Summary
- update the compatibility BeginChild overload to use `ImGuiChildFlags.Borders`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6551d34d88328a43abb2e2f13a2a4