### PR TITLE
Fix unreachable code warning in ChatBridge

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -62,7 +62,7 @@ public class ChatBridge : IChatBridge
     private static void OnFramework(Action action)
         => PluginServices.Instance?.Framework.RunOnTick(action);
 
-    private const bool SpreadAcrossFrames = true;
+    private static readonly bool SpreadAcrossFrames = true;
 
     // Dispatch list items to a handler in slices, scheduling each slice over successive framework ticks.
     private static void DispatchInTicks<T>(IReadOnlyList<T> items, int slice, Action<T> handler)


### PR DESCRIPTION
## Summary
- change the SpreadAcrossFrames flag from a const to a static readonly field
- allow the batching code path to remain reachable and silence CS0162

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e9b8a02c3c832880f02b3738c096b4