### PR TITLE
Implement SyncShell publish workflow and blob API updates

### DIFF
--- a/DemiCatPlugin/SyncShell/SyncShellClient.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -94,6 +95,22 @@ public sealed class SyncShellClient
         response.EnsureSuccessStatusCode();
     }
 
+    public async Task<bool> BlobExistsAsync(string sha256, CancellationToken cancellationToken)
+    {
+        var uri = BuildUri($"{BlobDownloadPath}?sha256={Uri.EscapeDataString(sha256)}");
+        using var request = new HttpRequestMessage(HttpMethod.Head, uri);
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return false;
+        }
+
+        response.EnsureSuccessStatusCode();
+        return true;
+    }
+
     private sealed class ResponseStream : Stream
     {
         private readonly HttpResponseMessage _response;
@@ -148,6 +165,36 @@ public sealed class SyncShellClient
 
         var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
+        var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        return new ResponseStream(response, stream);
+    }
+
+    public async Task<Stream> DownloadBlobRangeAsync(string sha256, long start, long end, CancellationToken cancellationToken)
+    {
+        if (start < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(start));
+        }
+
+        if (end < start)
+        {
+            throw new ArgumentOutOfRangeException(nameof(end));
+        }
+
+        var uri = BuildUri($"{BlobDownloadPath}?sha256={Uri.EscapeDataString(sha256)}");
+        using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+        ApiHelpers.AddAuthHeader(request, _tokenManager);
+        request.Headers.Range = new RangeHeaderValue(start, end);
+
+        var response = await _httpClient
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (response.StatusCode != HttpStatusCode.PartialContent && response.StatusCode != HttpStatusCode.OK)
+        {
+            response.EnsureSuccessStatusCode();
+        }
+
         var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         return new ResponseStream(response, stream);
     }

--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Plugin.Services;
@@ -28,6 +29,9 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     private readonly object _memberLock = new();
     private List<SyncshellMemberStatus> _members = new();
     private List<SyncshellMemberStatus> _activeMembers = new();
+    private readonly object _appearanceLock = new();
+    private readonly Dictionary<string, LocalBlobInfo> _localBlobs = new(StringComparer.OrdinalIgnoreCase);
+    private string? _glamourerJson;
 
     private CancellationTokenSource? _runCts;
     private Task? _presenceTask;
@@ -306,6 +310,33 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     public Task ResyncAllAsync(CancellationToken cancellationToken = default)
         => TriggerPublishAsync(cancellationToken);
 
+    internal void UpdateLocalAppearance(IEnumerable<LocalBlobInfo> blobs, string? glamourerJson)
+    {
+        lock (_appearanceLock)
+        {
+            _localBlobs.Clear();
+            if (blobs != null)
+            {
+                foreach (var blob in blobs)
+                {
+                    if (blob == null)
+                    {
+                        continue;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(blob.Sha256) || string.IsNullOrWhiteSpace(blob.FullPath))
+                    {
+                        continue;
+                    }
+
+                    _localBlobs[blob.Sha256] = blob;
+                }
+            }
+
+            _glamourerJson = string.IsNullOrWhiteSpace(glamourerJson) ? null : glamourerJson;
+        }
+    }
+
     public bool TryValidatePenumbraPath(string? path, out string? error)
     {
         if (string.IsNullOrWhiteSpace(path))
@@ -431,26 +462,158 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             return;
         }
 
+        PublishPayload payload;
+        Dictionary<string, LocalBlobInfo> localBlobs;
+        try
+        {
+            (payload, localBlobs) = BuildPublishPayload();
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to build SyncShell appearance payload");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(payload.DiscordId))
+        {
+            _log.Warning("SyncShell publish skipped due to missing Discord ID");
+            return;
+        }
+
+        var previousStatus = Status;
+        try
+        {
+            Status = "Publishing…";
+            var result = await _client.PublishAsync(payload, token).ConfigureAwait(false);
+            var missing = (result?.Missing ?? new List<string>())
+                .Where(hash => !string.IsNullOrWhiteSpace(hash))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (missing.Count > 0)
+            {
+                await UploadMissingBlobsAsync(missing, localBlobs, token).ConfigureAwait(false);
+                Status = "Publishing…";
+            }
+
+            payload.Complete = true;
+            await _client.PublishAsync(payload, token).ConfigureAwait(false);
+            Status = "Active";
+        }
+        catch (OperationCanceledException)
+        {
+            Status = previousStatus;
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to publish appearance");
+            Status = previousStatus;
+        }
+    }
+
+    private (PublishPayload Payload, Dictionary<string, LocalBlobInfo> LocalBlobs) BuildPublishPayload()
+    {
         var appearance = new AppearanceMeta
         {
             ActorHash = _clientState.LocalPlayer?.Name.TextValue ?? string.Empty,
-            GlamourerJson = null,
         };
+
+        Dictionary<string, LocalBlobInfo> localBlobs;
+        lock (_appearanceLock)
+        {
+            appearance.GlamourerJson = _glamourerJson;
+            localBlobs = _localBlobs.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        foreach (var blob in localBlobs.Values.OrderBy(b => b.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            appearance.Blobs.Add(new BlobRef
+            {
+                Name = blob.Name,
+                Sha256 = blob.Sha256,
+                Size = blob.Size,
+            });
+        }
 
         var payload = new PublishPayload
         {
             DiscordId = _tokenManager.Token ?? string.Empty,
             Appearance = appearance,
-            Complete = true,
+            Complete = false,
         };
 
-        try
+        return (payload, localBlobs);
+    }
+
+    private async Task UploadMissingBlobsAsync(
+        IReadOnlyList<string> missing,
+        IReadOnlyDictionary<string, LocalBlobInfo> localBlobs,
+        CancellationToken token)
+    {
+        if (missing.Count == 0)
         {
-            await _client.PublishAsync(payload, token).ConfigureAwait(false);
+            return;
         }
-        catch (Exception ex)
+
+        var remaining = missing.Count;
+        foreach (var hash in missing)
         {
-            _log.Warning(ex, "Failed to publish appearance");
+            token.ThrowIfCancellationRequested();
+            Status = $"Uploading {remaining} blob{(remaining == 1 ? string.Empty : "s")}…";
+            remaining--;
+
+            if (!localBlobs.TryGetValue(hash, out var blob))
+            {
+                _log.Warning("Missing local blob for hash {Hash}", hash);
+                continue;
+            }
+
+            if (!File.Exists(blob.FullPath))
+            {
+                _log.Warning("Local blob path not found: {Path}", blob.FullPath);
+                continue;
+            }
+
+            var shouldUpload = true;
+            try
+            {
+                shouldUpload = !await _client.BlobExistsAsync(hash, token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Failed to query blob {Hash} existence", hash);
+            }
+
+            if (!shouldUpload)
+            {
+                continue;
+            }
+
+            await using var stream = new FileStream(
+                blob.FullPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                64 * 1024,
+                useAsync: true);
+
+            try
+            {
+                await _client.UploadBlobAsync(hash, stream, token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Failed to upload blob {Hash}", hash);
+            }
         }
     }
 
@@ -605,6 +768,8 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         return null;
     }
+
+    internal sealed record LocalBlobInfo(string Name, string Sha256, long Size, string FullPath);
 
     public void Dispose()
     {

--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -36,6 +36,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/syncshell", tags=["syncshell"])
 
 BLOB_ROOT = Path(os.getenv("SYNC_SHELL_BLOB_ROOT", "data/blobs")).resolve()
+MAX_BLOB_SIZE_MIB = int(os.getenv("SYNC_SHELL_MAX_BLOB_SIZE_MIB", "0"))
+MAX_BLOB_SIZE_BYTES = MAX_BLOB_SIZE_MIB * 1024 * 1024 if MAX_BLOB_SIZE_MIB > 0 else 0
+CACHE_CONTROL_IMMUTABLE = "public, max-age=31536000, immutable"
 
 RATE_LIMIT = int(os.getenv("SYNC_SHELL_MAX_REQUESTS_PER_MINUTE", "30"))
 TOKEN_TTL = int(os.getenv("SYNC_SHELL_TOKEN_TTL", "300"))  # seconds
@@ -1023,7 +1026,10 @@ async def put_blob(
     request: Request,
     sha256: str,
     ctx: RequestContext = Depends(api_key_auth),
-) -> Response:  # noqa: ARG001
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
     sha256 = _validate_sha(sha256)
     destination = _blob_path(sha256)
     if destination.exists():
@@ -1041,6 +1047,9 @@ async def put_blob(
                 tmp_file.write(chunk)
                 hasher.update(chunk)
                 size += len(chunk)
+                if MAX_BLOB_SIZE_BYTES and size > MAX_BLOB_SIZE_BYTES:
+                    temp_path.unlink(missing_ok=True)
+                    raise HTTPException(status_code=413, detail="blob too large")
         except Exception:
             temp_path.unlink(missing_ok=True)
             raise
@@ -1058,6 +1067,7 @@ async def put_blob(
     os.chmod(destination, 0o600)
     response = Response(status_code=status.HTTP_201_CREATED)
     response.headers["Content-Length"] = str(size)
+    response.headers["Cache-Control"] = CACHE_CONTROL_IMMUTABLE
     return response
 
 
@@ -1065,7 +1075,10 @@ async def put_blob(
 async def head_blob(
     sha256: str,
     ctx: RequestContext = Depends(api_key_auth),
-) -> Response:  # noqa: ARG001
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
     sha256 = _validate_sha(sha256)
     path = _blob_path(sha256)
     if not path.exists():
@@ -1074,6 +1087,8 @@ async def head_blob(
     size = path.stat().st_size
     response = Response(status_code=status.HTTP_200_OK)
     response.headers["Content-Length"] = str(size)
+    response.headers["Cache-Control"] = CACHE_CONTROL_IMMUTABLE
+    response.headers["Accept-Ranges"] = "bytes"
     return response
 
 
@@ -1082,7 +1097,10 @@ async def get_blob(
     request: Request,
     sha256: str,
     ctx: RequestContext = Depends(api_key_auth),
-):  # noqa: ARG001
+    db: AsyncSession = Depends(get_db),
+):
+    await _require_pairing(ctx, db)
+    await _check_rate_limit(ctx.user.id, db)
     sha256 = _validate_sha(sha256)
     path = _blob_path(sha256)
     if not path.exists():
@@ -1091,7 +1109,14 @@ async def get_blob(
     size = path.stat().st_size
     range_header = request.headers.get("range")
     if not range_header:
-        return FileResponse(path, media_type="application/octet-stream")
+        return FileResponse(
+            path,
+            media_type="application/octet-stream",
+            headers={
+                "Cache-Control": CACHE_CONTROL_IMMUTABLE,
+                "Accept-Ranges": "bytes",
+            },
+        )
 
     if not range_header.lower().startswith("bytes="):
         raise HTTPException(status_code=416, detail="invalid range")
@@ -1118,6 +1143,7 @@ async def get_blob(
         "Content-Range": f"bytes {start}-{end}/{size}",
         "Content-Length": str(len(payload)),
         "Accept-Ranges": "bytes",
+        "Cache-Control": CACHE_CONTROL_IMMUTABLE,
     }
     return Response(
         content=payload,
@@ -1174,6 +1200,20 @@ class UserMetaModel(BaseModel):
         return value
 
 
+class PublishPayload(BaseModel):
+    discordId: str
+    appearance: AppearanceMetaModel
+    complete: bool = False
+
+    @field_validator("discordId")
+    @classmethod
+    def _validate_publish_discord_id(cls, value: str) -> str:  # noqa: D401
+        value = (value or "").strip()
+        if not value:
+            raise ValueError("discord id required")
+        return value
+
+
 def _coerce_int(value: str) -> int:
     try:
         return int(value)
@@ -1191,6 +1231,50 @@ def _parse_appearance(payload: dict[str, Any]) -> AppearanceMetaModel:
         return AppearanceMetaModel.model_validate(appearance)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=404, detail="appearance unavailable") from exc
+
+
+async def handle_publish_manifest(
+    payload: dict[str, Any],
+    ctx: RequestContext,
+    db: AsyncSession,
+) -> dict[str, Any]:
+    await _require_pairing(ctx, db)
+    payload_size = len(json.dumps(payload).encode())
+    if payload_size > MAX_MANIFEST_BYTES:
+        raise HTTPException(status_code=413, detail="manifest too large")
+    publish = PublishPayload.model_validate(payload)
+    await _check_rate_limit(ctx.user.id, db)
+
+    missing: set[str] = set()
+    for blob in publish.appearance.blobs:
+        if not blob.sha256:
+            continue
+        path = _blob_path(blob.sha256)
+        if not path.exists():
+            missing.add(blob.sha256)
+
+    missing_list = sorted(missing)
+
+    if publish.complete:
+        if missing_list:
+            raise HTTPException(status_code=409, detail="missing blobs")
+
+        manifest_payload = {
+            "discordId": str(ctx.user.discord_user_id or ctx.user.id),
+            "appearance": publish.appearance.model_dump(mode="json"),
+        }
+
+        payload_json = json.dumps(manifest_payload)
+        record = await db.get(SyncshellManifest, ctx.user.id)
+        if record:
+            record.manifest_json = payload_json
+            record.updated_at = datetime.utcnow()
+        else:
+            record = SyncshellManifest(user_id=ctx.user.id, manifest_json=payload_json)
+            db.add(record)
+        await db.commit()
+
+    return {"missing": missing_list}
 
 
 @router.get("/meta", response_model=UserMetaModel)

--- a/tests/SyncshellPublishFlowTests.cs
+++ b/tests/SyncshellPublishFlowTests.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dalamud.Game.ClientState;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
+using DemiCatPlugin;
+using DemiCatPlugin.SyncShell;
+using Moq;
+using Xunit;
+
+public class SyncshellPublishFlowTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly object _tokenLock = new();
+    private readonly System.Reflection.FieldInfo _tokenField;
+    private readonly TokenManager? _previousToken;
+
+    public SyncshellPublishFlowTests()
+    {
+        _tempRoot = Directory.CreateTempSubdirectory().FullName;
+        _tokenField = typeof(TokenManager).GetField("<Instance>k__BackingField", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!;
+        _previousToken = (TokenManager?)_tokenField.GetValue(null);
+        var tokenManager = new TokenManager();
+        _tokenField.SetValue(null, tokenManager);
+    }
+
+    [Fact]
+    public async Task TriggerPublishUploadsMissingBlobsAndFinalizes()
+    {
+        var services = new PluginServices();
+        var logMock = new Mock<IPluginLog>();
+        var pluginInterfaceMock = CreatePluginInterfaceMock();
+        typeof(PluginServices).GetProperty("PluginInterface", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(services, pluginInterfaceMock.Object);
+        typeof(PluginServices).GetProperty("Log", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(services, logMock.Object);
+
+        using var handler = new RecordingHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+
+        var config = new Config
+        {
+            EnableSyncShell = true,
+            ApiBaseUrl = "http://localhost"
+        };
+
+        using var blobStore = new BlobStore(pluginInterfaceMock.Object);
+        var penumbra = new PenumbraIpc(pluginInterfaceMock.Object, logMock.Object);
+        var clientStateMock = new Mock<IClientState>();
+        var frameworkMock = new Mock<IFramework>();
+        var service = new SyncShellService(
+            config,
+            TokenManager.Instance!,
+            new SyncShellClient(httpClient, config, TokenManager.Instance!),
+            blobStore,
+            penumbra,
+            logMock.Object,
+            clientStateMock.Object,
+            frameworkMock.Object);
+
+        try
+        {
+            await service.Start();
+
+            var statuses = new List<string>();
+            service.StatusChanged += (_, _) => statuses.Add(service.Status);
+
+            var payload = Encoding.UTF8.GetBytes("syncshell-test");
+            var localPath = Path.Combine(_tempRoot, "blob.bin");
+            await File.WriteAllBytesAsync(localPath, payload);
+            var sha = Hasher.Sha256Bytes(payload);
+
+            service.UpdateLocalAppearance(
+                new[] { new SyncShellService.LocalBlobInfo("blob.bin", sha, payload.Length, localPath) },
+                glamourerJson: null);
+
+            await service.TriggerPublishAsync();
+            await Task.Delay(50);
+
+            Assert.Contains(statuses, status => status == "Publishing…");
+            Assert.Contains(statuses, status => status.StartsWith("Uploading 1 blob", StringComparison.Ordinal));
+            Assert.Equal("Active", service.Status);
+
+            Assert.Contains(handler.Requests, r => r.Method == HttpMethod.Head && r.Path == "/api/syncshell/blobs");
+            Assert.Contains(handler.Requests, r => r.Method == HttpMethod.Put && r.Path == "/api/syncshell/blobs");
+            Assert.Equal(1, handler.CompleteCalls);
+            Assert.True(handler.StoredBlobs.Contains(sha));
+        }
+        finally
+        {
+            await service.Stop();
+            service.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task TriggerPublishSkipsUploadWhenBlobExists()
+    {
+        var services = new PluginServices();
+        var logMock = new Mock<IPluginLog>();
+        var pluginInterfaceMock = CreatePluginInterfaceMock();
+        typeof(PluginServices).GetProperty("PluginInterface", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(services, pluginInterfaceMock.Object);
+        typeof(PluginServices).GetProperty("Log", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(services, logMock.Object);
+
+        var existingPayload = Encoding.UTF8.GetBytes("existing-blob");
+        var sha = Hasher.Sha256Bytes(existingPayload);
+
+        using var handler = new RecordingHandler(new Dictionary<string, byte[]>
+        {
+            [sha] = existingPayload
+        });
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost")
+        };
+
+        var config = new Config
+        {
+            EnableSyncShell = true,
+            ApiBaseUrl = "http://localhost"
+        };
+
+        using var blobStore = new BlobStore(pluginInterfaceMock.Object);
+        var penumbra = new PenumbraIpc(pluginInterfaceMock.Object, logMock.Object);
+        var clientStateMock = new Mock<IClientState>();
+        var frameworkMock = new Mock<IFramework>();
+        var service = new SyncShellService(
+            config,
+            TokenManager.Instance!,
+            new SyncShellClient(httpClient, config, TokenManager.Instance!),
+            blobStore,
+            penumbra,
+            logMock.Object,
+            clientStateMock.Object,
+            frameworkMock.Object);
+
+        try
+        {
+            await service.Start();
+
+            var localPath = Path.Combine(_tempRoot, "existing.bin");
+            await File.WriteAllBytesAsync(localPath, existingPayload);
+
+            service.UpdateLocalAppearance(
+                new[] { new SyncShellService.LocalBlobInfo("existing.bin", sha, existingPayload.Length, localPath) },
+                glamourerJson: null);
+
+            await service.TriggerPublishAsync();
+            await Task.Delay(50);
+
+            Assert.Equal("Active", service.Status);
+            Assert.DoesNotContain(handler.Requests, r => r.Method == HttpMethod.Put && r.Path == "/api/syncshell/blobs");
+            Assert.Equal(1, handler.CompleteCalls);
+        }
+        finally
+        {
+            await service.Stop();
+            service.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_tokenLock)
+        {
+            _tokenField.SetValue(null, _previousToken);
+        }
+
+        try
+        {
+            Directory.Delete(_tempRoot, true);
+        }
+        catch
+        {
+        }
+    }
+
+    private Mock<IDalamudPluginInterface> CreatePluginInterfaceMock()
+    {
+        var mock = new Mock<IDalamudPluginInterface>();
+        mock.Setup(i => i.GetPluginConfigDirectory()).Returns(_tempRoot);
+        mock.Setup(i => i.GetIpcSubscriber<bool>(It.IsAny<string>())).Throws(new InvalidOperationException());
+        mock.Setup(i => i.GetIpcSubscriber<string>(It.IsAny<string>())).Throws(new InvalidOperationException());
+        mock.Setup(i => i.GetIpcSubscriber<string, object?>(It.IsAny<string>())).Throws(new InvalidOperationException());
+        mock.Setup(i => i.GetIpcSubscriber<(int, int), object?>(It.IsAny<string>())).Throws(new InvalidOperationException());
+        return mock;
+    }
+
+    private sealed record RecordedRequest(HttpMethod Method, string Path, string? Query);
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly object _gate = new();
+        private readonly Dictionary<string, byte[]> _initialBlobs;
+
+        public RecordingHandler()
+            : this(new Dictionary<string, byte[]>())
+        {
+        }
+
+        public RecordingHandler(Dictionary<string, byte[]> initialBlobs)
+        {
+            _initialBlobs = initialBlobs;
+            foreach (var pair in initialBlobs)
+            {
+                StoredBlobs.Add(pair.Key);
+                BlobContents[pair.Key] = pair.Value;
+            }
+        }
+
+        public List<RecordedRequest> Requests { get; } = new();
+        public HashSet<string> StoredBlobs { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, byte[]> BlobContents { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public int CompleteCalls { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            lock (_gate)
+            {
+                Requests.Add(new RecordedRequest(request.Method, path, request.RequestUri.Query));
+            }
+
+            if (request.Method == HttpMethod.Head && path == "/api/ping")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            if (request.Method == HttpMethod.Get && path == "/api/syncshell/memberships")
+            {
+                var payload = JsonSerializer.Serialize(new
+                {
+                    members = Array.Empty<object>(),
+                    currentlySynced = Array.Empty<object>(),
+                    pendingApprovals = Array.Empty<object>(),
+                    invites = Array.Empty<object>()
+                });
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
+                };
+            }
+
+            if (request.Method == HttpMethod.Post && path == "/api/syncshell/presence")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            if (path == "/api/syncshell/blobs" && request.Method == HttpMethod.Head)
+            {
+                var sha = GetSha(request.RequestUri);
+                if (sha != null && StoredBlobs.Contains(sha))
+                {
+                    var response = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(Array.Empty<byte>())
+                    };
+                    response.Content.Headers.ContentLength = BlobContents.TryGetValue(sha, out var bytes) ? bytes.LongLength : 0;
+                    return response;
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            if (path == "/api/syncshell/blobs" && request.Method == HttpMethod.Put)
+            {
+                var sha = GetSha(request.RequestUri);
+                var bytes = await request.Content!.ReadAsByteArrayAsync(cancellationToken);
+                var digest = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+                if (!string.Equals(sha, digest, StringComparison.OrdinalIgnoreCase))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.BadRequest);
+                }
+
+                StoredBlobs.Add(digest);
+                BlobContents[digest] = bytes;
+                return new HttpResponseMessage(HttpStatusCode.Created);
+            }
+
+            if (path == "/api/syncshell/manifest" && request.Method == HttpMethod.Post)
+            {
+                var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+                using var document = JsonDocument.Parse(body);
+                var root = document.RootElement;
+                var complete = root.TryGetProperty("complete", out var completeProp) && completeProp.GetBoolean();
+                var blobs = root.GetProperty("appearance").GetProperty("blobs");
+
+                var missing = new List<string>();
+                foreach (var item in blobs.EnumerateArray())
+                {
+                    var hash = item.GetProperty("sha256").GetString();
+                    if (string.IsNullOrWhiteSpace(hash))
+                    {
+                        continue;
+                    }
+
+                    if (!StoredBlobs.Contains(hash))
+                    {
+                        missing.Add(hash);
+                    }
+                }
+
+                if (complete)
+                {
+                    CompleteCalls++;
+                }
+
+                var responsePayload = JsonSerializer.Serialize(new { missing });
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responsePayload, Encoding.UTF8, "application/json")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        private static string? GetSha(Uri uri)
+        {
+            var query = uri.Query.TrimStart('?');
+            foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var kv = part.Split('=', 2);
+                if (kv.Length == 2 && kv[0] == "sha256")
+                {
+                    return Uri.UnescapeDataString(kv[1]);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/tests/syncshell_test_utils.py
+++ b/tests/syncshell_test_utils.py
@@ -94,3 +94,29 @@ def build_manifest_payload(base: Path) -> Tuple[dict, str]:
     # Normalise through JSON to avoid non-serialisable objects leaking into tests.
     normalised = json.loads(json.dumps(manifest))
     return normalised, file_hash
+
+
+def build_publish_payload(base: Path, *, discord_id: str = "1234") -> tuple[dict, Path, str]:
+    file_path = base / "appearance.bin"
+    content = b"syncshell-publish"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_bytes(content)
+    file_hash = hashlib.sha256(content).hexdigest()
+
+    payload = {
+        "discordId": discord_id,
+        "appearance": {
+            "actorHash": "actor-1",
+            "glamourer": "{\"foo\":1}",
+            "blobs": [
+                {
+                    "name": file_path.name,
+                    "sha256": file_hash,
+                    "size": len(content),
+                }
+            ],
+        },
+        "complete": False,
+    }
+
+    return payload, file_path, file_hash

--- a/tests/test_syncshell.py
+++ b/tests/test_syncshell.py
@@ -1,5 +1,6 @@
 import asyncio
-import logging
+import hashlib
+import json
 
 import pytest
 
@@ -9,7 +10,7 @@ from demibot.db.models import User, SyncshellPairing, SyncshellManifest
 from demibot.http.deps import RequestContext
 
 from .syncshell_import import syncshell
-from .syncshell_test_utils import build_manifest_payload
+from .syncshell_test_utils import build_publish_payload
 
 
 async def _prepare_db():
@@ -35,17 +36,31 @@ def test_pair_token_persistence_and_expiry(tmp_path):
             pairing = await db.get(SyncshellPairing, user.id)
             assert pairing and pairing.token == token
 
-            manifest, _ = build_manifest_payload(tmp_path)
-            syncshell._transfer_budgets.clear()
-            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
-            assert response["status"] == "ok"
-            assert response["diff"]["need"]
-            assert response["diff"]["remove"] == []
-            assert response["limits"]["budget"]["limitBytes"] > 0
+            payload, file_path, sha = build_publish_payload(
+                tmp_path, discord_id=str(user.discord_user_id)
+            )
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+            initial = await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
+            assert initial["missing"] == [sha]
+
+            blob_path = syncshell._blob_path(sha)
+            blob_path.parent.mkdir(parents=True, exist_ok=True)
+            blob_path.write_bytes(file_path.read_bytes())
+
+            payload["complete"] = True
+            complete = await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
+            assert complete["missing"] == []
+
+            record = await db.get(SyncshellManifest, user.id)
+            assert record is not None
+            stored = json.loads(record.manifest_json)
+            stored_blob = stored["appearance"]["blobs"][0]
+            assert stored_blob["sha256"] == sha
 
             await asyncio.sleep(1.1)
+            payload["complete"] = False
             with pytest.raises(syncshell.HTTPException) as exc:
-                await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+                await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
             assert exc.value.status_code == 401
     asyncio.run(_run())
 
@@ -62,12 +77,15 @@ def test_manifest_rate_limit(tmp_path):
             syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
             syncshell.RATE_LIMIT = 2
             await syncshell.pair(ctx=ctx, db=db)
-            manifest, _ = build_manifest_payload(tmp_path)
+            payload, _, _ = build_publish_payload(
+                tmp_path, discord_id=str(user.discord_user_id)
+            )
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
             syncshell._transfer_budgets.clear()
-            first = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
-            assert first["diff"]["need"]
+            first = await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
+            assert first["missing"]
             with pytest.raises(syncshell.HTTPException) as exc:
-                await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+                await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
             assert exc.value.status_code == 429
     asyncio.run(_run())
 
@@ -83,15 +101,17 @@ def test_manifest_too_large(tmp_path):
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
             syncshell.MAX_MANIFEST_BYTES = 10
             await syncshell.pair(ctx=ctx, db=db)
-            big_manifest, _ = build_manifest_payload(tmp_path)
-            big_manifest.setdefault("meta", []).append({"key": "x", "value": "y" * 50})
+            payload, _, _ = build_publish_payload(
+                tmp_path, discord_id=str(user.discord_user_id)
+            )
+            payload["appearance"]["glamourer"] = "x" * 100
             with pytest.raises(syncshell.HTTPException) as exc:
-                await syncshell.upload_manifest(big_manifest, ctx=ctx, db=db)
+                await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
             assert exc.value.status_code == 413
     asyncio.run(_run())
 
 
-def test_manifest_corrupt_previous_logs_warning(tmp_path, caplog):
+def test_publish_overwrites_corrupted_manifest(tmp_path):
     async def _run():
         session_factory = await _prepare_db()
         async with session_factory as db:
@@ -100,8 +120,6 @@ def test_manifest_corrupt_previous_logs_warning(tmp_path, caplog):
             await db.commit()
 
             ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
-            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
-            syncshell.RATE_LIMIT = 5
 
             await syncshell.pair(ctx=ctx, db=db)
 
@@ -109,15 +127,20 @@ def test_manifest_corrupt_previous_logs_warning(tmp_path, caplog):
             db.add(corrupted)
             await db.commit()
 
-            manifest, _ = build_manifest_payload(tmp_path)
-            syncshell._transfer_budgets.clear()
+            payload, file_path, sha = build_publish_payload(
+                tmp_path, discord_id=str(user.discord_user_id)
+            )
+            blob_path = syncshell._blob_path(sha)
+            blob_path.parent.mkdir(parents=True, exist_ok=True)
+            blob_path.write_bytes(file_path.read_bytes())
 
-            caplog.set_level(logging.WARNING, logger="demibot.http.routes.syncshell")
-            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
-            assert response["status"] == "ok"
+            payload["complete"] = True
+            result = await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
+            assert result["missing"] == []
+
+            updated = await db.get(SyncshellManifest, user.id)
+            assert updated is not None
+            stored = json.loads(updated.manifest_json)
+            assert stored["appearance"]["blobs"][0]["sha256"] == sha
 
     asyncio.run(_run())
-    assert any(
-        "syncshell.manifest.previous.decode_failed" in record.getMessage()
-        for record in caplog.records
-    )

--- a/tests/test_syncshell_blob_api.py
+++ b/tests/test_syncshell_blob_api.py
@@ -2,6 +2,10 @@ import asyncio
 import hashlib
 import json
 
+import asyncio
+import hashlib
+import json
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -10,6 +14,7 @@ from demibot.db.session import get_session, init_db
 import demibot.db.session as db_session
 
 from .syncshell_import import syncshell
+from .syncshell_test_utils import build_publish_payload
 
 
 async def _prepare_db() -> None:
@@ -47,6 +52,8 @@ def test_blob_upload_head_get_and_range(tmp_path, monkeypatch):
     sha = hashlib.sha256(payload).hexdigest()
     headers = {"X-Api-Key": "syncshell-token"}
 
+    assert client.post("/api/syncshell/pair", headers=headers).status_code == 200
+
     response = client.put(
         f"/api/syncshell/blobs?sha256={sha}", headers=headers, data=payload
     )
@@ -59,10 +66,14 @@ def test_blob_upload_head_get_and_range(tmp_path, monkeypatch):
     head = client.head(f"/api/syncshell/blobs?sha256={sha}", headers=headers)
     assert head.status_code == 200
     assert head.headers.get("Content-Length") == str(len(payload))
+    assert head.headers.get("Cache-Control") == "public, max-age=31536000, immutable"
+    assert head.headers.get("Accept-Ranges") == "bytes"
 
     whole = client.get(f"/api/syncshell/blobs?sha256={sha}", headers=headers)
     assert whole.status_code == 200
     assert whole.content == payload
+    assert whole.headers.get("Cache-Control") == "public, max-age=31536000, immutable"
+    assert whole.headers.get("Accept-Ranges") == "bytes"
 
     ranged = client.get(
         f"/api/syncshell/blobs?sha256={sha}",
@@ -71,6 +82,24 @@ def test_blob_upload_head_get_and_range(tmp_path, monkeypatch):
     assert ranged.status_code == 206
     assert ranged.headers.get("Content-Range") == f"bytes 0-3/{len(payload)}"
     assert ranged.content == payload[:4]
+    assert ranged.headers.get("Cache-Control") == "public, max-age=31536000, immutable"
+    assert ranged.headers.get("Accept-Ranges") == "bytes"
+
+
+def test_blob_upload_respects_size_limit(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    payload = b"syncshell-test"
+    sha = hashlib.sha256(payload).hexdigest()
+    headers = {"X-Api-Key": "syncshell-token"}
+
+    assert client.post("/api/syncshell/pair", headers=headers).status_code == 200
+
+    syncshell.MAX_BLOB_SIZE_BYTES = len(payload) - 1
+    response = client.put(
+        f"/api/syncshell/blobs?sha256={sha}", headers=headers, data=payload
+    )
+    assert response.status_code == 413
+    syncshell.MAX_BLOB_SIZE_BYTES = 0
 
 
 def test_blob_upload_mismatch_rejected(tmp_path, monkeypatch):
@@ -123,3 +152,52 @@ def test_meta_returns_latest_manifest(tmp_path, monkeypatch):
     assert body["discordId"] == "1234"
     assert body["appearance"]["actorHash"] == "actor-1"
     assert body["appearance"]["blobs"][0]["name"] == "mod/file"
+
+
+def test_publish_manifest_roundtrip(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    publish_payload, file_path, sha = build_publish_payload(tmp_path)
+    headers = {"X-Api-Key": "syncshell-token"}
+
+    assert client.post("/api/syncshell/pair", headers=headers).status_code == 200
+
+    initial = client.post(
+        "/api/syncshell/manifest", headers=headers, json=publish_payload
+    )
+    assert initial.status_code == 200
+    assert initial.json()["missing"] == [sha]
+
+    blob_bytes = file_path.read_bytes()
+    upload = client.put(
+        f"/api/syncshell/blobs?sha256={sha}", headers=headers, data=blob_bytes
+    )
+    assert upload.status_code in {201, 204}
+
+    publish_payload["complete"] = True
+    complete = client.post(
+        "/api/syncshell/manifest", headers=headers, json=publish_payload
+    )
+    assert complete.status_code == 200
+    assert complete.json()["missing"] == []
+
+    async def _verify_manifest() -> None:
+        async with get_session() as db:
+            record = await db.get(SyncshellManifest, 1)
+            assert record is not None
+            stored = json.loads(record.manifest_json)
+            stored_blob = stored["appearance"]["blobs"][0]
+            assert stored_blob["sha256"] == sha
+
+    asyncio.run(_verify_manifest())
+
+
+def test_publish_manifest_rejects_missing_on_complete(tmp_path, monkeypatch):
+    client = _make_client(tmp_path, monkeypatch)
+    payload, _, _ = build_publish_payload(tmp_path)
+    payload["complete"] = True
+    headers = {"X-Api-Key": "syncshell-token"}
+    assert client.post("/api/syncshell/pair", headers=headers).status_code == 200
+    response = client.post(
+        "/api/syncshell/manifest", headers=headers, json=payload
+    )
+    assert response.status_code == 409

--- a/tests/test_syncshell_blob_store.py
+++ b/tests/test_syncshell_blob_store.py
@@ -7,7 +7,7 @@ from demibot.db.models import User, SyncshellManifest
 from demibot.http.deps import RequestContext
 
 from .syncshell_import import syncshell
-from .syncshell_test_utils import build_manifest_payload
+from .syncshell_test_utils import build_publish_payload
 
 
 def test_manifest_blob_hashes_persist(tmp_path):
@@ -25,30 +25,46 @@ def test_manifest_blob_hashes_persist(tmp_path):
             syncshell.RATE_LIMIT = 5
             await syncshell.pair(ctx=ctx, db=db)
 
-            manifest, blob_hash = build_manifest_payload(tmp_path)
+            payload, file_path, blob_hash = build_publish_payload(
+                tmp_path, discord_id=str(user.discord_user_id)
+            )
             syncshell._transfer_budgets.clear()
-            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
-            need_hashes = {entry["hash"] for entry in response["diff"]["need"]}
-            assert blob_hash in need_hashes
+            response = await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
+            assert response["missing"] == [blob_hash]
+
+            blob_path = syncshell._blob_path(blob_hash)
+            blob_path.parent.mkdir(parents=True, exist_ok=True)
+            blob_path.write_bytes(file_path.read_bytes())
+
+            payload["complete"] = True
+            complete = await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
+            assert complete["missing"] == []
             record = await db.get(SyncshellManifest, user.id)
             assert record is not None
             stored = json.loads(record.manifest_json)
-            stored_file = stored["collections"][0]["mods"][0]["files"][0]
-            assert stored_file["hash"] == blob_hash
-            assert stored["wantBlobs"]["blobs"] == [blob_hash]
+            assert stored["appearance"]["blobs"][0]["sha256"] == blob_hash
 
-            # Updating the manifest replaces the stored payload.
-            newer_manifest, newer_hash = build_manifest_payload(tmp_path / "second")
-            response = await syncshell.upload_manifest(newer_manifest, ctx=ctx, db=db)
-            diff = response["diff"]
-            need_hashes = {entry["hash"] for entry in diff["need"]}
-            remove_hashes = {entry["hash"] for entry in diff["remove"]}
-            assert newer_hash in need_hashes
-            assert blob_hash in remove_hashes
-            assert diff["conflicts"]
+            newer_payload, newer_path, newer_hash = build_publish_payload(
+                tmp_path / "second", discord_id=str(user.discord_user_id)
+            )
+            newer_response = await syncshell.handle_publish_manifest(
+                newer_payload, ctx=ctx, db=db
+            )
+            assert newer_response["missing"] == [newer_hash]
+
+            newer_blob_path = syncshell._blob_path(newer_hash)
+            newer_blob_path.parent.mkdir(parents=True, exist_ok=True)
+            newer_blob_path.write_bytes(newer_path.read_bytes())
+
+            newer_payload["complete"] = True
+            newer_complete = await syncshell.handle_publish_manifest(
+                newer_payload, ctx=ctx, db=db
+            )
+            assert newer_complete["missing"] == []
+
             updated = await db.get(SyncshellManifest, user.id)
             assert updated is not None
             updated_payload = json.loads(updated.manifest_json)
-            assert updated_payload["collections"][0]["mods"][0]["files"][0]["hash"] == newer_hash
-            assert updated_payload["wantBlobs"]["blobs"] == [newer_hash]
+            stored_blob = updated_payload["appearance"]["blobs"][0]
+            assert stored_blob["sha256"] == newer_hash
     asyncio.run(_run())

--- a/tests/test_syncshell_limits.py
+++ b/tests/test_syncshell_limits.py
@@ -8,7 +8,7 @@ from demibot.db.models import User
 from demibot.http.deps import RequestContext
 
 from .syncshell_import import syncshell
-from .syncshell_test_utils import build_manifest_payload
+from .syncshell_test_utils import build_publish_payload
 
 
 def test_token_expiry(tmp_path):
@@ -25,13 +25,25 @@ def test_token_expiry(tmp_path):
             syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
             syncshell.TOKEN_TTL = 1
             await syncshell.pair(ctx=ctx, db=db)
-            manifest, _ = build_manifest_payload(tmp_path)
+            payload, file_path, sha = build_publish_payload(
+                tmp_path, discord_id=str(user.discord_user_id)
+            )
             syncshell._transfer_budgets.clear()
-            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
-            assert response["diff"]["need"]
+            response = await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
+            assert response["missing"] == [sha]
+
+            blob_path = syncshell._blob_path(sha)
+            blob_path.parent.mkdir(parents=True, exist_ok=True)
+            blob_path.write_bytes(file_path.read_bytes())
+
+            payload["complete"] = True
+            complete = await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
+            assert complete["missing"] == []
+
             await asyncio.sleep(1.1)
+            payload["complete"] = False
             with pytest.raises(syncshell.HTTPException):
-                await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
+                await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
     asyncio.run(_run())
 
 
@@ -49,11 +61,12 @@ def test_rate_limit_hits(tmp_path):
             syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
             syncshell.RATE_LIMIT = 2
             await syncshell.pair(ctx=ctx, db=db)
-            manifest, _ = build_manifest_payload(tmp_path)
+            payload, _, _ = build_publish_payload(
+                tmp_path, discord_id=str(user.discord_user_id)
+            )
             syncshell._transfer_budgets.clear()
-            response = await syncshell.upload_manifest(manifest, ctx=ctx, db=db)
-            assert response["diff"]["need"]
-            assert response["limits"]["budget"]["windowEndsAt"].endswith("Z")
+            response = await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
+            assert response["missing"]
             with pytest.raises(syncshell.HTTPException):
-                await syncshell.resync(ctx=ctx, db=db)
+                await syncshell.handle_publish_manifest(payload, ctx=ctx, db=db)
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add blob existence checks and range download support to the SyncShell client
- implement the full publish workflow in SyncShellService, including status updates and local blob tracking
- harden the SyncShell HTTP endpoints with size limits, cache headers, and a publish handler that stores manifests
- extend the shared test utilities and add coverage for the new client/server behaviour

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj --filter SyncshellPublishFlowTests *(fails: dotnet CLI unavailable in container)*
- pytest tests/test_syncshell_blob_api.py tests/test_syncshell.py tests/test_syncshell_blob_store.py tests/test_syncshell_limits.py *(fails: fastapi/sqlalchemy not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebe2a678bc8328828ea60bfe00e4da