### PR TITLE
Harden SyncShell framework and Penumbra integration

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -425,9 +425,17 @@ public class SettingsWindow : IDisposable
 
         var penumbraAvailable = service?.PenumbraAvailable ?? false;
         var detectedPath = service?.DetectedPenumbraPath;
-        if (penumbraAvailable && !string.IsNullOrEmpty(detectedPath))
+        var detectedFromSettings = service?.DetectedPenumbraPathFromSettingsJson ?? false;
+        if (!string.IsNullOrEmpty(detectedPath))
         {
-            ImGui.TextDisabled($"Detected Penumbra path: {detectedPath}");
+            var label = detectedFromSettings
+                ? $"Detected from Penumbra settings.json: {detectedPath}"
+                : $"Detected Penumbra path: {detectedPath}";
+            ImGui.TextDisabled(label);
+        }
+        else if (penumbraAvailable)
+        {
+            ImGui.TextDisabled("Penumbra IPC reported no mod directory. Set a path manually if needed.");
         }
         else
         {
@@ -450,6 +458,7 @@ public class SettingsWindow : IDisposable
                     _penumbraOverride = path;
                     _config.PenumbraPathOverride = path;
                     SaveConfig();
+                    service?.RefreshAppearanceCaches();
                 }
             });
         }

--- a/DemiCatPlugin/SyncShell/BlobStore.cs
+++ b/DemiCatPlugin/SyncShell/BlobStore.cs
@@ -339,8 +339,10 @@ public sealed class BlobStore : IDisposable
         }
     }
 
-    public static string? GuessDefaultPenumbraRoot()
+    public static string? GuessDefaultPenumbraRoot(out bool fromSettingsJson)
     {
+        fromSettingsJson = false;
+
         IEnumerable<string> Candidates()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -371,6 +373,7 @@ public sealed class BlobStore : IDisposable
                     var dir = md.GetString();
                     if (!string.IsNullOrWhiteSpace(dir) && Directory.Exists(dir))
                     {
+                        fromSettingsJson = true;
                         return dir;
                     }
                 }

--- a/DemiCatPlugin/SyncShell/ISyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/ISyncShellService.cs
@@ -17,6 +17,7 @@ public interface ISyncShellService
     IReadOnlyList<SyncshellMemberStatus> ActiveMembers { get; }
     bool PenumbraAvailable { get; }
     string? DetectedPenumbraPath { get; }
+    bool DetectedPenumbraPathFromSettingsJson { get; }
 
     SyncshellTargetStage GetStage(string memberId);
 
@@ -29,4 +30,5 @@ public interface ISyncShellService
     void ClearCache();
     Task EnforceCacheLimitAsync(CancellationToken cancellationToken = default);
     bool TryValidatePenumbraPath(string? path, out string? error);
+    void RefreshAppearanceCaches();
 }

--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -83,6 +83,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     private string? _glamourerJson;
     private DateTimeOffset _lastPublish;
     private DateTimeOffset _lastRedrawAt = DateTimeOffset.MinValue;
+    private bool _loggedSettingsJsonDetection;
 
     private List<SyncshellMemberStatus> _members = new();
     private List<SyncshellMemberStatus> _activeMembers = new();
@@ -114,6 +115,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         _tokenManager.OnUnlinked += HandleTokenUnlinked;
         _clientState.TerritoryChanged += HandleTerritoryChanged;
         _framework.Update += OnFrameworkTick;
+        _framework.RunOnFrameworkThread(() =>
+        {
+            _frameworkThreadId = Environment.CurrentManagedThreadId;
+        });
     }
 
     public event EventHandler? StatusChanged;
@@ -215,9 +220,34 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
     public bool PenumbraAvailable => _penumbra.Available;
 
-    public string? DetectedPenumbraPath => _penumbra.Available
-        ? _penumbra.GetModDirectory()
-        : BlobStore.GuessDefaultPenumbraRoot();
+    public string? DetectedPenumbraPath => TryGetDetectedPenumbraPath(out _);
+
+    public bool DetectedPenumbraPathFromSettingsJson
+    {
+        get
+        {
+            TryGetDetectedPenumbraPath(out var fromSettingsJson);
+            return fromSettingsJson;
+        }
+    }
+
+    private string? TryGetDetectedPenumbraPath(out bool fromSettingsJson)
+    {
+        if (_penumbra.Available)
+        {
+            fromSettingsJson = false;
+            return _penumbra.GetModDirectory();
+        }
+
+        var path = BlobStore.GuessDefaultPenumbraRoot(out fromSettingsJson);
+        if (fromSettingsJson && !_loggedSettingsJsonDetection && !string.IsNullOrWhiteSpace(path))
+        {
+            _log.Debug("Detected Penumbra path from settings.json: {Path}", path);
+            _loggedSettingsJsonDetection = true;
+        }
+
+        return path;
+    }
 
     public SyncshellTargetStage GetStage(string memberId)
     {
@@ -403,6 +433,11 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     }
 
     private void ThrowIfDisposed()
+    {
+        EnsureNotDisposed();
+    }
+
+    private void EnsureNotDisposed()
     {
         if (_disposed)
         {
@@ -630,12 +665,14 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             throw new ArgumentNullException(nameof(fn));
         }
 
+        EnsureNotDisposed();
+
         if (Environment.CurrentManagedThreadId == _frameworkThreadId)
         {
             return fn();
         }
 
-        var tcs = new TaskCompletionSource<T>();
+        var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
         _framework.RunOnFrameworkThread(() =>
         {
             try
@@ -658,13 +695,15 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             throw new ArgumentNullException(nameof(fn));
         }
 
+        EnsureNotDisposed();
+
         if (Environment.CurrentManagedThreadId == _frameworkThreadId)
         {
             fn();
             return;
         }
 
-        var tcs = new TaskCompletionSource<bool>();
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         _framework.RunOnFrameworkThread(() =>
         {
             try
@@ -999,8 +1038,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private void RefreshAppearanceCaches()
+    public void RefreshAppearanceCaches()
     {
+        EnsureNotDisposed();
+
         string? glamourerJson = null;
         try
         {
@@ -1022,7 +1063,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         if (string.IsNullOrWhiteSpace(modRoot))
         {
-            modRoot = BlobStore.GuessDefaultPenumbraRoot();
+            modRoot = TryGetDetectedPenumbraPath(out _);
         }
 
         var discovered = new Dictionary<string, LocalBlobInfo?>(StringComparer.OrdinalIgnoreCase);
@@ -1187,7 +1228,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         var root = _penumbra.GetModDirectory() ?? _config.PenumbraPathOverride;
         if (string.IsNullOrWhiteSpace(root))
         {
-            root = BlobStore.GuessDefaultPenumbraRoot();
+            root = TryGetDetectedPenumbraPath(out _);
         }
 
         if (string.IsNullOrWhiteSpace(root))

--- a/tests/SyncshellStateChangeFallbackTests.cs
+++ b/tests/SyncshellStateChangeFallbackTests.cs
@@ -56,6 +56,7 @@ public class SyncshellStateChangeFallbackTests
         public IReadOnlyList<SyncshellMemberStatus> ActiveMembers { get; private set; } = Array.Empty<SyncshellMemberStatus>();
         public bool PenumbraAvailable => false;
         public string? DetectedPenumbraPath => null;
+        public bool DetectedPenumbraPathFromSettingsJson => false;
 
         public Task Start(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
@@ -77,6 +78,10 @@ public class SyncshellStateChangeFallbackTests
         {
             error = null;
             return true;
+        }
+
+        public void RefreshAppearanceCaches()
+        {
         }
 
         public void EmitStatus(string status)


### PR DESCRIPTION
## Summary
- capture the framework thread id immediately on construction and guard framework invocations with asynchronous TaskCompletionSources
- expose whether the Penumbra path came from settings.json, logging it once, and reuse the detection helper when refreshing caches
- update the settings UI to surface the detection source, refresh caches after browsing for a path, and extend the sync service interface and tests accordingly

## Testing
- not run (dotnet CLI is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68ec5142d7dc8328a6303d8677993a24