### PR TITLE
Fix plugin build regressions

### DIFF
--- a/DemiCatPlugin/Config.cs
+++ b/DemiCatPlugin/Config.cs
@@ -387,51 +387,38 @@ public class Config : IPluginConfiguration
                         if (!migrated.ContainsKey(key))
                         {
                             migrated[key] = cursor;
-        }
-    }
+                        }
+                    }
+                }
 
-    public void PostLoadMigrations()
-    {
-        if (LegacySyncshellAllowedDiscordIds == null)
-        {
-            return;
-        }
-
-        foreach (var entry in LegacySyncshellAllowedDiscordIds)
-        {
-            if (string.IsNullOrWhiteSpace(entry))
-            {
-                continue;
-            }
-
-            if (ulong.TryParse(entry.Trim(), out var id))
-            {
-                ManualAutoList.Add(id);
-            }
-        }
-
-        LegacySyncshellAllowedDiscordIds.Clear();
-    }
-}
                 ChatCursors = migrated;
             }
 
             Version = 5;
             ExtensionData = null;
         }
+
         if (Version < 6)
         {
             if (ExtensionData != null)
             {
-                if (ExtensionData.TryGetValue("FcChatTransparency", out var fcOpacityElement) && fcOpacityElement.ValueKind == JsonValueKind.Number && fcOpacityElement.TryGetDouble(out var fcOpacity))
+                if (ExtensionData.TryGetValue("FcChatOpacity", out var fcOpacityElement)
+                    && fcOpacityElement.ValueKind == System.Text.Json.JsonValueKind.Number
+                    && fcOpacityElement.TryGetDouble(out var fcOpacity))
                 {
                     FcChatOpacity = (float)Math.Clamp(fcOpacity, 0d, 1d);
                 }
-                if (ExtensionData.TryGetValue("OfficerChatTransparency", out var officerOpacityElement) && officerOpacityElement.ValueKind == JsonValueKind.Number && officerOpacityElement.TryGetDouble(out var officerOpacity))
+
+                if (ExtensionData.TryGetValue("OfficerChatOpacity", out var officerOpacityElement)
+                    && officerOpacityElement.ValueKind == System.Text.Json.JsonValueKind.Number
+                    && officerOpacityElement.TryGetDouble(out var officerOpacity))
                 {
                     OfficerChatOpacity = (float)Math.Clamp(officerOpacity, 0d, 1d);
                 }
-                if (ExtensionData.TryGetValue("ChatFadeOutAlpha", out var fadeAlphaElement) && fadeAlphaElement.ValueKind == JsonValueKind.Number && fadeAlphaElement.TryGetDouble(out var fadeAlpha))
+
+                if (ExtensionData.TryGetValue("ChatFadeOutMinimumAlpha", out var fadeAlphaElement)
+                    && fadeAlphaElement.ValueKind == System.Text.Json.JsonValueKind.Number
+                    && fadeAlphaElement.TryGetDouble(out var fadeAlpha))
                 {
                     ChatFadeOutMinimumAlpha = (float)Math.Clamp(fadeAlpha, 0d, 1d);
                 }
@@ -661,6 +648,29 @@ public class Config : IPluginConfiguration
             Version = 22;
             ExtensionData = null;
         }
+    }
+
+    public void PostLoadMigrations()
+    {
+        if (LegacySyncshellAllowedDiscordIds == null)
+        {
+            return;
+        }
+
+        foreach (var entry in LegacySyncshellAllowedDiscordIds)
+        {
+            if (string.IsNullOrWhiteSpace(entry))
+            {
+                continue;
+            }
+
+            if (ulong.TryParse(entry.Trim(), out var id))
+            {
+                ManualAutoList.Add(id);
+            }
+        }
+
+        LegacySyncshellAllowedDiscordIds.Clear();
     }
 
     public static uint GetDefaultEmbedColor(string? channelKind)

--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -621,7 +621,32 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         if (player != null)
         {
             actorHash = player.Name.TextValue ?? string.Empty;
-            var worldName = player.HomeWorld?.GameData?.Name;
+            string? worldName = null;
+            try
+            {
+                var world = player.HomeWorld.ValueNullable;
+                if (world != null)
+                {
+                    worldName = world.Name?.ToString();
+                }
+            }
+            catch
+            {
+                // ignore lookup failures
+            }
+
+            if (string.IsNullOrEmpty(worldName))
+            {
+                try
+                {
+                    worldName = player.HomeWorld.Value.Name.ToString();
+                }
+                catch
+                {
+                    // ignore lookup failures
+                }
+            }
+
             if (!string.IsNullOrEmpty(worldName))
             {
                 actorHash = string.IsNullOrEmpty(actorHash)
@@ -679,7 +704,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             Status = $"Uploading {remaining} blob{(remaining == 1 ? string.Empty : "s")}…";
             remaining--;
 
-            if (!localBlobs.TryGetValue(hash, out var blobInfo) || blobInfo is not LocalBlobInfo blob)
+            if (!localBlobs.TryGetValue(hash, out LocalBlobInfo? blob) || blob is null)
             {
                 _log.Warning("Missing local blob for hash {Hash}", hash);
                 continue;

--- a/DemiCatPlugin/SyncshellWindow.cs
+++ b/DemiCatPlugin/SyncshellWindow.cs
@@ -180,7 +180,7 @@ public sealed class SyncshellWindow : IDisposable
         ImGui.TextDisabled("Prefetch downloads assets even when players are not currently visible.");
     }
 
-    private static void DrawActiveMembers(IReadOnlyList<SyncshellMemberStatus> activeMembers)
+    private void DrawActiveMembers(IReadOnlyList<SyncshellMemberStatus> activeMembers)
     {
         ImGui.TextUnformatted("Currently syncing");
         ImGui.Indent();


### PR DESCRIPTION
## Summary
- repair the SyncShell configuration migrations and restore the post-load migration helper
- clean up SyncShellService by handling nullable blob lookups and safely resolving player world names
- make the Syncshell window member renderer instance-based so helper calls no longer require a static context

## Testing
- not run (dotnet CLI is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ec3ae1d3f883289409729f8cecb559