### PR TITLE
Implement chat queue metrics, caching, and typing coalescing

### DIFF
--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -64,20 +64,61 @@ public class ChatBridge : IChatBridge
 
     private static readonly bool SpreadAcrossFrames = true;
 
-    private readonly Queue<string> _msgQ = new();
-    private readonly Queue<string> _deletedQ = new();
-    private readonly Queue<DiscordUserDto> _typingQ = new();
+    // Priority queues
+    private readonly Queue<string> _qHighText = new();
+    private readonly Queue<string> _qHighDelete = new();
+    private readonly Queue<DiscordUserDto> _qMediumTyping = new();
+    private readonly Queue<Action> _qLowAssets = new();
+
+    private const int BudgetHigh = 120;
+    private const int BudgetMedium = 60;
+    private const int BudgetLow = 20;
+    private const int MaxQueuedItems = 10_000;
+
+    private long _shedLowCount;
+    private long _shedMediumCount;
     private bool _drainScheduled;
 
     private void EnqueueDeliveries(List<string> msgs, List<string> deleted, List<DiscordUserDto> typings)
     {
         lock (_stateLock)
         {
-            foreach (var m in msgs) _msgQ.Enqueue(m);
-            foreach (var d in deleted) _deletedQ.Enqueue(d);
-            foreach (var t in typings) _typingQ.Enqueue(t);
+            foreach (var m in msgs)
+            {
+                _qHighText.Enqueue(m);
+            }
 
-            if (_drainScheduled) return;
+            foreach (var d in deleted)
+            {
+                _qHighDelete.Enqueue(d);
+            }
+
+            foreach (var t in typings)
+            {
+                _qMediumTyping.Enqueue(t);
+            }
+
+            var total = _qHighText.Count + _qHighDelete.Count + _qMediumTyping.Count + _qLowAssets.Count;
+
+            while (total > MaxQueuedItems && _qLowAssets.Count > 0)
+            {
+                _qLowAssets.Dequeue();
+                _shedLowCount++;
+                total--;
+            }
+
+            while (total > MaxQueuedItems && _qMediumTyping.Count > 0)
+            {
+                _qMediumTyping.Dequeue();
+                _shedMediumCount++;
+                total--;
+            }
+
+            if (_drainScheduled)
+            {
+                return;
+            }
+
             _drainScheduled = true;
         }
 
@@ -86,61 +127,136 @@ public class ChatBridge : IChatBridge
 
     private void DrainQueues()
     {
-        const int MaxPerFrame = 300;
-        var count = 0;
+        var hi = BudgetHigh;
+        var mid = BudgetMedium;
+        var lo = BudgetLow;
 
-        while (count < MaxPerFrame)
+        while (hi > 0)
         {
             string? payload = null;
+            string? deleteId = null;
+
             lock (_stateLock)
             {
-                if (_msgQ.Count == 0) break;
-                payload = _msgQ.Dequeue();
+                if (_qHighText.Count > 0)
+                {
+                    payload = _qHighText.Dequeue();
+                }
+                else if (_qHighDelete.Count > 0)
+                {
+                    deleteId = _qHighDelete.Dequeue();
+                }
+                else
+                {
+                    break;
+                }
             }
 
-            MessageReceived?.Invoke(payload);
-            count++;
+            if (payload != null)
+            {
+                MessageReceived?.Invoke(payload);
+            }
+            else if (deleteId != null)
+            {
+                MessageReceived?.Invoke($"{{\"deletedId\":\"{deleteId}\"}}");
+            }
+
+            hi--;
         }
 
-        while (count < MaxPerFrame)
+        while (mid > 0)
         {
-            string? id = null;
+            DiscordUserDto? typing = null;
             lock (_stateLock)
             {
-                if (_deletedQ.Count == 0) break;
-                id = _deletedQ.Dequeue();
+                if (_qMediumTyping.Count == 0)
+                {
+                    break;
+                }
+
+                typing = _qMediumTyping.Dequeue();
             }
 
-            MessageReceived?.Invoke($"{{\"deletedId\":\"{id}\"}}");
-            count++;
+            TypingReceived?.Invoke(typing!);
+            mid--;
         }
 
-        while (count < MaxPerFrame)
+        while (lo > 0)
         {
-            DiscordUserDto? author = null;
+            Action? action = null;
             lock (_stateLock)
             {
-                if (_typingQ.Count == 0) break;
-                author = _typingQ.Dequeue();
+                if (_qLowAssets.Count == 0)
+                {
+                    break;
+                }
+
+                action = _qLowAssets.Dequeue();
             }
 
-            TypingReceived?.Invoke(author);
-            count++;
+            try
+            {
+                action?.Invoke();
+            }
+            catch
+            {
+                // ignored
+            }
+
+            lo--;
         }
 
-        bool more;
+        bool hasMore;
         lock (_stateLock)
         {
-            more = _msgQ.Count > 0 || _deletedQ.Count > 0 || _typingQ.Count > 0;
-            if (!more)
+            hasMore = _qHighText.Count + _qHighDelete.Count + _qMediumTyping.Count + _qLowAssets.Count > 0;
+            if (!hasMore)
             {
                 _drainScheduled = false;
             }
         }
 
-        if (more)
+        if (hasMore)
         {
             OnFramework(DrainQueues);
+        }
+    }
+
+    public readonly struct QueueStats
+    {
+        public QueueStats(int highText, int highDelete, int mediumTyping, int lowAssets, long shedMedium, long shedLow)
+        {
+            HighText = highText;
+            HighDelete = highDelete;
+            MediumTyping = mediumTyping;
+            LowAssets = lowAssets;
+            ShedMedium = shedMedium;
+            ShedLow = shedLow;
+        }
+
+        public int HighText { get; }
+        public int HighDelete { get; }
+        public int MediumTyping { get; }
+        public int LowAssets { get; }
+        public long ShedMedium { get; }
+        public long ShedLow { get; }
+    }
+
+    public QueueStats GetQueueStats()
+    {
+        lock (_stateLock)
+        {
+            var stats = new QueueStats(
+                _qHighText.Count,
+                _qHighDelete.Count,
+                _qMediumTyping.Count,
+                _qLowAssets.Count,
+                _shedMediumCount,
+                _shedLowCount);
+
+            _shedMediumCount = 0;
+            _shedLowCount = 0;
+            return stats;
         }
     }
 #if TEST

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -59,6 +59,7 @@ public class ChatWindow : IDisposable
     protected readonly IChatBridge _bridge;
     private readonly bool _ownsBridge;
     private readonly ChannelSelectionService _channelSelection;
+    private readonly MessageCache _messageCache;
     private readonly AvatarCache? _avatarCache;
     private readonly string _channelKind;
     private const string ChannelUnavailableMessage = "Selected channel is no longer available";
@@ -76,7 +77,9 @@ public class ChatWindow : IDisposable
     private const int MaxInputLines = 8;
     private readonly Dictionary<string, TextureCacheEntry> _textureCache = new();
     private readonly LinkedList<string> _textureLru = new();
-    private readonly Dictionary<string, TypingUser> _typingUsers = new();
+    private readonly TypingCoalescer _typingCoalescer;
+    private readonly Dictionary<string, string> _typingNameMap = new(StringComparer.Ordinal);
+    private readonly List<string> _typingDisplayNames = new();
     private static readonly Vector4 MessageHoverBgColor = new(0.24f, 0.33f, 0.53f, 0.22f);
     private static readonly Vector4 MessageIdleBgColor = new(1f, 1f, 1f, 0.03f);
     private const float MessageHoverTextBlend = 0.2f;
@@ -105,6 +108,9 @@ public class ChatWindow : IDisposable
     private long _frameIndex;
     private const long TextureDisposeSafeLag = 2;
     private readonly List<ISharedImmediateTexture> _pendingDisposes = new();
+    private DateTime _lastConfigSave = DateTime.MinValue;
+    private CancellationTokenSource? _configSaveCts;
+    private static readonly TimeSpan ConfigSaveDebounceInterval = TimeSpan.FromSeconds(3);
 
     protected string CurrentChannelId => _channelSelection.GetChannel(_channelKind, _config.GuildId);
     protected string ChannelKindKey => _channelKind;
@@ -406,6 +412,9 @@ public class ChatWindow : IDisposable
         return new Vector2(width, height);
     }
 
+    private static bool IsRectVisible(float itemStartY, float itemHeight, float minY, float maxY)
+        => !(itemStartY + itemHeight < minY || itemStartY > maxY);
+
     private readonly struct WindowFontScaleScope : IDisposable
     {
         private readonly bool _active;
@@ -432,18 +441,6 @@ public class ChatWindow : IDisposable
     }
 
     private WindowFontScaleScope PushWindowFontScale(float scale) => new(scale);
-
-    private class TypingUser
-    {
-        public string Name;
-        public DateTime Expires;
-
-        public TypingUser(string name, DateTime expires)
-        {
-            Name = name;
-            Expires = expires;
-        }
-    }
 
     private class EmojiData
     {
@@ -536,6 +533,7 @@ public class ChatWindow : IDisposable
         TokenManager tokenManager,
         ChannelService channelService,
         ChannelSelectionService channelSelection,
+        MessageCache messageCache,
         string channelKind,
         AvatarCache? avatarCache,
         EmojiManager emojiManager,
@@ -547,6 +545,7 @@ public class ChatWindow : IDisposable
         _tokenManager = tokenManager;
         _channelService = channelService;
         _channelSelection = channelSelection;
+        _messageCache = messageCache;
         _avatarCache = avatarCache;
         _channelKind = channelKind;
         _emojiManager = emojiManager;
@@ -557,6 +556,9 @@ public class ChatWindow : IDisposable
         _bridge = chatBridge ?? new ChatBridge(config, httpClient, tokenManager, BuildWebSocketUri, channelSelection);
         _ownsBridge = chatBridge == null;
         AttachBridgeEvents();
+
+        _typingCoalescer = new TypingCoalescer();
+        _typingCoalescer.TypingUsersChanged += HandleTypingUsersChanged;
 
         _channelSelection.ChannelChanged += HandleChannelSelectionChanged;
     }
@@ -570,6 +572,7 @@ public class ChatWindow : IDisposable
             tokenManager,
             channelService,
             new ChannelSelectionService(config),
+            new MessageCache(),
             global::DemiCatPlugin.ChannelKind.Chat,
             null,
             new EmojiManager(httpClient, tokenManager, config))
@@ -618,6 +621,9 @@ public class ChatWindow : IDisposable
         _lastSubscribedChannelId = null;
         _lastSubscribedGuildId = null;
         _pendingRefreshAfterSubscribe = false;
+        _typingCoalescer.Clear();
+        _typingNameMap.Clear();
+        _typingDisplayNames.Clear();
     }
 
     protected bool TrySubscribeCurrentChannel(bool force = false, bool refreshMessages = true)
@@ -737,6 +743,10 @@ public class ChatWindow : IDisposable
                 _bridge.Unsubscribe(oldId);
             }
 
+            _typingCoalescer.Clear();
+            _typingNameMap.Clear();
+            _typingDisplayNames.Clear();
+
             if (string.IsNullOrEmpty(newId))
             {
                 _lastSubscribedChannelId = null;
@@ -745,6 +755,7 @@ public class ChatWindow : IDisposable
                 return;
             }
 
+            ApplyCachedMessages(newId);
             _lastSubscribedChannelId = null;
             _lastSubscribedGuildId = null;
             OnSubscriptionStateChanged(false);
@@ -755,57 +766,58 @@ public class ChatWindow : IDisposable
     public virtual void Draw()
     {
         _frameIndex++;
+        _typingCoalescer.Tick();
         try
         {
-        _fileDialog.Draw();
-        if (!_bridge.IsReady())
-        {
-            if (!string.IsNullOrEmpty(_statusMessage))
+            _fileDialog.Draw();
+            if (!_bridge.IsReady())
             {
-                ImGui.TextUnformatted(_statusMessage);
-            }
-            else
-            {
-                ImGui.TextUnformatted("Link DemiCat…");
-            }
-            return;
-        }
-
-        if (!_channelsLoaded && !_channelsLoading)
-        {
-            _ = FetchChannelsSafe();
-        }
-
-        if (_channels.Count > 0)
-        {
-            var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
-            var previousIndex = _selectedIndex;
-            var activeChannelId = CurrentChannelId;
-            string? selectedChannelId = null;
-
-            {
-                using var emojiFont = _emojiManager.PushEmojiFont();
-                if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
+                if (!string.IsNullOrEmpty(_statusMessage))
                 {
-                    selectedChannelId = _channels[_selectedIndex].Id;
-                    if (string.Equals(selectedChannelId, activeChannelId, StringComparison.Ordinal))
-                    {
-                        if (previousIndex != _selectedIndex)
-                        {
-                            _selectedIndex = previousIndex;
-                        }
+                    ImGui.TextUnformatted(_statusMessage);
+                }
+                else
+                {
+                    ImGui.TextUnformatted("Link DemiCat…");
+                }
+                return;
+            }
 
-                        selectedChannelId = null;
+            if (!_channelsLoaded && !_channelsLoading)
+            {
+                _ = FetchChannelsSafe();
+            }
+
+            if (_channels.Count > 0)
+            {
+                var channelNames = _channels.Select(c => c.ParentId == null ? c.Name : "  " + c.Name).ToArray();
+                var previousIndex = _selectedIndex;
+                var activeChannelId = CurrentChannelId;
+                string? selectedChannelId = null;
+
+                {
+                    using var emojiFont = _emojiManager.PushEmojiFont();
+                    if (ImGui.Combo("Channel", ref _selectedIndex, channelNames, channelNames.Length))
+                    {
+                        selectedChannelId = _channels[_selectedIndex].Id;
+                        if (string.Equals(selectedChannelId, activeChannelId, StringComparison.Ordinal))
+                        {
+                            if (previousIndex != _selectedIndex)
+                            {
+                                _selectedIndex = previousIndex;
+                            }
+
+                            selectedChannelId = null;
+                        }
                     }
                 }
-            }
 
-            if (selectedChannelId != null)
-            {
-                _channelSelection.SetChannel(_channelKind, _config.GuildId, selectedChannelId);
+                if (selectedChannelId != null)
+                {
+                    _channelSelection.SetChannel(_channelKind, _config.GuildId, selectedChannelId);
+                }
             }
-        }
-        else
+            else
         {
             ImGui.TextUnformatted(_channelFetchFailed ? _channelErrorMessage : "No channels available");
         }
@@ -921,7 +933,8 @@ public class ChatWindow : IDisposable
             }
 
             ImGui.BeginGroup();
-            if (msg.Author != null && msg.AvatarTexture == null && _avatarCache != null)
+            var avatarVisible = IsRectVisible(itemStartY, 20f, minVisibleY, maxVisibleY);
+            if (msg.Author != null && msg.AvatarTexture == null && _avatarCache != null && avatarVisible)
             {
                 _ = _avatarCache.GetAsync(msg.Author.AvatarUrl, msg.Author.Id)
                     .ContinueWith(t => PluginServices.Instance!.Framework.RunOnTick(() => msg.AvatarTexture = t.Result));
@@ -969,7 +982,13 @@ public class ChatWindow : IDisposable
             {
                 foreach (var embed in msg.Embeds)
                 {
-                    EmbedRenderer.Draw(embed, LoadTexture, _emojiManager, cid => _ = Interact(msg.Id, msg.ChannelId, cid), touchTexture: TouchTexture);
+                    EmbedRenderer.Draw(
+                        embed,
+                        LoadTexture,
+                        _emojiManager,
+                        cid => _ = Interact(msg.Id, msg.ChannelId, cid),
+                        touchTexture: TouchTexture,
+                        isVisible: (start, height) => IsRectVisible(start, height, minVisibleY, maxVisibleY));
                 }
             }
             if (msg.Attachments != null)
@@ -979,35 +998,50 @@ public class ChatWindow : IDisposable
                 {
                     if (att.ContentType != null && att.ContentType.StartsWith("image"))
                     {
+                        var imageStartY = ImGui.GetCursorPosY();
+                        var bounds = GetAttachmentBounds(attachmentCap);
+
                         if (att.Texture == null)
                         {
+                            if (!IsRectVisible(imageStartY, bounds.Y, minVisibleY, maxVisibleY))
+                            {
+                                ImGui.Dummy(bounds);
+                                continue;
+                            }
+
                             LoadTexture(att.Url, t => att.Texture = t);
+                            ImGui.Dummy(bounds);
+                            continue;
                         }
-                        if (att.Texture != null)
+
+                        try
                         {
-                            try
+                            var wrapAtt = att.Texture.GetWrapOrEmpty();
+                            var originalSize = new Vector2(wrapAtt.Width, wrapAtt.Height);
+                            var displaySize = CalculateAttachmentDisplaySize(originalSize, bounds);
+
+                            if (!IsRectVisible(imageStartY, displaySize.Y, minVisibleY, maxVisibleY))
                             {
-                                var wrapAtt = att.Texture.GetWrapOrEmpty();
-                                var originalSize = new Vector2(wrapAtt.Width, wrapAtt.Height);
-                                var bounds = GetAttachmentBounds(attachmentCap);
-                                var displaySize = CalculateAttachmentDisplaySize(originalSize, bounds);
-                                SafeImage(att.Texture, displaySize);
-                                TouchTexture(att.Url);
-                                if (ImGui.IsItemHovered())
-                                {
-                                    ImGui.BeginTooltip();
-                                    ImGui.TextUnformatted("Open original");
-                                    ImGui.EndTooltip();
-                                }
-                                if (ImGui.IsItemClicked())
-                                {
-                                    try { Process.Start(new ProcessStartInfo(att.Url) { UseShellExecute = true }); } catch { }
-                                }
+                                ImGui.Dummy(new Vector2(bounds.X, displaySize.Y));
+                                continue;
                             }
-                            catch (ObjectDisposedException)
+
+                            SafeImage(att.Texture, displaySize);
+                            TouchTexture(att.Url);
+                            if (ImGui.IsItemHovered())
                             {
-                                // texture disposed before draw completed
+                                ImGui.BeginTooltip();
+                                ImGui.TextUnformatted("Open original");
+                                ImGui.EndTooltip();
                             }
+                            if (ImGui.IsItemClicked())
+                            {
+                                try { Process.Start(new ProcessStartInfo(att.Url) { UseShellExecute = true }); } catch { }
+                            }
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // texture disposed before draw completed
                         }
                     }
                     else
@@ -1034,7 +1068,13 @@ public class ChatWindow : IDisposable
                     RowIndex = c.RowIndex
                 }).ToList();
                 var pseudo = new EmbedDto { Id = msg.Id + "_components", Buttons = buttons };
-                EmbedRenderer.Draw(pseudo, LoadTexture, _emojiManager, cid => _ = Interact(msg.Id, msg.ChannelId, cid), touchTexture: TouchTexture);
+                EmbedRenderer.Draw(
+                    pseudo,
+                    LoadTexture,
+                    _emojiManager,
+                    cid => _ = Interact(msg.Id, msg.ChannelId, cid),
+                    touchTexture: TouchTexture,
+                    isVisible: (start, height) => IsRectVisible(start, height, minVisibleY, maxVisibleY));
             }
             ImGui.Spacing();
             if (msg.Reactions != null && msg.Reactions.Count > 0)
@@ -1359,19 +1399,12 @@ public class ChatWindow : IDisposable
             DrawAttachmentChips();
         }
 
-        var now = DateTime.UtcNow;
-        foreach (var key in _typingUsers.Where(kvp => kvp.Value.Expires < now).Select(kvp => kvp.Key).ToList())
+        if (_typingDisplayNames.Count > 0)
         {
-            _typingUsers.Remove(key);
-        }
-        if (_typingUsers.Count > 0)
-        {
-            var names = string.Join(", ", _typingUsers.Values.Select(v => v.Name));
-            var verb = _typingUsers.Count > 1 ? "are" : "is";
-            {
-                using var emojiFont = _emojiManager.PushEmojiFont();
-                ImGui.TextUnformatted($"{names} {verb} typing...");
-            }
+            var names = string.Join(", ", _typingDisplayNames);
+            var verb = _typingDisplayNames.Count > 1 ? "are" : "is";
+            using var emojiFont = _emojiManager.PushEmojiFont();
+            ImGui.TextUnformatted($"{names} {verb} typing...");
         }
 
         DrawEmbedStyleControls();
@@ -3551,6 +3584,7 @@ public class ChatWindow : IDisposable
                     }
 
                     TrimMessages();
+                    _messageCache.Upsert(requestedChannelId, _messages);
                     return;
                 }
 
@@ -3576,6 +3610,7 @@ public class ChatWindow : IDisposable
                     }
                 }
                 TrimMessages();
+                _messageCache.Upsert(requestedChannelId, _messages);
                 _pendingInitialScroll = true;
                 _wasAtBottomLastFrame = true;
                 _chatTopPadding = 0f;
@@ -3595,6 +3630,32 @@ public class ChatWindow : IDisposable
             _messages.RemoveAt(0);
         }
         UpdateRestCursorBounds();
+    }
+
+    private void ApplyCachedMessages(string channelId)
+    {
+        foreach (var message in _messages)
+        {
+            DisposeMessageTextures(message);
+        }
+
+        _messages.Clear();
+        _messageHeightCache.Clear();
+        _messageHoverStates.Clear();
+
+        var snapshot = _messageCache.Snapshot(channelId);
+        if (snapshot.Count > 0)
+        {
+            foreach (var message in snapshot)
+            {
+                _messages.Add(message);
+            }
+        }
+
+        TrimMessages();
+        _pendingInitialScroll = true;
+        _wasAtBottomLastFrame = true;
+        _chatTopPadding = 0f;
     }
 
     private async Task<(bool hadExistingMessages, bool hasMatchingChannel, bool hasConflictingChannel)> GetExistingMessageStateAsync(string requestedChannelId)
@@ -3716,6 +3777,8 @@ public class ChatWindow : IDisposable
         StopNetworking();
         DetachBridgeEvents();
         _channelSelection.ChannelChanged -= HandleChannelSelectionChanged;
+        _typingCoalescer.TypingUsersChanged -= HandleTypingUsersChanged;
+        _typingCoalescer.Dispose();
         if (_ownsBridge)
         {
             _bridge.Dispose();
@@ -3725,6 +3788,7 @@ public class ChatWindow : IDisposable
             DisposeMessageTextures(message);
         }
         ClearTextureCache();
+        FlushPendingConfigSave();
     }
 
     protected void SaveConfig()
@@ -3736,14 +3800,108 @@ public class ChatWindow : IDisposable
             return;
         }
 
+        var now = DateTime.UtcNow;
+        if (_lastConfigSave == DateTime.MinValue || now - _lastConfigSave >= ConfigSaveDebounceInterval)
+        {
+            FlushPendingConfigSave(forceSave: false);
+            _lastConfigSave = now;
+            var framework = services?.Framework;
+            if (framework != null)
+            {
+                framework.RunOnTick(() => pluginInterface.SavePluginConfig(_config));
+            }
+            else
+            {
+                pluginInterface.SavePluginConfig(_config);
+            }
+            return;
+        }
+
+        _configSaveCts?.Cancel();
+        _configSaveCts?.Dispose();
+        var delay = ConfigSaveDebounceInterval - (now - _lastConfigSave);
+        var cts = new CancellationTokenSource();
+        _configSaveCts = cts;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(delay, cts.Token).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                cts.Dispose();
+                return;
+            }
+
+            var svc = PluginServices.Instance;
+            var pi = svc?.PluginInterface;
+            if (pi == null)
+            {
+                cts.Dispose();
+                return;
+            }
+
+            var framework = svc?.Framework;
+
+            void SaveAction()
+            {
+                if (!ReferenceEquals(_configSaveCts, cts))
+                {
+                    cts.Dispose();
+                    return;
+                }
+
+                _configSaveCts = null;
+                _lastConfigSave = DateTime.UtcNow;
+                pi.SavePluginConfig(_config);
+                cts.Dispose();
+            }
+
+            if (framework != null)
+            {
+                framework.RunOnTick(SaveAction);
+            }
+            else
+            {
+                SaveAction();
+            }
+        });
+    }
+
+    private void FlushPendingConfigSave(bool forceSave = true)
+    {
+        _configSaveCts?.Cancel();
+        _configSaveCts?.Dispose();
+        _configSaveCts = null;
+
+        var services = PluginServices.Instance;
+        var pluginInterface = services?.PluginInterface;
+        if (pluginInterface == null)
+        {
+            return;
+        }
+
+        if (!forceSave)
+        {
+            return;
+        }
+
         var framework = services?.Framework;
+        void Save()
+        {
+            _lastConfigSave = DateTime.UtcNow;
+            pluginInterface.SavePluginConfig(_config);
+        }
+
         if (framework != null)
         {
-            framework.RunOnTick(() => pluginInterface.SavePluginConfig(_config));
+            framework.RunOnTick(Save);
         }
         else
         {
-            pluginInterface.SavePluginConfig(_config);
+            Save();
         }
     }
 
@@ -3888,6 +4046,7 @@ public class ChatWindow : IDisposable
                             DisposeMessageTextures(_messages[index]);
                             _messages.RemoveAt(index);
                             TrimMessages();
+                            _messageCache.RemoveOne(CurrentChannelId, id);
                         }
                     });
                 }
@@ -3913,6 +4072,7 @@ public class ChatWindow : IDisposable
                                 _messages.Add(msg);
                             }
                             TrimMessages();
+                            _messageCache.UpsertOne(current, msg);
                         }
                     });
                 }
@@ -3928,8 +4088,32 @@ public class ChatWindow : IDisposable
     {
         _ = PluginServices.Instance!.Framework.RunOnTick(() =>
         {
-            _typingUsers[user.Id] = new TypingUser(user.Name, DateTime.UtcNow.AddSeconds(5));
+            _typingNameMap[user.Id] = user.Name;
+            _typingCoalescer.OnTyping(user.Id);
         });
+    }
+
+    private void HandleTypingUsersChanged(IReadOnlyList<string> userIds)
+    {
+        _typingDisplayNames.Clear();
+
+        foreach (var id in userIds)
+        {
+            if (_typingNameMap.TryGetValue(id, out var name) && !string.IsNullOrEmpty(name))
+            {
+                _typingDisplayNames.Add(name);
+            }
+        }
+
+        if (_typingNameMap.Count > 0)
+        {
+            var keep = new HashSet<string>(userIds, StringComparer.Ordinal);
+            var stale = _typingNameMap.Keys.Where(k => !keep.Contains(k)).ToList();
+            foreach (var key in stale)
+            {
+                _typingNameMap.Remove(key);
+            }
+        }
     }
 
     private void HandleBridgeLinked()

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -14,7 +14,13 @@ public static class EmbedRenderer
 {
     private static readonly Dictionary<string, ISharedImmediateTexture?> ThumbnailCache = new();
 
-    public static void Draw(EmbedDto dto, Action<string?, Action<ISharedImmediateTexture?>> loadTexture, EmojiManager emojiManager, Action<string>? onButtonClick = null, Action<string?>? touchTexture = null)
+    public static void Draw(
+        EmbedDto dto,
+        Action<string?, Action<ISharedImmediateTexture?>> loadTexture,
+        EmojiManager emojiManager,
+        Action<string>? onButtonClick = null,
+        Action<string?>? touchTexture = null,
+        Func<float, float, bool>? isVisible = null)
     {
         using var emojiFont = emojiManager.PushEmojiFont();
         if (!string.IsNullOrEmpty(dto.Title))
@@ -70,16 +76,31 @@ public static class EmbedRenderer
 
         if (!string.IsNullOrEmpty(dto.ThumbnailUrl))
         {
-            if (!ThumbnailCache.TryGetValue(dto.ThumbnailUrl, out var tex))
+            var startY = ImGui.GetCursorPosY();
+            const float DefaultThumbSize = 40f;
+            if (!ThumbnailCache.TryGetValue(dto.ThumbnailUrl, out var tex) || tex == null)
             {
-                ThumbnailCache[dto.ThumbnailUrl] = null;
-                loadTexture(dto.ThumbnailUrl, t => ThumbnailCache[dto.ThumbnailUrl] = t);
-                tex = null;
+                if (isVisible == null || isVisible(startY, DefaultThumbSize))
+                {
+                    ThumbnailCache[dto.ThumbnailUrl] = null;
+                    loadTexture(dto.ThumbnailUrl, t => ThumbnailCache[dto.ThumbnailUrl] = t);
+                }
+                ImGui.Dummy(new Vector2(DefaultThumbSize, DefaultThumbSize));
             }
-            if (tex != null)
+            else
             {
-                touchTexture?.Invoke(dto.ThumbnailUrl);
-                SafeImage(tex);
+                var wrap = tex.GetWrapOrEmpty();
+                var width = wrap.Width <= 0 ? DefaultThumbSize : wrap.Width;
+                var height = wrap.Height <= 0 ? DefaultThumbSize : wrap.Height;
+                if (isVisible == null || isVisible(startY, height))
+                {
+                    touchTexture?.Invoke(dto.ThumbnailUrl);
+                    SafeImage(tex);
+                }
+                else
+                {
+                    ImGui.Dummy(new Vector2(width, height));
+                }
             }
         }
 

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -23,6 +23,7 @@ public class FcChatWindow : ChatWindow
         TokenManager tokenManager,
         ChannelService channelService,
         ChannelSelectionService channelSelection,
+        MessageCache messageCache,
         AvatarCache avatarCache,
         EmojiManager emojiManager,
         IChatBridge? chatBridge = null)
@@ -33,6 +34,7 @@ public class FcChatWindow : ChatWindow
             tokenManager,
             channelService,
             channelSelection,
+            messageCache,
             global::DemiCatPlugin.ChannelKind.FcChat,
             avatarCache,
             emojiManager,

--- a/DemiCatPlugin/MessageCache.cs
+++ b/DemiCatPlugin/MessageCache.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DemiCatPlugin;
+
+public sealed class MessageCache
+{
+    // channelId -> recent messages (newest last)
+    private readonly Dictionary<string, LinkedList<DiscordMessageDto>> _perChannel = new();
+    private const int MaxPerChannel = 120; // ~2 pages
+
+    public IReadOnlyList<DiscordMessageDto> Snapshot(string channelId)
+    {
+        if (string.IsNullOrEmpty(channelId))
+        {
+            return Array.Empty<DiscordMessageDto>();
+        }
+
+        if (!_perChannel.TryGetValue(channelId, out var list))
+        {
+            return Array.Empty<DiscordMessageDto>();
+        }
+
+        return list.ToList(); // small
+    }
+
+    public void Upsert(string channelId, IEnumerable<DiscordMessageDto> messages)
+    {
+        if (string.IsNullOrEmpty(channelId))
+        {
+            return;
+        }
+
+        if (!_perChannel.TryGetValue(channelId, out var list))
+        {
+            list = new LinkedList<DiscordMessageDto>();
+            _perChannel[channelId] = list;
+        }
+
+        var byId = new HashSet<string>(list.Select(m => m.Id ?? string.Empty), StringComparer.Ordinal);
+        foreach (var message in messages)
+        {
+            if (message?.Id is not { } id)
+            {
+                continue;
+            }
+
+            if (byId.Contains(id))
+            {
+                continue;
+            }
+
+            list.AddLast(message);
+            byId.Add(id);
+
+            while (list.Count > MaxPerChannel)
+            {
+                list.RemoveFirst();
+            }
+        }
+    }
+
+    public void UpsertOne(string channelId, DiscordMessageDto message)
+        => Upsert(channelId, new[] { message });
+
+    public void RemoveOne(string channelId, string id)
+    {
+        if (string.IsNullOrEmpty(channelId) || string.IsNullOrEmpty(id))
+        {
+            return;
+        }
+
+        if (!_perChannel.TryGetValue(channelId, out var list))
+        {
+            return;
+        }
+
+        var node = list.First;
+        while (node != null)
+        {
+            if (string.Equals(node.Value?.Id, id, StringComparison.Ordinal))
+            {
+                list.Remove(node);
+                break;
+            }
+
+            node = node.Next;
+        }
+    }
+}

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -34,6 +34,7 @@ public class OfficerChatWindow : ChatWindow
         TokenManager tokenManager,
         ChannelService channelService,
         ChannelSelectionService channelSelection,
+        MessageCache messageCache,
         AvatarCache avatarCache,
         EmojiManager emojiManager,
         IChatBridge? chatBridge = null)
@@ -44,6 +45,7 @@ public class OfficerChatWindow : ChatWindow
             tokenManager,
             channelService,
             channelSelection,
+            messageCache,
             global::DemiCatPlugin.ChannelKind.OfficerChat,
             avatarCache,
             emojiManager,
@@ -79,6 +81,7 @@ public class OfficerChatWindow : ChatWindow
             tokenManager,
             channelService,
             new ChannelSelectionService(config),
+            new MessageCache(),
             null!,
             new EmojiManager(httpClient, tokenManager, config))
     {

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -49,6 +49,10 @@ public class Plugin : IDalamudPlugin
     private readonly ChannelSelectionService _channelSelection;
     private readonly EmojiManager _emojiManager;
     private readonly RefCountedChatBridge _sharedChatBridge;
+    private readonly MessageCache _messageCache;
+    private readonly ChatBridge _baseChatBridge;
+    private readonly Timer _queueMetricsTimer;
+    private bool _disposed;
 
     private Config _config = null!;
     private readonly HttpClient _httpClient;
@@ -95,6 +99,7 @@ public class Plugin : IDalamudPlugin
         _emojiManager = new EmojiManager(_httpClient, _tokenManager, _config);
         _emojiFontHandle = InitializeEmojiFont();
         _emojiManager.EmojiFontHandle = _emojiFontHandle;
+        _messageCache = new MessageCache();
         var baseChatBridge = new ChatBridge(
             _config,
             _httpClient,
@@ -115,6 +120,7 @@ public class Plugin : IDalamudPlugin
                 return builder.Uri;
             },
             _channelSelection);
+        _baseChatBridge = baseChatBridge;
         _sharedChatBridge = new RefCountedChatBridge(baseChatBridge);
         _ui = new UiRenderer(_config, _httpClient, _channelSelection, _emojiManager);
         _settings = new SettingsWindow(_config, _tokenManager, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
@@ -125,8 +131,8 @@ public class Plugin : IDalamudPlugin
 
         _channelService = new ChannelService(_config, _httpClient, _tokenManager);
         _avatarCache = new AvatarCache(TextureProvider, _httpClient);
-        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _avatarCache, _emojiManager, _sharedChatBridge);
-        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _avatarCache, _emojiManager, _sharedChatBridge);
+        _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _messageCache, _avatarCache, _emojiManager, _sharedChatBridge);
+        _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _messageCache, _avatarCache, _emojiManager, _sharedChatBridge);
 
         _presenceService?.Reset();
 
@@ -193,10 +199,13 @@ public class Plugin : IDalamudPlugin
         }
 
         _services.Log.Info("DemiCat loaded.");
+        _queueMetricsTimer = new Timer(LogQueueStats, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
     }
 
     public void Dispose()
     {
+        _disposed = true;
+        _queueMetricsTimer.Dispose();
         WebTextureCache.FetchOverride = null;
         try
         {
@@ -246,6 +255,25 @@ public class Plugin : IDalamudPlugin
         if (PluginServices.Instance != null)
         {
             PluginServices.Instance.ProgressOverlay = null;
+        }
+    }
+
+    private void LogQueueStats(object? state)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            var stats = _baseChatBridge.GetQueueStats();
+            _services.Log?.Info(
+                $"chat.q hiText={stats.HighText} hiDel={stats.HighDelete} midTy={stats.MediumTyping} lowAsset={stats.LowAssets} shedMid={stats.ShedMedium} shedLow={stats.ShedLow}");
+        }
+        catch (Exception ex)
+        {
+            _services.Log?.Warning(ex, "Failed to log chat queue stats.");
         }
     }
 

--- a/DemiCatPlugin/TypingCoalescer.cs
+++ b/DemiCatPlugin/TypingCoalescer.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DemiCatPlugin;
+
+public sealed class TypingCoalescer : IDisposable
+{
+    private readonly Dictionary<string, DateTime> _typingUntil = new();
+    private readonly TimeSpan _ttl = TimeSpan.FromSeconds(6);
+    private readonly TimeSpan _uiDebounce = TimeSpan.FromMilliseconds(350);
+    private DateTime _nextUiTick = DateTime.MinValue;
+
+    public event Action<IReadOnlyList<string>>? TypingUsersChanged;
+
+    public void OnTyping(string userId)
+    {
+        if (string.IsNullOrEmpty(userId))
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        _typingUntil[userId] = now + _ttl;
+        TryEmit(now);
+    }
+
+    public void Tick()
+    {
+        var now = DateTime.UtcNow;
+        if (now < _nextUiTick)
+        {
+            return;
+        }
+
+        var changed = Sweep(now);
+        if (changed)
+        {
+            Emit(now);
+        }
+    }
+
+    public void Clear()
+    {
+        _typingUntil.Clear();
+        _nextUiTick = DateTime.MinValue;
+        TypingUsersChanged?.Invoke(Array.Empty<string>());
+    }
+
+    private bool Sweep(DateTime now)
+    {
+        var expired = _typingUntil.Where(kv => kv.Value <= now).Select(kv => kv.Key).ToList();
+        if (expired.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var key in expired)
+        {
+            _typingUntil.Remove(key);
+        }
+
+        return true;
+    }
+
+    private void TryEmit(DateTime now)
+    {
+        if (now < _nextUiTick)
+        {
+            return;
+        }
+
+        Emit(now);
+    }
+
+    private void Emit(DateTime now)
+    {
+        _nextUiTick = now + _uiDebounce;
+        TypingUsersChanged?.Invoke(_typingUntil.Keys.ToList());
+    }
+
+    public void Dispose()
+    {
+        _typingUntil.Clear();
+    }
+}


### PR DESCRIPTION
## Summary
- replace the chat bridge drain with priority queues, per-frame budgets, and queue shedding statistics
- add a shared per-channel message cache and typing coalescer so chat windows render immediately on channel switch with smoother typing indicators
- gate avatar and attachment loading on viewport visibility, adjust embed thumbnail loading, and debounce chat config saves while adding a 30s queue metrics heartbeat

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e9c8f90b708328804e4d0235f2a53c