### PR TITLE
Fix embed preview start time clipping

### DIFF
--- a/DemiCatPlugin/EventView.cs
+++ b/DemiCatPlugin/EventView.cs
@@ -177,6 +177,11 @@ public class EventView : IDisposable
         var style = ImGui.GetStyle();
         var reserve = style.ItemSpacing.Y;
 
+        if (EventEmbedHelpers.ShouldDisplayStartTime(_dto))
+        {
+            reserve += ImGui.GetTextLineHeight() + style.ItemSpacing.Y;
+        }
+
         if (Buttons != null && Buttons.Count > 0)
         {
             var rowCount = Buttons


### PR DESCRIPTION
## Summary
- ensure the embed preview reserves space for the start time label so the footer is fully visible

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ebab717a08832897051a29d8899d63