### PR TITLE
Add empty path guard to Penumbra validation

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -422,7 +422,12 @@ public class SettingsWindow : IDisposable
         {
             string? error = null;
             var pathToCheck = string.IsNullOrWhiteSpace(_penumbraOverride) ? detectedPath : _penumbraOverride;
-            if (service != null && service.TryValidatePenumbraPath(pathToCheck, out error))
+            if (string.IsNullOrWhiteSpace(pathToCheck))
+            {
+                _penumbraValidationSuccess = false;
+                _penumbraValidationMessage = "No path to validate. Set an override or ensure Penumbra is running.";
+            }
+            else if (service != null && service.TryValidatePenumbraPath(pathToCheck, out error))
             {
                 _penumbraValidationSuccess = true;
                 _penumbraValidationMessage = "Penumbra path looks good.";


### PR DESCRIPTION
## Summary
- add a user-facing message when no Penumbra path is available to validate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebc020e22c8328843083d6cbd977dc