### PR TITLE
Fix deleted message dispatch string

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -851,7 +851,7 @@ public class ChatBridge : IChatBridge
                         DispatchInTicks(deleted, SliceSize, id =>
                         {
                             var handler = MessageReceived;
-                            handler?.Invoke($"{\"deletedId\":\"{id}\"}");
+                            handler?.Invoke($"{{\"deletedId\":\"{id}\"}}");
                         });
                         DispatchInTicks(typings, SliceSize, a =>
                         {


### PR DESCRIPTION
## Summary
- escape curly braces when dispatching deleted message notifications in ChatBridge

## Testing
- not run (dotnet not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e9b57372b08328b4b0371a124f0b82