### PR TITLE
Fix missing Apollo event helper reference

### DIFF
--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -190,7 +190,7 @@ public class EventView : IDisposable
                 reserve += rowCount * ImGui.GetFrameHeightWithSpacing();
             }
         }
-        else if (IsApolloEvent(_dto))
+        else if (EventEmbedHelpers.IsApolloEvent(_dto))
         {
             reserve += 3 * ImGui.GetFrameHeightWithSpacing();
         }


### PR DESCRIPTION
## Summary
- call the Apollo event detection helper with its full type name to match the rest of the file

## Testing
- ❌ `dotnet build -c Release` *(dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eba5a09ab483289e39fe0aea50e6e9