### PR TITLE
Define LocalBlobInfo struct for SyncShell

### DIFF
--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -788,4 +788,23 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         _lifecycleLock.Dispose();
     }
+
+    internal readonly record struct LocalBlobInfo
+    {
+        public LocalBlobInfo(string name, string sha256, long size, string fullPath)
+        {
+            Name = name ?? string.Empty;
+            Sha256 = sha256 ?? string.Empty;
+            Size = size;
+            FullPath = fullPath ?? string.Empty;
+        }
+
+        public string Name { get; }
+
+        public string Sha256 { get; }
+
+        public long Size { get; }
+
+        public string FullPath { get; }
+    }
 }


### PR DESCRIPTION
## Summary
- add the missing LocalBlobInfo record struct to SyncShellService so the publish flow can build and upload payloads
- ensure each LocalBlobInfo provides name, hash, size, and disk path data for cached blobs

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ec1d09c4e48328bf4480415fe31b8e