### PR TITLE
Bump DemiCat version to 1.3.1.0

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -11,9 +11,9 @@
     <RootNamespace>DemiCatPlugin</RootNamespace>
 
     <!-- Keep these in sync with manifest -->
-    <Version>1.2.2.1</Version>
-    <AssemblyVersion>1.2.2.1</AssemblyVersion>
-    <FileVersion>1.2.2.1</FileVersion>
+    <Version>1.3.1.0</Version>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
+    <FileVersion>1.3.1.0</FileVersion>
 
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>

--- a/DemiCatPlugin/DemiCatPlugin.json
+++ b/DemiCatPlugin/DemiCatPlugin.json
@@ -2,7 +2,7 @@
   "Author": "Demi Dev Studio",
   "Name": "DemiCat",
   "InternalName": "DemiCatPlugin",
-  "AssemblyVersion": "1.2.2.1",
+  "AssemblyVersion": "1.3.1.0",
   "Description": "DemiCat Dalamud plugin. =Mew=",
   "ApplicableVersion": "any",
   "RepoUrl": "https://github.com/jackandcarter/DemiCat",

--- a/repo.json
+++ b/repo.json
@@ -5,7 +5,7 @@
     "InternalName": "DemiCatPlugin",
     "Punchline": "Discord-linked FC tools and chat.",
     "Description": "A mod to manage Discord FC communities and Events.",
-    "AssemblyVersion": "1.2.2.1",
+    "AssemblyVersion": "1.3.1.0",
     "ApplicableVersion": "any",
     "DalamudApiLevel": 13,
     "RepoUrl": "https://github.com/jackandcarter/DemiCat",


### PR DESCRIPTION
## Summary
- update the plugin project version metadata to 1.3.1.0
- bump the manifest and repository listings to the same version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec53c1aedc8328b90213fbd3765966