### PR TITLE
Restore legacy manifest compatibility

### DIFF
--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import FileResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1251,7 +1251,11 @@ async def handle_publish_manifest(
     payload_size = len(json.dumps(payload).encode())
     if payload_size > MAX_MANIFEST_BYTES:
         raise HTTPException(status_code=413, detail="manifest too large")
-    publish = PublishPayload.model_validate(payload)
+    try:
+        publish = PublishPayload.model_validate(payload)
+    except ValidationError:
+        diff, limits = await handle_manifest_upload(payload, ctx, db)
+        return {"status": "ok", "diff": diff, "limits": limits}
     await _check_rate_limit(ctx.user.id, db)
 
     missing: set[str] = set()

--- a/tests/test_syncshell.py
+++ b/tests/test_syncshell.py
@@ -10,7 +10,7 @@ from demibot.db.models import User, SyncshellPairing, SyncshellManifest
 from demibot.http.deps import RequestContext
 
 from .syncshell_import import syncshell
-from .syncshell_test_utils import build_publish_payload
+from .syncshell_test_utils import build_manifest_payload, build_publish_payload
 
 
 async def _prepare_db():
@@ -142,5 +142,37 @@ def test_publish_overwrites_corrupted_manifest(tmp_path):
             assert updated is not None
             stored = json.loads(updated.manifest_json)
             assert stored["appearance"]["blobs"][0]["sha256"] == sha
+
+    asyncio.run(_run())
+
+
+def test_publish_accepts_legacy_manifest(tmp_path):
+    async def _run():
+        session_factory = await _prepare_db()
+        async with session_factory as db:
+            user = User(id=1, discord_user_id=1, global_name="Test")
+            db.add(user)
+            await db.commit()
+
+            ctx = RequestContext(user=user, guild=None, key=object(), roles=[])
+
+            await syncshell.pair(ctx=ctx, db=db)
+
+            manifest, file_hash = build_manifest_payload(tmp_path)
+            syncshell.MAX_MANIFEST_BYTES = 1024 * 1024
+
+            result = await syncshell.handle_publish_manifest(manifest, ctx=ctx, db=db)
+
+            assert result["status"] == "ok"
+            record = await db.get(SyncshellManifest, user.id)
+            assert record is not None
+            stored = json.loads(record.manifest_json)
+            stored_hash = (
+                stored.get("collections", [{}])[0]
+                .get("mods", [{}])[0]
+                .get("files", [{}])[0]
+                .get("hash")
+            )
+            assert stored_hash == file_hash
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- allow the publish manifest handler to fall back to the legacy manifest upload flow when the new payload schema is not satisfied
- add a regression test that verifies legacy hashed manifests can still be persisted via the publish handler

## Testing
- pytest tests/test_syncshell.py *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68ebef5bb5cc8328aa28b957fe3447d9