### PR TITLE
Enhance notepad UI and metadata

### DIFF
--- a/DemiCatPlugin/NotePadService.cs
+++ b/DemiCatPlugin/NotePadService.cs
@@ -81,6 +81,8 @@ public sealed class NotePadService : IDisposable
             return;
         }
 
+        await MembershipCache.EnsureLoaded(_httpClient, _config).ConfigureAwait(false);
+
         var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/notepad";
         var request = new HttpRequestMessage(HttpMethod.Get, url);
         ApiHelpers.AddAuthHeader(request, _tokenManager);
@@ -965,6 +967,14 @@ public sealed class NotePadService : IDisposable
             Id = source.Id,
             Name = source.Name,
             Color = source.Color,
+            CreatedById = source.CreatedById,
+            CreatedByDiscordId = source.CreatedByDiscordId,
+            CreatedByDisplayName = source.CreatedByDisplayName,
+            UpdatedById = source.UpdatedById,
+            UpdatedByDiscordId = source.UpdatedByDiscordId,
+            UpdatedByDisplayName = source.UpdatedByDisplayName,
+            CreatedAt = source.CreatedAt,
+            UpdatedAt = source.UpdatedAt,
             Pages = source.Pages.Select(ClonePage).ToList()
         };
     }
@@ -978,7 +988,14 @@ public sealed class NotePadService : IDisposable
             Content = source.Content,
             Version = source.Version,
             UpdatedAt = source.UpdatedAt,
-            Color = source.Color
+            CreatedAt = source.CreatedAt,
+            Color = source.Color,
+            CreatedById = source.CreatedById,
+            CreatedByDiscordId = source.CreatedByDiscordId,
+            CreatedByDisplayName = source.CreatedByDisplayName,
+            UpdatedById = source.UpdatedById,
+            UpdatedByDiscordId = source.UpdatedByDiscordId,
+            UpdatedByDisplayName = source.UpdatedByDisplayName
         };
     }
 }
@@ -989,6 +1006,14 @@ public sealed class NotePadSection
 
     public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
+    public string? CreatedById { get; set; }
+    public string? CreatedByDiscordId { get; set; }
+    public string? CreatedByDisplayName { get; set; }
+    public string? UpdatedById { get; set; }
+    public string? UpdatedByDiscordId { get; set; }
+    public string? UpdatedByDisplayName { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
 
     [JsonConverter(typeof(NotePadColorJsonConverter))]
     public string Color
@@ -1006,8 +1031,15 @@ public sealed class NotePadPage
     public string Title { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
     public int Version { get; set; }
-    public DateTimeOffset UpdatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
     public string? Color { get; set; }
+    public string? CreatedById { get; set; }
+    public string? CreatedByDiscordId { get; set; }
+    public string? CreatedByDisplayName { get; set; }
+    public string? UpdatedById { get; set; }
+    public string? UpdatedByDiscordId { get; set; }
+    public string? UpdatedByDisplayName { get; set; }
 }
 
 public sealed class NotePadListResponse

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
@@ -40,9 +41,7 @@ public sealed class NotePadWindow : IDisposable
     private bool _pageOrderDirty;
     private bool _focusEditorNextFrame;
     private string _newSectionName = string.Empty;
-    private string _newPageTitle = string.Empty;
     private bool _showNewSectionPopup;
-    private bool _showNewPagePopup;
     private string? _draggingSectionId;
     private string? _draggingPageId;
 
@@ -286,52 +285,57 @@ public sealed class NotePadWindow : IDisposable
             return;
         }
 
-        DrawNewPagePopup(section);
+        var style = ImGui.GetStyle();
+        var drawList = ImGui.GetWindowDrawList();
+        var headerPos = ImGui.GetCursorScreenPos();
+        var headerWidth = ImGui.GetContentRegionAvail().X;
+        var headerHeight = ImGui.GetTextLineHeightWithSpacing() + style.FramePadding.Y * 2f;
+        var headerRectMax = headerPos + new Vector2(headerWidth, headerHeight);
 
-        if (!IsReadOnly && ImGui.Button("New Page"))
+        var headerColor = style.Colors[(int)ImGuiCol.FrameBg];
+        headerColor.W = MathF.Min(headerColor.W + 0.15f, 1f);
+        drawList.AddRectFilled(headerPos, headerRectMax, ImGui.ColorConvertFloat4ToU32(headerColor), style.FrameRounding);
+        drawList.AddRect(headerPos, headerRectMax, ImGui.ColorConvertFloat4ToU32(style.Colors[(int)ImGuiCol.Border]), style.FrameRounding);
+
+        var title = string.IsNullOrWhiteSpace(section.Name) ? "Notes" : section.Name;
+        var titlePos = headerPos + new Vector2(style.FramePadding.X, style.FramePadding.Y);
+        ImGui.SetCursorScreenPos(titlePos);
+        ImGui.TextUnformatted(title);
+
+        var buttonText = "+";
+        var buttonTextSize = ImGui.CalcTextSize(buttonText);
+        var buttonPadding = style.FramePadding;
+        var buttonSize = new Vector2(buttonTextSize.X + buttonPadding.X * 2f, buttonTextSize.Y + buttonPadding.Y * 2f);
+        var buttonPos = new Vector2(
+            headerRectMax.X - buttonSize.X - style.FramePadding.X,
+            headerPos.Y + (headerHeight - buttonSize.Y) * 0.5f);
+        ImGui.SetCursorScreenPos(buttonPos);
+        ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, style.FrameRounding);
+        if (IsReadOnly)
         {
-            OpenNewPagePopup(section);
+            ImGui.BeginDisabled();
+            ImGui.Button(buttonText, buttonSize);
+            ImGui.EndDisabled();
         }
+        else if (ImGui.Button(buttonText, buttonSize))
+        {
+            CreateNewPage(section);
+        }
+        ImGui.PopStyleVar();
 
+        ImGui.SetCursorScreenPos(new Vector2(headerPos.X, headerRectMax.Y + style.ItemSpacing.Y));
         UiTheme.DrawSectionSeparator();
 
-        foreach (var page in section.Pages)
+        if (section.Pages.Count == 0)
         {
-            ImGui.PushID(page.Id);
-            var label = string.IsNullOrWhiteSpace(page.Title) ? "Untitled Page" : page.Title;
-            var isSelected = string.Equals(page.Id, _selectedPageId, StringComparison.Ordinal);
-            if (ImGui.Selectable(label, isSelected))
+            ImGui.TextDisabled("No notes yet.");
+        }
+        else
+        {
+            foreach (var page in section.Pages)
             {
-                SelectPage(section.Id, page.Id);
+                DrawNoteListEntry(section, page, selectedPage);
             }
-
-            if (ImGui.BeginDragDropSource())
-            {
-                _draggingPageId = page.Id;
-                ImGui.SetDragDropPayload("NotePadPage", ReadOnlySpan<byte>.Empty);
-                ImGui.TextUnformatted(label);
-                ImGui.EndDragDropSource();
-            }
-
-            if (ImGui.BeginDragDropTarget())
-            {
-                var payload = ImGui.AcceptDragDropPayload("NotePadPage");
-                if (!payload.Equals(default(ImGuiPayloadPtr)) && !string.IsNullOrEmpty(_draggingPageId) &&
-                    !string.Equals(_draggingPageId, page.Id, StringComparison.Ordinal))
-                {
-                    ReorderPages(section, _draggingPageId, page.Id);
-                    _draggingPageId = null;
-                }
-                ImGui.EndDragDropTarget();
-            }
-
-            if (ImGui.BeginPopupContextItem("PageContext"))
-            {
-                DrawPageContext(section, page);
-                ImGui.EndPopup();
-            }
-
-            ImGui.PopID();
         }
 
         if (!ImGui.IsMouseDown(ImGuiMouseButton.Left))
@@ -340,8 +344,252 @@ public sealed class NotePadWindow : IDisposable
         }
     }
 
+    private void DrawNoteListEntry(NotePadSection section, NotePadPage page, NotePadPage? selectedPage)
+    {
+        var style = ImGui.GetStyle();
+        var available = ImGui.GetContentRegionAvail();
+        var lineHeight = ImGui.GetTextLineHeight();
+        var entryHeight = lineHeight * 2f + style.FramePadding.Y * 3f;
+        var itemSize = new Vector2(available.X, entryHeight);
+
+        ImGui.PushID(page.Id);
+        var flags = ImGuiButtonFlags.MouseButtonLeft | ImGuiButtonFlags.MouseButtonRight;
+        ImGui.InvisibleButton("##NoteRow", itemSize, flags);
+
+        var hovered = ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenBlockedByActiveItem);
+        var clickedLeft = ImGui.IsItemClicked(ImGuiMouseButton.Left);
+        var itemMin = ImGui.GetItemRectMin();
+        var itemMax = ImGui.GetItemRectMax();
+        var drawList = ImGui.GetWindowDrawList();
+        var isSelected = selectedPage != null && string.Equals(page.Id, selectedPage.Id, StringComparison.Ordinal);
+        var background = GetNoteRowColor(isSelected, hovered);
+        drawList.AddRectFilled(itemMin, itemMax, background, 8f);
+        if (isSelected)
+        {
+            var borderColor = ImGui.ColorConvertFloat4ToU32(style.Colors[(int)ImGuiCol.Border]);
+            drawList.AddRect(itemMin, itemMax, borderColor, 8f, ImDrawFlags.RoundCornersAll, 1.5f);
+        }
+
+        var padding = new Vector2(style.FramePadding.X + 6f, style.FramePadding.Y + 3f);
+        var titlePos = itemMin + padding;
+        var title = string.IsNullOrWhiteSpace(page.Title) ? "Untitled" : page.Title;
+        drawList.AddText(titlePos, ImGui.GetColorU32(ImGuiCol.Text), title);
+
+        var timestamp = FormatTimestamp(page.UpdatedAt);
+        if (!string.IsNullOrEmpty(timestamp))
+        {
+            var timeSize = ImGui.CalcTextSize(timestamp);
+            var timePos = new Vector2(itemMax.X - padding.X - timeSize.X, titlePos.Y);
+            drawList.AddText(timePos, ImGui.GetColorU32(ImGuiCol.TextDisabled), timestamp);
+        }
+
+        var preview = BuildPreviewText(page);
+        if (!string.IsNullOrEmpty(preview))
+        {
+            var previewPos = titlePos + new Vector2(0f, lineHeight + style.ItemSpacing.Y * 0.5f);
+            drawList.AddText(previewPos, ImGui.GetColorU32(ImGuiCol.TextDisabled), preview);
+        }
+
+        ImGui.SetCursorScreenPos(new Vector2(itemMin.X, itemMax.Y + style.ItemSpacing.Y));
+
+        if (clickedLeft)
+        {
+            SelectPage(section.Id, page.Id);
+        }
+
+        if (ImGui.BeginDragDropSource())
+        {
+            _draggingPageId = page.Id;
+            ImGui.SetDragDropPayload("NotePadPage", ReadOnlySpan<byte>.Empty);
+            ImGui.TextUnformatted(title);
+            ImGui.EndDragDropSource();
+        }
+
+        if (ImGui.BeginDragDropTarget())
+        {
+            var payload = ImGui.AcceptDragDropPayload("NotePadPage");
+            if (!payload.Equals(default(ImGuiPayloadPtr)) && !string.IsNullOrEmpty(_draggingPageId) &&
+                !string.Equals(_draggingPageId, page.Id, StringComparison.Ordinal))
+            {
+                ReorderPages(section, _draggingPageId, page.Id);
+                _draggingPageId = null;
+            }
+            ImGui.EndDragDropTarget();
+        }
+
+        if (ImGui.BeginPopupContextItem($"PageContext##{page.Id}"))
+        {
+            DrawPageContext(section, page);
+            ImGui.EndPopup();
+        }
+
+        ImGui.PopID();
+    }
+
+    private static uint GetNoteRowColor(bool isSelected, bool hovered)
+    {
+        var style = ImGui.GetStyle();
+        Vector4 color;
+        if (isSelected)
+        {
+            color = style.Colors[(int)ImGuiCol.HeaderActive];
+        }
+        else if (hovered)
+        {
+            color = style.Colors[(int)ImGuiCol.HeaderHovered];
+        }
+        else
+        {
+            color = style.Colors[(int)ImGuiCol.FrameBg];
+            color.W = MathF.Min(color.W + 0.08f, 1f);
+        }
+
+        return ImGui.ColorConvertFloat4ToU32(color);
+    }
+
+    private static string BuildPreviewText(NotePadPage page)
+    {
+        var content = page.Content ?? string.Empty;
+        var normalized = content.ReplaceLineEndings(" ").Trim();
+        if (string.IsNullOrEmpty(normalized))
+        {
+            return "No additional text";
+        }
+
+        const int maxLength = 160;
+        if (normalized.Length <= maxLength)
+        {
+            return normalized;
+        }
+
+        var truncated = normalized[..maxLength].TrimEnd();
+        return truncated + "…";
+    }
+
+    private static DateTime ToLocalTimeSafe(DateTime value)
+    {
+        if (value == default)
+        {
+            return value;
+        }
+
+        if (value.Kind == DateTimeKind.Unspecified)
+        {
+            value = DateTime.SpecifyKind(value, DateTimeKind.Utc);
+        }
+
+        return value.Kind == DateTimeKind.Utc ? value.ToLocalTime() : value;
+    }
+
+    private static string FormatTimestamp(DateTime value)
+    {
+        if (value == default)
+        {
+            return string.Empty;
+        }
+
+        var local = ToLocalTimeSafe(value);
+        var now = DateTime.Now;
+        if (local.Date == now.Date)
+        {
+            return local.ToString("h:mm tt", CultureInfo.CurrentCulture);
+        }
+
+        if (local.Year == now.Year)
+        {
+            return local.ToString("MMM d", CultureInfo.CurrentCulture);
+        }
+
+        return local.ToString("MMM d, yyyy", CultureInfo.CurrentCulture);
+    }
+
+    private static string FormatFullTimestamp(DateTime value)
+    {
+        if (value == default)
+        {
+            return string.Empty;
+        }
+
+        var local = ToLocalTimeSafe(value);
+        return local.ToString("MMMM d, yyyy h:mm tt", CultureInfo.CurrentCulture);
+    }
+
+    private static string GenerateNewNoteTitle(NotePadSection section)
+    {
+        const string baseTitle = "New Note";
+        if (!section.Pages.Any(p => string.Equals(p.Title, baseTitle, StringComparison.OrdinalIgnoreCase)))
+        {
+            return baseTitle;
+        }
+
+        for (var i = 2; i < 1000; i++)
+        {
+            var candidate = $"{baseTitle} {i}";
+            if (!section.Pages.Any(p => string.Equals(p.Title, candidate, StringComparison.OrdinalIgnoreCase)))
+            {
+                return candidate;
+            }
+        }
+
+        return $"{baseTitle} {DateTime.UtcNow.Ticks}";
+    }
+
+    private void CreateNewPage(NotePadSection section)
+    {
+        if (IsReadOnly)
+        {
+            PluginServices.Instance?.ToastGui.ShowError("You do not have permission to create notes.");
+            return;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            var title = GenerateNewNoteTitle(section);
+            var page = await _service.CreatePageAsync(section.Id, title, CancellationToken.None).ConfigureAwait(false);
+            if (page != null)
+            {
+                SelectPage(section.Id, page.Id);
+            }
+        });
+    }
+
+    private static bool CanDeletePage(NotePadPage page)
+    {
+        var current = MembershipCache.DiscordUserId;
+        if (string.IsNullOrEmpty(current))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(page.CreatedByDiscordId))
+        {
+            return string.Equals(page.CreatedByDiscordId, current, StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+
     private void DrawPageContext(NotePadSection section, NotePadPage page)
     {
+        var creator = string.IsNullOrWhiteSpace(page.CreatedByDisplayName)
+            ? (!string.IsNullOrEmpty(page.CreatedByDiscordId) ? page.CreatedByDiscordId : "Unknown")
+            : page.CreatedByDisplayName;
+        ImGui.MenuItem($"Created by {creator}", string.Empty, false, false);
+
+        var createdAt = FormatFullTimestamp(page.CreatedAt);
+        if (!string.IsNullOrEmpty(createdAt))
+        {
+            ImGui.MenuItem($"Created {createdAt}", string.Empty, false, false);
+        }
+
+        var updatedAt = FormatFullTimestamp(page.UpdatedAt);
+        if (!string.IsNullOrEmpty(updatedAt))
+        {
+            ImGui.MenuItem($"Updated {updatedAt}", string.Empty, false, false);
+        }
+
+        ImGui.Separator();
+
         if (!IsReadOnly && ImGui.MenuItem("Rename"))
         {
             _pageRenameBuffers[page.Id] = page.Title;
@@ -373,7 +621,7 @@ public sealed class NotePadWindow : IDisposable
             ImGui.EndPopup();
         }
 
-        if (!IsReadOnly && ImGui.MenuItem("Delete"))
+        if (!IsReadOnly && CanDeletePage(page) && ImGui.MenuItem("Delete Note"))
         {
             _ = Task.Run(() => _service.DeletePageAsync(section.Id, page.Id, CancellationToken.None));
         }
@@ -545,45 +793,6 @@ public sealed class NotePadWindow : IDisposable
         }
     }
 
-    private void DrawNewPagePopup(NotePadSection section)
-    {
-        if (_showNewPagePopup)
-        {
-            ImGui.OpenPopup("CreatePage");
-            _showNewPagePopup = false;
-        }
-
-        if (ImGui.BeginPopup("CreatePage"))
-        {
-            ImGui.InputText("Title", ref _newPageTitle, 128);
-            _newPageTitle = ClampTitleLength(_newPageTitle);
-            if (ImGui.Button("Create"))
-            {
-                var title = _newPageTitle.Trim();
-                if (!string.IsNullOrEmpty(title))
-                {
-                    _ = Task.Run(async () =>
-                    {
-                        var page = await _service.CreatePageAsync(section.Id, title, CancellationToken.None);
-                        if (page != null)
-                        {
-                            SelectPage(section.Id, page.Id);
-                        }
-                    });
-                }
-                _newPageTitle = string.Empty;
-                ImGui.CloseCurrentPopup();
-            }
-            ImGui.SameLine();
-            if (ImGui.Button("Cancel"))
-            {
-                _newPageTitle = string.Empty;
-                ImGui.CloseCurrentPopup();
-            }
-            ImGui.EndPopup();
-        }
-    }
-
     private void HandleAutosave()
     {
         if (IsReadOnly || !_dirty)
@@ -620,7 +829,7 @@ public sealed class NotePadWindow : IDisposable
                 var actualSection = _service.Sections.FirstOrDefault(s => string.Equals(s.Id, section, StringComparison.Ordinal));
                 if (actualSection != null)
                 {
-                    OpenNewPagePopup(actualSection);
+                    CreateNewPage(actualSection);
                 }
             }
             else
@@ -915,18 +1124,6 @@ public sealed class NotePadWindow : IDisposable
 
         _showNewSectionPopup = true;
         _newSectionName = string.Empty;
-    }
-
-    private void OpenNewPagePopup(NotePadSection section)
-    {
-        if (IsReadOnly)
-        {
-            PluginServices.Instance?.ToastGui.ShowError("You do not have permission to create pages.");
-            return;
-        }
-
-        _showNewPagePopup = true;
-        _newPageTitle = string.Empty;
     }
 
     private void HandleServiceChanged()

--- a/demibot/demibot/http/routes/notepad.py
+++ b/demibot/demibot/http/routes/notepad.py
@@ -24,7 +24,7 @@ from ..schemas import (
     NoteSectionUpdateBody,
 )
 from ..ws import manager
-from ...db.models import NotePage, NoteSection
+from ...db.models import NotePage, NoteSection, User
 
 
 router = APIRouter(prefix="/api")
@@ -43,11 +43,44 @@ async def _load_sections(
 ) -> Sequence[NoteSection]:
     result = await db.execute(
         select(NoteSection)
-        .options(selectinload(NoteSection.pages))
+        .options(
+            selectinload(NoteSection.created_by),
+            selectinload(NoteSection.updated_by),
+            selectinload(NoteSection.pages).selectinload(NotePage.created_by),
+            selectinload(NoteSection.pages).selectinload(NotePage.updated_by),
+        )
         .where(NoteSection.guild_id == guild_id)
         .order_by(NoteSection.sort_order, NoteSection.id)
     )
     return result.scalars().unique().all()
+
+
+def _format_display_name(user: User | None) -> str | None:
+    if user is None:
+        return None
+
+    for candidate in (getattr(user, "global_name", None), getattr(user, "character_name", None)):
+        if candidate:
+            name = candidate.strip()
+            if name:
+                return name
+
+    discord_id = getattr(user, "discord_user_id", None)
+    if discord_id is not None:
+        return str(discord_id)
+
+    user_id = getattr(user, "id", None)
+    return str(user_id) if user_id is not None else None
+
+
+def _discord_id(user: User | None) -> str | None:
+    if user is None:
+        return None
+
+    discord_id = getattr(user, "discord_user_id", None)
+    if discord_id is None:
+        return None
+    return str(discord_id)
 
 
 def _serialize_note_page(page: NotePage) -> NotePageDto:
@@ -60,6 +93,10 @@ def _serialize_note_page(page: NotePage) -> NotePageDto:
         color=page.color,
         created_by_id=str(page.created_by_id) if page.created_by_id is not None else None,
         updated_by_id=str(page.updated_by_id) if page.updated_by_id is not None else None,
+        created_by_discord_id=_discord_id(page.created_by),
+        updated_by_discord_id=_discord_id(page.updated_by),
+        created_by_display_name=_format_display_name(page.created_by),
+        updated_by_display_name=_format_display_name(page.updated_by),
         created_at=page.created_at,
         updated_at=page.updated_at,
         version=page.version,
@@ -86,6 +123,10 @@ def _serialize_note_section(section: NoteSection) -> NoteSectionDto:
         str(section.created_by_id) if section.created_by_id is not None else None,
         updated_by_id=
         str(section.updated_by_id) if section.updated_by_id is not None else None,
+        created_by_discord_id=_discord_id(section.created_by),
+        updated_by_discord_id=_discord_id(section.updated_by),
+        created_by_display_name=_format_display_name(section.created_by),
+        updated_by_display_name=_format_display_name(section.updated_by),
         created_at=section.created_at,
         updated_at=section.updated_at,
         version=section.version,
@@ -117,7 +158,12 @@ async def _get_section(
 ) -> NoteSection:
     result = await db.execute(
         select(NoteSection)
-        .options(selectinload(NoteSection.pages))
+        .options(
+            selectinload(NoteSection.created_by),
+            selectinload(NoteSection.updated_by),
+            selectinload(NoteSection.pages).selectinload(NotePage.created_by),
+            selectinload(NoteSection.pages).selectinload(NotePage.updated_by),
+        )
         .where(NoteSection.id == section_id)
     )
     section = result.scalar_one_or_none()
@@ -134,6 +180,8 @@ async def _get_page(
     db: AsyncSession, guild_id: int, page_id: int, include_deleted: bool = False
 ) -> NotePage:
     page = await db.get(NotePage, page_id)
+    if page is not None:
+        await db.refresh(page, attribute_names=["created_by", "updated_by"])
     if (
         page is None
         or page.guild_id != guild_id
@@ -175,6 +223,7 @@ async def create_section(
     db.add(section)
     await db.commit()
     await db.refresh(section)
+    await db.refresh(section, attribute_names=["created_by", "updated_by"])
     dto = _serialize_note_section(section)
     await _broadcast_notepad_event(
         ctx,
@@ -203,6 +252,7 @@ async def update_section(
     section.updated_by_id = ctx.user.id
     await db.commit()
     await db.refresh(section)
+    await db.refresh(section, attribute_names=["created_by", "updated_by"])
     dto = _serialize_note_section(section)
     await _broadcast_notepad_event(
         ctx,
@@ -324,6 +374,7 @@ async def create_page(
     db.add(page)
     await db.commit()
     await db.refresh(page)
+    await db.refresh(page, attribute_names=["created_by", "updated_by"])
     dto = _serialize_note_page(page)
     await _broadcast_notepad_event(
         ctx,
@@ -352,6 +403,7 @@ async def update_page(
     page.updated_by_id = ctx.user.id
     await db.commit()
     await db.refresh(page)
+    await db.refresh(page, attribute_names=["created_by", "updated_by"])
     dto = _serialize_note_page(page)
     await _broadcast_notepad_event(
         ctx,
@@ -377,6 +429,7 @@ async def update_page_content(
     page.updated_by_id = ctx.user.id
     await db.commit()
     await db.refresh(page)
+    await db.refresh(page, attribute_names=["created_by", "updated_by"])
     dto = _serialize_note_page(page)
     await _broadcast_notepad_event(
         ctx,

--- a/demibot/demibot/http/schemas.py
+++ b/demibot/demibot/http/schemas.py
@@ -205,6 +205,18 @@ class NotePageDto(CamelModel):
     color: int | None = None
     created_by_id: str | None = Field(default=None, alias="createdById")
     updated_by_id: str | None = Field(default=None, alias="updatedById")
+    created_by_discord_id: str | None = Field(
+        default=None, alias="createdByDiscordId"
+    )
+    updated_by_discord_id: str | None = Field(
+        default=None, alias="updatedByDiscordId"
+    )
+    created_by_display_name: str | None = Field(
+        default=None, alias="createdByDisplayName"
+    )
+    updated_by_display_name: str | None = Field(
+        default=None, alias="updatedByDisplayName"
+    )
     created_at: datetime = Field(alias="createdAt")
     updated_at: datetime = Field(alias="updatedAt")
     version: int
@@ -217,6 +229,18 @@ class NoteSectionDto(CamelModel):
     color: int | None = None
     created_by_id: str | None = Field(default=None, alias="createdById")
     updated_by_id: str | None = Field(default=None, alias="updatedById")
+    created_by_discord_id: str | None = Field(
+        default=None, alias="createdByDiscordId"
+    )
+    updated_by_discord_id: str | None = Field(
+        default=None, alias="updatedByDiscordId"
+    )
+    created_by_display_name: str | None = Field(
+        default=None, alias="createdByDisplayName"
+    )
+    updated_by_display_name: str | None = Field(
+        default=None, alias="updatedByDisplayName"
+    )
     created_at: datetime = Field(alias="createdAt")
     updated_at: datetime = Field(alias="updatedAt")
     version: int

--- a/tests/NotePadWindowTests.cs
+++ b/tests/NotePadWindowTests.cs
@@ -73,7 +73,8 @@ public class NotePadWindowTests
                 Title = "Notes",
                 Content = "Updated",
                 Version = 2,
-                UpdatedAt = DateTimeOffset.UtcNow,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
             });
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
@@ -132,7 +133,8 @@ public class NotePadWindowTests
                 Title = "New Page",
                 Content = string.Empty,
                 Version = 0,
-                UpdatedAt = DateTimeOffset.UtcNow,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
                 Color = "#123456"
             });
 
@@ -218,7 +220,8 @@ public class NotePadWindowTests
                             Title = "Notes",
                             Content = "Initial",
                             Version = 1,
-                            UpdatedAt = DateTimeOffset.UtcNow
+                            CreatedAt = DateTime.UtcNow,
+                            UpdatedAt = DateTime.UtcNow
                         },
                         new()
                         {
@@ -226,7 +229,8 @@ public class NotePadWindowTests
                             Title = "Todo",
                             Content = "Items",
                             Version = 1,
-                            UpdatedAt = DateTimeOffset.UtcNow
+                            CreatedAt = DateTime.UtcNow,
+                            UpdatedAt = DateTime.UtcNow
                         },
                         new()
                         {
@@ -234,7 +238,8 @@ public class NotePadWindowTests
                             Title = "Archive",
                             Content = "Old",
                             Version = 1,
-                            UpdatedAt = DateTimeOffset.UtcNow
+                            CreatedAt = DateTime.UtcNow,
+                            UpdatedAt = DateTime.UtcNow
                         }
                     }
                 },
@@ -251,7 +256,8 @@ public class NotePadWindowTests
                             Title = "Log",
                             Content = "",
                             Version = 0,
-                            UpdatedAt = DateTimeOffset.UtcNow
+                            CreatedAt = DateTime.UtcNow,
+                            UpdatedAt = DateTime.UtcNow
                         }
                     }
                 },

--- a/tests/test_notepad_routes.py
+++ b/tests/test_notepad_routes.py
@@ -72,6 +72,10 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
         )
     assert section.name == "Raid"
     assert section.color == 123456
+    assert section.created_by_id == str(ctx_member.user.id)
+    assert section.created_by_discord_id == str(member.discord_user_id)
+    assert section.created_by_display_name == "Member"
+    assert section.updated_by_display_name == "Member"
 
     async with get_session() as db:
         renamed = await notepad.update_section(
@@ -82,6 +86,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
         )
     assert renamed.name == "Raid Alpha"
     assert renamed.version == section.version + 1
+    assert renamed.updated_by_display_name == "Member"
 
     async with get_session() as db:
         with pytest.raises(HTTPException) as excinfo:
@@ -105,6 +110,9 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
             db=db,
         )
     assert page.content == "A"
+    assert page.created_by_id == str(ctx_member.user.id)
+    assert page.created_by_discord_id == str(member.discord_user_id)
+    assert page.created_by_display_name == "Member"
 
     async with get_session() as db:
         updated_page = await notepad.update_page_content(
@@ -114,6 +122,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
             db=db,
         )
     assert updated_page.version == page.version + 1
+    assert updated_page.updated_by_display_name == "Member"
 
     async with get_session() as db:
         with pytest.raises(HTTPException) as excinfo:
@@ -134,6 +143,7 @@ async def test_notepad_crud_flow(tmp_path, monkeypatch):
         )
     assert updated_meta.title == "New Title"
     assert updated_meta.version == updated_page.version + 1
+    assert updated_meta.updated_by_display_name == "Officer"
 
     async with get_session() as db:
         section2 = await notepad.create_section(


### PR DESCRIPTION
## Summary
- include creator and editor identity details in notepad API payloads and eagerly load the related users to avoid lazy-load errors
- teach the plugin service and UI to consume the new metadata, switch timestamps to DateTime, and redesign the note list to mirror macOS Notes with previews, timestamps, and ownership-aware context menus
- update the existing tests to cover the additional metadata and revised models

## Testing
- pytest tests/test_notepad_routes.py tests/test_notepad_sync.py tests/test_notepad_ws.py
- dotnet test tests/DemiCatPlugin.Tests.csproj --filter NotePad *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb9945106483289015c1f3f06566cc