### PR TITLE
Avoid null dereference when disposing plugin interface

### DIFF
--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -251,7 +251,7 @@ public class Plugin : IDalamudPlugin
         _emojiFontHandle?.Dispose();
 
         // Unsubscribe UI draw handlers
-        var pluginInterface = _services.PluginInterface;
+        var pluginInterface = _services?.PluginInterface;
         if (pluginInterface != null)
         {
             pluginInterface.UiBuilder.Draw -= _mainWindow.Draw;


### PR DESCRIPTION
## Summary
- guard access to PluginInterface with a null-propagating operator during plugin disposal

## Testing
- dotnet build -c release *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebc7e8fff08328a0517010d91130b8