### PR TITLE
Fix SyncShell threading issues and Penumbra path selection

### DIFF
--- a/DemiCatPlugin/NotePadService.cs
+++ b/DemiCatPlugin/NotePadService.cs
@@ -43,6 +43,7 @@ public sealed class NotePadService : IDisposable
         _config = config;
         _httpClient = httpClient;
         _tokenManager = tokenManager;
+        _serializerOptions.Converters.Add(new NotePadColorJsonConverter());
     }
 
     public IReadOnlyList<NotePadSection> Sections
@@ -988,6 +989,8 @@ public sealed class NotePadPage
     public int Version { get; set; }
     public DateTime UpdatedAt { get; set; }
     public DateTime CreatedAt { get; set; }
+
+    [JsonConverter(typeof(NotePadColorJsonConverter))]
     public string? Color { get; set; }
     public string? CreatedById { get; set; }
     public string? CreatedByDiscordId { get; set; }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Globalization;
 using System.Linq;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Interface.Utility;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
@@ -26,6 +27,7 @@ public class SettingsWindow : IDisposable
     private readonly Func<Task> _startNetworking;
     private readonly DeveloperWindow _devWindow;
     private readonly IPluginLog _log;
+    private readonly FileDialogManager _fileDialog = new();
 
     private string _apiKey = string.Empty;
     private string _apiBaseUrl = string.Empty;
@@ -438,6 +440,20 @@ public class SettingsWindow : IDisposable
             SaveConfig();
         }
 
+        ImGui.SameLine();
+        if (ImGui.Button("Browse…"))
+        {
+            _fileDialog.OpenFolderDialog("Select Penumbra Mod Directory", (ok, path) =>
+            {
+                if (ok && !string.IsNullOrWhiteSpace(path))
+                {
+                    _penumbraOverride = path;
+                    _config.PenumbraPathOverride = path;
+                    SaveConfig();
+                }
+            });
+        }
+
         if (ImGui.Button("Validate Path"))
         {
             string? error = null;
@@ -464,6 +480,8 @@ public class SettingsWindow : IDisposable
             var color = _penumbraValidationSuccess ? new Vector4(0f, 0.8f, 0f, 1f) : new Vector4(0.9f, 0f, 0f, 1f);
             ImGui.TextColored(color, _penumbraValidationMessage);
         }
+
+        _fileDialog.Draw();
     }
 
     private void DrawAppearanceTab()

--- a/DemiCatPlugin/SyncShell/BlobStore.cs
+++ b/DemiCatPlugin/SyncShell/BlobStore.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.Plugin;
@@ -338,8 +339,48 @@ public sealed class BlobStore : IDisposable
         }
     }
 
-    public static string GuessDefaultPenumbraRoot()
+    public static string? GuessDefaultPenumbraRoot()
     {
+        IEnumerable<string> Candidates()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                yield return Path.Combine(appData, "XIVLauncher", "pluginConfigs", "Penumbra", "settings.json");
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                var home = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+                yield return Path.Combine(home, "Library", "Application Support", "XIV on Mac", "xivlauncher", "pluginConfigs", "Penumbra", "settings.json");
+            }
+        }
+
+        foreach (var cfg in Candidates())
+        {
+            try
+            {
+                if (!File.Exists(cfg))
+                {
+                    continue;
+                }
+
+                using var doc = JsonDocument.Parse(File.ReadAllText(cfg));
+                if (doc.RootElement.TryGetProperty("ModDirectory", out var md))
+                {
+                    var dir = md.GetString();
+                    if (!string.IsNullOrWhiteSpace(dir) && Directory.Exists(dir))
+                    {
+                        return dir;
+                    }
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
@@ -359,6 +400,6 @@ public sealed class BlobStore : IDisposable
             }
         }
 
-        return string.Empty;
+        return null;
     }
 }

--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -614,15 +614,61 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
+    private T OnFramework<T>(Func<T> fn)
+    {
+        if (fn == null)
+        {
+            throw new ArgumentNullException(nameof(fn));
+        }
+
+        var tcs = new TaskCompletionSource<T>();
+        _framework.RunOnFrameworkThread(() =>
+        {
+            try
+            {
+                tcs.SetResult(fn());
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+
+        return tcs.Task.GetAwaiter().GetResult();
+    }
+
+    private void OnFramework(Action fn)
+    {
+        if (fn == null)
+        {
+            throw new ArgumentNullException(nameof(fn));
+        }
+
+        var tcs = new TaskCompletionSource<bool>();
+        _framework.RunOnFrameworkThread(() =>
+        {
+            try
+            {
+                fn();
+                tcs.SetResult(true);
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+
+        tcs.Task.GetAwaiter().GetResult();
+    }
+
     private (PublishPayload Payload, Dictionary<string, LocalBlobInfo?> LocalBlobs) BuildPublishPayload()
     {
-        var actorHash = string.Empty;
-        var player = _clientState.LocalPlayer;
-        if (player != null)
+        var actorHash = OnFramework(() =>
         {
-            actorHash = player.Name.TextValue ?? string.Empty;
+            var player = _clientState.LocalPlayer;
+            return player?.Name.TextValue ?? string.Empty;
             // Omit world label to avoid GeneratedSheets dependency; actorHash is just the name.
-        }
+        });
 
         var appearance = new AppearanceMeta
         {
@@ -920,7 +966,11 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
                 await Task.Delay(wait, token).ConfigureAwait(false);
             }
 
-            _penumbra.RedrawObject(_clientState.LocalPlayer?.ObjectIndex ?? 0);
+            OnFramework(() =>
+            {
+                var index = _clientState.LocalPlayer?.ObjectIndex ?? 0;
+                _penumbra.RedrawObject(index);
+            });
             _lastRedrawAt = DateTimeOffset.UtcNow;
         }
         finally
@@ -936,7 +986,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         {
             if (_glamourer.Available)
             {
-                glamourerJson = _glamourer.TryGetPlayerDesignJson();
+                glamourerJson = OnFramework(() => _glamourer.TryGetPlayerDesignJson());
             }
         }
         catch (Exception ex)
@@ -1044,33 +1094,34 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         => NormalizeHandle(member.DisplayName);
 
     private HashSet<string> GetVisibleHandles()
-    {
-        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        try
+        => OnFramework(() =>
         {
-            for (var i = 0; i < _objects.Length; i++)
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
             {
-                var obj = _objects[i];
-                if (obj == null || obj.ObjectKind != ObjectKind.Player)
+                for (var i = 0; i < _objects.Length; i++)
                 {
-                    continue;
-                }
+                    var obj = _objects[i];
+                    if (obj == null || obj.ObjectKind != ObjectKind.Player)
+                    {
+                        continue;
+                    }
 
-                var name = obj.Name?.TextValue ?? string.Empty;
-                if (!string.IsNullOrWhiteSpace(name))
-                {
-                    // No world decoration to avoid GeneratedSheets dependency
-                    set.Add(NormalizeHandle(name, null));
+                    var name = obj.Name?.TextValue ?? string.Empty;
+                    if (!string.IsNullOrWhiteSpace(name))
+                    {
+                        // No world decoration to avoid GeneratedSheets dependency
+                        set.Add(NormalizeHandle(name, null));
+                    }
                 }
             }
-        }
-        catch (Exception ex)
-        {
-            _log.Warning(ex, "Failed to read visible players");
-        }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Failed to read visible players");
+            }
 
-        return set;
-    }
+            return set;
+        });
 
     private void StageTempModForMember(string memberId, AppearanceMeta appearance)
     {


### PR DESCRIPTION
## Summary
- prevent NotePad page color deserialization from crashing by applying the existing color converter and registering it with the JSON serializer
- add a folder picker alongside the Penumbra path override field to simplify manual configuration
- marshal SyncShell IPC calls onto the framework thread and improve automatic Penumbra path detection by reading Penumbra's settings file

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ec47fb7e3c83289808f15e88d7e544