### PR TITLE
Fix presence sidebar race and improve emoji rendering

### DIFF
--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -73,7 +73,7 @@ public class DiscordPresenceService : IDisposable
     {
         _loaded = false;
         _nextRefreshAllowed = DateTime.MinValue;
-        DisposeAllPresences();
+        _ = DisposeAllPresencesAsync();
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ public class DiscordPresenceService : IDisposable
         var socket = Interlocked.Exchange(ref _ws, null);
         socket?.Dispose();
 
-        DisposeAllPresences();
+        _ = DisposeAllPresencesAsync();
         SetConnectionState(PresenceConnectionState.Disconnected);
     }
 
@@ -160,7 +160,7 @@ public class DiscordPresenceService : IDisposable
         var socket = Interlocked.Exchange(ref _ws, null);
         socket?.Dispose();
 
-        DisposeAllPresences();
+        _ = DisposeAllPresencesAsync();
         SetConnectionState(PresenceConnectionState.Disconnected);
     }
 
@@ -384,7 +384,7 @@ public class DiscordPresenceService : IDisposable
                 _retryAttempt = 0;
                 hadTransportError = false;
                 _loaded = false;
-                DisposeAllPresences();
+                await DisposeAllPresencesAsync().ConfigureAwait(false);
                 await Refresh(force: true).ConfigureAwait(false);
                 SetConnectionState(PresenceConnectionState.Connected);
                 UpdateStatusMessage(string.Empty);
@@ -719,23 +719,23 @@ public class DiscordPresenceService : IDisposable
         }
     }
 
-    private void DisposeAllPresences()
+    private Task DisposeAllPresencesAsync()
     {
         var framework = PluginServices.Instance?.Framework;
-        if (framework == null)
+        if (framework != null)
         {
-            DisposePresencesUnlocked(_presences);
-            _presences.Clear();
-            _indexById.Clear();
-            return;
+            return framework.RunOnTick(() =>
+            {
+                DisposePresencesUnlocked(_presences);
+                _presences.Clear();
+                _indexById.Clear();
+            });
         }
 
-        framework.RunOnTick(() =>
-        {
-            DisposePresencesUnlocked(_presences);
-            _presences.Clear();
-            _indexById.Clear();
-        });
+        DisposePresencesUnlocked(_presences);
+        _presences.Clear();
+        _indexById.Clear();
+        return Task.CompletedTask;
     }
 
     private readonly struct RefreshOutcome

--- a/DemiCatPlugin/Emoji/EmojiManager.cs
+++ b/DemiCatPlugin/Emoji/EmojiManager.cs
@@ -22,6 +22,7 @@ public sealed class EmojiManager : IDisposable
     private Task? _customTask;
 
     private UnicodeEmoji[] _unicode = Array.Empty<UnicodeEmoji>();
+    private Dictionary<string, UnicodeEmoji> _unicodeLookup = new(StringComparer.Ordinal);
     private CustomEmoji[] _custom = Array.Empty<CustomEmoji>();
     private Dictionary<string, CustomEmoji> _customLookup = new(StringComparer.Ordinal);
 
@@ -79,6 +80,19 @@ public sealed class EmojiManager : IDisposable
     public Task RefreshUnicodeAsync(CancellationToken ct = default) => StartUnicodeLoad(ct, true);
     public Task EnsureCustomAsync(CancellationToken ct = default) => StartCustomLoad(ct, false);
     public Task RefreshCustomAsync(CancellationToken ct = default) => StartCustomLoad(ct, true);
+
+    public bool TryGetUnicodeEmoji(string value, out UnicodeEmoji? emoji)
+    {
+        var lookup = Volatile.Read(ref _unicodeLookup);
+        if (lookup != null && lookup.TryGetValue(value, out var found))
+        {
+            emoji = found;
+            return true;
+        }
+
+        emoji = null;
+        return false;
+    }
 
     public bool TryGetCustomEmoji(string id, out CustomEmoji? emoji)
     {
@@ -147,6 +161,7 @@ public sealed class EmojiManager : IDisposable
         {
             var result = await FetchUnicodeAsync(ct).ConfigureAwait(false);
             Volatile.Write(ref _unicode, result);
+            Volatile.Write(ref _unicodeLookup, BuildUnicodeLookup(result));
             UpdateUnicodeState(new LoadState(false, true, null));
         }
         catch (OperationCanceledException)
@@ -221,6 +236,23 @@ public sealed class EmojiManager : IDisposable
         var list = await JsonSerializer.DeserializeAsync<List<UnicodeEmoji>>(stream, JsonOptions, ct).ConfigureAwait(false)
                    ?? new List<UnicodeEmoji>();
         return list.FindAll(e => !string.IsNullOrWhiteSpace(e.Emoji)).ToArray();
+    }
+
+    private static Dictionary<string, UnicodeEmoji> BuildUnicodeLookup(IReadOnlyList<UnicodeEmoji> emojis)
+    {
+        var lookup = new Dictionary<string, UnicodeEmoji>(emojis.Count, StringComparer.Ordinal);
+        for (var i = 0; i < emojis.Count; i++)
+        {
+            var emoji = emojis[i];
+            if (emoji == null || string.IsNullOrWhiteSpace(emoji.Emoji))
+            {
+                continue;
+            }
+
+            lookup[emoji.Emoji] = emoji;
+        }
+
+        return lookup;
     }
 
     private async Task<(CustomEmoji[] Items, Dictionary<string, CustomEmoji> Lookup)> FetchCustomAsync(CancellationToken ct)

--- a/DemiCatPlugin/Emoji/EmojiRenderer.cs
+++ b/DemiCatPlugin/Emoji/EmojiRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
 
@@ -6,6 +7,9 @@ namespace DemiCatPlugin.Emoji;
 
 public static class EmojiRenderer
 {
+    private static readonly HashSet<string> PendingUnicodeTextures = new(StringComparer.Ordinal);
+    private static readonly object PendingLock = new();
+
     public static void Draw(string? value, EmojiManager manager, float size = 20f)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -15,8 +19,7 @@ public static class EmojiRenderer
 
         if (!EmojiFormatter.TryParseCustomToken(value, out var id, out var fallbackName, out var fallbackAnimated))
         {
-            using var font = manager.PushEmojiFont();
-            ImGui.TextUnformatted(value);
+            DrawUnicodeEmoji(value, manager, size);
             return;
         }
 
@@ -54,4 +57,63 @@ public static class EmojiRenderer
 
     private static string BuildCdnUrl(string id, bool animated)
         => $"https://cdn.discordapp.com/emojis/{id}.{(animated ? "gif" : "png")}";
+
+    private static void DrawUnicodeEmoji(string value, EmojiManager manager, float size)
+    {
+        if (manager.TryGetUnicodeEmoji(value, out var unicode) && unicode != null)
+        {
+            var tooltip = string.IsNullOrEmpty(unicode.Name) ? value : unicode.Name;
+            var imageUrl = unicode.ImageUrl;
+            if (!string.IsNullOrEmpty(imageUrl) &&
+                WebTextureCache.TryGetTexture(imageUrl, out var cached) &&
+                cached != null)
+            {
+                var wrap = cached.GetWrapOrEmpty();
+                if (wrap.Width > 0 && wrap.Height > 0)
+                {
+                    ImGui.Image(wrap.Handle, new Vector2(size, size));
+                    if (!string.IsNullOrEmpty(tooltip) && ImGui.IsItemHovered())
+                    {
+                        ImGui.SetTooltip(tooltip);
+                    }
+                    return;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(imageUrl) && !WebTextureCache.TryGetTexture(imageUrl, out _))
+            {
+                RequestUnicodeTexture(imageUrl);
+            }
+
+            using var font = manager.PushEmojiFont();
+            ImGui.TextUnformatted(value);
+            if (!string.IsNullOrEmpty(tooltip) && ImGui.IsItemHovered())
+            {
+                ImGui.SetTooltip(tooltip);
+            }
+            return;
+        }
+
+        using var fallbackFont = manager.PushEmojiFont();
+        ImGui.TextUnformatted(value);
+    }
+
+    private static void RequestUnicodeTexture(string imageUrl)
+    {
+        lock (PendingLock)
+        {
+            if (!PendingUnicodeTextures.Add(imageUrl))
+            {
+                return;
+            }
+        }
+
+        WebTextureCache.Get(imageUrl, _ =>
+        {
+            lock (PendingLock)
+            {
+                PendingUnicodeTextures.Remove(imageUrl);
+            }
+        });
+    }
 }

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -430,9 +430,7 @@ public class MainWindow : IDisposable
                 var max = winPos + winSize;
                 if (max.X > min.X && max.Y > min.Y)
                 {
-                    var topColor = ImGui.GetColorU32(gradientStart);
-                    var bottomColor = ImGui.GetColorU32(gradientEnd);
-                    drawList.AddRectFilledMultiColor(min, max, topColor, topColor, bottomColor, bottomColor);
+                    DrawRoundedVerticalGradient(drawList, min, max, gradientStart, gradientEnd, rounding);
                     var borderColorU32 = ImGui.GetColorU32(style.Colors[(int)ImGuiCol.Border]);
                     drawList.AddRect(min, max, borderColorU32, rounding, ImDrawFlags.RoundCornersAll, borderSize);
                 }
@@ -1200,6 +1198,49 @@ public class MainWindow : IDisposable
     private static Vector4 WithAlpha(Vector4 color, float alphaMultiplier)
     {
         return new Vector4(color.X, color.Y, color.Z, Math.Clamp(color.W * alphaMultiplier, 0f, 1f));
+    }
+
+    private static void DrawRoundedVerticalGradient(
+        ImDrawListPtr drawList,
+        Vector2 min,
+        Vector2 max,
+        Vector4 topColor,
+        Vector4 bottomColor,
+        float rounding)
+    {
+        if (max.X <= min.X || max.Y <= min.Y)
+        {
+            return;
+        }
+
+        var height = max.Y - min.Y;
+        var segments = Math.Clamp((int)MathF.Ceiling(height / 4f), 4, 64);
+        for (var i = 0; i < segments; i++)
+        {
+            var t0 = (float)i / segments;
+            var t1 = (float)(i + 1) / segments;
+            var y0 = min.Y + height * t0;
+            var y1 = min.Y + height * t1;
+            var segmentMin = new Vector2(min.X, y0);
+            var segmentMax = new Vector2(max.X, i == segments - 1 ? max.Y : y1);
+            var color = Vector4.Lerp(topColor, bottomColor, (t0 + t1) * 0.5f);
+            var colorU32 = ImGui.GetColorU32(color);
+
+            var segmentRounding = 0f;
+            var flags = ImDrawFlags.RoundCornersNone;
+            if (i == 0 && rounding > 0f)
+            {
+                segmentRounding = rounding;
+                flags = ImDrawFlags.RoundCornersTop;
+            }
+            else if (i == segments - 1 && rounding > 0f)
+            {
+                segmentRounding = rounding;
+                flags = ImDrawFlags.RoundCornersBottom;
+            }
+
+            drawList.AddRectFilled(segmentMin, segmentMax, colorU32, segmentRounding, flags);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- ensure presence snapshots are not cleared after reconnects by awaiting the disposal pass
- add a Unicode emoji lookup so standard Discord emoji render via cached CDN sprites
- draw the dock gradient with rounded corners so it fills the full window frame

## Testing
- `dotnet test` *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecf4ccac548328b9be221818167092