### PR TITLE
Fix nullability warning when unsubscribing UI events

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -251,7 +251,8 @@ public class Plugin : IDalamudPlugin
         _emojiFontHandle?.Dispose();
 
         // Unsubscribe UI draw handlers
-        if (_services.PluginInterface is { } pluginInterface)
+        var pluginInterface = _services?.PluginInterface;
+        if (pluginInterface != null)
         {
             pluginInterface.UiBuilder.Draw -= _mainWindow.Draw;
             pluginInterface.UiBuilder.Draw -= _settings.Draw;


### PR DESCRIPTION
## Summary
- cache the plugin interface before checking for null during shutdown
- prevent dereferencing a possibly null services instance when removing UI handlers

## Testing
- ⚠️ `dotnet build -c Release` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc50456c48328beefa02efeb2508e