### PR TITLE
Avoid deadlock when invoking framework helpers

### DIFF
--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -52,6 +52,8 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     private readonly IFramework _framework;
     private readonly IObjectTable _objects;
 
+    private int _frameworkThreadId = -1;
+
     private readonly object _statusLock = new();
     private readonly SemaphoreSlim _lifecycleLock = new(1, 1);
     private readonly object _memberLock = new();
@@ -111,6 +113,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         _tokenManager.OnLinked += HandleTokenLinked;
         _tokenManager.OnUnlinked += HandleTokenUnlinked;
         _clientState.TerritoryChanged += HandleTerritoryChanged;
+        _framework.Update += OnFrameworkTick;
     }
 
     public event EventHandler? StatusChanged;
@@ -389,8 +392,14 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         _tokenManager.OnLinked -= HandleTokenLinked;
         _tokenManager.OnUnlinked -= HandleTokenUnlinked;
         _clientState.TerritoryChanged -= HandleTerritoryChanged;
+        _framework.Update -= OnFrameworkTick;
         _lifecycleLock.Dispose();
         _redrawGate.Dispose();
+    }
+
+    private void OnFrameworkTick(IFramework _)
+    {
+        _frameworkThreadId = Environment.CurrentManagedThreadId;
     }
 
     private void ThrowIfDisposed()
@@ -621,6 +630,11 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             throw new ArgumentNullException(nameof(fn));
         }
 
+        if (Environment.CurrentManagedThreadId == _frameworkThreadId)
+        {
+            return fn();
+        }
+
         var tcs = new TaskCompletionSource<T>();
         _framework.RunOnFrameworkThread(() =>
         {
@@ -642,6 +656,12 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         if (fn == null)
         {
             throw new ArgumentNullException(nameof(fn));
+        }
+
+        if (Environment.CurrentManagedThreadId == _frameworkThreadId)
+        {
+            fn();
+            return;
         }
 
         var tcs = new TaskCompletionSource<bool>();


### PR DESCRIPTION
## Summary
- track the framework thread id via the framework Update event
- short-circuit OnFramework helpers when already executing on the framework thread
- unsubscribe from the Update event during disposal to avoid leaks

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ec4acf2f2c832888ccd5d79804400b