### PR TITLE
Handle nullable services when disposing

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -236,7 +236,7 @@ public class Plugin : IDalamudPlugin
         }
         _syncShellService.Dispose();
         _blobStore.Dispose();
-        var log = _services.Log;
+        var log = _services?.Log;
         try
         {
             RunOnFrameworkAsync(WebTextureCache.Clear).GetAwaiter().GetResult();


### PR DESCRIPTION
## Summary
- avoid dereferencing a potentially null services instance when disposing the plugin

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ebc3a531c883288643311363541393