### PR TITLE
Prevent avatar eviction and slow queue drain

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -86,7 +86,7 @@ public class ChatBridge : IChatBridge
 
     private void DrainQueues()
     {
-        const int MaxPerFrame = 500;
+        const int MaxPerFrame = 300;
         var count = 0;
 
         while (count < MaxPerFrame)

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -928,6 +928,8 @@ public class ChatWindow : IDisposable
             }
             if (msg.AvatarTexture != null)
             {
+                // prevent eviction this frame
+                TouchTexture($"avatar:{msg.Author?.Id}");
                 SafeImage(msg.AvatarTexture, new Vector2(20, 20));
             }
             else


### PR DESCRIPTION
## Summary
- touch author avatar textures before drawing so they stay resident in the frame cache
- lower the bridge drain batch size to smooth per-frame work

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e9c467155c8328a3db45a9180bfaa0