### PR TITLE
Add themed glass styling helpers

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -22,6 +22,7 @@ using System.Runtime.CompilerServices;
 using Dalamud.Interface.ImGuiFileDialog;
 using DemiCatPlugin.Emoji;
 using DemiCatPlugin.Avatars;
+using ImGuiNET;
 
 namespace DemiCatPlugin;
 
@@ -1889,6 +1890,27 @@ public class ChatWindow : IDisposable
         }
     }
 
+    public virtual void DrawThemedWindow(string title, ref bool isOpen, ImGuiWindowFlags flags = ImGuiWindowFlags.None)
+    {
+        using var scope = new UiStyleScope(_config);
+        var open = isOpen;
+        if (ImGui.Begin(title, ref open, flags))
+        {
+            UiTheme.DrawWindowChrome(_config, null, () => open = false);
+            Draw();
+        }
+        ImGui.End();
+
+        if (!open || UiTheme.RequestCloseThisFrame)
+        {
+            isOpen = false;
+        }
+        else
+        {
+            isOpen = open;
+        }
+    }
+
     protected List<ChannelDto> PrepareChannelsForDisplay(IEnumerable<ChannelDto> channels)
     {
         var channelList = channels?.ToList() ?? new List<ChannelDto>();
@@ -2495,7 +2517,7 @@ public class ChatWindow : IDisposable
             {
                 if (i > 0)
                 {
-                    ImGui.Separator();
+                    UiTheme.DrawSectionSeparator();
                 }
 
                 var header = candidate.Type == MentionCandidateType.User ? "Members" : "Roles";
@@ -2981,7 +3003,7 @@ public class ChatWindow : IDisposable
             if (!string.IsNullOrEmpty(fileName))
             {
                 ImGui.TextUnformatted(fileName);
-                ImGui.Separator();
+                UiTheme.DrawSectionSeparator();
             }
 
             long fileSize = 0;
@@ -3025,7 +3047,7 @@ public class ChatWindow : IDisposable
 
             if (errorForAttachment && !string.IsNullOrEmpty(_attachmentError))
             {
-                ImGui.Separator();
+                UiTheme.DrawSectionSeparator();
                 ImGui.TextWrapped(_attachmentError);
             }
 

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -6,6 +6,7 @@ using Dalamud.Bindings.ImGui;
 using System.Numerics;
 using DemiCatPlugin.Avatars;
 using DemiCatPlugin.Emoji;
+using ImGuiNET;
 
 namespace DemiCatPlugin;
 
@@ -103,5 +104,8 @@ public class FcChatWindow : ChatWindow
         }
         return base.FetchChannels(refreshed, cancellationToken);
     }
+
+    public void DrawThemedWindow(ref bool isOpen, ImGuiWindowFlags flags = ImGuiWindowFlags.None)
+        => base.DrawThemedWindow("FC Chat", ref isOpen, flags);
 }
 

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -985,27 +985,38 @@ public class MainWindow : IDisposable
             styleVarPushed = true;
         }
 
-        PushWindowOpacityStyles(primaryColor, childBaseColor, tabBaseColor, tabActiveBaseColor, tabHoveredBaseColor, alpha);
+        using var themeScope = new UiStyleScope(_config);
+        var pushedColors = PushWindowOpacityStyles(primaryColor, childBaseColor, tabBaseColor, tabActiveBaseColor, tabHoveredBaseColor, alpha);
 
         ImGui.SetNextWindowSize(new Vector2(800f, 600f), ImGuiCond.FirstUseEver);
         ImGui.SetNextWindowSizeConstraints(new Vector2(600f, 400f), new Vector2(float.MaxValue, float.MaxValue));
 
         var openRef = open;
         var windowInteracted = false;
+        var closeRequested = false;
         if (ImGui.Begin($"{title}##dc_{id}", ref openRef, ImGuiWindowFlags.NoCollapse))
         {
+            UiTheme.DrawWindowChrome(_config, null, () =>
+            {
+                openRef = false;
+                closeRequested = true;
+            });
+
             drawContent();
             windowInteracted = HasWindowInteraction();
         }
         ImGui.End();
 
-        ImGui.PopStyleColor(5);
+        if (pushedColors > 0)
+        {
+            ImGui.PopStyleColor(pushedColors);
+        }
         if (styleVarPushed)
         {
             ImGui.PopStyleVar();
         }
 
-        if (!openRef)
+        if (!openRef || closeRequested || UiTheme.RequestCloseThisFrame)
         {
             ForceWindowClosed(id);
         }
@@ -1132,7 +1143,7 @@ public class MainWindow : IDisposable
         style.Colors[(int)ImGuiCol.SeparatorActive] = accentActive;
     }
 
-    private static void PushWindowOpacityStyles(
+    private static int PushWindowOpacityStyles(
         Vector4 primaryColor,
         Vector4 childBaseColor,
         Vector4 tabBaseColor,
@@ -1145,6 +1156,7 @@ public class MainWindow : IDisposable
         ImGui.PushStyleColor(ImGuiCol.Tab, WithAlpha(tabBaseColor, alpha));
         ImGui.PushStyleColor(ImGuiCol.TabActive, WithAlpha(tabActiveBaseColor, alpha));
         ImGui.PushStyleColor(ImGuiCol.TabHovered, WithAlpha(tabHoveredBaseColor, alpha));
+        return 5;
     }
 
     private static Vector4 AdjustBrightness(Vector4 color, float factor)

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using DemiCatPlugin.Avatars;
 using DemiCatPlugin.Emoji;
+using ImGuiNET;
 
 namespace DemiCatPlugin;
 
@@ -508,6 +509,9 @@ public class OfficerChatWindow : ChatWindow
         _bridge.StatusChanged -= OnBridgeStatusChangedForOfficer;
         base.Dispose();
     }
+
+    public void DrawThemedWindow(ref bool isOpen, ImGuiWindowFlags flags = ImGuiWindowFlags.None)
+        => base.DrawThemedWindow("Officer Chat", ref isOpen, flags);
 
     private class RolesDto
     {

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -66,8 +66,12 @@ public class SettingsWindow : IDisposable
     {
         if (IsOpen)
         {
-            if (ImGui.Begin("DemiCat Settings", ref IsOpen))
+            using var scope = new UiStyleScope(_config);
+            var open = IsOpen;
+            if (ImGui.Begin("DemiCat Settings", ref open))
             {
+                UiTheme.DrawWindowChrome(_config, null, () => open = false);
+
                 if (!_settingsLoaded)
                 {
                     _settingsLoaded = true;
@@ -96,12 +100,16 @@ public class SettingsWindow : IDisposable
 
                     ImGui.EndTabBar();
                 }
+            }
+            ImGui.End();
 
-                ImGui.End();
+            if (!open || UiTheme.RequestCloseThisFrame)
+            {
+                IsOpen = false;
             }
             else
             {
-                ImGui.End();
+                IsOpen = open;
             }
         }
 
@@ -117,7 +125,7 @@ public class SettingsWindow : IDisposable
         if (!linked)
         {
             ImGui.TextColored(new Vector4(1f, 0.85f, 0f, 1f), "Link DemiCat: run `/demibot embed` in Discord and paste the key.");
-            ImGui.Separator();
+            UiTheme.DrawSectionSeparator();
         }
 
         if (ImGui.InputText("API Base URL", ref _apiBaseUrl, 256))
@@ -327,7 +335,7 @@ public class SettingsWindow : IDisposable
             }
         }
 
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
         ImGui.TextUnformatted("Dock appearance");
         ImGui.Spacing();
 
@@ -417,7 +425,7 @@ public class SettingsWindow : IDisposable
             SaveConfig();
         }
 
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
         ImGui.TextUnformatted("Dock behavior");
         ImGui.Spacing();
         ImGui.TextWrapped("Select which windows should open automatically when the dock is shown.");
@@ -470,7 +478,7 @@ public class SettingsWindow : IDisposable
             ImGui.SetTooltip("Disable fade-out to adjust per-tab opacity.");
 
         ImGui.NewLine();
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
 
         if (ImGui.Checkbox("Enable fade-out", ref fadeOutEnabled))
         {

--- a/DemiCatPlugin/UiStyleScope.cs
+++ b/DemiCatPlugin/UiStyleScope.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace DemiCatPlugin;
+
+public sealed class UiStyleScope : IDisposable
+{
+    private readonly int _pushVarCount;
+    private readonly int _pushColorCount;
+    private bool _disposed;
+
+    public UiStyleScope(Config config)
+    {
+        (_pushVarCount, _pushColorCount) = UiTheme.Apply(config);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_pushColorCount > 0 || _pushVarCount > 0)
+        {
+            UiTheme.Pop();
+        }
+
+        _disposed = true;
+    }
+}

--- a/DemiCatPlugin/UiTheme.cs
+++ b/DemiCatPlugin/UiTheme.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Dalamud.Interface.Utility;
+using ImGuiNET;
+
+namespace DemiCatPlugin;
+
+public static class UiTheme
+{
+    private struct FrameState
+    {
+        public uint Frame;
+        public Vector4 Primary;
+        public Vector4 Secondary;
+        public Vector4 Accent;
+        public Vector4 BorderColor;
+        public Vector4 BorderHoverColor;
+        public Vector4 FocusGlowColor;
+        public Vector4 SeparatorColor;
+        public Vector4 HeaderColor;
+        public Vector4 HeaderHoveredColor;
+        public Vector4 HeaderActiveColor;
+        public Vector4 FrameBgColor;
+        public Vector4 FrameBgHoveredColor;
+        public Vector4 FrameBgActiveColor;
+        public Vector4 ButtonColor;
+        public Vector4 ButtonHoveredColor;
+        public Vector4 ButtonActiveColor;
+        public Vector4 TabColor;
+        public Vector4 TabHoveredColor;
+        public Vector4 TabActiveColor;
+        public Vector4 TextColor;
+        public Vector4 CloseButtonColor;
+        public Vector4 CloseButtonHoveredColor;
+    }
+
+    private static readonly Stack<(int Vars, int Colors)> ScopeStack = new();
+    private static FrameState _frameState;
+
+    public static bool RequestCloseThisFrame { get; private set; }
+
+    public static (int VarCount, int ColorCount) Apply(Config config)
+    {
+        RequestCloseThisFrame = false;
+
+        var style = ImGui.GetStyle();
+        var sanitizedPrimary = Config.SanitizeColor(config.PrimaryWindowColor, Config.DefaultPrimaryWindowColor);
+        var sanitizedSecondary = Config.SanitizeColor(config.SecondaryAccentColor, Config.DefaultSecondaryAccentColor);
+        var sanitizedAccent = sanitizedSecondary; // Accent currently derives from secondary until a dedicated color exists.
+
+        sanitizedPrimary.W = ClampAlpha(sanitizedPrimary.W, 0.75f);
+        sanitizedSecondary.W = Math.Clamp(sanitizedSecondary.W, 0.2f, 1f);
+        sanitizedAccent.W = Math.Clamp(sanitizedAccent.W <= 0f ? sanitizedSecondary.W : sanitizedAccent.W, 0.3f, 1f);
+
+        CacheFrameState(sanitizedPrimary, sanitizedSecondary, sanitizedAccent, style);
+
+        var varCount = 0;
+        var colorCount = 0;
+
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 12f * ImGuiHelpers.GlobalScale);
+        varCount++;
+        ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 10f * ImGuiHelpers.GlobalScale);
+        varCount++;
+        ImGui.PushStyleVar(ImGuiStyleVar.ChildRounding, 10f * ImGuiHelpers.GlobalScale);
+        varCount++;
+        ImGui.PushStyleVar(ImGuiStyleVar.TabRounding, 8f * ImGuiHelpers.GlobalScale);
+        varCount++;
+        ImGui.PushStyleVar(ImGuiStyleVar.GrabRounding, 10f * ImGuiHelpers.GlobalScale);
+        varCount++;
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 1f);
+        varCount++;
+        ImGui.PushStyleVar(ImGuiStyleVar.FrameBorderSize, 1f);
+        varCount++;
+        ImGui.PushStyleVar(ImGuiStyleVar.PopupBorderSize, 1f);
+        varCount++;
+
+        colorCount += PushColor(ImGuiCol.WindowBg, _frameState.Primary);
+        colorCount += PushColor(ImGuiCol.Border, _frameState.BorderColor);
+        colorCount += PushColor(ImGuiCol.BorderShadow, new Vector4(_frameState.BorderColor.X, _frameState.BorderColor.Y, _frameState.BorderColor.Z, 0f));
+        colorCount += PushColor(ImGuiCol.Separator, _frameState.SeparatorColor);
+        colorCount += PushColor(ImGuiCol.SeparatorHovered, _frameState.HeaderHoveredColor);
+        colorCount += PushColor(ImGuiCol.SeparatorActive, _frameState.HeaderActiveColor);
+        colorCount += PushColor(ImGuiCol.Header, _frameState.HeaderColor);
+        colorCount += PushColor(ImGuiCol.HeaderHovered, _frameState.HeaderHoveredColor);
+        colorCount += PushColor(ImGuiCol.HeaderActive, _frameState.HeaderActiveColor);
+        colorCount += PushColor(ImGuiCol.FrameBg, _frameState.FrameBgColor);
+        colorCount += PushColor(ImGuiCol.FrameBgHovered, _frameState.FrameBgHoveredColor);
+        colorCount += PushColor(ImGuiCol.FrameBgActive, _frameState.FrameBgActiveColor);
+        colorCount += PushColor(ImGuiCol.Button, _frameState.ButtonColor);
+        colorCount += PushColor(ImGuiCol.ButtonHovered, _frameState.ButtonHoveredColor);
+        colorCount += PushColor(ImGuiCol.ButtonActive, _frameState.ButtonActiveColor);
+        colorCount += PushColor(ImGuiCol.SliderGrab, _frameState.ButtonHoveredColor);
+        colorCount += PushColor(ImGuiCol.SliderGrabActive, _frameState.ButtonActiveColor);
+        colorCount += PushColor(ImGuiCol.CheckMark, _frameState.ButtonActiveColor);
+        colorCount += PushColor(ImGuiCol.ResizeGrip, _frameState.ButtonColor);
+        colorCount += PushColor(ImGuiCol.ResizeGripHovered, _frameState.ButtonHoveredColor);
+        colorCount += PushColor(ImGuiCol.ResizeGripActive, _frameState.ButtonActiveColor);
+        colorCount += PushColor(ImGuiCol.Tab, _frameState.TabColor);
+        colorCount += PushColor(ImGuiCol.TabHovered, _frameState.TabHoveredColor);
+        colorCount += PushColor(ImGuiCol.TabActive, _frameState.TabActiveColor);
+        colorCount += PushColor(ImGuiCol.TabUnfocused, _frameState.TabColor);
+        colorCount += PushColor(ImGuiCol.TabUnfocusedActive, _frameState.TabActiveColor);
+        colorCount += PushColor(ImGuiCol.TitleBg, _frameState.Primary);
+        colorCount += PushColor(ImGuiCol.TitleBgActive, _frameState.HeaderActiveColor);
+        colorCount += PushColor(ImGuiCol.TitleBgCollapsed, _frameState.Primary);
+
+        var baseText = style.Colors[(int)ImGuiCol.Text];
+        var textColor = _frameState.TextColor.W > 0f ? _frameState.TextColor : baseText;
+        colorCount += PushColor(ImGuiCol.Text, textColor);
+
+        ScopeStack.Push((varCount, colorCount));
+        return (varCount, colorCount);
+    }
+
+    public static void Pop()
+    {
+        if (ScopeStack.Count == 0)
+        {
+            return;
+        }
+
+        var (vars, colors) = ScopeStack.Pop();
+        if (colors > 0)
+        {
+            ImGui.PopStyleColor(colors);
+        }
+
+        if (vars > 0)
+        {
+            ImGui.PopStyleVar(vars);
+        }
+    }
+
+    public static void DrawWindowChrome(Config config, string? titleOverride = null, Action? onClose = null)
+    {
+        RequestCloseThisFrame = false;
+
+        var drawList = ImGui.GetWindowDrawList();
+        if (drawList.NativePtr == IntPtr.Zero)
+        {
+            return;
+        }
+
+        var windowPos = ImGui.GetWindowPos();
+        var windowSize = ImGui.GetWindowSize();
+        if (windowSize.X <= 0f || windowSize.Y <= 0f)
+        {
+            return;
+        }
+
+        var style = ImGui.GetStyle();
+        var rounding = style.WindowRounding;
+        var scale = ImGuiHelpers.GlobalScale;
+        var highlightHeight = MathF.Min(windowSize.Y * 0.3f, 26f * scale);
+        if (highlightHeight > 0.5f)
+        {
+            var topColor = new Vector4(1f, 1f, 1f, 0.08f);
+            var bottomColor = new Vector4(1f, 1f, 1f, 0f);
+            var gradientMin = windowPos + new Vector2(style.WindowBorderSize, style.WindowBorderSize);
+            var gradientMax = windowPos + new Vector2(windowSize.X - style.WindowBorderSize, style.WindowBorderSize + highlightHeight);
+            drawList.AddRectFilledMultiColor(
+                gradientMin,
+                gradientMax,
+                ImGui.ColorConvertFloat4ToU32(topColor),
+                ImGui.ColorConvertFloat4ToU32(topColor),
+                ImGui.ColorConvertFloat4ToU32(bottomColor),
+                ImGui.ColorConvertFloat4ToU32(bottomColor));
+        }
+
+        var hovered = ImGui.IsWindowHovered(ImGuiHoveredFlags.RootWindow | ImGuiHoveredFlags.AllowWhenBlockedByActiveItem);
+        var borderColor = hovered
+            ? AdjustAlpha(_frameState.BorderHoverColor, Math.Clamp(_frameState.BorderHoverColor.W + 0.1f, 0f, 1f))
+            : _frameState.BorderColor;
+        drawList.AddRect(windowPos, windowPos + windowSize, ImGui.ColorConvertFloat4ToU32(borderColor), rounding, ImDrawFlags.RoundCornersAll, 1.5f);
+
+        var focused = ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows);
+        if (focused)
+        {
+            var glowThickness = 3f * scale;
+            drawList.AddRect(windowPos - new Vector2(1.5f * scale), windowPos + windowSize + new Vector2(1.5f * scale),
+                ImGui.ColorConvertFloat4ToU32(_frameState.FocusGlowColor), rounding + 3f * scale, ImDrawFlags.RoundCornersAll, glowThickness);
+        }
+
+        var previousCursor = ImGui.GetCursorScreenPos();
+        var buttonRadius = 7f * scale;
+        var buttonSize = new Vector2(buttonRadius * 2f, buttonRadius * 2f);
+        var buttonOffsetY = MathF.Max(2f * scale, style.FramePadding.Y * 0.25f);
+        var buttonPos = new Vector2(windowPos.X + style.WindowPadding.X, windowPos.Y + style.WindowPadding.Y + buttonOffsetY);
+        ImGui.SetCursorScreenPos(buttonPos);
+
+        ImGui.PushID("dc_theme_close");
+        var clicked = ImGui.InvisibleButton("##close", buttonSize);
+        var buttonHovered = ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenBlockedByActiveItem);
+        ImGui.PopID();
+        ImGui.SetCursorScreenPos(previousCursor);
+
+        var buttonCenter = buttonPos + new Vector2(buttonRadius);
+        var baseColor = buttonHovered ? _frameState.CloseButtonHoveredColor : _frameState.CloseButtonColor;
+        drawList.AddCircleFilled(buttonCenter, buttonRadius, ImGui.ColorConvertFloat4ToU32(baseColor));
+
+        var crossExtent = buttonRadius * 0.5f;
+        var crossThickness = Math.Max(1.5f, 1.5f * scale);
+        var crossColor = ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 0.9f));
+        drawList.AddLine(buttonCenter + new Vector2(-crossExtent, -crossExtent), buttonCenter + new Vector2(crossExtent, crossExtent), crossColor, crossThickness);
+        drawList.AddLine(buttonCenter + new Vector2(-crossExtent, crossExtent), buttonCenter + new Vector2(crossExtent, -crossExtent), crossColor, crossThickness);
+
+        if (!string.IsNullOrEmpty(titleOverride))
+        {
+            var textPos = windowPos + new Vector2(style.WindowPadding.X + buttonSize.X + 6f * scale, style.WindowPadding.Y + style.FramePadding.Y * 0.25f * scale);
+            drawList.AddText(textPos, ImGui.ColorConvertFloat4ToU32(_frameState.TextColor.W > 0f ? _frameState.TextColor : ImGui.GetStyle().Colors[(int)ImGuiCol.Text]), titleOverride);
+        }
+
+        if (clicked)
+        {
+            if (onClose != null)
+            {
+                onClose();
+            }
+            else
+            {
+                RequestCloseThisFrame = true;
+            }
+        }
+    }
+
+    public static void DrawSectionSeparator()
+    {
+        var drawList = ImGui.GetWindowDrawList();
+        if (drawList.NativePtr == IntPtr.Zero)
+        {
+            ImGui.Separator();
+            return;
+        }
+
+        var style = ImGui.GetStyle();
+        var scale = ImGuiHelpers.GlobalScale;
+        var startPos = ImGui.GetCursorScreenPos();
+        var width = ImGui.GetContentRegionAvail().X;
+        var spacing = style.ItemSpacing.Y * 0.5f;
+        var thickness = MathF.Max(1f, MathF.Round(1.2f * scale));
+        var centerY = startPos.Y + spacing + thickness * 0.5f;
+        var min = new Vector2(startPos.X, centerY - thickness * 0.5f);
+        var max = new Vector2(startPos.X + width, centerY + thickness * 0.5f);
+
+        var color = _frameState.Frame == ImGui.GetFrameCount()
+            ? _frameState.SeparatorColor
+            : ImGui.GetStyle().Colors[(int)ImGuiCol.Separator];
+        drawList.AddRectFilled(min, max, ImGui.ColorConvertFloat4ToU32(color), thickness * 0.5f);
+
+        ImGui.Dummy(new Vector2(0f, spacing * 2f + thickness));
+    }
+
+    private static float ClampAlpha(float alpha, float fallback)
+    {
+        if (alpha <= 0f)
+        {
+            return fallback;
+        }
+
+        return Math.Clamp(alpha, 0.15f, 0.95f);
+    }
+
+    private static int PushColor(ImGuiCol idx, Vector4 color)
+    {
+        ImGui.PushStyleColor(idx, color);
+        return 1;
+    }
+
+    private static void CacheFrameState(Vector4 primary, Vector4 secondary, Vector4 accent, ImGuiStylePtr style)
+    {
+        var frame = ImGui.GetFrameCount();
+        if (_frameState.Frame == frame)
+        {
+            return;
+        }
+
+        _frameState.Frame = frame;
+        _frameState.Primary = primary;
+        _frameState.Secondary = secondary;
+        _frameState.Accent = accent;
+
+        var border = Desaturate(secondary, 0.25f);
+        border.W = 0.75f;
+        _frameState.BorderColor = AdjustAlpha(border, 0.78f);
+        _frameState.BorderHoverColor = AdjustAlpha(border, 0.88f);
+        _frameState.FocusGlowColor = AdjustAlpha(accent, 0.18f);
+        _frameState.SeparatorColor = AdjustAlpha(secondary, 0.6f);
+
+        _frameState.HeaderColor = Blend(primary, accent, 0.2f, Math.Clamp(primary.W + 0.05f, 0f, 1f));
+        _frameState.HeaderHoveredColor = Blend(primary, accent, 0.35f, Math.Clamp(primary.W + 0.1f, 0f, 1f));
+        _frameState.HeaderActiveColor = Blend(primary, accent, 0.45f, Math.Clamp(primary.W + 0.12f, 0f, 1f));
+
+        _frameState.FrameBgColor = Blend(primary, secondary, 0.12f, Math.Clamp(primary.W + 0.05f, 0f, 1f));
+        _frameState.FrameBgHoveredColor = Blend(primary, accent, 0.28f, Math.Clamp(primary.W + 0.08f, 0f, 1f));
+        _frameState.FrameBgActiveColor = Blend(primary, accent, 0.4f, Math.Clamp(primary.W + 0.1f, 0f, 1f));
+
+        _frameState.ButtonColor = Blend(primary, secondary, 0.18f, Math.Clamp(primary.W + 0.04f, 0f, 1f));
+        _frameState.ButtonHoveredColor = Blend(primary, accent, 0.35f, Math.Clamp(primary.W + 0.08f, 0f, 1f));
+        _frameState.ButtonActiveColor = Blend(primary, accent, 0.45f, Math.Clamp(primary.W + 0.12f, 0f, 1f));
+
+        _frameState.TabColor = Blend(primary, secondary, 0.1f, primary.W);
+        _frameState.TabHoveredColor = Blend(primary, accent, 0.25f, Math.Clamp(primary.W + 0.05f, 0f, 1f));
+        _frameState.TabActiveColor = Blend(primary, accent, 0.4f, Math.Clamp(primary.W + 0.08f, 0f, 1f));
+
+        var textColor = style.Colors[(int)ImGuiCol.Text];
+        if (primary.W < 0.25f)
+        {
+            textColor = AdjustBrightness(textColor, 1.1f);
+        }
+        _frameState.TextColor = textColor;
+
+        _frameState.CloseButtonColor = AdjustAlpha(secondary, 0.7f);
+        _frameState.CloseButtonHoveredColor = AdjustAlpha(accent, 0.85f);
+    }
+
+    private static Vector4 Blend(Vector4 baseColor, Vector4 accent, float t, float alpha)
+    {
+        var amount = Math.Clamp(t, 0f, 1f);
+        var blended = Vector4.Lerp(
+            new Vector4(baseColor.X, baseColor.Y, baseColor.Z, 1f),
+            new Vector4(accent.X, accent.Y, accent.Z, 1f),
+            amount);
+        blended.W = Math.Clamp(alpha, 0f, 1f);
+        return blended;
+    }
+
+    private static Vector4 AdjustAlpha(Vector4 color, float alpha)
+    {
+        return new Vector4(color.X, color.Y, color.Z, Math.Clamp(alpha, 0f, 1f));
+    }
+
+    private static Vector4 AdjustBrightness(Vector4 color, float factor)
+    {
+        return new Vector4(
+            Math.Clamp(color.X * factor, 0f, 1f),
+            Math.Clamp(color.Y * factor, 0f, 1f),
+            Math.Clamp(color.Z * factor, 0f, 1f),
+            color.W);
+    }
+
+    private static Vector4 Desaturate(Vector4 color, float amount)
+    {
+        amount = Math.Clamp(amount, 0f, 1f);
+        var luma = color.X * 0.299f + color.Y * 0.587f + color.Z * 0.114f;
+        return new Vector4(
+            color.X + (luma - color.X) * amount,
+            color.Y + (luma - color.Y) * amount,
+            color.Z + (luma - color.Z) * amount,
+            color.W);
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable UiTheme and UiStyleScope helpers that apply a glass-inspired rounded window treatment based on appearance settings
- integrate the new theme into managed plugin windows and refresh separators to use the themed drawing helper
- expose chat window helpers for drawing standalone themed versions of FC and Officer chat panes

## Testing
- dotnet build (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68eaa8f54f2c83288b700c112e4343b5