### PR TITLE
Wire publish manifest route

### DIFF
--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -1200,6 +1200,15 @@ class UserMetaModel(BaseModel):
         return value
 
 
+@router.post("/manifest")
+async def publish_manifest(
+    payload: dict[str, Any],
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    return await handle_publish_manifest(payload, ctx, db)
+
+
 class PublishPayload(BaseModel):
     discordId: str
     appearance: AppearanceMetaModel


### PR DESCRIPTION
## Summary
- register the /manifest POST route with FastAPI to invoke handle_publish_manifest

## Testing
- pytest tests/test_syncshell.py *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68ebeca20c748328826a7cb42aa4f954