### PR TITLE
Fix manifest path for Dalamud packager

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -14,8 +14,8 @@
     <AssemblyVersion>1.3.1.0</AssemblyVersion>
     <FileVersion>1.3.1.0</FileVersion>
 
-    <DalamudManifest>manifest.json</DalamudManifest>
-    <DalamudPackagerManifest>manifest.json</DalamudPackagerManifest>
+    <DalamudManifest>$(MSBuildProjectDirectory)/manifest.json</DalamudManifest>
+    <DalamudPackagerManifest>$(DalamudManifest)</DalamudPackagerManifest>
     <DalamudIcon>images/icon.png</DalamudIcon>
 
     <NoWarn>CA1416</NoWarn>
@@ -43,6 +43,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Update="manifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <EmbeddedResource Include="images/icon.png" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- point the Dalamud manifest properties at an absolute project-local path so the packager can find the file
- convert the manifest copy configuration to update the existing item so the build always copies the manifest

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ec734fffb883289467d8338782832a