### PR TITLE
Tidy texture retention and avatar cache cleanup

### DIFF
--- a/DemiCatPlugin/Avatars/AvatarCache.cs
+++ b/DemiCatPlugin/Avatars/AvatarCache.cs
@@ -16,7 +16,7 @@ public class AvatarCache : IDisposable
     private readonly Dictionary<string, CacheEntry> _cache = new();
     private readonly Dictionary<string, (ISharedImmediateTexture Tex, long LastTouch)> _live = new(StringComparer.Ordinal);
     private readonly Dictionary<string, string> _userToUrl = new(StringComparer.Ordinal);
-    private const int LiveCap = 256;
+    private const int LiveCap = 384;
     private readonly TimeSpan _ttl = TimeSpan.FromHours(12);
     private readonly object _lock = new();
 

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -4178,6 +4178,7 @@ public class ChatWindow : IDisposable
             DisposeMessageTextures(message);
         }
         ClearTextureCache();
+        _avatarInflight.Clear();
         FlushPendingConfigSave();
         _subscribeCts?.Cancel();
         _subscribeCts?.Dispose();

--- a/DemiCatPlugin/EmbedRenderer.cs
+++ b/DemiCatPlugin/EmbedRenderer.cs
@@ -96,10 +96,10 @@ public static class EmbedRenderer
                     var height = wrap.Height <= 0 ? DefaultThumbSize : wrap.Height;
                     if (isVisible == null || isVisible(startY, height))
                     {
-                        touchTexture?.Invoke(dto.ThumbnailUrl);
                         if (wrap.Handle != IntPtr.Zero)
                         {
                             ImGui.Image(wrap.Handle, new Vector2(width, height));
+                            touchTexture?.Invoke(dto.ThumbnailUrl);
                         }
                         else
                         {


### PR DESCRIPTION
## Summary
- ensure embed thumbnail texture touches occur only after a successful draw
- raise the avatar cache live cap to accommodate larger free companies
- clear the in-flight avatar tracking set when disposing the chat window

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea9f21a3a083289c92112fdefc5a8c