### PR TITLE
Implement SyncShell Glamourer capture and apply loop

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -2,6 +2,7 @@ using Dalamud.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -27,7 +28,7 @@ public class Config : IPluginConfiguration
     public const uint DefaultFcEmbedColor = 0x5865F2;
     public const uint DefaultOfficerEmbedColor = 0xED4245;
     public const string DefaultEmbedBorderGlyph = "⬛";
-    public const int CurrentVersion = 21;
+    public const int CurrentVersion = 22;
 
     public int Version { get; set; } = CurrentVersion;
 
@@ -154,29 +155,37 @@ public class Config : IPluginConfiguration
     [JsonPropertyName("syncshellCacheLimitMb")]
     public int SyncshellCacheLimitMb { get; set; } = 4096;
 
-    [JsonPropertyName("syncshellAutoSyncAllUsers")]
-    public bool SyncshellAutoSyncAllUsers { get; set; } = true;
-
-    [JsonPropertyName("syncshellManualSyncAllUsers")]
-    public bool SyncshellManualSyncAllUsers { get; set; }
-
     [JsonPropertyName("enableSyncShell")]
     public bool EnableSyncShell { get; set; } = false;
 
+    [JsonPropertyName("syncshellAutoMode")]
+    public bool SyncshellAutoMode { get; set; } = true;
+
+    [JsonPropertyName("syncshellManualAllowList")]
+    public HashSet<ulong> SyncshellManualAllowList { get; set; } = new();
+
+    [JsonPropertyName("syncshellAutoSyncAllUsers")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool LegacySyncshellAutoSyncAllUsers { get; set; } = true;
+
+    [JsonPropertyName("syncshellManualSyncAllUsers")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool LegacySyncshellManualSyncAllUsers { get; set; }
+
     [JsonPropertyName("syncshellAutoAllUsers")]
-    public bool SyncshellAutoAllUsers { get; set; } = true;
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool LegacySyncshellAutoAllUsers { get; set; }
 
     [JsonPropertyName("syncshellManualAllUsers")]
-    public bool SyncshellManualAllUsers { get; set; } = false;
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool LegacySyncshellManualAllUsers { get; set; }
 
     [JsonPropertyName("syncshellAllowedDiscordIds")]
-    public List<string> SyncshellAllowedDiscordIds { get; set; } = new();
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<string>? LegacySyncshellAllowedDiscordIds { get; set; }
 
     [JsonPropertyName("penumbraPathOverride")]
     public string? PenumbraPathOverride { get; set; }
-
-    [JsonPropertyName("syncshellManualSyncCustom")]
-    public bool SyncshellManualSyncCustom { get; set; }
     [JsonPropertyName("fcEmbedBorder")]
     public EmbedBorderSettings FcEmbedBorder { get; set; } = EmbedBorderSettings.CreateDefault(ChannelKind.FcChat);
 
@@ -568,11 +577,50 @@ public class Config : IPluginConfiguration
         if (Version < 21)
         {
             EnableSyncShell = FCSyncShell;
-            SyncshellAutoAllUsers = SyncshellAutoSyncAllUsers;
-            SyncshellManualAllUsers = SyncshellManualSyncAllUsers;
-            SyncshellAllowedDiscordIds ??= new List<string>();
+            LegacySyncshellAutoAllUsers = LegacySyncshellAutoSyncAllUsers;
+            LegacySyncshellManualAllUsers = LegacySyncshellManualSyncAllUsers;
+            LegacySyncshellAllowedDiscordIds ??= new List<string>();
 
             Version = 21;
+            ExtensionData = null;
+        }
+        if (Version < 22)
+        {
+            SyncshellManualAllowList ??= new HashSet<ulong>();
+
+            if (LegacySyncshellAllowedDiscordIds is { Count: > 0 })
+            {
+                foreach (var id in LegacySyncshellAllowedDiscordIds)
+                {
+                    if (string.IsNullOrWhiteSpace(id))
+                    {
+                        continue;
+                    }
+
+                    if (ulong.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+                    {
+                        SyncshellManualAllowList.Add(parsed);
+                    }
+                }
+
+                LegacySyncshellAllowedDiscordIds = null;
+            }
+
+            if (!LegacySyncshellAutoAllUsers && LegacySyncshellManualAllUsers)
+            {
+                SyncshellAutoMode = false;
+            }
+            else if (LegacySyncshellAutoAllUsers)
+            {
+                SyncshellAutoMode = true;
+            }
+
+            LegacySyncshellAutoAllUsers = false;
+            LegacySyncshellManualAllUsers = false;
+            LegacySyncshellAutoSyncAllUsers = false;
+            LegacySyncshellManualSyncAllUsers = false;
+
+            Version = 22;
             ExtensionData = null;
         }
     }

--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="Penumbra.Api" Version="5.12.0" />
     <PackageReference Include="Glamourer.Api" Version="2.6.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -69,6 +69,7 @@ public class Plugin : IDalamudPlugin
     private readonly BlobStore _blobStore;
     private readonly SyncShellClient _syncShellClient;
     private readonly PenumbraIpc _penumbraIpc;
+    private readonly GlamourerIpc _glamourerIpc;
     private readonly SyncShellService _syncShellService;
 
     public Plugin()
@@ -108,15 +109,18 @@ public class Plugin : IDalamudPlugin
         _blobStore = new BlobStore(_services.PluginInterface);
         _syncShellClient = new SyncShellClient(_httpClient, _config, _tokenManager);
         _penumbraIpc = new PenumbraIpc(_services.PluginInterface, _services.Log);
+        _glamourerIpc = new GlamourerIpc(_services.PluginInterface, _services.ClientState, _services.Log);
         _syncShellService = new SyncShellService(
             _config,
             _tokenManager,
             _syncShellClient,
             _blobStore,
             _penumbraIpc,
+            _glamourerIpc,
             _services.Log,
             _services.ClientState,
             _services.Framework);
+        _services.GlamourerIpc = _glamourerIpc;
         _services.SyncShellService = _syncShellService;
         var baseChatBridge = new ChatBridge(
             _config,
@@ -235,6 +239,7 @@ public class Plugin : IDalamudPlugin
         if (services != null)
         {
             services.SyncShellService = null;
+            services.GlamourerIpc = null;
         }
 
         _syncShellService.Dispose();

--- a/DemiCatPlugin/PluginServices.cs
+++ b/DemiCatPlugin/PluginServices.cs
@@ -46,6 +46,8 @@ internal class PluginServices
 
     internal ISyncShellService? SyncShellService { get; set; }
 
+    internal GlamourerIpc? GlamourerIpc { get; set; }
+
     public PluginServices()
     {
         Instance = this;

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Globalization;
 using System.Linq;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
@@ -66,7 +67,11 @@ public class SettingsWindow : IDisposable
         _tokenManager.OnLinked += OnLinked;
         _tokenManager.OnUnlinked += OnUnlinked;
         _penumbraOverride = _config.PenumbraPathOverride ?? string.Empty;
-        _allowedDiscordIdsBuffer = string.Join("\n", _config.SyncshellAllowedDiscordIds);
+        _allowedDiscordIdsBuffer = string.Join(
+            "\n",
+            _config.SyncshellManualAllowList
+                .OrderBy(id => id)
+                .Select(id => id.ToString(CultureInfo.InvariantCulture)));
     }
 
     public void Draw()
@@ -297,32 +302,47 @@ public class SettingsWindow : IDisposable
 
         ImGui.Separator();
 
-        var autoAllUsers = _config.SyncshellAutoAllUsers;
-        if (ImGui.Checkbox("Auto Sync to all Connected Users", ref autoAllUsers))
+        var autoMode = _config.SyncshellAutoMode;
+        if (ImGui.RadioButton("Auto mode (sync all linked members)", autoMode))
         {
-            _config.SyncshellAutoAllUsers = autoAllUsers;
-            SaveConfig();
+            if (!_config.SyncshellAutoMode)
+            {
+                _config.SyncshellAutoMode = true;
+                SaveConfig();
+            }
+        }
+        ImGui.SameLine();
+        if (ImGui.RadioButton("Manual mode", !autoMode))
+        {
+            if (_config.SyncshellAutoMode)
+            {
+                _config.SyncshellAutoMode = false;
+                SaveConfig();
+            }
         }
 
-        var manualAllUsers = _config.SyncshellManualAllUsers;
-        if (ImGui.Checkbox("Manual Sync (All Users)", ref manualAllUsers))
-        {
-            _config.SyncshellManualAllUsers = manualAllUsers;
-            SaveConfig();
-        }
-
-        ImGui.TextUnformatted("Manual Sync (Custom Discord IDs)");
+        ImGui.TextUnformatted("Manual Sync Allow List (Discord IDs)");
         var listHeight = ImGui.GetTextLineHeightWithSpacing() * 4f;
         if (ImGui.InputTextMultiline("##SyncshellAllowedDiscordIds", ref _allowedDiscordIdsBuffer, 4096, new Vector2(-1, listHeight)))
         {
-            var ids = _allowedDiscordIdsBuffer
-                .Split(new[] { '\n', ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-            _config.SyncshellAllowedDiscordIds = ids;
+            var entries = _allowedDiscordIdsBuffer
+                .Split(new[] { '\n', ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var parsed = new HashSet<ulong>();
+            foreach (var entry in entries)
+            {
+                if (ulong.TryParse(entry, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+                {
+                    parsed.Add(id);
+                }
+            }
+
+            _config.SyncshellManualAllowList = parsed;
+            _allowedDiscordIdsBuffer = string.Join(
+                "\n",
+                parsed.OrderBy(id => id).Select(id => id.ToString(CultureInfo.InvariantCulture)));
             SaveConfig();
         }
-        ImGui.TextDisabled("One Discord ID per line.");
+        ImGui.TextDisabled("One Discord ID per line. Invalid entries are ignored.");
 
         ImGui.Separator();
 

--- a/DemiCatPlugin/SyncShell/BlobStore.cs
+++ b/DemiCatPlugin/SyncShell/BlobStore.cs
@@ -204,6 +204,20 @@ public sealed class BlobStore : IDisposable
         await Task.CompletedTask.ConfigureAwait(false);
     }
 
+    public string GetWorkspacePath(string name)
+    {
+        ThrowIfDisposed();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Name must be provided", nameof(name));
+        }
+
+        var sanitized = SanitizeWorkspaceName(name);
+        var path = Path.Combine(_tempPath, sanitized);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
     /// <summary>
     /// Removes all cached blobs.
     /// </summary>
@@ -253,6 +267,21 @@ public sealed class BlobStore : IDisposable
         {
             throw new ObjectDisposedException(nameof(BlobStore));
         }
+    }
+
+    private static string SanitizeWorkspaceName(string value)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var buffer = new char[value.Length];
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            buffer[i] = c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar || invalid.Contains(c)
+                ? '_'
+                : c;
+        }
+
+        return new string(buffer);
     }
 
     private static string GetShard(string sha256)

--- a/DemiCatPlugin/SyncShell/GlamourerIpc.cs
+++ b/DemiCatPlugin/SyncShell/GlamourerIpc.cs
@@ -1,0 +1,66 @@
+using System;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Services;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace DemiCatPlugin.SyncShell;
+
+public sealed class GlamourerIpc
+{
+    private readonly IDalamudPluginInterface _pluginInterface;
+    private readonly IClientState _clientState;
+    private readonly IPluginLog _log;
+    private readonly ICallGateSubscriber<int, uint, (int, JObject?)>? _getState;
+
+    public GlamourerIpc(IDalamudPluginInterface pluginInterface, IClientState clientState, IPluginLog log)
+    {
+        _pluginInterface = pluginInterface ?? throw new ArgumentNullException(nameof(pluginInterface));
+        _clientState = clientState ?? throw new ArgumentNullException(nameof(clientState));
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+
+        try
+        {
+            _getState = _pluginInterface.GetIpcSubscriber<int, uint, (int, JObject?)>("Glamourer.GetState");
+            Available = _getState != null;
+        }
+        catch (Exception ex)
+        {
+            Available = false;
+            _log.Information(ex, "Glamourer IPC unavailable");
+        }
+    }
+
+    public bool Available { get; }
+
+    public string? TryGetPlayerDesignJson()
+    {
+        if (!Available || _getState == null)
+        {
+            return null;
+        }
+
+        var player = _clientState.LocalPlayer;
+        if (player == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var (result, state) = _getState.InvokeFunc(player.ObjectIndex, 0);
+            if (result != 0 || state == null)
+            {
+                return null;
+            }
+
+            return state.ToString(Formatting.None);
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to capture Glamourer state");
+            return null;
+        }
+    }
+}

--- a/DemiCatPlugin/SyncShell/PenumbraIpc.cs
+++ b/DemiCatPlugin/SyncShell/PenumbraIpc.cs
@@ -27,7 +27,9 @@ public sealed class PenumbraIpc
             _modDirectory = _pluginInterface.GetIpcSubscriber<string>("Penumbra.ModDirectory");
             _setTemporaryMod = _pluginInterface.GetIpcSubscriber<string, object?>("Penumbra.Api/SetTemporaryMod");
             _redrawObject = _pluginInterface.GetIpcSubscriber<(int, int), object?>("Penumbra.Api/RedrawObject");
-            Available = _apiAvailable.InvokeFunc();
+            Available = _apiAvailable.InvokeFunc()
+                && _setTemporaryMod != null
+                && _redrawObject != null;
         }
         catch (Exception ex)
         {
@@ -58,7 +60,7 @@ public sealed class PenumbraIpc
 
     public void SetTemporaryMod(string modPath)
     {
-        if (!Available || _setTemporaryMod == null)
+        if (!Available || _setTemporaryMod == null || string.IsNullOrWhiteSpace(modPath))
         {
             return;
         }
@@ -73,7 +75,7 @@ public sealed class PenumbraIpc
         }
     }
 
-    public void Redraw(int objectIndex)
+    public void RedrawObject(int objectIndex)
     {
         if (!Available || _redrawObject == null)
         {

--- a/DemiCatPlugin/SyncShell/SyncShellClient.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellClient.cs
@@ -18,10 +18,10 @@ public sealed class SyncShellClient
     private readonly Config _config;
     private readonly TokenManager _tokenManager;
 
-    private const string GetMetaPath = "/api/syncshell/meta";               // TODO: backend to confirm availability
+    private const string GetMetaPath = "/api/syncshell/meta";
     private const string PublishPath = "/api/syncshell/manifest";
-    private const string BlobUploadPath = "/api/syncshell/blobs";           // TODO: backend implementation
-    private const string BlobDownloadPath = "/api/syncshell/blobs";         // TODO: backend implementation
+    private const string BlobUploadPath = "/api/syncshell/blobs";
+    private const string BlobDownloadPath = "/api/syncshell/blobs";
     private const string MembershipsPath = "/api/syncshell/memberships";
     private const string PresencePath = "/api/syncshell/presence";
 

--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Plugin.Services;
@@ -14,12 +15,33 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     private static readonly TimeSpan PresencePollInterval = TimeSpan.FromSeconds(12);
     private static readonly TimeSpan PublishCooldown = TimeSpan.FromSeconds(3);
     private static readonly TimeSpan TerritoryDebounce = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan ApplyPollInterval = TimeSpan.FromSeconds(6);
+    private const long MaxSyncshellFileSizeBytes = 64L * 1024L * 1024L;
+    private static readonly HashSet<string> SupportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".tex",
+        ".dds",
+        ".mdl",
+        ".mtrl",
+        ".png",
+        ".ttmp",
+        ".ttmp2",
+        ".scd",
+        ".tmb",
+        ".atex",
+        ".avfx",
+        ".sklb",
+        ".pap",
+        ".json",
+        ".meta",
+    };
 
     private readonly Config _config;
     private readonly TokenManager _tokenManager;
     private readonly SyncShellClient _client;
     private readonly BlobStore _blobStore;
     private readonly PenumbraIpc _penumbra;
+    private readonly GlamourerIpc _glamourer;
     private readonly IPluginLog _log;
     private readonly IClientState _clientState;
     private readonly IFramework _framework;
@@ -29,10 +51,17 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     private readonly object _memberLock = new();
     private List<SyncshellMemberStatus> _members = new();
     private List<SyncshellMemberStatus> _activeMembers = new();
+    private readonly object _appearanceLock = new();
+    private readonly Dictionary<string, LocalBlobInfo> _localBlobs = new(StringComparer.OrdinalIgnoreCase);
+    private string? _glamourerJson;
+    private readonly object _applyStateLock = new();
+    private readonly Dictionary<string, AppliedAppearanceState> _appliedTargets = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, DateTimeOffset> _localSyncedAt = new(StringComparer.OrdinalIgnoreCase);
 
     private CancellationTokenSource? _runCts;
     private Task? _presenceTask;
     private Task? _publishTask;
+    private Task? _applyTask;
     private bool _disposed;
     private DateTimeOffset _lastPublish;
     private string _status = "SyncShell disabled";
@@ -45,6 +74,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         SyncShellClient client,
         BlobStore blobStore,
         PenumbraIpc penumbra,
+        GlamourerIpc glamourer,
         IPluginLog log,
         IClientState clientState,
         IFramework framework)
@@ -54,6 +84,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _blobStore = blobStore ?? throw new ArgumentNullException(nameof(blobStore));
         _penumbra = penumbra ?? throw new ArgumentNullException(nameof(penumbra));
+        _glamourer = glamourer ?? throw new ArgumentNullException(nameof(glamourer));
         _log = log ?? throw new ArgumentNullException(nameof(log));
         _clientState = clientState ?? throw new ArgumentNullException(nameof(clientState));
         _framework = framework ?? throw new ArgumentNullException(nameof(framework));
@@ -86,6 +117,408 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
+    private void RefreshAppearanceCaches()
+    {
+        string? glamourerJson = null;
+        try
+        {
+            if (_glamourer.Available)
+            {
+                glamourerJson = _glamourer.TryGetPlayerDesignJson();
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Glamourer IPC failed");
+        }
+
+        var modRoot = _penumbra.GetModDirectory();
+        if (string.IsNullOrWhiteSpace(modRoot))
+        {
+            modRoot = _config.PenumbraPathOverride;
+        }
+
+        if (string.IsNullOrWhiteSpace(modRoot))
+        {
+            modRoot = BlobStore.GuessDefaultPenumbraRoot();
+        }
+
+        var discovered = new Dictionary<string, LocalBlobInfo>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(modRoot) && Directory.Exists(modRoot))
+        {
+            foreach (var path in EnumerateSyncshellFiles(modRoot))
+            {
+                try
+                {
+                    var info = new FileInfo(path);
+                    var sha = Hasher.Sha256File(path);
+                    var name = MakeStableBlobName(path, modRoot);
+                    discovered[sha] = new LocalBlobInfo(name, sha, info.Length, path);
+                }
+                catch (Exception ex)
+                {
+                    _log.Warning(ex, "Failed to index Penumbra asset {Path}", path);
+                }
+            }
+        }
+
+        lock (_appearanceLock)
+        {
+            _glamourerJson = string.IsNullOrWhiteSpace(glamourerJson) ? null : glamourerJson;
+            _localBlobs.Clear();
+            foreach (var entry in discovered)
+            {
+                _localBlobs[entry.Key] = entry.Value;
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateSyncshellFiles(string root)
+    {
+        foreach (var path in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+        {
+            string extension;
+            try
+            {
+                extension = Path.GetExtension(path);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(extension) || !SupportedExtensions.Contains(extension))
+            {
+                continue;
+            }
+
+            FileInfo info;
+            try
+            {
+                info = new FileInfo(path);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (!info.Exists || info.Length <= 0 || info.Length > MaxSyncshellFileSizeBytes)
+            {
+                continue;
+            }
+
+            yield return info.FullName;
+        }
+    }
+
+    private static string MakeStableBlobName(string fullPath, string root)
+    {
+        var relative = Path.GetRelativePath(root, fullPath);
+        return relative.Replace('\\', '/').ToLowerInvariant();
+    }
+
+    private async Task ApplyLoopAsync(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(ApplyPollInterval, token).ConfigureAwait(false);
+
+                if (_paused)
+                {
+                    continue;
+                }
+
+                var targets = GetApplyTargets();
+                foreach (var target in targets)
+                {
+                    token.ThrowIfCancellationRequested();
+
+                    var meta = await _client.GetLatestMetaAsync(target, token).ConfigureAwait(false);
+                    if (meta?.Appearance == null)
+                    {
+                        continue;
+                    }
+
+                    if (!ShouldApply(target, meta))
+                    {
+                        continue;
+                    }
+
+                    var localPaths = await EnsureBlobsLocalAsync(meta.Appearance, token).ConfigureAwait(false);
+                    if (localPaths == null)
+                    {
+                        continue;
+                    }
+
+                    var workspace = await MaterializeTemporaryModAsync(target, meta.Appearance, localPaths, token).ConfigureAwait(false);
+                    _penumbra.SetTemporaryMod(workspace);
+
+                    var objectIndex = _clientState.LocalPlayer?.ObjectIndex ?? -1;
+                    if (objectIndex >= 0)
+                    {
+                        _penumbra.RedrawObject(objectIndex);
+                    }
+
+                    var appliedAt = DateTimeOffset.UtcNow;
+                    var hash = string.IsNullOrWhiteSpace(meta.Hash)
+                        ? ComputeAppearanceHash(meta.Appearance)
+                        : meta.Hash!;
+
+                    lock (_applyStateLock)
+                    {
+                        _appliedTargets[target] = new AppliedAppearanceState(hash, appliedAt);
+                        _localSyncedAt[target] = appliedAt;
+                    }
+
+                    ApplyLocalSyncedAt(target, appliedAt);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Apply loop failed");
+            }
+        }
+    }
+
+    private List<string> GetApplyTargets()
+    {
+        var results = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var selfId = _tokenManager.Token;
+
+        List<SyncshellMemberStatus> members;
+        lock (_memberLock)
+        {
+            members = _members.ToList();
+        }
+
+        if (_config.SyncshellAutoMode)
+        {
+            foreach (var member in members)
+            {
+                if (string.IsNullOrWhiteSpace(member.Id) || string.Equals(member.Id, selfId, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (!member.TokenLinked)
+                {
+                    continue;
+                }
+
+                if (string.Equals(member.Presence, "offline", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (seen.Add(member.Id))
+                {
+                    results.Add(member.Id);
+                }
+            }
+        }
+        else
+        {
+            var manualList = _config.SyncshellManualAllowList.ToArray();
+            foreach (var id in manualList)
+            {
+                var idString = id.ToString(CultureInfo.InvariantCulture);
+                if (string.IsNullOrWhiteSpace(idString) || string.Equals(idString, selfId, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (!seen.Add(idString))
+                {
+                    continue;
+                }
+
+                var member = members.FirstOrDefault(m => string.Equals(m.Id, idString, StringComparison.OrdinalIgnoreCase));
+                if (member == null || !member.TokenLinked)
+                {
+                    continue;
+                }
+
+                results.Add(idString);
+            }
+        }
+
+        return results;
+    }
+
+    internal IReadOnlyList<string> GetApplyTargetsForTesting()
+        => GetApplyTargets();
+
+    private bool ShouldApply(string target, UserMetaDto meta)
+    {
+        if (meta.Appearance == null)
+        {
+            return false;
+        }
+
+        var hash = string.IsNullOrWhiteSpace(meta.Hash)
+            ? ComputeAppearanceHash(meta.Appearance)
+            : meta.Hash!;
+
+        lock (_applyStateLock)
+        {
+            if (_appliedTargets.TryGetValue(target, out var state) &&
+                string.Equals(state.Hash, hash, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<Dictionary<string, string>?> EnsureBlobsLocalAsync(AppearanceMeta appearance, CancellationToken token)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var blob in appearance.Blobs)
+        {
+            if (string.IsNullOrWhiteSpace(blob.Sha256))
+            {
+                continue;
+            }
+
+            var localPath = await _blobStore.EnsureLocalAsync(blob.Sha256, () => _client.DownloadBlobAsync(blob.Sha256, token), token).ConfigureAwait(false);
+            if (string.IsNullOrEmpty(localPath))
+            {
+                _log.Warning("Failed to ensure local blob {Hash}", blob.Sha256);
+                return null;
+            }
+
+            result[blob.Sha256] = localPath;
+        }
+
+        return result;
+    }
+
+    private async Task<string> MaterializeTemporaryModAsync(string targetId, AppearanceMeta appearance, IReadOnlyDictionary<string, string> localPaths, CancellationToken token)
+    {
+        var workspace = _blobStore.GetWorkspacePath($"apply-{targetId}");
+        try
+        {
+            if (Directory.Exists(workspace))
+            {
+                Directory.Delete(workspace, true);
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to reset temporary workspace {Workspace}", workspace);
+        }
+
+        Directory.CreateDirectory(workspace);
+
+        foreach (var blob in appearance.Blobs)
+        {
+            if (string.IsNullOrWhiteSpace(blob.Name))
+            {
+                continue;
+            }
+
+            if (!localPaths.TryGetValue(blob.Sha256, out var sourcePath) || string.IsNullOrWhiteSpace(sourcePath))
+            {
+                continue;
+            }
+
+            var destination = Path.Combine(workspace, blob.Name.Replace('/', Path.DirectorySeparatorChar));
+            var directory = Path.GetDirectoryName(destination);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await CopyFileAsync(sourcePath, destination, token).ConfigureAwait(false);
+        }
+
+        return workspace;
+    }
+
+    private static async Task CopyFileAsync(string source, string destination, CancellationToken token)
+    {
+        await using var input = new FileStream(source, FileMode.Open, FileAccess.Read, FileShare.Read, 64 * 1024, useAsync: true);
+        await using var output = new FileStream(destination, FileMode.Create, FileAccess.Write, FileShare.None, 64 * 1024, useAsync: true);
+        await input.CopyToAsync(output, 64 * 1024, token).ConfigureAwait(false);
+        await output.FlushAsync(token).ConfigureAwait(false);
+    }
+
+    private static string ComputeAppearanceHash(AppearanceMeta appearance)
+    {
+        var builder = new StringBuilder();
+        if (!string.IsNullOrEmpty(appearance.ActorHash))
+        {
+            builder.Append(appearance.ActorHash);
+        }
+
+        if (!string.IsNullOrEmpty(appearance.GlamourerJson))
+        {
+            builder.Append(appearance.GlamourerJson);
+        }
+
+        foreach (var blob in appearance.Blobs.OrderBy(b => b.Sha256, StringComparer.OrdinalIgnoreCase))
+        {
+            builder.Append(blob.Sha256);
+            builder.Append(':');
+            builder.Append(blob.Size);
+            builder.Append(':');
+            builder.Append(blob.Name);
+            builder.Append(';');
+        }
+
+        return Hasher.Sha256Bytes(Encoding.UTF8.GetBytes(builder.ToString()));
+    }
+
+    private void ApplyLocalSyncedAt(string targetId, DateTimeOffset timestamp)
+    {
+        lock (_memberLock)
+        {
+            _members = _members.Select(member => UpdateSyncedAtEntry(member, targetId, timestamp)).ToList();
+            _activeMembers = _activeMembers.Select(member => UpdateSyncedAtEntry(member, targetId, timestamp)).ToList();
+        }
+
+        OnStatusChanged();
+    }
+
+    private static SyncshellMemberStatus UpdateSyncedAtEntry(SyncshellMemberStatus member, string targetId, DateTimeOffset timestamp)
+    {
+        if (!string.Equals(member.Id, targetId, StringComparison.OrdinalIgnoreCase))
+        {
+            return member;
+        }
+
+        return new SyncshellMemberStatus
+        {
+            Id = member.Id,
+            DisplayName = member.DisplayName,
+            Presence = member.Presence,
+            SyncStatus = member.SyncStatus,
+            LastSeen = member.LastSeen,
+            SyncedAt = timestamp,
+            TokenLinked = member.TokenLinked,
+        };
+    }
+
+    private DateTimeOffset? GetLocalSyncedAt(string? memberId)
+    {
+        if (string.IsNullOrWhiteSpace(memberId))
+        {
+            return null;
+        }
+
+        lock (_applyStateLock)
+        {
+            return _localSyncedAt.TryGetValue(memberId, out var timestamp) ? timestamp : null;
+        }
+    }
     public string Status
     {
         get
@@ -204,9 +637,11 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
                 return;
             }
 
+            RefreshAppearanceCaches();
             _runCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             _presenceTask = Task.Run(() => PresenceLoopAsync(_runCts.Token));
             _publishTask = Task.Run(() => PublishLoopAsync(_runCts.Token));
+            _applyTask = Task.Run(() => ApplyLoopAsync(_runCts.Token));
             Status = "Active";
         }
         finally
@@ -250,8 +685,20 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             {
             }
 
+            try
+            {
+                if (_applyTask != null)
+                {
+                    await _applyTask.ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
             _presenceTask = null;
             _publishTask = null;
+            _applyTask = null;
             _runCts.Dispose();
             _runCts = null;
             Status = _config.EnableSyncShell ? "Idle" : "SyncShell disabled";
@@ -396,13 +843,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
                 try
                 {
-                    var activeIds = ActiveMembers
-                        .Select(m => m.Id)
-                        .Where(id => !string.IsNullOrWhiteSpace(id))
-                        .ToArray();
-                    if (activeIds.Length > 0)
+                    var targets = GetApplyTargets();
+                    if (targets.Count > 0)
                     {
-                        await _client.UpdatePresenceAsync(activeIds, token).ConfigureAwait(false);
+                        await _client.UpdatePresenceAsync(targets, token).ConfigureAwait(false);
                     }
                 }
                 catch (Exception ex)
@@ -459,6 +903,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             return;
         }
 
+        RefreshAppearanceCaches();
         PublishPayload payload;
         Dictionary<string, LocalBlobInfo> localBlobs;
         try
@@ -511,9 +956,23 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
     private (PublishPayload Payload, Dictionary<string, LocalBlobInfo> LocalBlobs) BuildPublishPayload()
     {
+        var actorHash = string.Empty;
+        var player = _clientState.LocalPlayer;
+        if (player != null)
+        {
+            actorHash = player.Name.TextValue ?? string.Empty;
+            var worldName = player.HomeWorld?.GameData?.Name;
+            if (!string.IsNullOrEmpty(worldName))
+            {
+                actorHash = string.IsNullOrEmpty(actorHash)
+                    ? worldName!
+                    : $"{actorHash}@{worldName}";
+            }
+        }
+
         var appearance = new AppearanceMeta
         {
-            ActorHash = _clientState.LocalPlayer?.Name.TextValue ?? string.Empty,
+            ActorHash = actorHash,
         };
 
         Dictionary<string, LocalBlobInfo> localBlobs;
@@ -626,6 +1085,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             try
             {
                 await Task.Delay(TerritoryDebounce, _runCts?.Token ?? CancellationToken.None).ConfigureAwait(false);
+                RefreshAppearanceCaches();
                 await TriggerPublishAsync(_runCts?.Token ?? CancellationToken.None).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
@@ -648,6 +1108,11 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
     private void HandleTokenUnlinked(string? reason)
     {
+        lock (_applyStateLock)
+        {
+            _appliedTargets.Clear();
+            _localSyncedAt.Clear();
+        }
         _ = Stop();
     }
 
@@ -668,7 +1133,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
                     continue;
                 }
 
-                var status = MapMember(entry);
+                var status = MapMember(entry, GetLocalSyncedAt(entry.Id));
                 members.Add(status);
             }
         }
@@ -682,7 +1147,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
                     continue;
                 }
 
-                var status = MapMember(entry);
+                var status = MapMember(entry, GetLocalSyncedAt(entry.Id));
                 activeMembers.Add(status);
             }
         }
@@ -733,7 +1198,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         => activeCount > 0
             ? $"Syncing {activeCount} member{(activeCount == 1 ? string.Empty : "s")}" : "Idle";
 
-    private static SyncshellMemberStatus MapMember(MembershipEntryDto entry)
+    private static SyncshellMemberStatus MapMember(MembershipEntryDto entry, DateTimeOffset? localSyncedAt)
     {
         var displayName = string.IsNullOrWhiteSpace(entry.DisplayName)
             ? entry.Id ?? string.Empty
@@ -746,7 +1211,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             Presence = entry.Presence ?? "offline",
             SyncStatus = entry.SyncStatus,
             LastSeen = ParseTimestamp(entry.LastSeen),
-            SyncedAt = ParseTimestamp(entry.SyncedAt),
+            SyncedAt = localSyncedAt ?? ParseTimestamp(entry.SyncedAt),
             TokenLinked = entry.TokenLinked,
         };
     }
@@ -807,4 +1272,6 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         public string FullPath { get; }
     }
+
+    private sealed record AppliedAppearanceState(string Hash, DateTimeOffset Timestamp);
 }

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -72,26 +72,13 @@ public sealed class SyncshellWindow : IDisposable
         ImGui.Unindent();
 
         ImGui.Separator();
+        DrawModeControls(service.Members);
+
+        ImGui.Separator();
         DrawActiveMembers(service.ActiveMembers);
 
         ImGui.Separator();
         DrawMemberRoster(service.Members);
-
-        ImGui.Separator();
-        ImGui.TextUnformatted("Allowed Discord IDs");
-        ImGui.Indent();
-        if (_config.SyncshellAllowedDiscordIds.Count == 0)
-        {
-            ImGui.TextDisabled("No custom IDs configured.");
-        }
-        else
-        {
-            foreach (var id in _config.SyncshellAllowedDiscordIds)
-            {
-                ImGui.BulletText(id);
-            }
-        }
-        ImGui.Unindent();
 
         ImGui.Separator();
         var buttonWidth = 150f * ImGuiHelpers.GlobalScale;
@@ -127,6 +114,56 @@ public sealed class SyncshellWindow : IDisposable
         }
     }
 
+    private void DrawModeControls(IReadOnlyList<SyncshellMemberStatus> members)
+    {
+        var autoMode = _config.SyncshellAutoMode;
+        if (ImGui.RadioButton("Auto mode (sync all linked members)", autoMode))
+        {
+            if (!_config.SyncshellAutoMode)
+            {
+                _config.SyncshellAutoMode = true;
+                SaveConfig();
+            }
+        }
+        ImGui.SameLine();
+        if (ImGui.RadioButton("Manual mode (use allow list)", !autoMode))
+        {
+            if (_config.SyncshellAutoMode)
+            {
+                _config.SyncshellAutoMode = false;
+                SaveConfig();
+            }
+        }
+
+        if (autoMode)
+        {
+            ImGui.TextDisabled("Allow list is ignored while auto mode is enabled.");
+        }
+        else
+        {
+            ImGui.TextDisabled("Only allow-listed Discord IDs will be synced.");
+        }
+
+        ImGui.Spacing();
+        ImGui.TextUnformatted("Manual allow list");
+        ImGui.Indent();
+        if (_config.SyncshellManualAllowList.Count == 0)
+        {
+            ImGui.TextDisabled("No Discord IDs selected.");
+        }
+        else
+        {
+            foreach (var id in _config.SyncshellManualAllowList.OrderBy(id => id))
+            {
+                var idString = id.ToString(CultureInfo.InvariantCulture);
+                var name = ResolveDisplayName(members, idString);
+                var label = string.IsNullOrEmpty(name) ? idString : $"{name} ({idString})";
+                ImGui.BulletText(label);
+            }
+        }
+        ImGui.Unindent();
+    }
+
     private static void DrawActiveMembers(IReadOnlyList<SyncshellMemberStatus> activeMembers)
     {
         ImGui.TextUnformatted("Currently syncing");
@@ -139,7 +176,7 @@ public sealed class SyncshellWindow : IDisposable
         {
             foreach (var member in activeMembers)
             {
-                DrawMemberLine(member, highlight: true);
+                DrawMemberLine(member, highlight: true, manualMode: false);
                 if (member.SyncedAt != null)
                 {
                     ImGui.Indent();
@@ -151,7 +188,7 @@ public sealed class SyncshellWindow : IDisposable
         ImGui.Unindent();
     }
 
-    private static void DrawMemberRoster(IReadOnlyList<SyncshellMemberStatus> members)
+    private void DrawMemberRoster(IReadOnlyList<SyncshellMemberStatus> members)
     {
         ImGui.TextUnformatted("Member roster");
         ImGui.Indent();
@@ -161,9 +198,10 @@ public sealed class SyncshellWindow : IDisposable
         }
         else
         {
+            var manualMode = !_config.SyncshellAutoMode;
             foreach (var member in members.OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase))
             {
-                DrawMemberLine(member, highlight: member.IsActive);
+                DrawMemberLine(member, highlight: member.IsActive, manualMode);
                 if (member.LastSeen != null)
                 {
                     ImGui.Indent();
@@ -175,7 +213,7 @@ public sealed class SyncshellWindow : IDisposable
         ImGui.Unindent();
     }
 
-    private static void DrawMemberLine(SyncshellMemberStatus member, bool highlight)
+    private void DrawMemberLine(SyncshellMemberStatus member, bool highlight, bool manualMode)
     {
         var presenceLabel = string.IsNullOrEmpty(member.SyncStatus)
             ? member.Presence
@@ -183,15 +221,34 @@ public sealed class SyncshellWindow : IDisposable
         var linkedSuffix = member.TokenLinked ? " • linked" : string.Empty;
         var label = $"{member.DisplayName} [{presenceLabel}]{linkedSuffix}";
 
+        ImGui.Bullet();
+        ImGui.SameLine();
+
+        if (manualMode)
+        {
+            var allowListed = IsAllowListed(member.Id);
+            var buttonLabel = allowListed ? "-" : "+";
+            if (ImGui.SmallButton($"{buttonLabel}##allow-{member.Id}"))
+            {
+                ToggleAllowList(member.Id, !allowListed);
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.SetTooltip(allowListed ? "Remove from allow list" : "Add to allow list");
+            }
+            ImGui.SameLine();
+        }
+
         if (highlight)
         {
             ImGui.PushStyleColor(ImGuiCol.Text, ActiveMemberColor);
-            ImGui.BulletText(label);
-            ImGui.PopStyleColor();
         }
-        else
+
+        ImGui.TextUnformatted(label);
+
+        if (highlight)
         {
-            ImGui.BulletText(label);
+            ImGui.PopStyleColor();
         }
     }
 
@@ -209,6 +266,57 @@ public sealed class SyncshellWindow : IDisposable
     public void ClearCaches()
     {
         _service?.ClearCache();
+    }
+
+    private bool IsAllowListed(string id)
+    {
+        if (!ulong.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return false;
+        }
+
+        return _config.SyncshellManualAllowList.Contains(parsed);
+    }
+
+    private void ToggleAllowList(string id, bool allow)
+    {
+        if (!ulong.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return;
+        }
+
+        var changed = allow
+            ? _config.SyncshellManualAllowList.Add(parsed)
+            : _config.SyncshellManualAllowList.Remove(parsed);
+
+        if (changed)
+        {
+            SaveConfig();
+        }
+    }
+
+    private static string ResolveDisplayName(IReadOnlyList<SyncshellMemberStatus> members, string id)
+    {
+        if (members == null)
+        {
+            return string.Empty;
+        }
+
+        foreach (var member in members)
+        {
+            if (string.Equals(member.Id, id, StringComparison.OrdinalIgnoreCase))
+            {
+                return member.DisplayName;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private void SaveConfig()
+    {
+        var pluginInterface = PluginServices.Instance?.PluginInterface;
+        pluginInterface?.SavePluginConfig(_config);
     }
 
     private void HandleStatusChanged(object? sender, EventArgs e)

--- a/tests/SyncshellPublishFlowTests.cs
+++ b/tests/SyncshellPublishFlowTests.cs
@@ -60,12 +60,14 @@ public class SyncshellPublishFlowTests : IDisposable
         var penumbra = new PenumbraIpc(pluginInterfaceMock.Object, logMock.Object);
         var clientStateMock = new Mock<IClientState>();
         var frameworkMock = new Mock<IFramework>();
+        var glamourer = new GlamourerIpc(pluginInterfaceMock.Object, clientStateMock.Object, logMock.Object);
         var service = new SyncShellService(
             config,
             TokenManager.Instance!,
             new SyncShellClient(httpClient, config, TokenManager.Instance!),
             blobStore,
             penumbra,
+            glamourer,
             logMock.Object,
             clientStateMock.Object,
             frameworkMock.Object);
@@ -138,12 +140,14 @@ public class SyncshellPublishFlowTests : IDisposable
         var penumbra = new PenumbraIpc(pluginInterfaceMock.Object, logMock.Object);
         var clientStateMock = new Mock<IClientState>();
         var frameworkMock = new Mock<IFramework>();
+        var glamourer = new GlamourerIpc(pluginInterfaceMock.Object, clientStateMock.Object, logMock.Object);
         var service = new SyncShellService(
             config,
             TokenManager.Instance!,
             new SyncShellClient(httpClient, config, TokenManager.Instance!),
             blobStore,
             penumbra,
+            glamourer,
             logMock.Object,
             clientStateMock.Object,
             frameworkMock.Object);

--- a/tests/SyncshellServiceHelperTests.cs
+++ b/tests/SyncshellServiceHelperTests.cs
@@ -1,6 +1,16 @@
 using System;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
 using System.Text.Json;
+using Dalamud.Game.ClientState;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
+using DemiCatPlugin;
 using DemiCatPlugin.SyncShell;
+using Moq;
 using Xunit;
 
 public class SyncshellServiceHelperTests
@@ -44,6 +54,78 @@ public class SyncshellServiceHelperTests
         else
         {
             Assert.Null(result);
+        }
+    }
+
+    [Fact]
+    public void ApplyTargetsHonorModeConfiguration()
+    {
+        var tempDir = Directory.CreateTempSubdirectory();
+        var tokenField = typeof(TokenManager).GetField("<Instance>k__BackingField", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var previousToken = (TokenManager?)tokenField.GetValue(null);
+        try
+        {
+            var pluginInterfaceMock = new Mock<IDalamudPluginInterface>();
+            pluginInterfaceMock.Setup(i => i.GetPluginConfigDirectory()).Returns(tempDir.FullName);
+            pluginInterfaceMock.Setup(i => i.GetIpcSubscriber<bool>(It.IsAny<string>())).Throws(new InvalidOperationException());
+            pluginInterfaceMock.Setup(i => i.GetIpcSubscriber<string>(It.IsAny<string>())).Throws(new InvalidOperationException());
+            pluginInterfaceMock.Setup(i => i.GetIpcSubscriber<string, object?>(It.IsAny<string>())).Throws(new InvalidOperationException());
+            pluginInterfaceMock.Setup(i => i.GetIpcSubscriber<(int, int), object?>(It.IsAny<string>())).Throws(new InvalidOperationException());
+
+            var logMock = new Mock<IPluginLog>();
+            var clientStateMock = new Mock<IClientState>();
+            var frameworkMock = new Mock<IFramework>();
+
+            using var blobStore = new BlobStore(pluginInterfaceMock.Object);
+            var penumbra = new PenumbraIpc(pluginInterfaceMock.Object, logMock.Object);
+            var glamourer = new GlamourerIpc(pluginInterfaceMock.Object, clientStateMock.Object, logMock.Object);
+
+            var config = new Config
+            {
+                EnableSyncShell = true,
+                ApiBaseUrl = "http://localhost",
+                SyncshellAutoMode = false,
+            };
+
+            config.SyncshellManualAllowList.Add(123UL);
+
+            var tokenManager = new TokenManager();
+            tokenField.SetValue(null, tokenManager);
+            using var httpClient = new HttpClient(new HttpClientHandler()) { BaseAddress = new Uri("http://localhost") };
+            var client = new SyncShellClient(httpClient, config, tokenManager);
+            var service = new SyncShellService(
+                config,
+                tokenManager,
+                client,
+                blobStore,
+                penumbra,
+                glamourer,
+                logMock.Object,
+                clientStateMock.Object,
+                frameworkMock.Object);
+
+            var members = new List<SyncshellMemberStatus>
+            {
+                new SyncshellMemberStatus { Id = "123", DisplayName = "One", Presence = "online", TokenLinked = true },
+                new SyncshellMemberStatus { Id = "456", DisplayName = "Two", Presence = "online", TokenLinked = true },
+            };
+
+            typeof(SyncShellService).GetField("_members", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(service, members);
+
+            var manualTargets = service.GetApplyTargetsForTesting();
+            Assert.Single(manualTargets);
+            Assert.Equal("123", manualTargets[0]);
+
+            config.SyncshellAutoMode = true;
+            var autoTargets = service.GetApplyTargetsForTesting();
+            Assert.Contains("123", autoTargets);
+            Assert.Contains("456", autoTargets);
+        }
+        finally
+        {
+            tokenField.SetValue(null, previousToken);
+            Directory.Delete(tempDir.FullName, true);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a Glamourer IPC wrapper and register it so SyncShellService can capture live appearance JSON
- refresh local Penumbra asset caches before publishing manifests and include blob metadata in payloads
- run an apply loop with manual/auto targeting options, updated UI controls, and supporting tests

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ec289e99348328949404c33232aa7f