### PR TITLE
Share chat bridge connection between windows

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -12,7 +12,7 @@ using System.Diagnostics;
 
 namespace DemiCatPlugin;
 
-public class ChatBridge : IDisposable
+public class ChatBridge : IChatBridge
 {
     private readonly Config _config;
     private readonly HttpClient _httpClient;

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -56,7 +56,8 @@ public class ChatWindow : IDisposable
     private readonly EmojiManager _emojiManager;
     private readonly EmojiPicker _emojiPicker;
     private readonly Dictionary<string, EmojiData> _emojiCatalog = new();
-    protected readonly ChatBridge _bridge;
+    protected readonly IChatBridge _bridge;
+    private readonly bool _ownsBridge;
     private readonly ChannelSelectionService _channelSelection;
     private readonly AvatarCache? _avatarCache;
     private readonly string _channelKind;
@@ -396,7 +397,8 @@ public class ChatWindow : IDisposable
         ChannelSelectionService channelSelection,
         string channelKind,
         AvatarCache? avatarCache,
-        EmojiManager emojiManager)
+        EmojiManager emojiManager,
+        IChatBridge? chatBridge = null)
     {
         _config = config;
         _httpClient = httpClient;
@@ -411,17 +413,9 @@ public class ChatWindow : IDisposable
         _ = _emojiManager.EnsureUnicodeAsync();
         _ = _emojiManager.EnsureCustomAsync();
         _useCharacterName = config.UseCharacterName;
-        _bridge = new ChatBridge(config, httpClient, tokenManager, BuildWebSocketUri, channelSelection);
-        _bridge.MessageReceived += HandleBridgeMessage;
-        _bridge.TypingReceived += HandleBridgeTyping;
-        _bridge.Linked += HandleBridgeLinked;
-        _bridge.Unlinked += HandleBridgeUnlinked;
-        _bridge.StatusChanged += s => _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = s);
-        _bridge.ResyncRequested += (ch, cur) =>
-            PluginServices.Instance!.Framework.RunOnTick(async () =>
-            {
-                if (ch == CurrentChannelId) await RefreshMessages();
-            });
+        _bridge = chatBridge ?? new ChatBridge(config, httpClient, tokenManager, BuildWebSocketUri, channelSelection);
+        _ownsBridge = chatBridge == null;
+        AttachBridgeEvents();
 
         _channelSelection.ChannelChanged += HandleChannelSelectionChanged;
     }
@@ -446,9 +440,35 @@ public class ChatWindow : IDisposable
     {
     }
 
-    protected void MarkNetworkingStarted()
+    private void AttachBridgeEvents()
     {
+        _bridge.MessageReceived += HandleBridgeMessage;
+        _bridge.TypingReceived += HandleBridgeTyping;
+        _bridge.Linked += HandleBridgeLinked;
+        _bridge.Unlinked += HandleBridgeUnlinked;
+        _bridge.StatusChanged += HandleBridgeStatusChanged;
+        _bridge.ResyncRequested += HandleBridgeResyncRequested;
+    }
+
+    private void DetachBridgeEvents()
+    {
+        _bridge.MessageReceived -= HandleBridgeMessage;
+        _bridge.TypingReceived -= HandleBridgeTyping;
+        _bridge.Linked -= HandleBridgeLinked;
+        _bridge.Unlinked -= HandleBridgeUnlinked;
+        _bridge.StatusChanged -= HandleBridgeStatusChanged;
+        _bridge.ResyncRequested -= HandleBridgeResyncRequested;
+    }
+
+    protected bool MarkNetworkingStarted()
+    {
+        if (_networkingActive)
+        {
+            return false;
+        }
+
         _networkingActive = true;
+        return true;
     }
 
     protected void MarkNetworkingStopped()
@@ -537,7 +557,12 @@ public class ChatWindow : IDisposable
 
     public virtual void StartNetworking()
     {
-        MarkNetworkingStarted();
+        if (!MarkNetworkingStarted())
+        {
+            TrySubscribeCurrentChannel(force: true);
+            return;
+        }
+
         _presence?.SetPresenceReady(true);
         _bridge.Start();
         TrySubscribeCurrentChannel(force: true);
@@ -3488,8 +3513,12 @@ public class ChatWindow : IDisposable
     public void Dispose()
     {
         StopNetworking();
+        DetachBridgeEvents();
         _channelSelection.ChannelChanged -= HandleChannelSelectionChanged;
-        _bridge.Dispose();
+        if (_ownsBridge)
+        {
+            _bridge.Dispose();
+        }
         foreach (var message in _messages)
         {
             DisposeMessageTextures(message);
@@ -3608,6 +3637,22 @@ public class ChatWindow : IDisposable
                 _channelsLoading = false;
             });
         }
+    }
+
+    private void HandleBridgeStatusChanged(string status)
+    {
+        _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = status);
+    }
+
+    private void HandleBridgeResyncRequested(string channel, long cursor)
+    {
+        PluginServices.Instance!.Framework.RunOnTick(async () =>
+        {
+            if (channel == CurrentChannelId)
+            {
+                await RefreshMessages();
+            }
+        });
     }
 
     private void HandleBridgeMessage(string json)

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -23,7 +23,8 @@ public class FcChatWindow : ChatWindow
         ChannelService channelService,
         ChannelSelectionService channelSelection,
         AvatarCache avatarCache,
-        EmojiManager emojiManager)
+        EmojiManager emojiManager,
+        IChatBridge? chatBridge = null)
         : base(
             config,
             httpClient,
@@ -33,7 +34,8 @@ public class FcChatWindow : ChatWindow
             channelSelection,
             global::DemiCatPlugin.ChannelKind.FcChat,
             avatarCache,
-            emojiManager)
+            emojiManager,
+            chatBridge)
     {
         if (presence != null)
         {

--- a/DemiCatPlugin/IChatBridge.cs
+++ b/DemiCatPlugin/IChatBridge.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DemiCatPlugin;
+
+public interface IChatBridge : IDisposable
+{
+    void Start();
+    void Stop();
+    bool IsReady();
+    void Subscribe(string channel, string? guildId, string? kind);
+    void Unsubscribe(string channel);
+    void Ack(string channel, string? guildId, string? kind);
+    Task Send(string channel, object payload);
+    void Resync(string channel);
+
+    event Action<string>? MessageReceived;
+    event Action<DiscordUserDto>? TypingReceived;
+    event Action? Linked;
+    event Action? Unlinked;
+    event Action<string>? StatusChanged;
+    event Action<string, long>? ResyncRequested;
+    event Action? TemplatesUpdated;
+}

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -35,7 +35,8 @@ public class OfficerChatWindow : ChatWindow
         ChannelService channelService,
         ChannelSelectionService channelSelection,
         AvatarCache avatarCache,
-        EmojiManager emojiManager)
+        EmojiManager emojiManager,
+        IChatBridge? chatBridge = null)
         : base(
             config,
             httpClient,
@@ -45,7 +46,8 @@ public class OfficerChatWindow : ChatWindow
             channelSelection,
             global::DemiCatPlugin.ChannelKind.OfficerChat,
             avatarCache,
-            emojiManager)
+            emojiManager,
+            chatBridge)
     {
         if (presence != null)
         {
@@ -114,7 +116,13 @@ public class OfficerChatWindow : ChatWindow
             return;
         }
 
-        MarkNetworkingStarted();
+        if (!MarkNetworkingStarted())
+        {
+            Subscribe();
+            TryRefreshRoles();
+            return;
+        }
+
         _presence?.SetPresenceReady(true);
         _bridge.Start();
         Subscribe();

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -48,6 +48,7 @@ public class Plugin : IDalamudPlugin
     private readonly NotePadWindow _notePadWindow;
     private readonly ChannelSelectionService _channelSelection;
     private readonly EmojiManager _emojiManager;
+    private readonly RefCountedChatBridge _sharedChatBridge;
 
     private Config _config = null!;
     private readonly HttpClient _httpClient;
@@ -94,6 +95,27 @@ public class Plugin : IDalamudPlugin
         _emojiManager = new EmojiManager(_httpClient, _tokenManager, _config);
         _emojiFontHandle = InitializeEmojiFont();
         _emojiManager.EmojiFontHandle = _emojiFontHandle;
+        var baseChatBridge = new ChatBridge(
+            _config,
+            _httpClient,
+            _tokenManager,
+            () =>
+            {
+                var baseUri = _config.ApiBaseUrl.TrimEnd('/') + "/ws/chat";
+                var builder = new UriBuilder(baseUri);
+                if (builder.Scheme == "https")
+                {
+                    builder.Scheme = "wss";
+                }
+                else if (builder.Scheme == "http")
+                {
+                    builder.Scheme = "ws";
+                }
+
+                return builder.Uri;
+            },
+            _channelSelection);
+        _sharedChatBridge = new RefCountedChatBridge(baseChatBridge);
         _ui = new UiRenderer(_config, _httpClient, _channelSelection, _emojiManager);
         _settings = new SettingsWindow(_config, _tokenManager, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
 
@@ -103,8 +125,8 @@ public class Plugin : IDalamudPlugin
 
         _channelService = new ChannelService(_config, _httpClient, _tokenManager);
         _avatarCache = new AvatarCache(TextureProvider, _httpClient);
-        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _avatarCache, _emojiManager);
-        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _avatarCache, _emojiManager);
+        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _avatarCache, _emojiManager, _sharedChatBridge);
+        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _avatarCache, _emojiManager, _sharedChatBridge);
 
         _presenceService?.Reset();
 
@@ -214,6 +236,7 @@ public class Plugin : IDalamudPlugin
         _presenceService?.Dispose();
         _chatWindow.Dispose();
         _officerChatWindow.Dispose();
+        _sharedChatBridge.Dispose();
         _mainWindow.Dispose();
         _ui.DisposeAsync().GetAwaiter().GetResult();
         _settings.Dispose();

--- a/DemiCatPlugin/RefCountedChatBridge.cs
+++ b/DemiCatPlugin/RefCountedChatBridge.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DemiCatPlugin;
+
+public sealed class RefCountedChatBridge : IChatBridge
+{
+    private readonly IChatBridge _inner;
+    private readonly object _sync = new();
+    private int _startCount;
+    private bool _disposed;
+
+    public RefCountedChatBridge(IChatBridge inner)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    public void Start()
+    {
+        lock (_sync)
+        {
+            ThrowIfDisposed();
+            if (_startCount++ == 0)
+            {
+                _inner.Start();
+            }
+        }
+    }
+
+    public void Stop()
+    {
+        lock (_sync)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (_startCount == 0)
+            {
+                return;
+            }
+
+            if (--_startCount == 0)
+            {
+                _inner.Stop();
+            }
+        }
+    }
+
+    public bool IsReady() => _inner.IsReady();
+
+    public void Subscribe(string channel, string? guildId, string? kind)
+        => _inner.Subscribe(channel, guildId, kind);
+
+    public void Unsubscribe(string channel)
+        => _inner.Unsubscribe(channel);
+
+    public void Ack(string channel, string? guildId, string? kind)
+        => _inner.Ack(channel, guildId, kind);
+
+    public Task Send(string channel, object payload)
+        => _inner.Send(channel, payload);
+
+    public void Resync(string channel)
+        => _inner.Resync(channel);
+
+    public event Action<string>? MessageReceived
+    {
+        add => _inner.MessageReceived += value;
+        remove => _inner.MessageReceived -= value;
+    }
+
+    public event Action<DiscordUserDto>? TypingReceived
+    {
+        add => _inner.TypingReceived += value;
+        remove => _inner.TypingReceived -= value;
+    }
+
+    public event Action? Linked
+    {
+        add => _inner.Linked += value;
+        remove => _inner.Linked -= value;
+    }
+
+    public event Action? Unlinked
+    {
+        add => _inner.Unlinked += value;
+        remove => _inner.Unlinked -= value;
+    }
+
+    public event Action<string>? StatusChanged
+    {
+        add => _inner.StatusChanged += value;
+        remove => _inner.StatusChanged -= value;
+    }
+
+    public event Action<string, long>? ResyncRequested
+    {
+        add => _inner.ResyncRequested += value;
+        remove => _inner.ResyncRequested -= value;
+    }
+
+    public event Action? TemplatesUpdated
+    {
+        add => _inner.TemplatesUpdated += value;
+        remove => _inner.TemplatesUpdated -= value;
+    }
+
+    public void Dispose()
+    {
+        int startCount;
+        lock (_sync)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            startCount = _startCount;
+            _startCount = 0;
+        }
+
+        if (startCount > 0)
+        {
+            _inner.Stop();
+        }
+
+        _inner.Dispose();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(RefCountedChatBridge));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce an `IChatBridge` abstraction with a ref-counted wrapper so multiple chat windows share a single websocket connection
- update `ChatWindow` and its FC/Officer variants to consume the shared bridge and manage event subscriptions safely
- construct and dispose the shared bridge from the plugin to keep FC and officer chat networking coordinated

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e9aa4a8d348328b9d45af48fbf9c13