### PR TITLE
Fix dock gradient fill to cover full window

### DIFF
--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -426,8 +426,8 @@ public class MainWindow : IDisposable
                 var drawList = ImGui.GetWindowDrawList();
                 var winPos = ImGui.GetWindowPos();
                 var winSize = ImGui.GetWindowSize();
-                var min = winPos + new Vector2(borderSize, borderSize);
-                var max = winPos + winSize - new Vector2(borderSize, borderSize);
+                var min = winPos;
+                var max = winPos + winSize;
                 if (max.X > min.X && max.Y > min.Y)
                 {
                     var topColor = ImGui.GetColorU32(gradientStart);


### PR DESCRIPTION
## Summary
- adjust the dock gradient rendering to span the entire window bounds
- ensure the custom border draw uses the window extents so the gradient sits beneath it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ece9c86a9c832885d1fec6388183bc