### PR TITLE
Fix ImGui usage for Dalamud bindings

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -162,19 +162,20 @@ public class ChatWindow : IDisposable
         try
         {
             var wrap = tex.GetWrapOrEmpty();
-            var handle = wrap.Handle;
-            if (handle == IntPtr.Zero)
+            var ip = wrap.Handle;
+            if (ip == IntPtr.Zero)
             {
                 return;
             }
 
+            var texId = ImTextureID.FromIntPtr(ip);
             if (rounding > 0f)
             {
-                ImGui.Image(handle, size);
+                ImGui.Image(texId, size);
             }
             else
             {
-                ImGui.Image(handle, size);
+                ImGui.Image(texId, size);
             }
         }
         catch (ObjectDisposedException)
@@ -193,13 +194,14 @@ public class ChatWindow : IDisposable
         try
         {
             var wrap = tex.GetWrapOrEmpty();
-            var handle = wrap.Handle;
-            if (handle == IntPtr.Zero)
+            var ip = wrap.Handle;
+            if (ip == IntPtr.Zero)
             {
                 return false;
             }
 
-            return ImGui.ImageButton(handle, size);
+            var texId = ImTextureID.FromIntPtr(ip);
+            return ImGui.ImageButton(texId, size);
         }
         catch (ObjectDisposedException)
         {
@@ -1162,7 +1164,8 @@ public class ChatWindow : IDisposable
 
                 if (handle != IntPtr.Zero)
                 {
-                    ImGui.Image(handle, new Vector2(20, 20));
+                    var texId = ImTextureID.FromIntPtr(handle);
+                    ImGui.Image(texId, new Vector2(20, 20));
                 }
                 else
                 {
@@ -1256,8 +1259,8 @@ public class ChatWindow : IDisposable
                                 continue;
                             }
 
-                            var handle = wrapAtt.Handle;
-                            if (handle == IntPtr.Zero)
+                            var ip = wrapAtt.Handle;
+                            if (ip == IntPtr.Zero)
                             {
                                 att.Texture = null;
                                 LoadTexture(att.Url, t => att.Texture = t);
@@ -1265,7 +1268,8 @@ public class ChatWindow : IDisposable
                                 continue;
                             }
 
-                            ImGui.Image(handle, displaySize);
+                            var texId = ImTextureID.FromIntPtr(ip);
+                            ImGui.Image(texId, displaySize);
                             TouchTexture(att.Url);
                             if (ImGui.IsItemHovered())
                             {
@@ -1345,10 +1349,11 @@ public class ChatWindow : IDisposable
                             try
                             {
                                 var wrap = reaction.Texture.GetWrapOrEmpty();
-                                var handle = wrap.Handle;
-                                if (handle != IntPtr.Zero)
+                                var ip = wrap.Handle;
+                                if (ip != IntPtr.Zero)
                                 {
-                                    if (ImGui.ImageButton(handle, new Vector2(20, 20)))
+                                    var texId = ImTextureID.FromIntPtr(ip);
+                                    if (ImGui.ImageButton(texId, new Vector2(20, 20)))
                                     {
                                         _ = React(msg.Id, reaction.Emoji, reaction.Me);
                                     }
@@ -2100,9 +2105,11 @@ public class ChatWindow : IDisposable
                     try
                     {
                         var wrap = emoji.Texture.GetWrapOrEmpty();
-                        if (wrap.Handle != IntPtr.Zero)
+                        var ip = wrap.Handle;
+                        if (ip != IntPtr.Zero)
                         {
-                            ImGui.Image(wrap.Handle, new Vector2(20, 20));
+                            var texId = ImTextureID.FromIntPtr(ip);
+                            ImGui.Image(texId, new Vector2(20, 20));
                             TouchTexture(emoji.ImageUrl);
                         }
                         else

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -561,9 +561,7 @@ public class SettingsWindow : IDisposable
         var color = value;
         const ImGuiColorEditFlags flags = ImGuiColorEditFlags.AlphaBar
                                           | ImGuiColorEditFlags.AlphaPreviewHalf
-                                          | ImGuiColorEditFlags.DisplayHSV
-                                          | ImGuiColorEditFlags.InputRGB
-                                          | ImGuiColorEditFlags.PickerHueBar;
+                                          | ImGuiColorEditFlags.PickerHueWheel;
         var changed = ImGui.ColorPicker4("##picker", ref color, flags);
         ImGui.PopID();
 

--- a/DemiCatPlugin/UiTheme.cs
+++ b/DemiCatPlugin/UiTheme.cs
@@ -137,10 +137,7 @@ public static class UiTheme
         RequestCloseThisFrame = false;
 
         var drawList = ImGui.GetWindowDrawList();
-        if (drawList.NativePtr == IntPtr.Zero)
-        {
-            return;
-        }
+        // drawList is valid inside a begun window; no NativePtr check needed
 
         var windowPos = ImGui.GetWindowPos();
         var windowSize = ImGui.GetWindowSize();
@@ -227,11 +224,7 @@ public static class UiTheme
     public static void DrawSectionSeparator()
     {
         var drawList = ImGui.GetWindowDrawList();
-        if (drawList.NativePtr == IntPtr.Zero)
-        {
-            ImGui.Separator();
-            return;
-        }
+        // drawList is valid inside a begun window; no NativePtr check needed
 
         var style = ImGui.GetStyle();
         var scale = ImGuiHelpers.GlobalScale;
@@ -243,7 +236,7 @@ public static class UiTheme
         var min = new Vector2(startPos.X, centerY - thickness * 0.5f);
         var max = new Vector2(startPos.X + width, centerY + thickness * 0.5f);
 
-        var color = _frameState.Frame == ImGui.GetFrameCount()
+        var color = _frameState.Frame == (uint)ImGui.GetFrameCount()
             ? _frameState.SeparatorColor
             : ImGui.GetStyle().Colors[(int)ImGuiCol.Separator];
         drawList.AddRectFilled(min, max, ImGui.ColorConvertFloat4ToU32(color), thickness * 0.5f);
@@ -269,7 +262,7 @@ public static class UiTheme
 
     private static void CacheFrameState(Vector4 primary, Vector4 secondary, Vector4 accent, ImGuiStylePtr style)
     {
-        var frame = ImGui.GetFrameCount();
+        var frame = (uint)ImGui.GetFrameCount();
         if (_frameState.Frame == frame)
         {
             return;


### PR DESCRIPTION
## Summary
- remove redundant ImGui draw list pointer checks and align frame caching with uint storage
- wrap texture handles with ImTextureID when rendering chat images and reactions
- replace unsupported ImGui color picker flags with Dalamud-supported alternatives

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68eab781e1a88328b5afa1d9e6059c9d