### PR TITLE
Fix embed color selection previews

### DIFF
--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -36,7 +36,7 @@ public class EventCreateWindow
     private string _imageUrl = string.Empty;
     private string _url = string.Empty;
     private string _thumbnailUrl = string.Empty;
-    private uint _color;
+    private uint? _embedColor;
     private readonly List<Field> _fields = new();
     private string? _lastResult;
     private readonly List<Template.TemplateButton> _buttons = new();
@@ -333,9 +333,12 @@ public class EventCreateWindow
         ImGui.TextUnformatted("Embed Banner Color:");
         ImGui.SameLine();
 
-        var colorVec = ColorUtils.ImGuiToVector(_color);
+        var colorVector4 = _embedColor.HasValue
+            ? ColorUtils.RgbToVector4(_embedColor.Value)
+            : new Vector4(0f, 0f, 0f, 1f);
+        var colorVec = new Vector3(colorVector4.X, colorVector4.Y, colorVector4.Z);
         var colorDisplaySize = new Vector2(ImGui.GetFrameHeight() * 2.5f, ImGui.GetFrameHeight());
-        if (ImGui.ColorButton("##embedColorButton", new Vector4(colorVec, 1f), ImGuiColorEditFlags.None, colorDisplaySize))
+        if (ImGui.ColorButton("##embedColorButton", colorVector4, ImGuiColorEditFlags.NoAlpha, colorDisplaySize))
         {
             ImGui.OpenPopup("embedColorPicker");
         }
@@ -345,11 +348,12 @@ public class EventCreateWindow
             var pickerColor = colorVec;
             if (ImGui.ColorPicker3("##embedColorPicker", ref pickerColor, ImGuiColorEditFlags.NoSidePreview | ImGuiColorEditFlags.NoSmallPreview))
             {
-                _color = ColorUtils.VectorToImGui(pickerColor);
+                var imGuiColor = ColorUtils.Vector4ToImGui(new Vector4(pickerColor, 1f));
+                _embedColor = ColorUtils.ImGuiToRgb(imGuiColor);
             }
             if (ImGui.Button("Clear"))
             {
-                _color = 0;
+                _embedColor = null;
                 ImGui.CloseCurrentPopup();
             }
             ImGui.EndPopup();
@@ -686,7 +690,7 @@ public class EventCreateWindow
         _thumbnailUrl = template.ThumbnailUrl;
         ResetUploadState(_bannerUpload, template.ImageId, template.ImageUrl);
         ResetUploadState(_thumbnailUpload, template.ThumbnailId, template.ThumbnailUrl);
-        _color = ColorUtils.RgbToImGui(template.Color);
+        _embedColor = template.Color != 0 ? template.Color : null;
         _mentions.Clear();
         if (template.Mentions != null)
         {
@@ -1026,7 +1030,7 @@ public class EventCreateWindow
             string.IsNullOrWhiteSpace(_url) ? null : _url,
             string.IsNullOrWhiteSpace(_imageUrl) ? null : _imageUrl,
             string.IsNullOrWhiteSpace(_thumbnailUrl) ? null : _thumbnailUrl,
-            _color > 0 ? (uint?)ColorUtils.ImGuiToRgb(_color) : null,
+            _embedColor,
             fields,
             buttons,
             mentionIds,

--- a/tests/ColorConversionTests.cs
+++ b/tests/ColorConversionTests.cs
@@ -100,10 +100,11 @@ public class ColorConversionTests
         var selection = new ChannelSelectionService(config);
         var emojiManager = new EmojiManager(http, tokenManager, config);
         var window = new EventCreateWindow(config, http, channelService, selection, emojiManager);
-        typeof(EventCreateWindow).GetField("_color", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .SetValue(window, ColorUtils.RgbToImGui(rgb));
-        var preview = (EmbedDto)typeof(EventCreateWindow).GetMethod("BuildPreview", BindingFlags.NonPublic | BindingFlags.Instance)!
+        typeof(EventCreateWindow).GetField("_embedColor", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(window, rgb);
+        var preview = (EventPreviewFormatter.Result)typeof(EventCreateWindow)
+            .GetMethod("BuildPreview", BindingFlags.NonPublic | BindingFlags.Instance)!
             .Invoke(window, Array.Empty<object>())!;
-        Assert.Equal(rgb, preview.Color);
+        Assert.Equal(rgb, preview.Embed.Color);
     }
 }


### PR DESCRIPTION
## Summary
- store event embed color in RGB form so the preview stripe updates reliably
- translate color picker selections directly into RGB values and allow clearing the color
- update the color conversion test to exercise the new event preview result API

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68eaa172b8a4832896c1dfc8c19209cc