### PR TITLE
Support camelCase presence payloads

### DIFF
--- a/DemiCatPlugin/GuildRolesResponseDto.cs
+++ b/DemiCatPlugin/GuildRolesResponseDto.cs
@@ -8,7 +8,29 @@ internal sealed class GuildRolesResponseDto
     [JsonPropertyName("roles")]
     public List<RoleDto> Roles { get; set; } = new();
 
+    private List<string> _mentionRoleIds = new();
+
+    [JsonIgnore]
+    public List<string> MentionRoleIds
+    {
+        get => _mentionRoleIds;
+        set => _mentionRoleIds = value ?? new List<string>();
+    }
+
     [JsonPropertyName("mention_role_ids")]
-    public List<string> MentionRoleIds { get; set; } = new();
+    [JsonInclude]
+    public List<string> LegacyMentionRoleIds
+    {
+        get => _mentionRoleIds;
+        set => MentionRoleIds = value;
+    }
+
+    [JsonPropertyName("mentionRoleIds")]
+    [JsonInclude]
+    public List<string> MentionRoleIdsCamel
+    {
+        get => _mentionRoleIds;
+        set => MentionRoleIds = value;
+    }
 }
 

--- a/DemiCatPlugin/PresenceDto.cs
+++ b/DemiCatPlugin/PresenceDto.cs
@@ -10,15 +10,91 @@ public class PresenceDto
     [JsonPropertyName("id")] public string Id { get; set; } = string.Empty;
     [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
     [JsonPropertyName("status")] public string Status { get; set; } = string.Empty;
-    [JsonPropertyName("status_text")] public string? StatusText { get; set; }
-    [JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; }
+
+    private string? _statusText;
+
+    [JsonIgnore]
+    public string? StatusText
+    {
+        get => _statusText;
+        set => _statusText = string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    [JsonPropertyName("status_text")]
+    [JsonInclude]
+    public string? LegacyStatusText
+    {
+        get => _statusText;
+        set => StatusText = value;
+    }
+
+    [JsonPropertyName("statusText")]
+    [JsonInclude]
+    public string? StatusTextCamel
+    {
+        get => _statusText;
+        set => StatusText = value;
+    }
+
+    private string? _avatarUrl;
+
+    [JsonIgnore]
+    public string? AvatarUrl
+    {
+        get => _avatarUrl;
+        set => _avatarUrl = string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    [JsonPropertyName("avatar_url")]
+    [JsonInclude]
+    public string? LegacyAvatarUrl
+    {
+        get => _avatarUrl;
+        set => AvatarUrl = value;
+    }
+
+    [JsonPropertyName("avatarUrl")]
+    [JsonInclude]
+    public string? AvatarUrlCamel
+    {
+        get => _avatarUrl;
+        set => AvatarUrl = value;
+    }
+
     [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
     [JsonIgnore] public bool AvatarLoadRequested { get; set; }
-    [JsonPropertyName("banner_url")] public string? BannerUrl { get; set; }
+
+    private string? _bannerUrl;
+
+    [JsonIgnore]
+    public string? BannerUrl
+    {
+        get => _bannerUrl;
+        set => _bannerUrl = string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    [JsonPropertyName("banner_url")]
+    [JsonInclude]
+    public string? LegacyBannerUrl
+    {
+        get => _bannerUrl;
+        set => BannerUrl = value;
+    }
+
+    [JsonPropertyName("bannerUrl")]
+    [JsonInclude]
+    public string? BannerUrlCamel
+    {
+        get => _bannerUrl;
+        set => BannerUrl = value;
+    }
+
     [JsonIgnore] public ISharedImmediateTexture? BannerTexture { get; set; }
     [JsonIgnore] public bool BannerLoadRequested { get; set; }
+
     private uint? _accentColorValue;
-    [JsonPropertyName("accent_color")]
+
+    [JsonIgnore]
     public uint? AccentColorValue
     {
         get => _accentColorValue;
@@ -28,9 +104,51 @@ public class PresenceDto
             AccentColor = value.HasValue ? ColorUtils.RgbToVector4(value.Value) : null;
         }
     }
+
+    [JsonPropertyName("accent_color")]
+    [JsonInclude]
+    public uint? LegacyAccentColor
+    {
+        get => _accentColorValue;
+        set => AccentColorValue = value;
+    }
+
+    [JsonPropertyName("accentColor")]
+    [JsonInclude]
+    public uint? AccentColorCamel
+    {
+        get => _accentColorValue;
+        set => AccentColorValue = value;
+    }
+
     [JsonIgnore] public Vector4? AccentColor { get; private set; }
+
     [JsonPropertyName("roles")] public List<string> Roles { get; set; } = new();
-    [JsonPropertyName("role_details")] public List<PresenceRoleDto> RoleDetails { get; set; } = new();
+
+    private List<PresenceRoleDto> _roleDetails = new();
+
+    [JsonIgnore]
+    public List<PresenceRoleDto> RoleDetails
+    {
+        get => _roleDetails;
+        set => _roleDetails = value ?? new List<PresenceRoleDto>();
+    }
+
+    [JsonPropertyName("role_details")]
+    [JsonInclude]
+    public List<PresenceRoleDto> LegacyRoleDetails
+    {
+        get => _roleDetails;
+        set => RoleDetails = value;
+    }
+
+    [JsonPropertyName("roleDetails")]
+    [JsonInclude]
+    public List<PresenceRoleDto> RoleDetailsCamel
+    {
+        get => _roleDetails;
+        set => RoleDetails = value;
+    }
 }
 
 public class PresenceRoleDto

--- a/DemiCatPlugin/RoleDto.cs
+++ b/DemiCatPlugin/RoleDto.cs
@@ -16,7 +16,29 @@ public class RoleDto
 
 public class RoleTagsDto
 {
+    private bool _premiumSubscriber;
+
+    [JsonIgnore]
+    public bool PremiumSubscriber
+    {
+        get => _premiumSubscriber;
+        set => _premiumSubscriber = value;
+    }
+
     [JsonPropertyName("premium_subscriber")]
-    public bool PremiumSubscriber { get; set; }
+    [JsonInclude]
+    public bool LegacyPremiumSubscriber
+    {
+        get => _premiumSubscriber;
+        set => _premiumSubscriber = value;
+    }
+
+    [JsonPropertyName("premiumSubscriber")]
+    [JsonInclude]
+    public bool PremiumSubscriberCamel
+    {
+        get => _premiumSubscriber;
+        set => _premiumSubscriber = value;
+    }
 }
 


### PR DESCRIPTION
## Summary
- allow presence DTOs to populate from either snake_case or camelCase payload properties
- accept camelCase mentionRoleIds and premiumSubscriber fields when caching guild role metadata

## Testing
- not run (dotnet CLI is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ecea073b548328820e2814ca6b145e