### PR TITLE
Fix embed preview stripe rounding

### DIFF
--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -202,11 +202,12 @@ public static class EmbedPreviewRenderer
             {
                 var colorVec = ColorUtils.RgbToVector4(dto.Color.Value);
                 var color = ImGui.ColorConvertFloat4ToU32(colorVec);
+                var stripeRounding = Math.Min(cardRounding, stripeWidth * 0.5f);
                 dl.AddRectFilled(
                     stripeMin,
                     stripeMax,
                     color,
-                    cardRounding,
+                    stripeRounding,
                     ImDrawFlags.RoundCornersTopLeft | ImDrawFlags.RoundCornersBottomLeft);
             }
         }


### PR DESCRIPTION
## Summary
- prevent the embed preview color stripe from collapsing when the child window rounding exceeds the stripe width

## Testing
- `dotnet test` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebaac8ac00832896263d7a756bfa69