### PR TITLE
Fix naming conflict in RefreshOutcome struct

### DIFF
--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -608,11 +608,11 @@ public class DiscordPresenceService : IDisposable
     {
         public RefreshOutcome(bool success, TimeSpan delay)
         {
-            Success = success;
+            Succeeded = success;
             Delay = delay > TimeSpan.Zero ? delay : TimeSpan.Zero;
         }
 
-        public bool Success { get; }
+        public bool Succeeded { get; }
         public TimeSpan Delay { get; }
 
         public static RefreshOutcome Success(TimeSpan delay) => new(true, delay);


### PR DESCRIPTION
## Summary
- rename the RefreshOutcome success flag property to avoid conflicting with the existing factory method

## Testing
- not run (dotnet CLI is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e8fef5a58c8328a495377183b5d89d