### PR TITLE
Add SyncShell blob storage endpoints

### DIFF
--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
-import os
-from uuid import uuid4
-from typing import Any, Optional
-from datetime import datetime, timedelta, timezone
-from dataclasses import dataclass
+import hashlib
 import json
 import logging
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -29,6 +34,8 @@ logger = logging.getLogger(__name__)
 
 
 router = APIRouter(prefix="/api/syncshell", tags=["syncshell"])
+
+BLOB_ROOT = Path(os.getenv("SYNC_SHELL_BLOB_ROOT", "data/blobs")).resolve()
 
 RATE_LIMIT = int(os.getenv("SYNC_SHELL_MAX_REQUESTS_PER_MINUTE", "30"))
 TOKEN_TTL = int(os.getenv("SYNC_SHELL_TOKEN_TTL", "300"))  # seconds
@@ -995,3 +1002,225 @@ async def clear_cache(
     await _check_rate_limit(ctx.user.id, db)
     await _clear_manifest(ctx, db)
     return {"status": "ok"}
+def _validate_sha(value: str) -> str:
+    if not isinstance(value, str) or len(value) != 64:
+        raise HTTPException(status_code=400, detail="invalid sha256")
+    try:
+        int(value, 16)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid sha256") from exc
+    return value.lower()
+
+
+def _blob_path(sha256: str) -> Path:
+    shard_a = sha256[:2]
+    shard_b = sha256[2:4]
+    return BLOB_ROOT / shard_a / shard_b / sha256
+
+
+@router.put("/blobs", status_code=status.HTTP_201_CREATED)
+async def put_blob(
+    request: Request,
+    sha256: str,
+    ctx: RequestContext = Depends(api_key_auth),
+) -> Response:  # noqa: ARG001
+    sha256 = _validate_sha(sha256)
+    destination = _blob_path(sha256)
+    if destination.exists():
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=str(destination.parent), delete=False) as tmp_file:
+        temp_path = Path(tmp_file.name)
+        hasher = hashlib.sha256()
+        size = 0
+        try:
+            async for chunk in request.stream():
+                if not chunk:
+                    continue
+                tmp_file.write(chunk)
+                hasher.update(chunk)
+                size += len(chunk)
+        except Exception:
+            temp_path.unlink(missing_ok=True)
+            raise
+
+    digest = hasher.hexdigest()
+    if digest != sha256:
+        temp_path.unlink(missing_ok=True)
+        raise HTTPException(status_code=400, detail="sha256 mismatch")
+
+    if destination.exists():
+        temp_path.unlink(missing_ok=True)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    shutil.move(str(temp_path), str(destination))
+    os.chmod(destination, 0o600)
+    response = Response(status_code=status.HTTP_201_CREATED)
+    response.headers["Content-Length"] = str(size)
+    return response
+
+
+@router.head("/blobs")
+async def head_blob(
+    sha256: str,
+    ctx: RequestContext = Depends(api_key_auth),
+) -> Response:  # noqa: ARG001
+    sha256 = _validate_sha(sha256)
+    path = _blob_path(sha256)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="blob not found")
+
+    size = path.stat().st_size
+    response = Response(status_code=status.HTTP_200_OK)
+    response.headers["Content-Length"] = str(size)
+    return response
+
+
+@router.get("/blobs")
+async def get_blob(
+    request: Request,
+    sha256: str,
+    ctx: RequestContext = Depends(api_key_auth),
+):  # noqa: ARG001
+    sha256 = _validate_sha(sha256)
+    path = _blob_path(sha256)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="blob not found")
+
+    size = path.stat().st_size
+    range_header = request.headers.get("range")
+    if not range_header:
+        return FileResponse(path, media_type="application/octet-stream")
+
+    if not range_header.lower().startswith("bytes="):
+        raise HTTPException(status_code=416, detail="invalid range")
+
+    range_spec = range_header.split("=", 1)[1]
+    start_str, _, end_str = range_spec.partition("-")
+    try:
+        start = int(start_str) if start_str else 0
+        end = int(end_str) if end_str else size - 1
+    except ValueError as exc:
+        raise HTTPException(status_code=416, detail="invalid range") from exc
+
+    if start < 0 or end < start or start >= size:
+        headers = {"Content-Range": f"bytes */{size}"}
+        raise HTTPException(status_code=416, detail="invalid range", headers=headers)
+
+    end = min(end, size - 1)
+    length = end - start + 1
+    with path.open("rb") as handle:
+        handle.seek(start)
+        payload = handle.read(length)
+
+    headers = {
+        "Content-Range": f"bytes {start}-{end}/{size}",
+        "Content-Length": str(len(payload)),
+        "Accept-Ranges": "bytes",
+    }
+    return Response(
+        content=payload,
+        media_type="application/octet-stream",
+        status_code=status.HTTP_206_PARTIAL_CONTENT,
+        headers=headers,
+    )
+
+
+class BlobRefModel(BaseModel):
+    name: str
+    sha256: str
+    size: int = Field(ge=0)
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:  # noqa: D401
+        value = (value or "").strip()
+        if not value:
+            raise ValueError("name must be provided")
+        return value
+
+    @field_validator("sha256")
+    @classmethod
+    def _validate_sha_field(cls, value: str) -> str:  # noqa: D401
+        _validate_sha(value)
+        return value.lower()
+
+
+class AppearanceMetaModel(BaseModel):
+    actorHash: str
+    glamourer: Optional[str] = None
+    blobs: list[BlobRefModel] = Field(default_factory=list)
+
+    @field_validator("actorHash")
+    @classmethod
+    def _validate_actor_hash(cls, value: str) -> str:  # noqa: D401
+        value = (value or "").strip()
+        if not value:
+            raise ValueError("actor hash required")
+        return value
+
+
+class UserMetaModel(BaseModel):
+    discordId: str
+    appearance: AppearanceMetaModel
+
+    @field_validator("discordId")
+    @classmethod
+    def _validate_discord_id(cls, value: str) -> str:  # noqa: D401
+        value = (value or "").strip()
+        if not value:
+            raise ValueError("discord id required")
+        return value
+
+
+def _coerce_int(value: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="invalid discordId") from exc
+
+
+def _parse_appearance(payload: dict[str, Any]) -> AppearanceMetaModel:
+    appearance = payload.get("appearance")
+    if not isinstance(appearance, dict):
+        appearance = payload.get("appearanceMeta")
+    if not isinstance(appearance, dict):
+        raise HTTPException(status_code=404, detail="appearance unavailable")
+    try:
+        return AppearanceMetaModel.model_validate(appearance)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=404, detail="appearance unavailable") from exc
+
+
+@router.get("/meta", response_model=UserMetaModel)
+async def get_latest_meta(
+    discordId: str,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> UserMetaModel:
+    discord_id_value = (discordId or "").strip()
+    if not discord_id_value:
+        raise HTTPException(status_code=400, detail="discordId required")
+
+    discord_numeric = _coerce_int(discord_id_value)
+    stmt = select(User).where(User.discord_user_id == discord_numeric)
+    result = await db.execute(stmt)
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=404, detail="user not found")
+
+    record = await db.get(SyncshellManifest, user.id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="appearance unavailable")
+
+    try:
+        manifest_payload = json.loads(record.manifest_json)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "syncshell.meta.decode_failed user_id=%s", user.id, exc_info=exc
+        )
+        raise HTTPException(status_code=404, detail="appearance unavailable") from exc
+
+    appearance = _parse_appearance(manifest_payload)
+    return UserMetaModel(discordId=str(user.discord_user_id), appearance=appearance)

--- a/tests/test_syncshell_blob_api.py
+++ b/tests/test_syncshell_blob_api.py
@@ -1,0 +1,125 @@
+import asyncio
+import hashlib
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from demibot.db.models import Guild, Membership, SyncshellManifest, User, UserKey
+from demibot.db.session import get_session, init_db
+import demibot.db.session as db_session
+
+from .syncshell_import import syncshell
+
+
+async def _prepare_db() -> None:
+    db_session._engine = None
+    db_session._Session = None
+    await init_db("sqlite+aiosqlite://")
+
+    async with get_session() as db:
+        guild = Guild(id=1, discord_guild_id=1, name="Test Guild")
+        user = User(id=1, discord_user_id=1234, global_name="Tester")
+        key = UserKey(
+            id=1,
+            user_id=user.id,
+            guild_id=guild.id,
+            token="syncshell-token",
+            enabled=True,
+        )
+        membership = Membership(id=1, guild_id=guild.id, user_id=user.id)
+        db.add_all([guild, user, key, membership])
+        await db.commit()
+
+
+def _make_client(tmp_path, monkeypatch):
+    blob_root = tmp_path / "blobs"
+    monkeypatch.setattr(syncshell, "BLOB_ROOT", blob_root)
+    asyncio.run(_prepare_db())
+    app = FastAPI()
+    app.include_router(syncshell.router)
+    return TestClient(app)
+
+
+def test_blob_upload_head_get_and_range(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    payload = b"syncshell-test"
+    sha = hashlib.sha256(payload).hexdigest()
+    headers = {"X-Api-Key": "syncshell-token"}
+
+    response = client.put(
+        f"/api/syncshell/blobs?sha256={sha}", headers=headers, data=payload
+    )
+    assert response.status_code == 201
+    assert response.headers.get("Content-Length") == str(len(payload))
+
+    second = client.put(f"/api/syncshell/blobs?sha256={sha}", headers=headers, data=payload)
+    assert second.status_code == 204
+
+    head = client.head(f"/api/syncshell/blobs?sha256={sha}", headers=headers)
+    assert head.status_code == 200
+    assert head.headers.get("Content-Length") == str(len(payload))
+
+    whole = client.get(f"/api/syncshell/blobs?sha256={sha}", headers=headers)
+    assert whole.status_code == 200
+    assert whole.content == payload
+
+    ranged = client.get(
+        f"/api/syncshell/blobs?sha256={sha}",
+        headers={"X-Api-Key": "syncshell-token", "Range": "bytes=0-3"},
+    )
+    assert ranged.status_code == 206
+    assert ranged.headers.get("Content-Range") == f"bytes 0-3/{len(payload)}"
+    assert ranged.content == payload[:4]
+
+
+def test_blob_upload_mismatch_rejected(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    payload = b"syncshell"
+    sha = hashlib.sha256(b"other").hexdigest()
+
+    response = client.put(
+        f"/api/syncshell/blobs?sha256={sha}",
+        headers={"X-Api-Key": "syncshell-token"},
+        data=payload,
+    )
+    assert response.status_code == 400
+
+
+def test_meta_returns_latest_manifest(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    payload = {
+        "appearance": {
+            "actorHash": "actor-1",
+            "glamourer": "{\"foo\":1}",
+            "blobs": [
+                {
+                    "name": "mod/file",
+                    "sha256": hashlib.sha256(b"asset").hexdigest(),
+                    "size": 5,
+                }
+            ],
+        }
+    }
+
+    async def _store_manifest() -> None:
+        async with get_session() as db:
+            record = SyncshellManifest(
+                user_id=1,
+                manifest_json=json.dumps(payload),
+            )
+            db.add(record)
+            await db.commit()
+
+    asyncio.run(_store_manifest())
+
+    response = client.get(
+        "/api/syncshell/meta",
+        headers={"X-Api-Key": "syncshell-token"},
+        params={"discordId": "1234"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["discordId"] == "1234"
+    assert body["appearance"]["actorHash"] == "actor-1"
+    assert body["appearance"]["blobs"][0]["name"] == "mod/file"


### PR DESCRIPTION
## Summary
- implement filesystem-backed blob storage endpoints for SyncShell with validation, range support, and metadata lookup
- expose `/api/syncshell/meta` using stored manifests to return the latest published appearance
- cover the new REST APIs with integration tests using a lightweight FastAPI app

## Testing
- pytest tests/test_syncshell_blob_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ebd764439c83289c5f6bf68956c1a3