### PR TITLE
Add defensive event invocation before dispatch handlers

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -843,9 +843,21 @@ public class ChatBridge : IChatBridge
                     const int SliceSize = 100;
                     if (SpreadAcrossFrames)
                     {
-                        DispatchInTicks(deliveries, SliceSize, p => MessageReceived?.Invoke(p));
-                        DispatchInTicks(deleted, SliceSize, id => MessageReceived?.Invoke($"{{\"deletedId\":\"{id}\"}}"));
-                        DispatchInTicks(typings, SliceSize, a => TypingReceived?.Invoke(a));
+                        DispatchInTicks(deliveries, SliceSize, p =>
+                        {
+                            var handler = MessageReceived;
+                            handler?.Invoke(p);
+                        });
+                        DispatchInTicks(deleted, SliceSize, id =>
+                        {
+                            var handler = MessageReceived;
+                            handler?.Invoke($"{\"deletedId\":\"{id}\"}");
+                        });
+                        DispatchInTicks(typings, SliceSize, a =>
+                        {
+                            var handler = TypingReceived;
+                            handler?.Invoke(a);
+                        });
                     }
                     else
                     {


### PR DESCRIPTION
## Summary
- capture event handlers locally inside DispatchInTicks lambdas to avoid nulling races

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e9b133eb0483288f4c66be82b80cf7