### PR TITLE
Update Dalamud repository manifest with download metadata

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -3,12 +3,23 @@
     "Author": "Demi Dev Unit",
     "Name": "DemiCat",
     "InternalName": "DemiCatPlugin",
-    "Punchline": "Discord-linked FC tools and chat.",
-    "Description": "A mod to manage Discord FC communities and Events.",
     "AssemblyVersion": "1.3.1.0",
+    "Description": "DemiCat Dalamud plugin. =Mew=",
     "ApplicableVersion": "any",
-    "DalamudApiLevel": 13,
     "RepoUrl": "https://github.com/jackandcarter/DemiCat",
-    "IconUrl": "https://the-demiurge.com/DemiDevUnit/icon.png"
+    "DalamudApiLevel": 13,
+    "DownloadLinkInstall": "https://the-demiurge.com/DemiCat.zip",
+    "DownloadLinkUpdate": "https://the-demiurge.com/DemiCat.zip",
+    "DownloadLinkTesting": "https://the-demiurge.com/DemiCat.zip",
+    "LoadRequiredState": 0,
+    "LoadSync": false,
+    "CanUnloadAsync": false,
+    "LoadPriority": 0,
+    "IconUrl": "https://the-demiurge.com/icon.png",
+    "Punchline": "Your Friendly Mechanical Catto!",
+    "AcceptsFeedback": true,
+    "IsHide": false,
+    "IsTestingExclusive": false,
+    "Changelog": ""
   }
 ]


### PR DESCRIPTION
## Summary
- add download links and runtime metadata to the plugin's repo manifest so Dalamud can fetch the package

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec5b1d87788328a1a86e11e365b670