### PR TITLE
Refine custom chrome window styling

### DIFF
--- a/DemiCatPlugin/ButtonRowsImGui.cs
+++ b/DemiCatPlugin/ButtonRowsImGui.cs
@@ -14,7 +14,7 @@ public static class ButtonRowsImGui
         for (int r = 0; r < state.Rows.Count; r++)
         {
             ImGui.PushID(r);
-            ImGui.Separator();
+            UiTheme.DrawSectionSeparator();
             ImGui.Text($"Row {r + 1} ({state.Rows[r].Count}/{ButtonRows.MaxPerRow})");
 
             ImGui.SameLine();

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -1895,7 +1895,9 @@ public class ChatWindow : IDisposable
         using var scope = new UiStyleScope(_config);
         flags |= ImGuiWindowFlags.NoTitleBar;
         var open = isOpen;
-        if (ImGui.Begin(title, ref open, flags))
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0f);
+        var began = ImGui.Begin(title, ref open, flags);
+        if (began)
         {
             UiTheme.DrawWindowChrome(_config, title, () => open = false);
 
@@ -1907,6 +1909,7 @@ public class ChatWindow : IDisposable
             Draw();
         }
         ImGui.End();
+        ImGui.PopStyleVar();
 
         isOpen = (!open || UiTheme.RequestCloseThisFrame) ? false : open;
     }

--- a/DemiCatPlugin/EmbedStyleControls.cs
+++ b/DemiCatPlugin/EmbedStyleControls.cs
@@ -189,7 +189,7 @@ public static class EmbedStyleControls
                 GlyphSearchTerms[searchKey] = search;
             }
 
-            ImGui.Separator();
+            UiTheme.DrawSectionSeparator();
 
             _ = manager.EnsureUnicodeAsync();
             var status = manager.UnicodeStatus;

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -60,7 +60,7 @@ public sealed class EmojiPicker
             SetGridHeight(height);
         }
 
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
 
         if (ImGui.BeginTabBar("##dc_emoji_tabs"))
         {
@@ -92,7 +92,7 @@ public sealed class EmojiPicker
     private string? DrawStandard()
     {
         ImGui.InputTextWithHint("##emoji_std_search", "Search…", ref _search, 64);
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
 
         if (!_manager.CanLoadStandard)
         {
@@ -193,7 +193,7 @@ public sealed class EmojiPicker
             _ = _manager.RefreshCustomAsync();
         }
         if (!canLoad) ImGui.EndDisabled();
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
 
         if (!canLoad)
         {

--- a/DemiCatPlugin/EventCreateWindow.cs
+++ b/DemiCatPlugin/EventCreateWindow.cs
@@ -359,7 +359,7 @@ public class EventCreateWindow
             ImGui.EndPopup();
         }
 
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
         ImGui.TextUnformatted("RSVP Buttons");
         ImGui.Spacing();
 
@@ -461,7 +461,7 @@ public class EventCreateWindow
                     _fields.RemoveAt(i);
                     i--;
                 }
-                ImGui.Separator();
+                UiTheme.DrawSectionSeparator();
             }
             if (ImGui.Button("Add Field"))
             {
@@ -489,7 +489,7 @@ public class EventCreateWindow
 
         if (_previewView != null)
         {
-            ImGui.Separator();
+            UiTheme.DrawSectionSeparator();
             var previewHeight = EventViewImGuiHelpers.BeginPreviewChild("eventCreatePreview");
             _previewView.Draw(previewHeight);
             ImGui.EndChild();
@@ -501,7 +501,7 @@ public class EventCreateWindow
         }
         if (_schedulesLoaded && _schedules.Count > 0)
         {
-            ImGui.Separator();
+            UiTheme.DrawSectionSeparator();
             ImGui.TextUnformatted("Repeat Schedules");
             for (var i = 0; i < _schedules.Count; i++)
             {

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -143,7 +143,7 @@ public class EventView : IDisposable
             {
                 ImGui.TextColored(warnColor, $"⚠ {warning}");
             }
-            ImGui.Separator();
+            UiTheme.DrawSectionSeparator();
         }
 
         var mentionText = BuildDisplayContent();
@@ -169,7 +169,7 @@ public class EventView : IDisposable
 
         DrawButtons();
 
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
     }
 
     private float EstimateFooterHeight()

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -995,7 +995,9 @@ public class MainWindow : IDisposable
         var windowInteracted = false;
         var closeRequested = false;
         var windowFlags = ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoTitleBar;
-        if (ImGui.Begin($"{title}##dc_{id}", ref openRef, windowFlags))
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0f);
+        var began = ImGui.Begin($"{title}##dc_{id}", ref openRef, windowFlags);
+        if (began)
         {
             UiTheme.DrawWindowChrome(_config, title, () =>
             {
@@ -1012,6 +1014,7 @@ public class MainWindow : IDisposable
             windowInteracted = HasWindowInteraction();
         }
         ImGui.End();
+        ImGui.PopStyleVar();
 
         if (pushedColors > 0)
         {

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -77,7 +77,7 @@ public sealed class NotePadWindow : IDisposable
         DrawConflictModal(selectedPage);
 
         DrawSectionTabs(sections);
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
 
         var region = ImGui.GetContentRegionAvail();
         if (region.X <= 0f || region.Y <= 0f)
@@ -293,7 +293,7 @@ public sealed class NotePadWindow : IDisposable
             OpenNewPagePopup(section);
         }
 
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
 
         foreach (var page in section.Pages)
         {
@@ -473,7 +473,7 @@ public sealed class NotePadWindow : IDisposable
         if (ImGui.BeginPopupModal("NotePadConflict", ImGuiWindowFlags.AlwaysAutoResize))
         {
             ImGui.TextWrapped(_conflictMessage);
-            ImGui.Separator();
+            UiTheme.DrawSectionSeparator();
 
             if (ImGui.Button("Reload"))
             {
@@ -838,7 +838,7 @@ public sealed class NotePadWindow : IDisposable
         }
 
         ImGui.Spacing();
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
         ImGui.TextColored(new Vector4(0.7f, 0.7f, 0.7f, 1f), "Formatted Preview");
         ImGui.PushTextWrapPos();
         ImGui.TextUnformatted(MarkdownFormatter.Format(content));

--- a/DemiCatPlugin/ProgressOverlay.cs
+++ b/DemiCatPlugin/ProgressOverlay.cs
@@ -135,7 +135,7 @@ public sealed class ProgressOverlay
         if (ImGui.Begin(windowId, flags))
         {
             ImGui.TextUnformatted("Sync Progress");
-            ImGui.Separator();
+            UiTheme.DrawSectionSeparator();
 
             var barWidth = 240f * scale;
 

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -89,7 +89,7 @@ public class RequestBoardWindow
             {
                 ImGui.TextUnformatted("[Legacy Status: Denied]");
             }
-            ImGui.Separator();
+            UiTheme.DrawSectionSeparator();
             ImGui.PopID();
         }
         ImGui.EndChild();

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -69,7 +69,9 @@ public class SettingsWindow : IDisposable
             using var scope = new UiStyleScope(_config);
             var open = IsOpen;
             var flags = ImGuiWindowFlags.NoTitleBar;
-            if (ImGui.Begin("DemiCat Settings", ref open, flags))
+            ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0f);
+            var began = ImGui.Begin("DemiCat Settings", ref open, flags);
+            if (began)
             {
                 UiTheme.DrawWindowChrome(_config, "DemiCat Settings", () => open = false);
 
@@ -109,6 +111,7 @@ public class SettingsWindow : IDisposable
                 }
             }
             ImGui.End();
+            ImGui.PopStyleVar();
 
             IsOpen = (!open || UiTheme.RequestCloseThisFrame) ? false : open;
         }

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -445,11 +445,11 @@ public class SyncshellWindow : IDisposable
             _syncSettingsHeightDirty = false;
         }
 
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
 
         DrawMembershipPanels();
 
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
 
         var saveSeen = false;
         if (_updatesAvailable.Count > 0)
@@ -797,7 +797,7 @@ public class SyncshellWindow : IDisposable
         var id = $"syncshell-panel-{label.Replace(' ', '-').ToLowerInvariant()}";
         ImGui.BeginChild(id, new Vector2(-1, height), true);
         ImGui.TextUnformatted(label);
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
         content();
         ImGui.EndChild();
     }
@@ -916,7 +916,7 @@ public class SyncshellWindow : IDisposable
             ImGui.TextDisabled("Matching members must link their SyncShell token before they can receive invites.");
         }
 
-        ImGui.Separator();
+        UiTheme.DrawSectionSeparator();
 
         var invites = _syncshellState.Invites
             .OrderByDescending(static i => i.UpdatedAt)
@@ -1106,7 +1106,7 @@ public class SyncshellWindow : IDisposable
 
             if (_inviteSuggestionFiltered)
             {
-                ImGui.Separator();
+                UiTheme.DrawSectionSeparator();
                 var wrap = ImGui.GetCursorPosX() + 280f;
                 ImGui.PushTextWrapPos(wrap);
                 ImGui.TextDisabled("Some members must link their SyncShell token before they can receive invites.");

--- a/DemiCatPlugin/TemplatesWindow.cs
+++ b/DemiCatPlugin/TemplatesWindow.cs
@@ -212,7 +212,7 @@ public class TemplatesWindow
             {
                 if (_roles.Count > 0)
                 {
-                    ImGui.Separator();
+                    UiTheme.DrawSectionSeparator();
                     ImGui.Text("Mention Roles");
                     {
                         using var emojiFont = _emojiManager.PushEmojiFont();


### PR DESCRIPTION
## Summary
- zero out ImGui window borders when drawing custom chrome to prevent double outlines
- replace remaining `ImGui.Separator()` usages with `UiTheme.DrawSectionSeparator()` for consistent theming across tools

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68eab015ada88328a0581b1ae0408066