### PR TITLE
Fix ImGui color conversions and dock border variable shadowing

### DIFF
--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -218,7 +218,8 @@ public static class EmbedPreviewRenderer
         if (borderEnabled && rectMax.X > rectMin.X && rectMax.Y > rectMin.Y)
         {
             var drawList = ImGui.GetWindowDrawList();
-            var color = ColorUtils.RgbToImGui(borderColor);
+            var colorVec = ColorUtils.RgbToImGui(borderColor);
+            var color = ImGui.ColorConvertFloat4ToU32(colorVec);
             var inset = new Vector2(1f, 1f);
             drawList.AddRect(rectMin + inset, rectMax - inset, color, 0f, ImDrawFlags.None, 1.5f);
         }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -433,8 +433,8 @@ public class MainWindow : IDisposable
                     var topColor = ImGui.GetColorU32(gradientStart);
                     var bottomColor = ImGui.GetColorU32(gradientEnd);
                     drawList.AddRectFilledMultiColor(min, max, topColor, topColor, bottomColor, bottomColor);
-                    var borderColor = ImGui.GetColorU32(style.Colors[(int)ImGuiCol.Border]);
-                    drawList.AddRect(min, max, borderColor, rounding, ImDrawFlags.RoundCornersAll, borderSize);
+                    var borderColorU32 = ImGui.GetColorU32(style.Colors[(int)ImGuiCol.Border]);
+                    drawList.AddRect(min, max, borderColorU32, rounding, ImDrawFlags.RoundCornersAll, borderSize);
                 }
             }
 


### PR DESCRIPTION
## Summary
- convert the embed preview border color to an ImGui U32 before drawing
- rename the dock gradient border color variable to avoid shadowing the surrounding Vector4

## Testing
- ⚠️ `dotnet build DemiCatPlugin -c Release` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eaee664cc083288518e8158ab231af