### PR TITLE
Specify manifest file for Dalamud packaging

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -14,8 +14,8 @@
     <AssemblyVersion>1.3.1.0</AssemblyVersion>
     <FileVersion>1.3.1.0</FileVersion>
 
-    <DalamudManifest>$(MSBuildProjectDirectory)/manifest.json</DalamudManifest>
-    <DalamudPackagerManifest>$(DalamudManifest)</DalamudPackagerManifest>
+    <DalamudManifest>manifest.json</DalamudManifest>
+    <DalamudPackagerManifest>manifest.json</DalamudPackagerManifest>
     <DalamudIcon>images/icon.png</DalamudIcon>
 
     <NoWarn>CA1416</NoWarn>


### PR DESCRIPTION
## Summary
- set the Dalamud manifest and packager manifest properties to manifest.json so the build uses the correct manifest file

## Testing
- `dotnet build -c Release` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec7c53b26883289146c12ae9f5d8c2