### PR TITLE
Implement SyncShell membership presence tracking

### DIFF
--- a/DemiCatPlugin/SyncShell/ISyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/ISyncShellService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,6 +13,8 @@ public interface ISyncShellService
     bool IsPaused { get; }
     string Status { get; }
     int NearbyUserCount { get; }
+    IReadOnlyList<SyncshellMemberStatus> Members { get; }
+    IReadOnlyList<SyncshellMemberStatus> ActiveMembers { get; }
     bool PenumbraAvailable { get; }
     string? DetectedPenumbraPath { get; }
 

--- a/DemiCatPlugin/SyncShell/Models.cs
+++ b/DemiCatPlugin/SyncShell/Models.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace DemiCatPlugin.SyncShell;
@@ -80,4 +81,102 @@ public sealed class PresenceSnapshot
 
     [JsonPropertyName("timestamp")]
     public DateTimeOffset Timestamp { get; }
+}
+
+public sealed class MembershipEntryDto
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("presence")]
+    public string? Presence { get; set; }
+
+    [JsonPropertyName("syncStatus")]
+    public string? SyncStatus { get; set; }
+
+    [JsonPropertyName("lastSeen")]
+    public string? LastSeen { get; set; }
+
+    [JsonPropertyName("syncedAt")]
+    public string? SyncedAt { get; set; }
+
+    [JsonPropertyName("tokenLinked")]
+    public bool TokenLinked { get; set; }
+}
+
+public sealed class MembershipsResponseDto
+{
+    [JsonPropertyName("members")]
+    public List<MembershipEntryDto> Members { get; set; } = new();
+
+    [JsonPropertyName("currentlySynced")]
+    public List<MembershipEntryDto> CurrentlySynced { get; set; } = new();
+
+    [JsonPropertyName("pendingApprovals")]
+    public List<JsonElement> PendingApprovals { get; set; } = new();
+
+    [JsonPropertyName("invites")]
+    public List<JsonElement> Invites { get; set; } = new();
+}
+
+public sealed class PresenceUpdateDto
+{
+    [JsonPropertyName("activeMemberIds")]
+    public List<long> ActiveMemberIds { get; set; } = new();
+}
+
+public sealed class PresenceResponseEntryDto
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("presence")]
+    public string? Presence { get; set; }
+
+    [JsonPropertyName("syncStatus")]
+    public string? SyncStatus { get; set; }
+
+    [JsonPropertyName("lastSeen")]
+    public string? LastSeen { get; set; }
+
+    [JsonPropertyName("syncedAt")]
+    public string? SyncedAt { get; set; }
+
+    [JsonPropertyName("tokenLinked")]
+    public bool TokenLinked { get; set; }
+}
+
+public sealed class PresenceResponseDto
+{
+    [JsonPropertyName("presence")]
+    public List<PresenceResponseEntryDto> Presence { get; set; } = new();
+
+    [JsonPropertyName("currentlySynced")]
+    public List<PresenceResponseEntryDto> CurrentlySynced { get; set; } = new();
+}
+
+public sealed class SyncshellMemberStatus
+{
+    public string Id { get; init; } = string.Empty;
+
+    public string DisplayName { get; init; } = string.Empty;
+
+    public string Presence { get; init; } = "offline";
+
+    public string? SyncStatus { get; init; }
+
+    public DateTimeOffset? LastSeen { get; init; }
+
+    public DateTimeOffset? SyncedAt { get; init; }
+
+    public bool TokenLinked { get; init; }
+
+    [JsonIgnore]
+    public bool IsActive => string.Equals(SyncStatus, "syncing", StringComparison.OrdinalIgnoreCase);
 }

--- a/DemiCatPlugin/SyncShell/SyncShellClient.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -16,10 +17,12 @@ public sealed class SyncShellClient
     private readonly Config _config;
     private readonly TokenManager _tokenManager;
 
-    private const string GetMetaPath = "/syncshell/meta";               // TODO(backend): confirm route
-    private const string PublishPath = "/syncshell/publish";            // TODO(backend): confirm route
-    private const string BlobUploadPath = "/syncshell/blobs";           // TODO(backend): confirm route
-    private const string BlobDownloadPath = "/syncshell/blobs";         // TODO(backend): confirm route
+    private const string GetMetaPath = "/api/syncshell/meta";               // TODO: backend to confirm availability
+    private const string PublishPath = "/api/syncshell/manifest";
+    private const string BlobUploadPath = "/api/syncshell/blobs";           // TODO: backend implementation
+    private const string BlobDownloadPath = "/api/syncshell/blobs";         // TODO: backend implementation
+    private const string MembershipsPath = "/api/syncshell/memberships";
+    private const string PresencePath = "/api/syncshell/presence";
 
     public SyncShellClient(HttpClient httpClient, Config config, TokenManager tokenManager)
     {
@@ -100,6 +103,41 @@ public sealed class SyncShellClient
         var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<MembershipsResponseDto?> GetMembershipsAsync(CancellationToken cancellationToken)
+    {
+        var uri = BuildUri(MembershipsPath);
+        using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        return await JsonSerializer.DeserializeAsync<MembershipsResponseDto>(stream, SerializerOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdatePresenceAsync(IEnumerable<long> activeMemberIds, CancellationToken cancellationToken)
+    {
+        var payload = new PresenceUpdateDto
+        {
+            ActiveMemberIds = new List<long>(activeMemberIds ?? Array.Empty<long>())
+        };
+
+        var uri = BuildUri(PresencePath);
+        using var request = new HttpRequestMessage(HttpMethod.Post, uri)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload, SerializerOptions))
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
     }
 
     public async Task<bool> ValidateAsync(CancellationToken cancellationToken)

--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Plugin.Services;
@@ -25,6 +25,9 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     private readonly object _statusLock = new();
     private readonly SemaphoreSlim _lifecycleLock = new(1, 1);
     private readonly HashSet<string> _nearbyUsers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _memberLock = new();
+    private List<SyncshellMemberStatus> _members = new();
+    private List<SyncshellMemberStatus> _activeMembers = new();
 
     private CancellationTokenSource? _runCts;
     private Task? _presenceTask;
@@ -134,6 +137,28 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             lock (_nearbyUsers)
             {
                 return _nearbyUsers.Count;
+            }
+        }
+    }
+
+    public IReadOnlyList<SyncshellMemberStatus> Members
+    {
+        get
+        {
+            lock (_memberLock)
+            {
+                return _members.ToArray();
+            }
+        }
+    }
+
+    public IReadOnlyList<SyncshellMemberStatus> ActiveMembers
+    {
+        get
+        {
+            lock (_memberLock)
+            {
+                return _activeMembers.ToArray();
             }
         }
     }
@@ -316,23 +341,30 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
     private async Task PresenceLoopAsync(CancellationToken token)
     {
+        var initial = true;
         while (!token.IsCancellationRequested)
         {
             try
             {
-                await Task.Delay(PresencePollInterval, token).ConfigureAwait(false);
+                if (!initial)
+                {
+                    await Task.Delay(PresencePollInterval, token).ConfigureAwait(false);
+                }
+                else
+                {
+                    initial = false;
+                }
+
                 if (_paused)
                 {
                     continue;
                 }
 
-                lock (_nearbyUsers)
+                var memberships = await _client.GetMembershipsAsync(token).ConfigureAwait(false);
+                if (memberships != null)
                 {
-                    _nearbyUsers.Clear();
-                    // Placeholder – future implementation will resolve Discord IDs of nearby actors.
+                    UpdateMemberSnapshot(memberships);
                 }
-
-                OnStatusChanged();
             }
             catch (OperationCanceledException)
             {
@@ -445,6 +477,116 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
     private void OnStatusChanged()
         => StatusChanged?.Invoke(this, EventArgs.Empty);
+
+    private void UpdateMemberSnapshot(MembershipsResponseDto snapshot)
+    {
+        var members = new List<SyncshellMemberStatus>();
+        var activeMembers = new List<SyncshellMemberStatus>();
+
+        if (snapshot.Members != null)
+        {
+            foreach (var entry in snapshot.Members)
+            {
+                if (entry == null)
+                {
+                    continue;
+                }
+
+                var status = MapMember(entry);
+                members.Add(status);
+            }
+        }
+
+        if (snapshot.CurrentlySynced != null)
+        {
+            foreach (var entry in snapshot.CurrentlySynced)
+            {
+                if (entry == null)
+                {
+                    continue;
+                }
+
+                var status = MapMember(entry);
+                activeMembers.Add(status);
+            }
+        }
+
+        lock (_memberLock)
+        {
+            _members = members;
+            _activeMembers = activeMembers;
+        }
+
+        lock (_nearbyUsers)
+        {
+            _nearbyUsers.Clear();
+            foreach (var entry in activeMembers)
+            {
+                if (!string.IsNullOrEmpty(entry.Id))
+                {
+                    _nearbyUsers.Add(entry.Id);
+                }
+            }
+        }
+
+        var statusChanged = false;
+        if (!_paused)
+        {
+            statusChanged = UpdateStatusForMembers(activeMembers.Count);
+        }
+
+        if (!statusChanged)
+        {
+            OnStatusChanged();
+        }
+    }
+
+    private bool UpdateStatusForMembers(int activeCount)
+    {
+        var status = activeCount > 0
+            ? $"Syncing {activeCount} member{(activeCount == 1 ? string.Empty : "s")}";
+            : "Active";
+        if (!string.Equals(Status, status, StringComparison.Ordinal))
+        {
+            Status = status;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static SyncshellMemberStatus MapMember(MembershipEntryDto entry)
+    {
+        var displayName = string.IsNullOrWhiteSpace(entry.DisplayName)
+            ? entry.Id ?? string.Empty
+            : entry.DisplayName;
+
+        return new SyncshellMemberStatus
+        {
+            Id = entry.Id ?? string.Empty,
+            DisplayName = displayName,
+            Presence = entry.Presence ?? "offline",
+            SyncStatus = entry.SyncStatus,
+            LastSeen = ParseTimestamp(entry.LastSeen),
+            SyncedAt = ParseTimestamp(entry.SyncedAt),
+            TokenLinked = entry.TokenLinked,
+        };
+    }
+
+    private static DateTimeOffset? ParseTimestamp(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed))
+        {
+            return parsed;
+        }
+
+        return null;
+    }
 
     public void Dispose()
     {

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
@@ -19,6 +21,7 @@ public sealed class SyncshellWindow : IDisposable
     private readonly List<string> _statusHistory = new();
     private bool _disposed;
     private string _latestStatus = string.Empty;
+    private static readonly Vector4 ActiveMemberColor = new(0.45f, 0.86f, 0.55f, 1f);
 
     public SyncshellWindow(Config config, ISyncShellService? service = null)
     {
@@ -69,6 +72,12 @@ public sealed class SyncshellWindow : IDisposable
         ImGui.Unindent();
 
         ImGui.Separator();
+        DrawActiveMembers(service.ActiveMembers);
+
+        ImGui.Separator();
+        DrawMemberRoster(service.Members);
+
+        ImGui.Separator();
         ImGui.TextUnformatted("Allowed Discord IDs");
         ImGui.Indent();
         if (_config.SyncshellAllowedDiscordIds.Count == 0)
@@ -116,6 +125,85 @@ public sealed class SyncshellWindow : IDisposable
                 _log?.Warning(ex, "Failed to clear SyncShell cache");
             }
         }
+    }
+
+    private static void DrawActiveMembers(IReadOnlyList<SyncshellMemberStatus> activeMembers)
+    {
+        ImGui.TextUnformatted("Currently syncing");
+        ImGui.Indent();
+        if (activeMembers.Count == 0)
+        {
+            ImGui.TextDisabled("No active members detected.");
+        }
+        else
+        {
+            foreach (var member in activeMembers)
+            {
+                DrawMemberLine(member, highlight: true);
+                if (member.SyncedAt != null)
+                {
+                    ImGui.Indent();
+                    ImGui.TextDisabled($"Synced at {FormatTimestamp(member.SyncedAt)}");
+                    ImGui.Unindent();
+                }
+            }
+        }
+        ImGui.Unindent();
+    }
+
+    private static void DrawMemberRoster(IReadOnlyList<SyncshellMemberStatus> members)
+    {
+        ImGui.TextUnformatted("Member roster");
+        ImGui.Indent();
+        if (members.Count == 0)
+        {
+            ImGui.TextDisabled("No linked members yet.");
+        }
+        else
+        {
+            foreach (var member in members.OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase))
+            {
+                DrawMemberLine(member, highlight: member.IsActive);
+                if (member.LastSeen != null)
+                {
+                    ImGui.Indent();
+                    ImGui.TextDisabled($"Last seen {FormatTimestamp(member.LastSeen)}");
+                    ImGui.Unindent();
+                }
+            }
+        }
+        ImGui.Unindent();
+    }
+
+    private static void DrawMemberLine(SyncshellMemberStatus member, bool highlight)
+    {
+        var presenceLabel = string.IsNullOrEmpty(member.SyncStatus)
+            ? member.Presence
+            : $"{member.Presence}, {member.SyncStatus}";
+        var linkedSuffix = member.TokenLinked ? " • linked" : string.Empty;
+        var label = $"{member.DisplayName} [{presenceLabel}]{linkedSuffix}";
+
+        if (highlight)
+        {
+            ImGui.PushStyleColor(ImGuiCol.Text, ActiveMemberColor);
+            ImGui.BulletText(label);
+            ImGui.PopStyleColor();
+        }
+        else
+        {
+            ImGui.BulletText(label);
+        }
+    }
+
+    private static string FormatTimestamp(DateTimeOffset? timestamp)
+    {
+        if (timestamp == null)
+        {
+            return string.Empty;
+        }
+
+        var local = timestamp.Value.ToLocalTime();
+        return local.ToString("g", CultureInfo.CurrentCulture);
     }
 
     public void ClearCaches()

--- a/tests/SyncshellStateChangeFallbackTests.cs
+++ b/tests/SyncshellStateChangeFallbackTests.cs
@@ -52,6 +52,8 @@ public class SyncshellStateChangeFallbackTests
         public bool IsPaused => _paused;
         public string Status { get; private set; } = "Idle";
         public int NearbyUserCount { get; set; }
+        public IReadOnlyList<SyncshellMemberStatus> Members { get; private set; } = Array.Empty<SyncshellMemberStatus>();
+        public IReadOnlyList<SyncshellMemberStatus> ActiveMembers { get; private set; } = Array.Empty<SyncshellMemberStatus>();
         public bool PenumbraAvailable => false;
         public string? DetectedPenumbraPath => null;
 


### PR DESCRIPTION
## Summary
- add SyncShell client models and requests for membership rosters and presence updates
- poll the memberships endpoint during the service presence loop to maintain active member state and update service status
- surface member rosters in the SyncShell window and extend the service interface/tests to expose the new data

## Testing
- dotnet build (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ebc69443408328805b312d5f54df02