### PR TITLE
Refine dock appearance controls

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -17,6 +17,7 @@ public class Config : IPluginConfiguration
     public static readonly Vector4 DefaultPrimaryWindowColor = new(0.11f, 0.11f, 0.12f, 1f);
     public static readonly Vector4 DefaultSecondaryAccentColor = new(0.2f, 0.6f, 1f, 1f);
     public static readonly Vector4 DefaultDockBackgroundColor = new(0.05f, 0.05f, 0.06f, 1f);
+    public static readonly Vector4 DefaultDockBorderColor = DefaultSecondaryAccentColor;
 
     // Required by Dalamud
     public const float MinEmojiTileSize = 16f;
@@ -26,7 +27,7 @@ public class Config : IPluginConfiguration
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
     public const string DefaultEmbedBorderGlyph = "⬛";
-    public const int CurrentVersion = 19;
+    public const int CurrentVersion = 20;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -102,6 +103,9 @@ public class Config : IPluginConfiguration
 
     [JsonPropertyName("dockBackgroundColor")]
     public Vector4 DockBackgroundColor { get; set; } = DefaultDockBackgroundColor;
+
+    [JsonPropertyName("dockBorderColor")]
+    public Vector4 DockBorderColor { get; set; } = DefaultDockBorderColor;
 
     [JsonPropertyName("dockOpacity")]
     public float DockOpacity { get; set; } = 0.85f;
@@ -537,6 +541,13 @@ public class Config : IPluginConfiguration
                 .ToList();
 
             Version = 19;
+            ExtensionData = null;
+        }
+        if (Version < 20)
+        {
+            DockBorderColor = SanitizeColor(DockBorderColor, DefaultDockBorderColor);
+
+            Version = 20;
             ExtensionData = null;
         }
     }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -45,6 +45,7 @@ public class MainWindow : IDisposable
     private const float DockIconSpacing = 12f;
     private const float DockIndicatorRadius = 4f;
     private const float DockIconRounding = 12f;
+    private const float DockWindowRounding = 20f;
     private const string DockDragPayloadType = "DEMICAT_DOCK_ITEM";
     private static readonly string[] ManagedWindowIds =
     {
@@ -181,6 +182,7 @@ public class MainWindow : IDisposable
         var primaryColor = Config.SanitizeColor(_config.PrimaryWindowColor, Config.DefaultPrimaryWindowColor);
         var childBaseColor = AdjustBrightness(primaryColor, 0.9f);
         var accentColor = Config.SanitizeColor(_config.SecondaryAccentColor, Config.DefaultSecondaryAccentColor);
+        var dockBorderColor = Config.SanitizeColor(_config.DockBorderColor, Config.DefaultDockBorderColor);
         var tabBaseColor = AdjustBrightness(primaryColor, 1.05f);
         var tabActiveBaseColor = accentColor;
         var tabHoveredBaseColor = AdjustBrightness(accentColor, 1.1f);
@@ -194,7 +196,7 @@ public class MainWindow : IDisposable
         var styleAlpha = _config.ChatFadeOutEnabled ? fadeAlpha : 1f;
         var dockFadeAlpha = _config.ChatFadeOutEnabled && _config.DockAutoFadeEnabled ? fadeAlpha : 1f;
 
-        var interactedWithDock = DrawDock(accentColor, dockFadeAlpha);
+        var interactedWithDock = DrawDock(dockBorderColor, dockFadeAlpha);
         var interactedWithWindows = DrawManagedWindows(primaryColor, childBaseColor, tabBaseColor, tabActiveBaseColor, tabHoveredBaseColor, styleAlpha, fadeAlpha);
 
         if (_dockOrderDirty)
@@ -373,23 +375,37 @@ public class MainWindow : IDisposable
         }
     }
 
-    private bool DrawDock(Vector4 accentColor, float fadeAlpha)
+    private bool DrawDock(Vector4 borderColor, float fadeAlpha)
     {
         var background = Config.SanitizeColor(_config.DockBackgroundColor, Config.DefaultDockBackgroundColor);
         var gradientStartColor = Config.SanitizeColor(_config.DockGradientStartColor, Config.DefaultDockBackgroundColor);
         var gradientEndColor = Config.SanitizeColor(_config.DockGradientEndColor, Config.DefaultDockBackgroundColor);
         var opacity = Math.Clamp(_config.DockOpacity, 0f, 1f);
         var fade = Math.Clamp(fadeAlpha, 0f, 1f);
-        var alpha = Math.Clamp(opacity * fade, 0f, 1f);
-        var dockColor = new Vector4(background.X, background.Y, background.Z, alpha);
-        var gradientStart = new Vector4(gradientStartColor.X, gradientStartColor.Y, gradientStartColor.Z, alpha);
-        var gradientEnd = new Vector4(gradientEndColor.X, gradientEndColor.Y, gradientEndColor.Z, alpha);
-        var useGradient = _config.DockGradientEnabled && alpha > 0f;
+
+        var dockColor = new Vector4(
+            background.X,
+            background.Y,
+            background.Z,
+            Math.Clamp(background.W * opacity * fade, 0f, 1f));
+        var gradientStart = new Vector4(
+            gradientStartColor.X,
+            gradientStartColor.Y,
+            gradientStartColor.Z,
+            Math.Clamp(gradientStartColor.W * opacity * fade, 0f, 1f));
+        var gradientEnd = new Vector4(
+            gradientEndColor.X,
+            gradientEndColor.Y,
+            gradientEndColor.Z,
+            Math.Clamp(gradientEndColor.W * opacity * fade, 0f, 1f));
+
+        var useGradient = _config.DockGradientEnabled && (gradientStart.W > 0f || gradientEnd.W > 0f);
+        var borderColorWithFade = WithAlpha(borderColor, fade);
 
         ImGui.PushStyleColor(ImGuiCol.WindowBg, useGradient ? Vector4.Zero : dockColor);
-        ImGui.PushStyleColor(ImGuiCol.Border, accentColor);
+        ImGui.PushStyleColor(ImGuiCol.Border, borderColorWithFade);
         ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(16f, 12f));
-        ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 20f);
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, DockWindowRounding);
         ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 2f);
         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(DockIconSpacing, 8f));
 
@@ -406,13 +422,7 @@ public class MainWindow : IDisposable
                 var drawList = ImGui.GetWindowDrawList();
                 var min = ImGui.GetWindowPos();
                 var max = min + ImGui.GetWindowSize();
-                drawList.AddRectFilledMultiColor(
-                    min,
-                    max,
-                    ImGui.GetColorU32(gradientStart),
-                    ImGui.GetColorU32(gradientStart),
-                    ImGui.GetColorU32(gradientEnd),
-                    ImGui.GetColorU32(gradientEnd));
+                DrawRoundedVerticalGradient(drawList, min, max, gradientStart, gradientEnd, DockWindowRounding);
             }
 
             var first = true;
@@ -435,7 +445,7 @@ public class MainWindow : IDisposable
                 first = false;
 
                 EnsureDockIcon(item);
-                DrawDockIcon(item, accentColor);
+                DrawDockIcon(item, borderColor, fade);
             }
         }
         ImGui.End();
@@ -519,7 +529,7 @@ public class MainWindow : IDisposable
         });
     }
 
-    private void DrawDockIcon(DockItem item, Vector4 accentColor)
+    private void DrawDockIcon(DockItem item, Vector4 borderColor, float fadeAlpha)
     {
         ImGui.PushID(item.Id);
 
@@ -584,14 +594,20 @@ public class MainWindow : IDisposable
             drawList.AddText(labelPos, ImGui.GetColorU32(Vector4.One), item.DisplayName);
         }
 
-        var borderAlpha = hovered || active ? 1f : 0.6f;
-        var borderColor = new Vector4(accentColor.X, accentColor.Y, accentColor.Z, Math.Clamp(accentColor.W * borderAlpha, 0f, 1f));
-        drawList.AddRect(iconMin, iconMax, ImGui.GetColorU32(borderColor), DockIconRounding, ImDrawFlags.None, hovered || active ? 2f : 1f);
+        var fade = Math.Clamp(fadeAlpha, 0f, 1f);
+        var baseColor = borderColor;
+        var hoveredColor = AdjustBrightness(borderColor, 1.1f);
+        var activeColor = AdjustBrightness(borderColor, 1.2f);
+        var stateColor = active ? activeColor : hovered ? hoveredColor : baseColor;
+        var drawColor = WithAlpha(stateColor, fade);
+        drawColor.W = Math.Clamp(drawColor.W * (hovered || active ? 1f : 0.6f), 0f, 1f);
+        drawList.AddRect(iconMin, iconMax, ImGui.GetColorU32(drawColor), DockIconRounding, ImDrawFlags.None, hovered || active ? 2f : 1f);
 
         if (active)
         {
             var center = new Vector2(iconMin.X + iconSize * 0.5f, iconMax.Y + DockIndicatorRadius + 2f);
-            drawList.AddCircleFilled(center, DockIndicatorRadius, ImGui.GetColorU32(accentColor));
+            var indicatorColor = WithAlpha(activeColor, fade);
+            drawList.AddCircleFilled(center, DockIndicatorRadius, ImGui.GetColorU32(indicatorColor));
         }
 
         if (hovered)
@@ -1143,6 +1159,54 @@ public class MainWindow : IDisposable
     private static Vector4 WithAlpha(Vector4 color, float alphaMultiplier)
     {
         return new Vector4(color.X, color.Y, color.Z, Math.Clamp(color.W * alphaMultiplier, 0f, 1f));
+    }
+
+    private static void DrawRoundedVerticalGradient(ImDrawListPtr drawList, Vector2 min, Vector2 max, Vector4 topColor, Vector4 bottomColor, float rounding)
+    {
+        var height = max.Y - min.Y;
+        if (height <= 0f)
+        {
+            return;
+        }
+
+        var steps = Math.Clamp((int)Math.Ceiling(height / 2f), 1, 64);
+        var stepHeight = height / steps;
+
+        for (var i = 0; i < steps; i++)
+        {
+            var y0 = min.Y + stepHeight * i;
+            var y1 = i == steps - 1 ? max.Y : y0 + stepHeight;
+            var tMid = height <= 0f ? 0f : ((y0 + y1) * 0.5f - min.Y) / height;
+            var color = Vector4.Lerp(topColor, bottomColor, Math.Clamp(tMid, 0f, 1f));
+            var segmentMin = new Vector2(min.X, y0);
+            var segmentMax = new Vector2(max.X, y1);
+
+            float segmentRounding = 0f;
+            var flags = ImDrawFlags.None;
+            if (rounding > 0f)
+            {
+                if (steps == 1)
+                {
+                    segmentRounding = rounding;
+                    flags = ImDrawFlags.RoundCornersAll;
+                }
+                else
+                {
+                    if (i == 0)
+                    {
+                        segmentRounding = rounding;
+                        flags |= ImDrawFlags.RoundCornersTopLeft | ImDrawFlags.RoundCornersTopRight;
+                    }
+                    if (i == steps - 1)
+                    {
+                        segmentRounding = rounding;
+                        flags |= ImDrawFlags.RoundCornersBottomLeft | ImDrawFlags.RoundCornersBottomRight;
+                    }
+                }
+            }
+
+            drawList.AddRectFilled(segmentMin, segmentMax, ImGui.GetColorU32(color), segmentRounding, flags);
+        }
     }
 
 }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
+using ImGuiNET;
 
 namespace DemiCatPlugin;
 
@@ -330,18 +331,18 @@ public class SettingsWindow : IDisposable
         ImGui.TextUnformatted("Dock appearance");
         ImGui.Spacing();
 
-        var dockColor = _config.DockBackgroundColor;
-        var dockColorVec3 = new Vector3(dockColor.X, dockColor.Y, dockColor.Z);
-        if (ImGui.ColorEdit3("Dock base color", ref dockColorVec3))
+        var dockBorderColor = _config.DockBorderColor;
+        if (DrawAdvancedColorPicker("Dock border color", ref dockBorderColor))
         {
-            var sanitized = Config.SanitizeColor(new Vector4(dockColorVec3, 1f), Config.DefaultDockBackgroundColor);
-            var current = _config.DockBackgroundColor;
-            if (!ColorsAlmostEqual(sanitized, current))
+            var sanitized = Config.SanitizeColor(dockBorderColor, Config.DefaultDockBorderColor);
+            if (!ColorsAlmostEqual(sanitized, _config.DockBorderColor))
             {
-                _config.DockBackgroundColor = new Vector4(sanitized.X, sanitized.Y, sanitized.Z, 1f);
+                _config.DockBorderColor = sanitized;
                 SaveConfig();
             }
         }
+
+        ImGui.Spacing();
 
         var gradientEnabled = _config.DockGradientEnabled;
         if (ImGui.Checkbox("Enable gradient background", ref gradientEnabled))
@@ -350,31 +351,53 @@ public class SettingsWindow : IDisposable
             SaveConfig();
         }
 
-        ImGui.BeginDisabled(!gradientEnabled);
-        var gradientStart = _config.DockGradientStartColor;
-        var gradientStartVec3 = new Vector3(gradientStart.X, gradientStart.Y, gradientStart.Z);
-        if (ImGui.ColorEdit3("Gradient start color", ref gradientStartVec3))
+        ImGui.Spacing();
+
+        ImGui.BeginDisabled(gradientEnabled);
+        var dockColor = _config.DockBackgroundColor;
+        if (DrawAdvancedColorPicker("Dock background color", ref dockColor))
         {
-            var sanitized = Config.SanitizeColor(new Vector4(gradientStartVec3, 1f), Config.DefaultDockBackgroundColor);
-            if (!ColorsAlmostEqual(sanitized, _config.DockGradientStartColor))
+            var sanitized = Config.SanitizeColor(dockColor, Config.DefaultDockBackgroundColor);
+            if (!ColorsAlmostEqual(sanitized, _config.DockBackgroundColor))
             {
-                _config.DockGradientStartColor = new Vector4(sanitized.X, sanitized.Y, sanitized.Z, 1f);
+                _config.DockBackgroundColor = sanitized;
                 SaveConfig();
             }
         }
+        var solidHovered = ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled);
+        if (gradientEnabled && solidHovered)
+        {
+            ImGui.SetTooltip("Disable gradient background to adjust the solid dock color.");
+        }
+        ImGui.Spacing();
+        ImGui.EndDisabled();
+
+        ImGui.BeginDisabled(!gradientEnabled);
+        var gradientStart = _config.DockGradientStartColor;
+        if (DrawAdvancedColorPicker("Gradient start color", ref gradientStart))
+        {
+            var sanitized = Config.SanitizeColor(gradientStart, Config.DefaultDockBackgroundColor);
+            if (!ColorsAlmostEqual(sanitized, _config.DockGradientStartColor))
+            {
+                _config.DockGradientStartColor = sanitized;
+                SaveConfig();
+            }
+        }
+        ImGui.Spacing();
 
         var gradientEnd = _config.DockGradientEndColor;
-        var gradientEndVec3 = new Vector3(gradientEnd.X, gradientEnd.Y, gradientEnd.Z);
-        if (ImGui.ColorEdit3("Gradient end color", ref gradientEndVec3))
+        if (DrawAdvancedColorPicker("Gradient end color", ref gradientEnd))
         {
-            var sanitized = Config.SanitizeColor(new Vector4(gradientEndVec3, 1f), Config.DefaultDockBackgroundColor);
+            var sanitized = Config.SanitizeColor(gradientEnd, Config.DefaultDockBackgroundColor);
             if (!ColorsAlmostEqual(sanitized, _config.DockGradientEndColor))
             {
-                _config.DockGradientEndColor = new Vector4(sanitized.X, sanitized.Y, sanitized.Z, 1f);
+                _config.DockGradientEndColor = sanitized;
                 SaveConfig();
             }
         }
         ImGui.EndDisabled();
+
+        ImGui.Spacing();
 
         var dockOpacity = _config.DockOpacity * 100f;
         if (ImGui.SliderFloat("Dock background opacity", ref dockOpacity, 0f, 100f, "%.0f%%"))
@@ -519,6 +542,28 @@ public class SettingsWindow : IDisposable
     private static bool ColorsAlmostEqual(Vector4 a, Vector4 b)
     {
         return Vector4.DistanceSquared(a, b) <= 0.0001f;
+    }
+
+    private static bool DrawAdvancedColorPicker(string label, ref Vector4 value)
+    {
+        ImGui.TextUnformatted(label);
+        ImGui.PushID(label);
+        var color = value;
+        const ImGuiColorEditFlags flags = ImGuiColorEditFlags.AlphaBar
+                                          | ImGuiColorEditFlags.AlphaPreviewHalf
+                                          | ImGuiColorEditFlags.DisplayHSV
+                                          | ImGuiColorEditFlags.InputRGB
+                                          | ImGuiColorEditFlags.PickerHueBar;
+        var changed = ImGui.ColorPicker4("##picker", ref color, flags);
+        ImGui.PopID();
+
+        if (changed && !ColorsAlmostEqual(color, value))
+        {
+            value = color;
+            return true;
+        }
+
+        return false;
     }
 
     private static void DrawFadePreview(string id, float alpha)


### PR DESCRIPTION
## Summary
- add a dedicated dock border color configuration value with migration support
- update the appearance settings to use advanced color pickers for dock colors and separate solid versus gradient controls
- render dock gradients with rounded corners and respect the custom border color during drawing

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ea8fbd51f883289b6dde6992b6b71c