### PR TITLE
Handle default guild sentinel during channel validation

### DIFF
--- a/DemiCatPlugin/ChannelKeyHelper.cs
+++ b/DemiCatPlugin/ChannelKeyHelper.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace DemiCatPlugin;
 
 public static class ChannelKeyHelper
@@ -22,5 +24,13 @@ public static class ChannelKeyHelper
     public static string BuildCursorKey(string? guildId, string? kind, string channelId)
         => $"{NormalizeGuildId(guildId)}:{NormalizeKind(kind)}:{channelId}";
 
-    public static bool IsDefaultGuild(string? guildId) => string.IsNullOrWhiteSpace(guildId);
+    public static bool IsDefaultGuild(string? guildId)
+    {
+        if (string.IsNullOrWhiteSpace(guildId))
+        {
+            return true;
+        }
+
+        return string.Equals(guildId.Trim(), DefaultGuildSentinel, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/ChannelKeyHelperTests.cs
+++ b/tests/ChannelKeyHelperTests.cs
@@ -1,0 +1,24 @@
+using DemiCatPlugin;
+using Xunit;
+
+public class ChannelKeyHelperTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("default")]
+    [InlineData("DEFAULT")]
+    public void IsDefaultGuild_TreatsSentinelAsDefault(string? value)
+    {
+        Assert.True(ChannelKeyHelper.IsDefaultGuild(value));
+    }
+
+    [Fact]
+    public void NormalizeGuildId_ReturnsSentinelForEmptyValues()
+    {
+        Assert.Equal("default", ChannelKeyHelper.NormalizeGuildId(null));
+        Assert.Equal("default", ChannelKeyHelper.NormalizeGuildId("   "));
+        Assert.Equal("guild-123", ChannelKeyHelper.NormalizeGuildId("guild-123"));
+    }
+}


### PR DESCRIPTION
## Summary
- treat the `default` guild sentinel as an unset guild when building channel keys
- add coverage to ensure the helper returns the sentinel for blank guild ids and flags the sentinel as default

## Testing
- `dotnet test tests/DemiCatPlugin.Tests.csproj --filter ChannelKeyHelperTests` *(fails: `dotnet` not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ece99795c0832892237d52f41680a2