### PR TITLE
Improve chat batching and channel fetch resilience

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -64,27 +64,84 @@ public class ChatBridge : IChatBridge
 
     private static readonly bool SpreadAcrossFrames = true;
 
-    // Dispatch list items to a handler in slices, scheduling each slice over successive framework ticks.
-    private static void DispatchInTicks<T>(IReadOnlyList<T> items, int slice, Action<T> handler)
-    {
-        if (items == null || items.Count == 0 || slice <= 0 || handler == null) return;
+    private readonly Queue<string> _msgQ = new();
+    private readonly Queue<string> _deletedQ = new();
+    private readonly Queue<DiscordUserDto> _typingQ = new();
+    private bool _drainScheduled;
 
-        var idx = 0;
-        void Step()
+    private void EnqueueDeliveries(List<string> msgs, List<string> deleted, List<DiscordUserDto> typings)
+    {
+        lock (_stateLock)
         {
-            var end = Math.Min(idx + slice, items.Count);
-            for (; idx < end; idx++)
+            foreach (var m in msgs) _msgQ.Enqueue(m);
+            foreach (var d in deleted) _deletedQ.Enqueue(d);
+            foreach (var t in typings) _typingQ.Enqueue(t);
+
+            if (_drainScheduled) return;
+            _drainScheduled = true;
+        }
+
+        OnFramework(DrainQueues);
+    }
+
+    private void DrainQueues()
+    {
+        const int MaxPerFrame = 500;
+        var count = 0;
+
+        while (count < MaxPerFrame)
+        {
+            string? payload = null;
+            lock (_stateLock)
             {
-                handler(items[idx]);
+                if (_msgQ.Count == 0) break;
+                payload = _msgQ.Dequeue();
             }
 
-            if (idx < items.Count)
+            MessageReceived?.Invoke(payload);
+            count++;
+        }
+
+        while (count < MaxPerFrame)
+        {
+            string? id = null;
+            lock (_stateLock)
             {
-                OnFramework(Step); // schedule next frame
+                if (_deletedQ.Count == 0) break;
+                id = _deletedQ.Dequeue();
+            }
+
+            MessageReceived?.Invoke($"{{\"deletedId\":\"{id}\"}}");
+            count++;
+        }
+
+        while (count < MaxPerFrame)
+        {
+            DiscordUserDto? author = null;
+            lock (_stateLock)
+            {
+                if (_typingQ.Count == 0) break;
+                author = _typingQ.Dequeue();
+            }
+
+            TypingReceived?.Invoke(author);
+            count++;
+        }
+
+        bool more;
+        lock (_stateLock)
+        {
+            more = _msgQ.Count > 0 || _deletedQ.Count > 0 || _typingQ.Count > 0;
+            if (!more)
+            {
+                _drainScheduled = false;
             }
         }
 
-        OnFramework(Step);
+        if (more)
+        {
+            OnFramework(DrainQueues);
+        }
     }
 #if TEST
     internal bool? ForceWebSocketOpen { get; set; }
@@ -843,21 +900,7 @@ public class ChatBridge : IChatBridge
                     const int SliceSize = 100;
                     if (SpreadAcrossFrames)
                     {
-                        DispatchInTicks(deliveries, SliceSize, p =>
-                        {
-                            var handler = MessageReceived;
-                            handler?.Invoke(p);
-                        });
-                        DispatchInTicks(deleted, SliceSize, id =>
-                        {
-                            var handler = MessageReceived;
-                            handler?.Invoke($"{{\"deletedId\":\"{id}\"}}");
-                        });
-                        DispatchInTicks(typings, SliceSize, a =>
-                        {
-                            var handler = TypingReceived;
-                            handler?.Invoke(a);
-                        });
+                        EnqueueDeliveries(deliveries, deleted, typings);
                     }
                     else
                     {

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -773,7 +773,7 @@ public class ChatWindow : IDisposable
 
         if (!_channelsLoaded && !_channelsLoading)
         {
-            _ = FetchChannels();
+            _ = FetchChannelsSafe();
         }
 
         if (_channels.Count > 0)
@@ -3752,10 +3752,24 @@ public class ChatWindow : IDisposable
             return Task.CompletedTask;
         }
         _channelsLoaded = false;
-        return FetchChannels();
+        return FetchChannelsSafe();
     }
 
-    protected virtual async Task FetchChannels(bool refreshed = false)
+    private async Task FetchChannelsSafe(bool refreshed = false)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(25));
+        try
+        {
+            await FetchChannels(refreshed, cts.Token);
+        }
+        catch (TaskCanceledException)
+        {
+            using var retryCts = new CancellationTokenSource(TimeSpan.FromSeconds(25));
+            await FetchChannels(refreshed, retryCts.Token);
+        }
+    }
+
+    protected virtual async Task FetchChannels(bool refreshed = false, CancellationToken cancellationToken = default)
     {
         if (_channelsLoading && !refreshed)
         {
@@ -3786,7 +3800,7 @@ public class ChatWindow : IDisposable
 
         try
         {
-            var channels = (await _channelService.FetchAsync(_channelKind, CancellationToken.None)).ToList();
+            var channels = (await _channelService.FetchAsync(_channelKind, cancellationToken)).ToList();
             if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true)))
             {
                 if (refreshed)

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using System.Numerics;
@@ -88,13 +89,13 @@ public class FcChatWindow : ChatWindow
         return base.RefreshMessages();
     }
 
-    protected override Task FetchChannels(bool refreshed = false)
+    protected override Task FetchChannels(bool refreshed = false, CancellationToken cancellationToken = default)
     {
         if (!_config.SyncedChat || !_config.EnableFcChat)
         {
             return Task.CompletedTask;
         }
-        return base.FetchChannels(refreshed);
+        return base.FetchChannels(refreshed, cancellationToken);
     }
 }
 

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -300,7 +300,7 @@ public class OfficerChatWindow : ChatWindow
         }
     }
 
-    protected override async Task FetchChannels(bool refreshed = false)
+    protected override async Task FetchChannels(bool refreshed = false, CancellationToken cancellationToken = default)
     {
         if (_channelsLoading && !refreshed)
         {
@@ -331,7 +331,7 @@ public class OfficerChatWindow : ChatWindow
 
         try
         {
-            var channels = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(global::DemiCatPlugin.ChannelKind.OfficerChat, CancellationToken.None)).ToList());
+            var channels = ChannelDtoExtensions.SortForDisplay((await _channelService.FetchAsync(global::DemiCatPlugin.ChannelKind.OfficerChat, cancellationToken)).ToList());
             if (await ChannelNameResolver.Resolve(channels, _httpClient, _config, refreshed, () => FetchChannels(true)))
             {
                 if (refreshed)


### PR DESCRIPTION
## Summary
- throttle chat deliveries through per-frame draining queues to prevent UI floods
- add a per-request timeout with a retry wrapper when loading channels to reduce fetch timeouts
- plumb cancellation tokens through FC and officer chat channel fetch overrides

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e9c262e330832893fbccd7cfecbe5b