### PR TITLE
Use Dalamud ImGui bindings

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -22,7 +22,6 @@ using System.Runtime.CompilerServices;
 using Dalamud.Interface.ImGuiFileDialog;
 using DemiCatPlugin.Emoji;
 using DemiCatPlugin.Avatars;
-using ImGuiNET;
 
 namespace DemiCatPlugin;
 

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -6,7 +6,6 @@ using Dalamud.Bindings.ImGui;
 using System.Numerics;
 using DemiCatPlugin.Avatars;
 using DemiCatPlugin.Emoji;
-using ImGuiNET;
 
 namespace DemiCatPlugin;
 

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -14,7 +14,6 @@ using System.IO;
 using System.Linq;
 using DemiCatPlugin.Avatars;
 using DemiCatPlugin.Emoji;
-using ImGuiNET;
 
 namespace DemiCatPlugin;
 

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
-using ImGuiNET;
 
 namespace DemiCatPlugin;
 

--- a/DemiCatPlugin/UiTheme.cs
+++ b/DemiCatPlugin/UiTheme.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
-using ImGuiNET;
 
 namespace DemiCatPlugin;
 


### PR DESCRIPTION
## Summary
- switch plugin ImGui usages to Dalamud.Bindings.ImGui
- remove obsolete ImGuiNET using directives to rely on bundled bindings

## Testing
- ⚠️ `dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release` *(fails in container: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68eab40d639083288862665c3acd4312