### PR TITLE
Use /api/presences endpoint for presence refresh

### DIFF
--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -215,7 +215,7 @@ public class DiscordPresenceService : IDisposable
 
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/presences");
             ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             using var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
             if (response.StatusCode == (HttpStatusCode)429)

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -238,7 +238,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         if (!ApiHelpers.ValidateApiBaseUrl(_config)) return;
         try
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/users");
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{_config.ApiBaseUrl.TrimEnd('/')}/api/presences");
             ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode) return;

--- a/tests/DiscordPresenceServiceTests.cs
+++ b/tests/DiscordPresenceServiceTests.cs
@@ -24,7 +24,7 @@ public class DiscordPresenceServiceTests
             }
 
             if (request.Method == HttpMethod.Get && request.RequestUri != null &&
-                request.RequestUri.AbsolutePath.EndsWith("/api/users", StringComparison.OrdinalIgnoreCase))
+                request.RequestUri.AbsolutePath.EndsWith("/api/presences", StringComparison.OrdinalIgnoreCase))
             {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {

--- a/tests/PresenceServiceLifecycleTests.cs
+++ b/tests/PresenceServiceLifecycleTests.cs
@@ -114,7 +114,7 @@ public class PresenceServiceLifecycleTests : IDisposable
             }
 
             if (request.Method == HttpMethod.Get && request.RequestUri != null &&
-                request.RequestUri.AbsolutePath.EndsWith("/api/users", StringComparison.OrdinalIgnoreCase))
+                request.RequestUri.AbsolutePath.EndsWith("/api/presences", StringComparison.OrdinalIgnoreCase))
             {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {


### PR DESCRIPTION
## Summary
- fetch presence data from the dedicated /api/presences endpoint for the UI renderer and presence service
- update unit test stubs to expect the new endpoint

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebe755cf5c83289394e3f8d38d1b35