### PR TITLE
Ensure manifest is included in plugin build output

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -43,6 +43,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="manifest.json" CopyToOutputDirectory="PreserveNewest" />
     <EmbeddedResource Include="images/icon.png" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add manifest.json to the project items so it is copied alongside the build output

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ec734fffb883289467d8338782832a