### PR TITLE
Refine event time display and calendar picker

### DIFF
--- a/DemiCatPlugin/DateTimePicker.cs
+++ b/DemiCatPlugin/DateTimePicker.cs
@@ -43,7 +43,7 @@ internal sealed class DateTimePicker
     {
         var local = _value.ToLocalTime();
         var preview = local.ToString("MMM d, yyyy h:mm tt", CultureInfo.CurrentCulture);
-        var popupId = $"TimePickerPopup##{idSuffix}";
+        var popupId = $"Calendar##{idSuffix}";
         newValue = _value;
         var changed = false;
 
@@ -55,7 +55,13 @@ internal sealed class DateTimePicker
             ImGui.OpenPopup(popupId);
         }
 
-        if (ImGui.BeginPopupModal(popupId, ImGuiWindowFlags.AlwaysAutoResize))
+        if (ImGui.IsPopupOpen(popupId))
+        {
+            ImGui.SetNextWindowSize(new Vector2(420f, 360f), ImGuiCond.Appearing);
+            ImGui.SetNextWindowSizeConstraints(new Vector2(320f, 300f), new Vector2(820f, 720f));
+        }
+
+        if (ImGui.BeginPopupModal(popupId, ImGuiWindowFlags.None))
         {
             DrawMonthHeader(idSuffix);
             DrawCalendar(idSuffix);

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -81,10 +81,11 @@ public static class EmbedPreviewRenderer
             ImGui.TextUnformatted(dto.Title);
         }
 
-        if (!string.IsNullOrEmpty(dto.Description))
+        var description = EventEmbedHelpers.RemoveAppendedStartLine(dto.Description, dto.Timestamp, out _);
+        if (!string.IsNullOrEmpty(description))
         {
             BeginSection();
-            ImGui.TextWrapped(dto.Description);
+            ImGui.TextWrapped(description);
         }
 
         if (!string.IsNullOrEmpty(dto.ThumbnailUrl))
@@ -116,20 +117,19 @@ public static class EmbedPreviewRenderer
         }
 
         var footerText = dto.FooterText ?? string.Empty;
-        if (dto.Timestamp.HasValue)
-        {
-            if (footerText.Length > 0)
-            {
-                footerText += " • ";
-            }
-
-            footerText += dto.Timestamp.Value.LocalDateTime.ToString();
-        }
 
         if (!string.IsNullOrEmpty(footerText))
         {
             BeginSection();
             ImGui.TextUnformatted(footerText);
+        }
+
+        var showStartTime = EventEmbedHelpers.ShouldDisplayStartTime(dto);
+        if (showStartTime)
+        {
+            BeginSection();
+            var label = $"Starts: {EventEmbedHelpers.FormatLocalStartTime(dto.Timestamp!.Value)}";
+            ImGui.TextUnformatted(label);
         }
 
         if (dto.Buttons != null && dto.Buttons.Count > 0)

--- a/DemiCatPlugin/EventEmbedHelpers.cs
+++ b/DemiCatPlugin/EventEmbedHelpers.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using DiscordHelper;
+
+namespace DemiCatPlugin;
+
+internal static class EventEmbedHelpers
+{
+    private const string RsvpPrefix = "rsvp:";
+
+    public static bool HasRsvpButtons(IReadOnlyList<EmbedButtonDto>? buttons)
+    {
+        if (buttons == null)
+        {
+            return false;
+        }
+
+        foreach (var button in buttons)
+        {
+            if (button?.CustomId == null)
+            {
+                continue;
+            }
+
+            if (button.CustomId.StartsWith(RsvpPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static bool IsApolloEvent(EmbedDto dto)
+    {
+        if (dto == null)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(dto.FooterText) &&
+            dto.FooterText.Contains("apollo", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(dto.ProviderName) &&
+            dto.ProviderName.Contains("apollo", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrEmpty(dto.AuthorName) &&
+            dto.AuthorName.Contains("apollo", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (dto.Authors != null)
+        {
+            return dto.Authors.Any(a =>
+                !string.IsNullOrEmpty(a?.Name) &&
+                a!.Name!.Contains("apollo", StringComparison.OrdinalIgnoreCase));
+        }
+
+        return false;
+    }
+
+    public static bool ShouldDisplayStartTime(EmbedDto dto)
+    {
+        if (dto == null || !dto.Timestamp.HasValue)
+        {
+            return false;
+        }
+
+        if (HasRsvpButtons(dto.Buttons))
+        {
+            return true;
+        }
+
+        return IsApolloEvent(dto);
+    }
+
+    public static string FormatLocalStartTime(DateTimeOffset timestamp)
+    {
+        var local = timestamp.ToLocalTime();
+        return local.ToString("f", CultureInfo.CurrentCulture);
+    }
+
+    public static string BuildDiscordStartLine(DateTimeOffset timestamp)
+    {
+        var unix = timestamp.ToUnixTimeSeconds();
+        return $"**Starts:** <t:{unix}:F>";
+    }
+
+    public static string? AppendDiscordStartLine(string? description, DateTimeOffset? timestamp)
+    {
+        if (!timestamp.HasValue)
+        {
+            return description;
+        }
+
+        var startLine = BuildDiscordStartLine(timestamp.Value);
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return startLine;
+        }
+
+        var trimmed = description.TrimEnd();
+        if (trimmed.EndsWith(startLine, StringComparison.Ordinal))
+        {
+            return description;
+        }
+
+        return $"{trimmed}\n\n{startLine}";
+    }
+
+    public static string? RemoveAppendedStartLine(string? description, DateTimeOffset? timestamp, out bool removed)
+    {
+        removed = false;
+        if (string.IsNullOrEmpty(description) || !timestamp.HasValue)
+        {
+            return description;
+        }
+
+        var startLine = BuildDiscordStartLine(timestamp.Value);
+        var trimmed = description.TrimEnd();
+        if (!trimmed.EndsWith(startLine, StringComparison.Ordinal))
+        {
+            return description;
+        }
+
+        removed = true;
+        var withoutLine = trimmed.Substring(0, trimmed.Length - startLine.Length).TrimEnd();
+        return string.IsNullOrEmpty(withoutLine) ? null : withoutLine;
+    }
+}

--- a/DemiCatPlugin/EventPreviewFormatter.cs
+++ b/DemiCatPlugin/EventPreviewFormatter.cs
@@ -74,11 +74,14 @@ public static class EventPreviewFormatter
 
         var footer = NormalizeFooter(creatorLabel);
 
+        var normalizedDescription = string.IsNullOrWhiteSpace(description) ? null : description;
+        var descriptionWithStart = EventEmbedHelpers.AppendDiscordStartLine(normalizedDescription, timestamp);
+
         var embed = new EmbedDto
         {
             Id = string.IsNullOrWhiteSpace(embedId) ? "preview" : embedId!,
             Title = string.IsNullOrWhiteSpace(title) ? null : title,
-            Description = string.IsNullOrWhiteSpace(description) ? null : description,
+            Description = descriptionWithStart,
             Url = string.IsNullOrWhiteSpace(url) ? null : url,
             ImageUrl = string.IsNullOrWhiteSpace(imageUrl) ? null : imageUrl,
             ThumbnailUrl = string.IsNullOrWhiteSpace(thumbnailUrl) ? null : thumbnailUrl,

--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -297,10 +297,11 @@ public class EventView : IDisposable
             DrawTitleSection(dto);
         }
 
-        if (!string.IsNullOrEmpty(dto.Description))
+        var description = EventEmbedHelpers.RemoveAppendedStartLine(dto.Description, dto.Timestamp, out _);
+        if (!string.IsNullOrEmpty(description))
         {
             BeginSection();
-            ImGui.TextWrapped(dto.Description);
+            ImGui.TextWrapped(description);
         }
 
         if (_thumbnail != null)
@@ -321,7 +322,7 @@ public class EventView : IDisposable
             DrawImageSection();
         }
 
-        if (_footerIcon != null || !string.IsNullOrEmpty(dto.FooterText) || dto.Timestamp.HasValue)
+        if (_footerIcon != null || !string.IsNullOrEmpty(dto.FooterText))
         {
             BeginSection();
             DrawFooterSection(dto);
@@ -463,11 +464,6 @@ public class EventView : IDisposable
             parts.Add(dto.FooterText!.Trim());
         }
 
-        if (dto.Timestamp.HasValue)
-        {
-            parts.Add(dto.Timestamp.Value.LocalDateTime.ToString());
-        }
-
         var hasText = parts.Count > 0;
 
         if (_footerIcon != null)
@@ -490,6 +486,14 @@ public class EventView : IDisposable
     public void DrawButtons()
     {
         using var emojiFont = _emojiManager.PushEmojiFont();
+        var showStartTime = EventEmbedHelpers.ShouldDisplayStartTime(_dto);
+        if (showStartTime)
+        {
+            var label = $"Starts: {EventEmbedHelpers.FormatLocalStartTime(_dto.Timestamp!.Value)}";
+            ImGui.TextUnformatted(label);
+            ImGui.Spacing();
+        }
+
         if (Buttons != null && Buttons.Count > 0)
         {
             foreach (var row in Buttons
@@ -536,7 +540,7 @@ public class EventView : IDisposable
                 }
             }
         }
-        else if (IsApolloEvent(_dto))
+        else if (EventEmbedHelpers.IsApolloEvent(_dto))
         {
             if (ImGui.Button($"Yes##rsvpYes{_dto.Id}", new Vector2(-1, 0)))
             {
@@ -556,26 +560,6 @@ public class EventView : IDisposable
         {
             ImGui.TextUnformatted(_lastResult);
         }
-    }
-
-    private static bool IsApolloEvent(EmbedDto dto)
-    {
-        if (!string.IsNullOrEmpty(dto.FooterText) &&
-            dto.FooterText.Contains("apollo", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-        if (!string.IsNullOrEmpty(dto.ProviderName) &&
-            dto.ProviderName.Contains("apollo", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-        if (!string.IsNullOrEmpty(dto.AuthorName) &&
-            dto.AuthorName.Contains("apollo", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-        return false;
     }
 
     private void LoadTexture(string? url, Action<ISharedImmediateTexture?> set)

--- a/demibot/demibot/http/routes/events.py
+++ b/demibot/demibot/http/routes/events.py
@@ -285,6 +285,22 @@ class FormattedEvent(NamedTuple):
     buttons: List[EmbedButtonDto]
 
 
+def _append_start_line(description: str | None, start: datetime | None) -> str | None:
+    if start is None:
+        return description
+
+    unix = int(start.timestamp())
+    start_line = f"**Starts:** <t:{unix}:F>"
+    if not description:
+        return start_line
+
+    trimmed = description.rstrip()
+    if trimmed.endswith(start_line):
+        return description
+
+    return f"{trimmed}\n\n{start_line}"
+
+
 def format_event_embed(
     body: "CreateEventBody",
     *,
@@ -298,8 +314,9 @@ def format_event_embed(
                 EmbedButtonDto(label=tag.capitalize(), custom_id=f"rsvp:{tag}")
             )
 
-    embed = discord.Embed(title=body.title, description=body.description)
-    embed.timestamp = timestamp
+    description = _append_start_line(body.description, body.time)
+
+    embed = discord.Embed(title=body.title, description=description)
     if body.color is not None:
         embed.colour = body.color
     if body.url:
@@ -364,12 +381,12 @@ async def create_event(
 
     dto = EmbedDto(
         id=eid,
-        timestamp=ts,
+        timestamp=body.time,
         color=body.color,
         author_name=None,
         author_icon_url=None,
         title=body.title,
-        description=body.description,
+        description=formatted.embed.description,
         url=body.url,
         fields=[
             EmbedFieldDto(name=f.name, value=f.value, inline=f.inline)

--- a/tests/EventPreviewFormatterTests.cs
+++ b/tests/EventPreviewFormatterTests.cs
@@ -169,6 +169,7 @@ public class EventPreviewFormatterTests
     private static void AssertPreviewMatches(JsonElement expected, EventPreviewFormatter.Result actual)
     {
         Assert.Equal(expected.GetProperty("content").GetString(), actual.Content);
+        Assert.Equal(Timestamp, actual.Embed.Timestamp);
         AssertJsonEqual(expected.GetProperty("embed"), BuildEmbedElement(actual.Embed));
         AssertJsonEqual(expected.GetProperty("buttons"), BuildButtonsElement(actual.Buttons));
     }
@@ -185,8 +186,6 @@ public class EventPreviewFormatterTests
         if (!string.IsNullOrWhiteSpace(embed.Description)) obj["description"] = embed.Description;
         if (!string.IsNullOrWhiteSpace(embed.Url)) obj["url"] = embed.Url;
         if (embed.Color.HasValue) obj["color"] = (int)embed.Color.Value;
-        if (embed.Timestamp.HasValue) obj["timestamp"] = embed.Timestamp.Value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss+00:00");
-
         if (embed.Fields != null && embed.Fields.Count > 0)
         {
             obj["fields"] = embed.Fields.Select(f => new Dictionary<string, object?>

--- a/tests/data/event_preview_samples.json
+++ b/tests/data/event_preview_samples.json
@@ -22,9 +22,8 @@
       ],
       "flags": 0,
       "color": 1193046,
-      "timestamp": "2024-04-01T20:00:00+00:00",
       "type": "rich",
-      "description": "Clear the raid together.",
+      "description": "Clear the raid together.\n\n**Starts:** <t:1712001600:F>",
       "url": "https://example.com/event",
       "title": "Raid Night",
       "footer": {
@@ -71,9 +70,8 @@
       ],
       "flags": 0,
       "color": 1193046,
-      "timestamp": "2024-04-01T20:00:00+00:00",
       "type": "rich",
-      "description": "Clear the raid together.",
+      "description": "Clear the raid together.\n\n**Starts:** <t:1712001600:F>",
       "url": "https://example.com/event",
       "title": "Raid Night",
       "footer": {
@@ -120,9 +118,8 @@
       ],
       "flags": 0,
       "color": 11163084,
-      "timestamp": "2024-04-01T20:00:00+00:00",
       "type": "rich",
-      "description": "Discuss strategy.",
+      "description": "Discuss strategy.\n\n**Starts:** <t:1712001600:F>",
       "url": "https://example.com/template",
       "title": "Static Meeting",
       "footer": {
@@ -183,9 +180,8 @@
       ],
       "flags": 0,
       "color": 11163084,
-      "timestamp": "2024-04-01T20:00:00+00:00",
       "type": "rich",
-      "description": "Discuss strategy.",
+      "description": "Discuss strategy.\n\n**Starts:** <t:1712001600:F>",
       "url": "https://example.com/template",
       "title": "Static Meeting",
       "footer": {


### PR DESCRIPTION
## Summary
- add shared helpers to strip embed timestamps, surface RSVP start times in the UI, and append Discord-compatible start markers to event descriptions
- update event preview/rendering, backend formatting, and tests/fixtures so event embeds show a bold "Starts" line while omitting redundant timestamp metadata
- rename the calendar popup and make it resizable with sensible default and size limits for easier time selection

## Testing
- `dotnet test` *(fails: command not found in container)*
- `pytest tests/test_event_format_helper_parity.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68eb9ba0c5c883289a69cc83f9c21d0a