### PR TITLE
Prevent presence avatars from being disposed

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -138,7 +138,7 @@ public class ChatWindow : IDisposable
         }
     }
 
-    private void TouchTexture(string? key)
+    protected void TouchTexture(string? key)
     {
         if (string.IsNullOrEmpty(key))
         {
@@ -645,6 +645,7 @@ public class ChatWindow : IDisposable
 
     public DiscordPresenceService? Presence => _presence;
     public Action<string?, Action<ISharedImmediateTexture?>> TextureLoader => LoadTexture;
+    public Action<string?> TextureTouchAction => TouchTexture;
 
     protected virtual string MessagesPath => "/api/messages";
     protected virtual bool MentionsEnabled => false;

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -42,7 +42,11 @@ public class FcChatWindow : ChatWindow
     {
         if (presence != null)
         {
-            _presenceSidebar = new PresenceSidebar(presence) { TextureLoader = LoadTexture };
+            _presenceSidebar = new PresenceSidebar(presence)
+            {
+                TextureLoader = LoadTexture,
+                TextureTouch = TextureTouchAction
+            };
         }
     }
 

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -53,7 +53,11 @@ public class OfficerChatWindow : ChatWindow
     {
         if (presence != null)
         {
-            _presenceSidebar = new PresenceSidebar(presence) { TextureLoader = LoadTexture };
+            _presenceSidebar = new PresenceSidebar(presence)
+            {
+                TextureLoader = LoadTexture,
+                TextureTouch = TextureTouchAction
+            };
         }
 
         _bridge.StatusChanged += OnBridgeStatusChangedForOfficer;

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -47,6 +47,7 @@ public class PresenceSidebar : IDisposable
     private DateTime _nextRefreshAllowed = DateTime.MinValue;
 
     public Action<string?, Action<ISharedImmediateTexture?>>? TextureLoader { get; set; }
+    public Action<string?>? TextureTouch { get; set; }
 
     public PresenceSidebar(DiscordPresenceService service)
     {
@@ -304,6 +305,7 @@ public class PresenceSidebar : IDisposable
             {
                 var wrap = p.AvatarTexture.GetWrapOrEmpty();
                 ImGui.Image(wrap.Handle, avatarSize);
+                TextureTouch?.Invoke(p.AvatarUrl);
                 drewAvatar = true;
             }
             catch (ObjectDisposedException)
@@ -414,6 +416,7 @@ public class PresenceSidebar : IDisposable
             {
                 var wrap = presence.BannerTexture.GetWrapOrEmpty();
                 drawList.AddImage(wrap.Handle, min, max);
+                TextureTouch?.Invoke(presence.BannerUrl);
                 bannerDrawn = true;
             }
             catch (ObjectDisposedException)

--- a/tests/PresenceSidebarTests.cs
+++ b/tests/PresenceSidebarTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DemiCatPlugin;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Textures;
+using Dalamud.Interface.Textures.TextureWraps;
 using Moq;
 using Xunit;
 
@@ -109,6 +110,37 @@ public class PresenceSidebarTests
         scope.EndFrame();
 
         Assert.False(loaderCalled);
+    }
+
+    [Fact]
+    public void DrawPresence_TouchesAvatarTextureWhenDrawn()
+    {
+        using var scope = new ImGuiContextScope();
+        var sidebar = CreateSidebar();
+        var presence = new PresenceDto
+        {
+            Id = "3",
+            Name = "Avatar",
+            Status = "online",
+            AvatarUrl = "https://example.com/avatar.png"
+        };
+
+        var wrapMock = new Mock<IImmediateTextureWrap>();
+        wrapMock.SetupGet(w => w.Handle).Returns(new IntPtr(1));
+
+        var textureMock = new Mock<ISharedImmediateTexture>();
+        textureMock.Setup(t => t.GetWrapOrEmpty()).Returns(wrapMock.Object);
+
+        sidebar.TextureLoader = (url, assign) => assign(textureMock.Object);
+
+        var touches = 0;
+        sidebar.TextureTouch = _ => touches++;
+
+        scope.BeginFrame();
+        InvokeDrawPresence(sidebar, presence);
+        scope.EndFrame();
+
+        Assert.Equal(1, touches);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- keep presence avatars and banners alive by touching the cache when they are drawn
- expose the texture touch delegate from ChatWindow and pass it into presence sidebars
- add a regression test that ensures avatar draws register cache usage

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ea517e908083289cb6d6451383ee76