### PR TITLE
Fix SyncShell namespace imports

### DIFF
--- a/DemiCatPlugin/SyncShell/BlobStore.cs
+++ b/DemiCatPlugin/SyncShell/BlobStore.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 
 namespace DemiCatPlugin.SyncShell;

--- a/DemiCatPlugin/SyncShell/PenumbraIpc.cs
+++ b/DemiCatPlugin/SyncShell/PenumbraIpc.cs
@@ -1,4 +1,5 @@
 using System;
+using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Services;
 using Penumbra.Api.Enums;

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Threading.Tasks;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 using Dalamud.Plugin.Services;
 using DemiCatPlugin.SyncShell;
-using ImGuiNET;
 
 namespace DemiCatPlugin;
 


### PR DESCRIPTION
## Summary
- switch SyncshellWindow to Dalamud's ImGui binding to match the rest of the plugin
- import Dalamud.Plugin in SyncShell components that depend on IDalamudPluginInterface

## Testing
- dotnet build -c Release *(fails: dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebb7e575d08328b12a800dfa0bdeca