### PR TITLE
Ensure DalamudPackager uses canonical manifest file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ demibot/demibot/config.json
 
 # Local build configuration
 Directory.Build.props
+DemiCatPlugin/DemiCatPlugin.json

--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -60,5 +60,11 @@
     <DalamudIcon>icon.png</DalamudIcon>
   </PropertyGroup>
 
+  <Target Name="CopyDalamudManifest" BeforeTargets="Build">
+    <Copy SourceFiles="$(ProjectDir)manifest.json"
+          DestinationFiles="$(ProjectDir)$(AssemblyName).json"
+          SkipUnchangedFiles="true" />
+  </Target>
+
   <!-- DO NOT import a custom DalamudPackager.targets for v13 -->
 </Project>

--- a/DemiCatPlugin/manifest.json
+++ b/DemiCatPlugin/manifest.json
@@ -11,7 +11,7 @@
   "LoadSync": false,
   "CanUnloadAsync": false,
   "LoadPriority": 0,
-  "IconUrl": "https://raw.githubusercontent.com/jackandcarter/DemiCat/main/Demi_Bot_Logo.png",
-  "Punchline": "Discord-linked FC tools and chat.",
+  "IconUrl": "https://the-demiurge.com/icon.png",
+  "Punchline": "Your Friendly Mechanical Catto!",
   "AcceptsFeedback": true
 }

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ ephemeral reply. Each user should generate their own key with this command for
 plugin authentication.
 
 ### 3. Configure the Dalamud plugin
-Update `DemiCatPlugin/DemiCatPlugin.json` with the usual plugin metadata. In-game,
+Update `DemiCatPlugin/manifest.json` with the usual plugin metadata. In-game,
 open the plugin configuration and set the `ApiBaseUrl` if needed (default
 `http://127.0.0.1:5050`).
 
@@ -157,9 +157,9 @@ Alternatively, add this repository to Dalamud so it can install and update the p
 3. Enable the **DemiCat** plugin from the available plugin list.
 
 The plugin icon is hosted at `https://cdn.discordapp.com/attachments/1337791050294755380/1337854067560550422/Demi_Bot_Logo.png`.
-Update `IconUrl` in `DemiCatPlugin/DemiCatPlugin.json` and the matching entry in `repo.json` if this image changes.
+Update `IconUrl` in `DemiCatPlugin/manifest.json` and the matching entry in `repo.json` if this image changes.
 When releasing, bump `AssemblyVersion` and `FileVersion` in `DemiCatPlugin/DemiCatPlugin.csproj`,
-and keep `DemiCatPlugin/DemiCatPlugin.json` and `repo.json` in sync with the new version number.
+and keep `DemiCatPlugin/manifest.json` and `repo.json` in sync with the new version number.
 
 ## Usage
 

--- a/repo.json
+++ b/repo.json
@@ -3,12 +3,23 @@
     "Author": "Demi Dev Unit",
     "Name": "DemiCat",
     "InternalName": "DemiCatPlugin",
-    "Punchline": "Discord-linked FC tools and chat.",
-    "Description": "A mod to manage Discord FC communities and Events.",
     "AssemblyVersion": "1.3.1.0",
+    "Description": "DemiCat Dalamud plugin. =Mew=",
     "ApplicableVersion": "any",
-    "DalamudApiLevel": 13,
     "RepoUrl": "https://github.com/jackandcarter/DemiCat",
-    "IconUrl": "https://the-demiurge.com/DemiDevUnit/icon.png"
+    "DalamudApiLevel": 13,
+    "DownloadLinkInstall": "https://the-demiurge.com/DemiCat.zip",
+    "DownloadLinkUpdate": "https://the-demiurge.com/DemiCat.zip",
+    "DownloadLinkTesting": "https://the-demiurge.com/DemiCat.zip",
+    "LoadRequiredState": 0,
+    "LoadSync": false,
+    "CanUnloadAsync": false,
+    "LoadPriority": 0,
+    "IconUrl": "https://the-demiurge.com/icon.png",
+    "Punchline": "Your Friendly Mechanical Catto!",
+    "AcceptsFeedback": true,
+    "IsHide": false,
+    "IsTestingExclusive": false,
+    "Changelog": ""
   }
 ]

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -194,7 +194,7 @@ fi
 
 "$DOTNET_CMD" restore DemiCatPlugin/DemiCatPlugin.csproj
 "$DOTNET_CMD" build DemiCatPlugin/DemiCatPlugin.csproj -c Release
-cp DemiCatPlugin/DemiCatPlugin.json DemiCatPlugin/bin/Release/net9.0/
+cp DemiCatPlugin/manifest.json DemiCatPlugin/bin/Release/net9.0/DemiCatPlugin.json
 
 # Run .NET tests
 find tests -name '*Tests.csproj' -print0 | while IFS= read -r -d '' testproj; do


### PR DESCRIPTION
## Summary
- move the plugin manifest to `manifest.json` and copy it into place before the DalamudPackager task runs so builds always see a JSON object
- ignore the generated `DemiCatPlugin.json` file, and update docs and setup tooling to reference the new canonical manifest path

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ec5b1d87788328a1a86e11e365b670