### PR TITLE
Fix custom chrome windows and refresh override

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1893,22 +1893,22 @@ public class ChatWindow : IDisposable
     public virtual void DrawThemedWindow(string title, ref bool isOpen, ImGuiWindowFlags flags = ImGuiWindowFlags.None)
     {
         using var scope = new UiStyleScope(_config);
+        flags |= ImGuiWindowFlags.NoTitleBar;
         var open = isOpen;
         if (ImGui.Begin(title, ref open, flags))
         {
-            UiTheme.DrawWindowChrome(_config, null, () => open = false);
+            UiTheme.DrawWindowChrome(_config, title, () => open = false);
+
+            var dragHeight = ImGui.GetFrameHeight();
+            ImGui.SetCursorPosY(ImGui.GetStyle().WindowPadding.Y);
+            ImGui.InvisibleButton($"##drag_zone_{title}", new Vector2(ImGui.GetContentRegionAvail().X, dragHeight));
+
+            ImGui.Dummy(new Vector2(0f, ImGui.GetStyle().FramePadding.Y * 2f));
             Draw();
         }
         ImGui.End();
 
-        if (!open || UiTheme.RequestCloseThisFrame)
-        {
-            isOpen = false;
-        }
-        else
-        {
-            isOpen = open;
-        }
+        isOpen = (!open || UiTheme.RequestCloseThisFrame) ? false : open;
     }
 
     protected List<ChannelDto> PrepareChannelsForDisplay(IEnumerable<ChannelDto> channels)

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -87,13 +87,13 @@ public class FcChatWindow : ChatWindow
         ImGui.EndChild();
     }
 
-    public override Task RefreshMessages()
+    public override Task RefreshMessages(CancellationToken cancellationToken = default)
     {
         if (!_config.SyncedChat || !_config.EnableFcChat)
         {
             return Task.CompletedTask;
         }
-        return base.RefreshMessages();
+        return base.RefreshMessages(cancellationToken);
     }
 
     protected override Task FetchChannels(bool refreshed = false, CancellationToken cancellationToken = default)

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -994,14 +994,20 @@ public class MainWindow : IDisposable
         var openRef = open;
         var windowInteracted = false;
         var closeRequested = false;
-        if (ImGui.Begin($"{title}##dc_{id}", ref openRef, ImGuiWindowFlags.NoCollapse))
+        var windowFlags = ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoTitleBar;
+        if (ImGui.Begin($"{title}##dc_{id}", ref openRef, windowFlags))
         {
-            UiTheme.DrawWindowChrome(_config, null, () =>
+            UiTheme.DrawWindowChrome(_config, title, () =>
             {
                 openRef = false;
                 closeRequested = true;
             });
 
+            var dragHeight = ImGui.GetFrameHeight();
+            ImGui.SetCursorPosY(ImGui.GetStyle().WindowPadding.Y);
+            ImGui.InvisibleButton($"##drag_zone_dc_{id}", new Vector2(ImGui.GetContentRegionAvail().X, dragHeight));
+
+            ImGui.Dummy(new Vector2(0f, ImGui.GetStyle().FramePadding.Y * 2f));
             drawContent();
             windowInteracted = HasWindowInteraction();
         }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -68,9 +68,16 @@ public class SettingsWindow : IDisposable
         {
             using var scope = new UiStyleScope(_config);
             var open = IsOpen;
-            if (ImGui.Begin("DemiCat Settings", ref open))
+            var flags = ImGuiWindowFlags.NoTitleBar;
+            if (ImGui.Begin("DemiCat Settings", ref open, flags))
             {
-                UiTheme.DrawWindowChrome(_config, null, () => open = false);
+                UiTheme.DrawWindowChrome(_config, "DemiCat Settings", () => open = false);
+
+                var dragHeight = ImGui.GetFrameHeight();
+                ImGui.SetCursorPosY(ImGui.GetStyle().WindowPadding.Y);
+                ImGui.InvisibleButton("##drag_zone_settings", new Vector2(ImGui.GetContentRegionAvail().X, dragHeight));
+
+                ImGui.Dummy(new Vector2(0f, ImGui.GetStyle().FramePadding.Y * 2f));
 
                 if (!_settingsLoaded)
                 {
@@ -103,14 +110,7 @@ public class SettingsWindow : IDisposable
             }
             ImGui.End();
 
-            if (!open || UiTheme.RequestCloseThisFrame)
-            {
-                IsOpen = false;
-            }
-            else
-            {
-                IsOpen = open;
-            }
+            IsOpen = (!open || UiTheme.RequestCloseThisFrame) ? false : open;
         }
 
         _devWindow.Draw();


### PR DESCRIPTION
## Summary
- update FcChatWindow.RefreshMessages to accept the optional cancellation token like the base signature
- hide ImGui title bars on themed windows and feed the title text into the custom chrome renderer
- add dedicated drag-space padding beneath the themed chrome to keep interactions comfortable

## Testing
- ❌ `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(dotnet is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68eaae6c2c148328b4105c561361607c