### PR TITLE
Fix SyncShell event handler and Penumbra validation feedback

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -420,8 +420,9 @@ public class SettingsWindow : IDisposable
 
         if (ImGui.Button("Validate Path"))
         {
+            string? error = null;
             var pathToCheck = string.IsNullOrWhiteSpace(_penumbraOverride) ? detectedPath : _penumbraOverride;
-            if (service != null && service.TryValidatePenumbraPath(pathToCheck, out var error))
+            if (service != null && service.TryValidatePenumbraPath(pathToCheck, out error))
             {
                 _penumbraValidationSuccess = true;
                 _penumbraValidationMessage = "Penumbra path looks good.";

--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -406,7 +406,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private void HandleTerritoryChanged(object? sender, ushort e)
+    private void HandleTerritoryChanged(ushort _)
     {
         if (!IsRunning)
         {


### PR DESCRIPTION
## Summary
- adjust the SyncShell territory change handler signature to match Dalamud's Action<ushort> delegate
- preserve the Penumbra validation error message when validation fails

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebba4d2f5483288ebd874fc3ac1555