### PR TITLE
Fix UI regressions and improve presence reliability

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -569,6 +569,7 @@ public class ChatWindow : IDisposable
         public string Id;
         public bool Animated;
         public ISharedImmediateTexture? Texture;
+        public bool LoadRequested;
 
         public EmojiData(string id, bool animated)
         {
@@ -1229,6 +1230,20 @@ public class ChatWindow : IDisposable
                     {
                         var imageStartY = ImGui.GetCursorPosY();
                         var bounds = GetAttachmentBounds(attachmentCap);
+                        void RequestAttachmentTexture()
+                        {
+                            if (att.LoadRequested)
+                            {
+                                return;
+                            }
+
+                            att.LoadRequested = true;
+                            LoadTexture(att.Url, t =>
+                            {
+                                att.Texture = t;
+                                att.LoadRequested = false;
+                            });
+                        }
 
                         if (att.Texture == null)
                         {
@@ -1238,7 +1253,7 @@ public class ChatWindow : IDisposable
                                 continue;
                             }
 
-                            LoadTexture(att.Url, t => att.Texture = t);
+                            RequestAttachmentTexture();
                             ImGui.Dummy(bounds);
                             continue;
                         }
@@ -1258,8 +1273,6 @@ public class ChatWindow : IDisposable
 
                             if (wrapAtt.Width <= 0 || wrapAtt.Height <= 0)
                             {
-                                att.Texture = null;
-                                LoadTexture(att.Url, t => att.Texture = t);
                                 ImGui.Dummy(new Vector2(bounds.X, displaySize.Y));
                                 continue;
                             }
@@ -1280,7 +1293,8 @@ public class ChatWindow : IDisposable
                         catch (ObjectDisposedException)
                         {
                             att.Texture = null;
-                            LoadTexture(att.Url, t => att.Texture = t);
+                            att.LoadRequested = false;
+                            RequestAttachmentTexture();
                             ImGui.Dummy(new Vector2(bounds.X, displaySize.Y));
                         }
                     }
@@ -1332,7 +1346,15 @@ public class ChatWindow : IDisposable
                         {
                             var ext = reaction.IsAnimated ? "gif" : "png";
                             textureUrl = $"https://cdn.discordapp.com/emojis/{reaction.EmojiId}.{ext}";
-                            LoadTexture(textureUrl, t => reaction.Texture = t);
+                            if (!reaction.TextureRequested)
+                            {
+                                reaction.TextureRequested = true;
+                                LoadTexture(textureUrl, t =>
+                                {
+                                    reaction.Texture = t;
+                                    reaction.TextureRequested = false;
+                                });
+                            }
                         }
                         else
                         {
@@ -1357,12 +1379,26 @@ public class ChatWindow : IDisposable
                                 }
                                 else
                                 {
-                                    reaction.Texture = null;
+                                    ImGui.Dummy(new Vector2(20f, 20f));
+                                    ImGui.SameLine();
+                                    ImGui.TextUnformatted(reaction.Count.ToString());
+                                    handled = true;
                                 }
                             }
                             catch (ObjectDisposedException)
                             {
                                 reaction.Texture = null;
+                                reaction.TextureRequested = false;
+                                if (!reaction.TextureRequested && textureUrl != null)
+                                {
+                                    var requestUrl = textureUrl;
+                                    reaction.TextureRequested = true;
+                                    LoadTexture(requestUrl, t =>
+                                    {
+                                        reaction.Texture = t;
+                                        reaction.TextureRequested = false;
+                                    });
+                                }
                             }
                         }
                     }
@@ -1898,11 +1934,18 @@ public class ChatWindow : IDisposable
         {
             UiTheme.DrawWindowChrome(_config, title, () => open = false);
 
-            var dragHeight = ImGui.GetFrameHeight();
-            ImGui.SetCursorPosY(ImGui.GetStyle().WindowPadding.Y);
-            ImGui.InvisibleButton($"##drag_zone_{title}", new Vector2(ImGui.GetContentRegionAvail().X, dragHeight));
+            var style = ImGui.GetStyle();
+            var chromeHeight = Math.Max(14f * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight());
+            ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y));
+            var dragSize = new Vector2(ImGui.GetContentRegionAvail().X, chromeHeight);
+            ImGui.InvisibleButton($"##drag_zone_{title}", dragSize);
+            if (ImGui.IsItemActive() && ImGui.IsMouseDragging(0))
+            {
+                var io = ImGui.GetIO();
+                ImGui.SetWindowPos(ImGui.GetWindowPos() + io.MouseDelta);
+            }
 
-            ImGui.Dummy(new Vector2(0f, ImGui.GetStyle().FramePadding.Y * 2f));
+            ImGui.Dummy(new Vector2(1f, style.FramePadding.Y + chromeHeight));
             Draw();
         }
         ImGui.End();
@@ -2090,7 +2133,15 @@ public class ChatWindow : IDisposable
                 }
                 if (emoji.Texture == null)
                 {
-                    LoadTexture(emoji.ImageUrl, t => emoji.Texture = t);
+                    if (!emoji.LoadRequested)
+                    {
+                        emoji.LoadRequested = true;
+                        LoadTexture(emoji.ImageUrl, t =>
+                        {
+                            emoji.Texture = t;
+                            emoji.LoadRequested = false;
+                        });
+                    }
                     ImGui.TextUnformatted($":{name}:");
                 }
                 else
@@ -2105,13 +2156,23 @@ public class ChatWindow : IDisposable
                         }
                         else
                         {
-                            emoji.Texture = null;
-                            ImGui.TextUnformatted($":{name}:");
+                            ImGui.Dummy(new Vector2(20f, 20f));
                         }
                     }
                     catch (ObjectDisposedException)
                     {
                         emoji.Texture = null;
+                        emoji.LoadRequested = false;
+                        if (!emoji.LoadRequested)
+                        {
+                            emoji.LoadRequested = true;
+                            var requestUrl = emoji.ImageUrl;
+                            LoadTexture(requestUrl, t =>
+                            {
+                                emoji.Texture = t;
+                                emoji.LoadRequested = false;
+                            });
+                        }
                         ImGui.TextUnformatted($":{name}:");
                     }
                 }

--- a/DemiCatPlugin/DiscordMessageDto.cs
+++ b/DemiCatPlugin/DiscordMessageDto.cs
@@ -43,6 +43,7 @@ public class DiscordAttachmentDto
     public string? Filename { get; set; }
     public string? ContentType { get; set; }
     [JsonIgnore] public ISharedImmediateTexture? Texture { get; set; }
+    [JsonIgnore] public bool LoadRequested { get; set; }
 }
 
 public class MessageReferenceDto
@@ -60,6 +61,8 @@ public class ReactionDto
     public bool Me { get; set; }
     [JsonIgnore]
     public ISharedImmediateTexture? Texture { get; set; }
+    [JsonIgnore]
+    public bool TextureRequested { get; set; }
 }
 
 public class ButtonComponentDto

--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.IO;
@@ -36,6 +37,7 @@ public class DiscordPresenceService : IDisposable
     private DateTime _lastErrorLog;
     private Task<RefreshOutcome>? _refreshTask;
     private DateTime _nextRefreshAllowed = DateTime.MinValue;
+    private volatile PresenceConnectionState _connectionState = PresenceConnectionState.Disconnected;
     private static readonly TimeSpan ErrorLogThrottle = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan RefreshSuccessCooldown = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan RefreshFailureCooldown = TimeSpan.FromSeconds(5);
@@ -48,6 +50,11 @@ public class DiscordPresenceService : IDisposable
     public string StatusMessage => _statusMessage;
     public bool Loaded => _loaded;
     public bool IsPresenceReady => _presenceReady;
+    public PresenceConnectionState ConnectionState => _connectionState;
+    public IReadOnlyList<PresenceDto> GetSnapshot()
+    {
+        return _presences.ToList();
+    }
 
     public DiscordPresenceService(Config config, HttpClient httpClient)
     {
@@ -141,6 +148,7 @@ public class DiscordPresenceService : IDisposable
         socket?.Dispose();
 
         DisposeAllPresences();
+        SetConnectionState(PresenceConnectionState.Disconnected);
     }
 
     public void Dispose()
@@ -153,6 +161,7 @@ public class DiscordPresenceService : IDisposable
         socket?.Dispose();
 
         DisposeAllPresences();
+        SetConnectionState(PresenceConnectionState.Disconnected);
     }
 
     public Task Refresh(bool force = false)
@@ -298,6 +307,7 @@ public class DiscordPresenceService : IDisposable
         {
             if (!ApiHelpers.ValidateApiBaseUrl(_config))
             {
+                SetConnectionState(PresenceConnectionState.Disconnected);
                 UpdateStatusMessage(InvalidApiStatus);
                 await DelayWithBackoff(TimeSpan.FromSeconds(5), token).ConfigureAwait(false);
                 _retryAttempt = 0;
@@ -306,6 +316,7 @@ public class DiscordPresenceService : IDisposable
 
             if (TokenManager.Instance?.IsReady() != true)
             {
+                SetConnectionState(PresenceConnectionState.Disconnected);
                 UpdateStatusMessage(ApiKeyMissingStatus);
                 await DelayWithBackoff(TimeSpan.FromSeconds(5), token).ConfigureAwait(false);
                 _retryAttempt = 0;
@@ -314,6 +325,7 @@ public class DiscordPresenceService : IDisposable
 
             if (!_config.Enabled)
             {
+                SetConnectionState(PresenceConnectionState.Disconnected);
                 UpdateStatusMessage(PluginDisabledStatus);
                 await DelayWithBackoff(TimeSpan.FromSeconds(5), token).ConfigureAwait(false);
                 _retryAttempt = 0;
@@ -363,6 +375,7 @@ public class DiscordPresenceService : IDisposable
                 }
 
                 connectionScope = EnterConnectionScope();
+                SetConnectionState(PresenceConnectionState.Connecting);
                 await ConnectAsync(socket, uri!, token).ConfigureAwait(false);
 
                 var previousSocket = Interlocked.Exchange(ref _ws, socket);
@@ -371,7 +384,9 @@ public class DiscordPresenceService : IDisposable
                 _retryAttempt = 0;
                 hadTransportError = false;
                 _loaded = false;
+                DisposeAllPresences();
                 await Refresh(force: true).ConfigureAwait(false);
+                SetConnectionState(PresenceConnectionState.Connected);
                 UpdateStatusMessage(string.Empty);
 
                 await ReceiveLoopAsync(socket, token).ConfigureAwait(false);
@@ -417,6 +432,7 @@ public class DiscordPresenceService : IDisposable
             }
             finally
             {
+                SetConnectionState(PresenceConnectionState.Disconnected);
                 connectionScope?.Dispose();
 
                 if (socket != null)
@@ -746,11 +762,31 @@ public class DiscordPresenceService : IDisposable
     private void UpdateStatusMessage(string message)
         => _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = message);
 
+    private void SetConnectionState(PresenceConnectionState state)
+    {
+        if (_connectionState == state)
+        {
+            return;
+        }
+
+        var services = PluginServices.Instance;
+        if (services?.Framework != null)
+        {
+            var target = state;
+            services.Framework.RunOnTick(() => _connectionState = target);
+        }
+        else
+        {
+            _connectionState = state;
+        }
+    }
+
     private async Task BackoffReconnectAsync(CancellationToken token)
     {
         _retryAttempt++;
         var delay = GetRetryDelay(_retryAttempt);
         UpdateStatusMessage($"Reconnecting in {delay.TotalSeconds:0.#}s...");
+        SetConnectionState(PresenceConnectionState.Reconnecting);
         await DelayWithBackoff(delay, token).ConfigureAwait(false);
     }
 
@@ -816,5 +852,13 @@ public class DiscordPresenceService : IDisposable
         else if (builder.Scheme == "http") builder.Scheme = "ws";
         return builder.Uri;
     }
+}
+
+public enum PresenceConnectionState
+{
+    Disconnected,
+    Connecting,
+    Connected,
+    Reconnecting
 }
 

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -16,7 +16,8 @@ public static class EmbedPreviewRenderer
     public static void Draw(EmbedDto dto, Action<string?, Action<ISharedImmediateTexture?>> loadTexture, EmojiManager emojiManager, Action<string>? onButtonClick = null)
     {
         using var emojiFont = emojiManager.PushEmojiFont();
-        const float stripeWidth = 4f;
+        var style = ImGui.GetStyle();
+        var stripeWidth = dto.Color.HasValue ? Math.Max(4f, style.FramePadding.X * 0.75f) : 0f;
         const float contentPadding = 8f;
         const float verticalPadding = 4f;
 
@@ -24,7 +25,7 @@ public static class EmbedPreviewRenderer
         var borderEnabled = borderInfo?.Enabled == true;
         var borderColor = borderInfo?.Color ?? 0u;
 
-        var indent = contentPadding + (dto.Color.HasValue ? stripeWidth : 0f);
+        var indent = contentPadding + stripeWidth;
         var avail = ImGui.GetContentRegionAvail().X;
         if (avail <= 0)
         {
@@ -188,14 +189,31 @@ public static class EmbedPreviewRenderer
         ImGui.Dummy(new Vector2(0f, verticalPadding));
         ImGui.Unindent(indent);
 
+        if (dto.Color.HasValue)
+        {
+            var dl = ImGui.GetWindowDrawList();
+            var cardMin = ImGui.GetWindowPos();
+            var cardMax = cardMin + ImGui.GetWindowSize();
+            var cardRounding = style.ChildRounding;
+            var borderInset = Math.Max(1f, style.ChildBorderSize > 0f ? style.ChildBorderSize : style.FrameBorderSize);
+            var stripeMin = new Vector2(cardMin.X + borderInset, cardMin.Y + borderInset);
+            var stripeMax = new Vector2(cardMin.X + borderInset + stripeWidth, cardMax.Y - borderInset);
+            if (stripeMax.X > stripeMin.X && stripeMax.Y > stripeMin.Y)
+            {
+                var colorVec = ColorUtils.RgbToImGui(dto.Color.Value);
+                var color = ImGui.ColorConvertFloat4ToU32(colorVec);
+                dl.AddRectFilled(
+                    stripeMin,
+                    stripeMax,
+                    color,
+                    cardRounding,
+                    ImDrawFlags.RoundCornersTopLeft | ImDrawFlags.RoundCornersBottomLeft);
+            }
+        }
+
         ImGui.EndChild();
         var rectMin = ImGui.GetItemRectMin();
         var rectMax = ImGui.GetItemRectMax();
-        if (dto.Color.HasValue)
-        {
-            var color = ColorUtils.RgbToImGui(dto.Color.Value);
-            ImGui.GetWindowDrawList().AddRectFilled(rectMin, new Vector2(rectMin.X + stripeWidth, rectMax.Y), color);
-        }
 
         if (borderEnabled && rectMax.X > rectMin.X && rectMax.Y > rectMin.Y)
         {

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.ManagedFontAtlas;
 using Dalamud.Interface.Textures;
+using Dalamud.Interface.Utility;
 using DemiCatPlugin.Emoji;
 using StbImageSharp;
 
@@ -419,10 +420,22 @@ public class MainWindow : IDisposable
 
             if (useGradient)
             {
+                var style = ImGui.GetStyle();
+                var rounding = style.WindowRounding;
+                var borderSize = Math.Max(1f, style.WindowBorderSize);
                 var drawList = ImGui.GetWindowDrawList();
-                var min = ImGui.GetWindowPos();
-                var max = min + ImGui.GetWindowSize();
-                DrawRoundedVerticalGradient(drawList, min, max, gradientStart, gradientEnd, DockWindowRounding);
+                var winPos = ImGui.GetWindowPos();
+                var winSize = ImGui.GetWindowSize();
+                var min = winPos + new Vector2(borderSize, borderSize);
+                var max = winPos + winSize - new Vector2(borderSize, borderSize);
+                if (max.X > min.X && max.Y > min.Y)
+                {
+                    var topColor = ImGui.GetColorU32(gradientStart);
+                    var bottomColor = ImGui.GetColorU32(gradientEnd);
+                    drawList.AddRectFilledMultiColor(min, max, topColor, topColor, bottomColor, bottomColor);
+                    var borderColor = ImGui.GetColorU32(style.Colors[(int)ImGuiCol.Border]);
+                    drawList.AddRect(min, max, borderColor, rounding, ImDrawFlags.RoundCornersAll, borderSize);
+                }
             }
 
             var first = true;
@@ -1005,11 +1018,18 @@ public class MainWindow : IDisposable
                 closeRequested = true;
             });
 
-            var dragHeight = ImGui.GetFrameHeight();
-            ImGui.SetCursorPosY(ImGui.GetStyle().WindowPadding.Y);
-            ImGui.InvisibleButton($"##drag_zone_dc_{id}", new Vector2(ImGui.GetContentRegionAvail().X, dragHeight));
+            var style = ImGui.GetStyle();
+            var chromeHeight = Math.Max(14f * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight());
+            ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y));
+            var dragSize = new Vector2(ImGui.GetContentRegionAvail().X, chromeHeight);
+            ImGui.InvisibleButton($"##drag_zone_dc_{id}", dragSize);
+            if (ImGui.IsItemActive() && ImGui.IsMouseDragging(0))
+            {
+                var io = ImGui.GetIO();
+                ImGui.SetWindowPos(ImGui.GetWindowPos() + io.MouseDelta);
+            }
 
-            ImGui.Dummy(new Vector2(0f, ImGui.GetStyle().FramePadding.Y * 2f));
+            ImGui.Dummy(new Vector2(1f, style.FramePadding.Y + chromeHeight));
             drawContent();
             windowInteracted = HasWindowInteraction();
         }
@@ -1180,54 +1200,6 @@ public class MainWindow : IDisposable
     private static Vector4 WithAlpha(Vector4 color, float alphaMultiplier)
     {
         return new Vector4(color.X, color.Y, color.Z, Math.Clamp(color.W * alphaMultiplier, 0f, 1f));
-    }
-
-    private static void DrawRoundedVerticalGradient(ImDrawListPtr drawList, Vector2 min, Vector2 max, Vector4 topColor, Vector4 bottomColor, float rounding)
-    {
-        var height = max.Y - min.Y;
-        if (height <= 0f)
-        {
-            return;
-        }
-
-        var steps = Math.Clamp((int)Math.Ceiling(height / 2f), 1, 64);
-        var stepHeight = height / steps;
-
-        for (var i = 0; i < steps; i++)
-        {
-            var y0 = min.Y + stepHeight * i;
-            var y1 = i == steps - 1 ? max.Y : y0 + stepHeight;
-            var tMid = height <= 0f ? 0f : ((y0 + y1) * 0.5f - min.Y) / height;
-            var color = Vector4.Lerp(topColor, bottomColor, Math.Clamp(tMid, 0f, 1f));
-            var segmentMin = new Vector2(min.X, y0);
-            var segmentMax = new Vector2(max.X, y1);
-
-            float segmentRounding = 0f;
-            var flags = ImDrawFlags.None;
-            if (rounding > 0f)
-            {
-                if (steps == 1)
-                {
-                    segmentRounding = rounding;
-                    flags = ImDrawFlags.RoundCornersAll;
-                }
-                else
-                {
-                    if (i == 0)
-                    {
-                        segmentRounding = rounding;
-                        flags |= ImDrawFlags.RoundCornersTopLeft | ImDrawFlags.RoundCornersTopRight;
-                    }
-                    if (i == steps - 1)
-                    {
-                        segmentRounding = rounding;
-                        flags |= ImDrawFlags.RoundCornersBottomLeft | ImDrawFlags.RoundCornersBottomRight;
-                    }
-                }
-            }
-
-            drawList.AddRectFilled(segmentMin, segmentMax, ImGui.GetColorU32(color), segmentRounding, flags);
-        }
     }
 
 }

--- a/DemiCatPlugin/NotePadService.cs
+++ b/DemiCatPlugin/NotePadService.cs
@@ -664,7 +664,14 @@ public sealed class NotePadService : IDisposable
             return;
         }
 
-        await onSuccess(stream).ConfigureAwait(false);
+        try
+        {
+            await onSuccess(stream).ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            PluginServices.Instance?.Log.Error(ex, "NotePad JSON parse error");
+        }
     }
 
     private static async Task<string> ReadErrorAsync(Stream stream)

--- a/DemiCatPlugin/PresenceDto.cs
+++ b/DemiCatPlugin/PresenceDto.cs
@@ -13,8 +13,10 @@ public class PresenceDto
     [JsonPropertyName("status_text")] public string? StatusText { get; set; }
     [JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; }
     [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
+    [JsonIgnore] public bool AvatarLoadRequested { get; set; }
     [JsonPropertyName("banner_url")] public string? BannerUrl { get; set; }
     [JsonIgnore] public ISharedImmediateTexture? BannerTexture { get; set; }
+    [JsonIgnore] public bool BannerLoadRequested { get; set; }
     private uint? _accentColorValue;
     [JsonPropertyName("accent_color")]
     public uint? AccentColorValue

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -41,10 +41,14 @@ public class PresenceSidebar : IDisposable
 
     private const string PresenceUnavailableMessage = "Presence unavailable";
     private static readonly TimeSpan RefreshCooldown = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan RebuildInterval = TimeSpan.FromMilliseconds(250);
 
     private Task? _refreshTask;
     private bool _refreshInFlight;
     private DateTime _nextRefreshAllowed = DateTime.MinValue;
+    private readonly List<PresenceDto> _items = new();
+    private DateTime _lastRebuild = DateTime.MinValue;
+    private PresenceConnectionState _lastConn = PresenceConnectionState.Disconnected;
 
     public Action<string?, Action<ISharedImmediateTexture?>>? TextureLoader { get; set; }
     public Action<string?>? TextureTouch { get; set; }
@@ -64,6 +68,21 @@ public class PresenceSidebar : IDisposable
             ImGui.TextUnformatted(text);
             ImGui.Spacing();
             shouldReturn = true;
+        }
+
+        var snapshot = _service.GetSnapshot();
+        var connection = _service.ConnectionState;
+        if (_lastConn != connection && connection == PresenceConnectionState.Connected)
+        {
+            _items.Clear();
+            _lastRebuild = DateTime.MinValue;
+        }
+        _lastConn = connection;
+
+        if (DateTime.UtcNow - _lastRebuild >= RebuildInterval)
+        {
+            RebuildFrom(snapshot);
+            _lastRebuild = DateTime.UtcNow;
         }
 
         ImGui.BeginChild("##presence", new Vector2(width, 0), true);
@@ -105,7 +124,7 @@ public class PresenceSidebar : IDisposable
             }
             else
             {
-                var presencesSource = _service.Presences;
+                var presencesSource = _items;
                 if (presencesSource == null || presencesSource.Count == 0)
                 {
                     ShowStatus(_service.StatusMessage);
@@ -294,7 +313,15 @@ public class PresenceSidebar : IDisposable
 
         if (TextureLoader != null && !string.IsNullOrEmpty(p.AvatarUrl) && p.AvatarTexture == null)
         {
-            TextureLoader(p.AvatarUrl, t => p.AvatarTexture = t);
+            if (!p.AvatarLoadRequested)
+            {
+                p.AvatarLoadRequested = true;
+                TextureLoader(p.AvatarUrl, t =>
+                {
+                    p.AvatarTexture = t;
+                    p.AvatarLoadRequested = false;
+                });
+            }
         }
 
         var avatarPos = ImGui.GetCursorScreenPos();
@@ -304,16 +331,28 @@ public class PresenceSidebar : IDisposable
             try
             {
                 var wrap = p.AvatarTexture.GetWrapOrEmpty();
-                ImGui.Image(wrap.Handle, avatarSize);
-                TextureTouch?.Invoke(p.AvatarUrl);
-                drewAvatar = true;
+                if (wrap.Width > 0 && wrap.Height > 0)
+                {
+                    ImGui.Image(wrap.Handle, avatarSize);
+                    TextureTouch?.Invoke(p.AvatarUrl);
+                    drewAvatar = true;
+                }
             }
             catch (ObjectDisposedException)
             {
                 p.AvatarTexture = null;
+                p.AvatarLoadRequested = false;
                 if (TextureLoader != null && !string.IsNullOrEmpty(p.AvatarUrl))
                 {
-                    TextureLoader(p.AvatarUrl, t => p.AvatarTexture = t);
+                    if (!p.AvatarLoadRequested)
+                    {
+                        p.AvatarLoadRequested = true;
+                        TextureLoader(p.AvatarUrl, t =>
+                        {
+                            p.AvatarTexture = t;
+                            p.AvatarLoadRequested = false;
+                        });
+                    }
                 }
             }
         }
@@ -404,7 +443,15 @@ public class PresenceSidebar : IDisposable
         {
             if (TextureLoader != null && !string.IsNullOrEmpty(presence.BannerUrl) && presence.BannerTexture == null)
             {
-                TextureLoader(presence.BannerUrl, t => presence.BannerTexture = t);
+                if (!presence.BannerLoadRequested)
+                {
+                    presence.BannerLoadRequested = true;
+                    TextureLoader(presence.BannerUrl, t =>
+                    {
+                        presence.BannerTexture = t;
+                        presence.BannerLoadRequested = false;
+                    });
+                }
             }
             return;
         }
@@ -415,19 +462,31 @@ public class PresenceSidebar : IDisposable
             try
             {
                 var wrap = presence.BannerTexture.GetWrapOrEmpty();
-                drawList.AddImage(wrap.Handle, min, max);
-                TextureTouch?.Invoke(presence.BannerUrl);
-                bannerDrawn = true;
+                if (wrap.Width > 0 && wrap.Height > 0)
+                {
+                    drawList.AddImage(wrap.Handle, min, max);
+                    TextureTouch?.Invoke(presence.BannerUrl);
+                    bannerDrawn = true;
+                }
             }
             catch (ObjectDisposedException)
             {
                 presence.BannerTexture = null;
+                presence.BannerLoadRequested = false;
             }
         }
 
         if (!bannerDrawn && TextureLoader != null && !string.IsNullOrEmpty(presence.BannerUrl) && presence.BannerTexture == null)
         {
-            TextureLoader(presence.BannerUrl, t => presence.BannerTexture = t);
+            if (!presence.BannerLoadRequested)
+            {
+                presence.BannerLoadRequested = true;
+                TextureLoader(presence.BannerUrl, t =>
+                {
+                    presence.BannerTexture = t;
+                    presence.BannerLoadRequested = false;
+                });
+            }
         }
 
         if (!bannerDrawn)
@@ -474,6 +533,25 @@ public class PresenceSidebar : IDisposable
 
         ImGui.InvisibleButton("##badge", totalSize);
         drawList.AddText(cursor + padding, textColor, text);
+    }
+
+    private void RebuildFrom(IReadOnlyList<PresenceDto>? snapshot)
+    {
+        _items.Clear();
+        if (snapshot == null)
+        {
+            return;
+        }
+
+        foreach (var presence in snapshot)
+        {
+            if (presence == null || string.IsNullOrWhiteSpace(presence.Id))
+            {
+                continue;
+            }
+
+            _items.Add(presence);
+        }
     }
 
     public void Dispose()

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 
@@ -74,11 +75,18 @@ public class SettingsWindow : IDisposable
             {
                 UiTheme.DrawWindowChrome(_config, "DemiCat Settings", () => open = false);
 
-                var dragHeight = ImGui.GetFrameHeight();
-                ImGui.SetCursorPosY(ImGui.GetStyle().WindowPadding.Y);
-                ImGui.InvisibleButton("##drag_zone_settings", new Vector2(ImGui.GetContentRegionAvail().X, dragHeight));
+                var style = ImGui.GetStyle();
+                var chromeHeight = Math.Max(14f * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight());
+                ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y));
+                var dragSize = new Vector2(ImGui.GetContentRegionAvail().X, chromeHeight);
+                ImGui.InvisibleButton("##drag_zone_settings", dragSize);
+                if (ImGui.IsItemActive() && ImGui.IsMouseDragging(0))
+                {
+                    var io = ImGui.GetIO();
+                    ImGui.SetWindowPos(ImGui.GetWindowPos() + io.MouseDelta);
+                }
 
-                ImGui.Dummy(new Vector2(0f, ImGui.GetStyle().FramePadding.Y * 2f));
+                ImGui.Dummy(new Vector2(1f, style.FramePadding.Y + chromeHeight));
 
                 if (!_settingsLoaded)
                 {
@@ -265,6 +273,9 @@ public class SettingsWindow : IDisposable
     private void DrawAppearanceTab()
     {
         var fadeOutEnabled = _config.ChatFadeOutEnabled;
+        var scale = ImGuiHelpers.GlobalScale;
+        var maxPicker = 420f * scale;
+        var minPicker = 240f * scale;
 
         ImGui.TextUnformatted("Chat Options");
         ImGui.Spacing();
@@ -341,6 +352,17 @@ public class SettingsWindow : IDisposable
         ImGui.TextUnformatted("Dock appearance");
         ImGui.Spacing();
 
+        var style = ImGui.GetStyle();
+        var availWidth = MathF.Max(1f, ImGui.GetContentRegionAvail().X);
+        var twoColumnLayout = availWidth > (maxPicker * 2f + style.ItemSpacing.X * 3f);
+        var pickerWidth = Math.Clamp(twoColumnLayout ? (availWidth - style.ItemSpacing.X * 3f) * 0.5f : availWidth, minPicker, maxPicker);
+
+        if (twoColumnLayout)
+        {
+            ImGui.Columns(2, "appearance_cols", false);
+        }
+
+        ImGui.PushItemWidth(pickerWidth);
         var dockBorderColor = _config.DockBorderColor;
         if (DrawAdvancedColorPicker("Dock border color", ref dockBorderColor))
         {
@@ -351,7 +373,12 @@ public class SettingsWindow : IDisposable
                 SaveConfig();
             }
         }
+        ImGui.PopItemWidth();
 
+        if (twoColumnLayout)
+        {
+            ImGui.Columns(1);
+        }
         ImGui.Spacing();
 
         var gradientEnabled = _config.DockGradientEnabled;
@@ -363,9 +390,30 @@ public class SettingsWindow : IDisposable
 
         ImGui.Spacing();
 
+        if (twoColumnLayout)
+        {
+            ImGui.Columns(2, "appearance_cols", false);
+        }
+
+        void AdvancePickerColumn()
+        {
+            if (twoColumnLayout)
+            {
+                ImGui.NextColumn();
+            }
+            else
+            {
+                ImGui.Spacing();
+            }
+        }
+
         ImGui.BeginDisabled(gradientEnabled);
         var dockColor = _config.DockBackgroundColor;
-        if (DrawAdvancedColorPicker("Dock background color", ref dockColor))
+        ImGui.PushItemWidth(pickerWidth);
+        var dockColorChanged = DrawAdvancedColorPicker("Dock background color", ref dockColor);
+        var solidHovered = ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled);
+        ImGui.PopItemWidth();
+        if (dockColorChanged)
         {
             var sanitized = Config.SanitizeColor(dockColor, Config.DefaultDockBackgroundColor);
             if (!ColorsAlmostEqual(sanitized, _config.DockBackgroundColor))
@@ -374,16 +422,16 @@ public class SettingsWindow : IDisposable
                 SaveConfig();
             }
         }
-        var solidHovered = ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled);
+        AdvancePickerColumn();
+        ImGui.EndDisabled();
         if (gradientEnabled && solidHovered)
         {
             ImGui.SetTooltip("Disable gradient background to adjust the solid dock color.");
         }
-        ImGui.Spacing();
-        ImGui.EndDisabled();
 
         ImGui.BeginDisabled(!gradientEnabled);
         var gradientStart = _config.DockGradientStartColor;
+        ImGui.PushItemWidth(pickerWidth);
         if (DrawAdvancedColorPicker("Gradient start color", ref gradientStart))
         {
             var sanitized = Config.SanitizeColor(gradientStart, Config.DefaultDockBackgroundColor);
@@ -393,9 +441,11 @@ public class SettingsWindow : IDisposable
                 SaveConfig();
             }
         }
-        ImGui.Spacing();
+        ImGui.PopItemWidth();
+        AdvancePickerColumn();
 
         var gradientEnd = _config.DockGradientEndColor;
+        ImGui.PushItemWidth(pickerWidth);
         if (DrawAdvancedColorPicker("Gradient end color", ref gradientEnd))
         {
             var sanitized = Config.SanitizeColor(gradientEnd, Config.DefaultDockBackgroundColor);
@@ -405,7 +455,14 @@ public class SettingsWindow : IDisposable
                 SaveConfig();
             }
         }
+        ImGui.PopItemWidth();
+        AdvancePickerColumn();
         ImGui.EndDisabled();
+
+        if (twoColumnLayout)
+        {
+            ImGui.Columns(1);
+        }
 
         ImGui.Spacing();
 
@@ -562,7 +619,10 @@ public class SettingsWindow : IDisposable
         const ImGuiColorEditFlags flags = ImGuiColorEditFlags.AlphaBar
                                           | ImGuiColorEditFlags.AlphaPreviewHalf
                                           | ImGuiColorEditFlags.PickerHueWheel;
+        var width = ImGui.CalcItemWidth();
+        ImGui.PushItemWidth(width);
         var changed = ImGui.ColorPicker4("##picker", ref color, flags);
+        ImGui.PopItemWidth();
         ImGui.PopID();
 
         if (changed && !ColorsAlmostEqual(color, value))


### PR DESCRIPTION
## Summary
- redraw the embed preview banner stripe using the child window clip rect and matching rounding
- render the dock gradient inside the window border, expand draggable chrome zones, and guard window dragging
- debounce presence sidebar refreshes with connection state tracking while avoiding redundant texture loads for avatars, attachments, and emoji
- clamp appearance color pickers to reasonable sizes and harden NotePad JSON handling

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eadb75cf988328ad4a2e4ee6a9b1b8