### PR TITLE
Fix SyncShell event handler parameter names

### DIFF
--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -406,7 +406,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private void HandleTerritoryChanged(ushort _)
+    private void HandleTerritoryChanged(ushort territoryId)
     {
         if (!IsRunning)
         {
@@ -438,7 +438,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private void HandleTokenUnlinked(string? _)
+    private void HandleTokenUnlinked(string? reason)
     {
         _ = Stop();
     }


### PR DESCRIPTION
## Summary
- rename SyncShell event handler parameters to avoid Task discard shadowing

## Testing
- dotnet build -c Release *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc0f220d8832898eafe3369101104