### PR TITLE
Fix disconnect log counter type

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -1093,7 +1093,7 @@ public class ChatBridge : IDisposable
     private void LogDisconnect(WebSocketCloseStatus? status, string? description)
     {
         var now = DateTime.UtcNow;
-        int disconnectCount;
+        long disconnectCount;
         var shouldLog = false;
         lock (_stateLock)
         {


### PR DESCRIPTION
## Summary
- make the local disconnect counter use a long to match the field and prevent implicit conversion issues

## Testing
- dotnet build -c Release (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68e9a7a875208328873e212aabb8cbc7