### PR TITLE
Fix ChatWindow RunOnTick discard

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -3859,7 +3859,7 @@ public class ChatWindow : IDisposable
 
             if (framework != null)
             {
-                framework.RunOnTick(SaveAction);
+                _ = framework.RunOnTick(SaveAction);
             }
             else
             {


### PR DESCRIPTION
## Summary
- discard the task returned by Framework.RunOnTick when scheduling a config save so the compiler warning is silenced

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e9cf91f2c08328a42087b369f915a1