### PR TITLE
Remove redundant long-based presence overload

### DIFF
--- a/DemiCatPlugin/SyncShell/SyncShellClient.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellClient.cs
@@ -187,25 +187,6 @@ public sealed class SyncShellClient
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task UpdatePresenceAsync(IEnumerable<long> activeMemberIds, CancellationToken cancellationToken)
-    {
-        var payload = new PresenceUpdateDto
-        {
-            ActiveMemberIds = new List<long>(activeMemberIds ?? Array.Empty<long>())
-        };
-
-        var uri = BuildUri(PresencePath);
-        using var request = new HttpRequestMessage(HttpMethod.Post, uri)
-        {
-            Content = new StringContent(JsonSerializer.Serialize(payload, SerializerOptions))
-        };
-        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-        ApiHelpers.AddAuthHeader(request, _tokenManager);
-
-        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
-    }
-
     public async Task<bool> ValidateAsync(CancellationToken cancellationToken)
     {
         var response = await ApiHelpers.PingAsync(_httpClient, _config, _tokenManager, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- remove the UpdatePresenceAsync overload that accepted IEnumerable<long>
- ensure the remaining presence payload uses string member identifiers

## Testing
- dotnet build -c Release *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebd6127f9c8328906355d0cd908b2d