### PR TITLE
Improve UI chrome, embeds, and note management

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -524,12 +524,20 @@ public class ChatWindow : IDisposable
     {
         var width = MathF.Max(1f, baseBounds.X);
         var height = MathF.Max(1f, baseBounds.Y);
+        var aspect = height / MathF.Max(1f, width);
+
+        var availableWidth = MathF.Max(1f, ImGui.GetContentRegionAvail().X);
 
         if (allowAutoStretch && _config.ChatImageAutoStretch)
         {
-            var availableWidth = MathF.Max(1f, ImGui.GetContentRegionAvail().X);
             width = availableWidth;
         }
+        else
+        {
+            width = MathF.Min(width, availableWidth);
+        }
+
+        height = MathF.Max(1f, width * aspect);
 
         return new Vector2(width, height);
     }
@@ -1932,21 +1940,13 @@ public class ChatWindow : IDisposable
         var began = ImGui.Begin(title, ref open, flags);
         if (began)
         {
-            UiTheme.DrawWindowChrome(_config, title, () => open = false);
-
             var style = ImGui.GetStyle();
-            var chromeHeight = Math.Max(14f * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight());
+            var chromeHeight = Math.Max(22f * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight() + style.FramePadding.Y * 1.5f);
             ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y));
-            var dragSize = new Vector2(ImGui.GetContentRegionAvail().X, chromeHeight);
-            ImGui.InvisibleButton($"##drag_zone_{title}", dragSize);
-            if (ImGui.IsItemActive() && ImGui.IsMouseDragging(0))
-            {
-                var io = ImGui.GetIO();
-                ImGui.SetWindowPos(ImGui.GetWindowPos() + io.MouseDelta);
-            }
-
-            ImGui.Dummy(new Vector2(1f, style.FramePadding.Y + chromeHeight));
+            ImGui.Dummy(new Vector2(1f, chromeHeight));
+            ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y + chromeHeight));
             Draw();
+            UiTheme.DrawWindowChrome(_config, title, () => open = false, chromeHeight);
         }
         ImGui.End();
         ImGui.PopStyleVar();

--- a/DemiCatPlugin/EmbedPreviewRenderer.cs
+++ b/DemiCatPlugin/EmbedPreviewRenderer.cs
@@ -17,7 +17,7 @@ public static class EmbedPreviewRenderer
     {
         using var emojiFont = emojiManager.PushEmojiFont();
         var style = ImGui.GetStyle();
-        var stripeWidth = dto.Color.HasValue ? Math.Max(4f, style.FramePadding.X * 0.75f) : 0f;
+        var stripeWidth = dto.Color.HasValue ? Math.Max(6f, style.FramePadding.X * 0.9f) : 0f;
         const float contentPadding = 8f;
         const float verticalPadding = 4f;
 
@@ -195,20 +195,25 @@ public static class EmbedPreviewRenderer
             var cardMin = ImGui.GetWindowPos();
             var cardMax = cardMin + ImGui.GetWindowSize();
             var cardRounding = style.ChildRounding;
-            var borderInset = Math.Max(1f, style.ChildBorderSize > 0f ? style.ChildBorderSize : style.FrameBorderSize);
+            var borderInset = Math.Max(0f, style.ChildBorderSize > 0f ? style.ChildBorderSize : style.FrameBorderSize);
             var stripeMin = new Vector2(cardMin.X + borderInset, cardMin.Y + borderInset);
             var stripeMax = new Vector2(cardMin.X + borderInset + stripeWidth, cardMax.Y - borderInset);
             if (stripeMax.X > stripeMin.X && stripeMax.Y > stripeMin.Y)
             {
                 var colorVec = ColorUtils.RgbToVector4(dto.Color.Value);
                 var color = ImGui.ColorConvertFloat4ToU32(colorVec);
-                var stripeRounding = Math.Min(cardRounding, stripeWidth * 0.5f);
-                dl.AddRectFilled(
-                    stripeMin,
-                    stripeMax,
-                    color,
-                    stripeRounding,
-                    ImDrawFlags.RoundCornersTopLeft | ImDrawFlags.RoundCornersBottomLeft);
+                dl.AddRectFilled(stripeMin, stripeMax, color);
+
+                if (cardRounding > 0f)
+                {
+                    var stripeRounding = Math.Min(cardRounding, Math.Min(stripeWidth, stripeMax.Y - stripeMin.Y) * 0.5f);
+                    dl.AddRectFilled(
+                        stripeMin,
+                        stripeMax,
+                        color,
+                        stripeRounding,
+                        ImDrawFlags.RoundCornersTopLeft | ImDrawFlags.RoundCornersBottomLeft);
+                }
             }
         }
 

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -1010,26 +1010,18 @@ public class MainWindow : IDisposable
         var began = ImGui.Begin($"{title}##dc_{id}", ref openRef, windowFlags);
         if (began)
         {
+            var style = ImGui.GetStyle();
+            var chromeHeight = Math.Max(22f * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight() + style.FramePadding.Y * 1.5f);
+            ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y));
+            ImGui.Dummy(new Vector2(1f, chromeHeight));
+            ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y + chromeHeight));
+            drawContent();
+            windowInteracted = HasWindowInteraction();
             UiTheme.DrawWindowChrome(_config, title, () =>
             {
                 openRef = false;
                 closeRequested = true;
-            });
-
-            var style = ImGui.GetStyle();
-            var chromeHeight = Math.Max(14f * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight());
-            ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y));
-            var dragSize = new Vector2(ImGui.GetContentRegionAvail().X, chromeHeight);
-            ImGui.InvisibleButton($"##drag_zone_dc_{id}", dragSize);
-            if (ImGui.IsItemActive() && ImGui.IsMouseDragging(0))
-            {
-                var io = ImGui.GetIO();
-                ImGui.SetWindowPos(ImGui.GetWindowPos() + io.MouseDelta);
-            }
-
-            ImGui.Dummy(new Vector2(1f, style.FramePadding.Y + chromeHeight));
-            drawContent();
-            windowInteracted = HasWindowInteraction();
+            }, chromeHeight);
         }
         ImGui.End();
         ImGui.PopStyleVar();

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -264,9 +264,23 @@ public sealed class NotePadWindow : IDisposable
             ImGui.EndPopup();
         }
 
-        if (!IsReadOnly && ImGui.MenuItem("Delete"))
+        var canDeleteSection = OfficerPermissions.HasAccess(_config);
+        if (!IsReadOnly)
         {
-            _ = Task.Run(() => _service.DeleteSectionAsync(section.Id, CancellationToken.None));
+            if (!canDeleteSection)
+            {
+                ImGui.BeginDisabled();
+            }
+
+            if (ImGui.MenuItem("Delete"))
+            {
+                _ = Task.Run(() => _service.DeleteSectionAsync(section.Id, CancellationToken.None));
+            }
+
+            if (!canDeleteSection)
+            {
+                ImGui.EndDisabled();
+            }
         }
 
         if (ImGui.MenuItem("Copy Link"))
@@ -554,8 +568,13 @@ public sealed class NotePadWindow : IDisposable
         });
     }
 
-    private static bool CanDeletePage(NotePadPage page)
+    private bool CanDeletePage(NotePadPage page)
     {
+        if (OfficerPermissions.HasAccess(_config))
+        {
+            return true;
+        }
+
         var current = MembershipCache.DiscordUserId;
         if (string.IsNullOrEmpty(current))
         {
@@ -622,9 +641,23 @@ public sealed class NotePadWindow : IDisposable
             ImGui.EndPopup();
         }
 
-        if (!IsReadOnly && CanDeletePage(page) && ImGui.MenuItem("Delete Note"))
+        if (!IsReadOnly)
         {
-            _ = Task.Run(() => _service.DeletePageAsync(section.Id, page.Id, CancellationToken.None));
+            var canDelete = CanDeletePage(page);
+            if (!canDelete)
+            {
+                ImGui.BeginDisabled();
+            }
+
+            if (ImGui.MenuItem("Delete Note"))
+            {
+                _ = Task.Run(() => _service.DeletePageAsync(section.Id, page.Id, CancellationToken.None));
+            }
+
+            if (!canDelete)
+            {
+                ImGui.EndDisabled();
+            }
         }
 
         if (ImGui.MenuItem("Copy Link"))
@@ -652,13 +685,21 @@ public sealed class NotePadWindow : IDisposable
         if (IsReadOnly)
         {
             var content = page.Content ?? string.Empty;
-            var readOnlyBuffer = ImGuiTextUtil.MakeUtf8Buffer(content, Math.Max(1024, content.Length + 512));
-            ImGui.BeginDisabled();
-            ImGui.InputTextMultiline("##NotePadEditorReadOnly", readOnlyBuffer, new Vector2(-1, -1), ImGuiInputTextFlags.ReadOnly);
-            ImGui.EndDisabled();
+            var formatted = MarkdownFormatter.Format(content);
+            ImGui.BeginChild("NotePadReadOnlyPreview", ImGui.GetContentRegionAvail(), true);
+            ImGui.PushTextWrapPos();
+            if (string.IsNullOrEmpty(formatted))
+            {
+                ImGui.TextDisabled("No content available.");
+            }
+            else
+            {
+                ImGui.TextUnformatted(formatted);
+            }
+            ImGui.PopTextWrapPos();
+            ImGui.EndChild();
             _editorContent = content;
             _editorVersion = page.Version;
-            DrawPreview(content);
             return;
         }
 
@@ -669,9 +710,37 @@ public sealed class NotePadWindow : IDisposable
             _focusEditorNextFrame = false;
         }
 
+        var style = ImGui.GetStyle();
+        var available = ImGui.GetContentRegionAvail();
+        var previewHeight = 0f;
+        if (available.Y > 220f)
+        {
+            var maxPreview = MathF.Max(120f, available.Y - 160f);
+            previewHeight = MathF.Clamp(available.Y * 0.35f, 120f, maxPreview);
+        }
+
+        if (previewHeight > 0f)
+        {
+            ImGui.BeginChild("NotePadLivePreview", new Vector2(-1, previewHeight), true);
+            ImGui.PushTextWrapPos();
+            var formatted = MarkdownFormatter.Format(_editorContent);
+            if (string.IsNullOrEmpty(formatted))
+            {
+                ImGui.TextDisabled("Start typing to see formatted output.");
+            }
+            else
+            {
+                ImGui.TextUnformatted(formatted);
+            }
+            ImGui.PopTextWrapPos();
+            ImGui.EndChild();
+            ImGui.Dummy(new Vector2(0f, style.ItemSpacing.Y * 0.5f));
+        }
+
+        var editorHeight = MathF.Max(150f, ImGui.GetContentRegionAvail().Y);
         ImGui.PushItemWidth(-1);
         var flags = ImGuiInputTextFlags.AllowTabInput | ImGuiInputTextFlags.CallbackAlways | ImGuiInputTextFlags.CallbackHistory;
-        var edited = ImGui.InputTextMultiline("##NotePadEditor", buffer, new Vector2(-1, -1), flags, new ImGui.ImGuiInputTextCallbackDelegate(OnEditorEdited));
+        var edited = ImGui.InputTextMultiline("##NotePadEditor", buffer, new Vector2(-1, editorHeight), flags, new ImGui.ImGuiInputTextCallbackDelegate(OnEditorEdited));
         ImGui.PopItemWidth();
 
         var newValue = ImGuiTextUtil.ReadUtf8Buffer(buffer);
@@ -686,8 +755,6 @@ public sealed class NotePadWindow : IDisposable
         {
             _ = SavePageAsync(section.Id, page.Id, force: true);
         }
-
-        DrawPreview(_editorContent);
     }
 
     private void DrawFormattingToolbar()
@@ -1055,21 +1122,6 @@ public sealed class NotePadWindow : IDisposable
         _editorContent = text ?? string.Empty;
         _dirty = true;
         _lastEditUtc = DateTime.UtcNow;
-    }
-
-    private void DrawPreview(string content)
-    {
-        if (string.IsNullOrEmpty(content))
-        {
-            return;
-        }
-
-        ImGui.Spacing();
-        UiTheme.DrawSectionSeparator();
-        ImGui.TextColored(new Vector4(0.7f, 0.7f, 0.7f, 1f), "Formatted Preview");
-        ImGui.PushTextWrapPos();
-        ImGui.TextUnformatted(MarkdownFormatter.Format(content));
-        ImGui.PopTextWrapPos();
     }
 
     private int OnEditorEdited(ref ImGuiInputTextCallbackData data)

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -42,6 +42,7 @@ public class PresenceSidebar : IDisposable
     private const string PresenceUnavailableMessage = "Presence unavailable";
     private static readonly TimeSpan RefreshCooldown = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan RebuildInterval = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan ForceRefreshInterval = TimeSpan.FromSeconds(10);
 
     private Task? _refreshTask;
     private bool _refreshInFlight;
@@ -49,6 +50,7 @@ public class PresenceSidebar : IDisposable
     private readonly List<PresenceDto> _items = new();
     private DateTime _lastRebuild = DateTime.MinValue;
     private PresenceConnectionState _lastConn = PresenceConnectionState.Disconnected;
+    private DateTime _lastForceRefresh = DateTime.MinValue;
 
     public Action<string?, Action<ISharedImmediateTexture?>>? TextureLoader { get; set; }
     public Action<string?>? TextureTouch { get; set; }
@@ -136,14 +138,20 @@ public class PresenceSidebar : IDisposable
                 else
                 {
                     var presences = presencesSource.ToList();
-                    if (presences.Count == 0)
+                if (presences.Count == 0)
+                {
+                    if (DateTime.UtcNow - _lastForceRefresh >= ForceRefreshInterval)
                     {
-                        ShowStatus(_service.StatusMessage);
+                        _lastForceRefresh = DateTime.UtcNow;
+                        _ = _service.Refresh(force: true);
                     }
-                    else
+
+                    ShowStatus(string.IsNullOrWhiteSpace(_service.StatusMessage) ? null : _service.StatusMessage);
+                }
+                else
+                {
+                    if (!string.IsNullOrEmpty(_service.StatusMessage))
                     {
-                        if (!string.IsNullOrEmpty(_service.StatusMessage))
-                        {
                             ImGui.TextUnformatted(_service.StatusMessage);
                             ImGui.Spacing();
                         }

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -87,20 +87,11 @@ public class SettingsWindow : IDisposable
             var began = ImGui.Begin("DemiCat Settings", ref open, flags);
             if (began)
             {
-                UiTheme.DrawWindowChrome(_config, "DemiCat Settings", () => open = false);
-
                 var style = ImGui.GetStyle();
-                var chromeHeight = Math.Max(14f * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight());
+                var chromeHeight = Math.Max(22f * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight() + style.FramePadding.Y * 1.5f);
                 ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y));
-                var dragSize = new Vector2(ImGui.GetContentRegionAvail().X, chromeHeight);
-                ImGui.InvisibleButton("##drag_zone_settings", dragSize);
-                if (ImGui.IsItemActive() && ImGui.IsMouseDragging(0))
-                {
-                    var io = ImGui.GetIO();
-                    ImGui.SetWindowPos(ImGui.GetWindowPos() + io.MouseDelta);
-                }
-
-                ImGui.Dummy(new Vector2(1f, style.FramePadding.Y + chromeHeight));
+                ImGui.Dummy(new Vector2(1f, chromeHeight));
+                ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y + chromeHeight));
 
                 if (!_settingsLoaded)
                 {
@@ -130,6 +121,8 @@ public class SettingsWindow : IDisposable
 
                     ImGui.EndTabBar();
                 }
+
+                UiTheme.DrawWindowChrome(_config, "DemiCat Settings", () => open = false, chromeHeight);
             }
             ImGui.End();
             ImGui.PopStyleVar();

--- a/DemiCatPlugin/UiTheme.cs
+++ b/DemiCatPlugin/UiTheme.cs
@@ -33,10 +33,15 @@ public static class UiTheme
         public Vector4 TextColor;
         public Vector4 CloseButtonColor;
         public Vector4 CloseButtonHoveredColor;
+        public Vector4 TitlePillColor;
+        public Vector4 TitlePillBorderColor;
     }
 
     private static readonly Stack<(int Vars, int Colors)> ScopeStack = new();
     private static FrameState _frameState;
+    private static bool _draggingWindow;
+    private static uint _dragWindowId;
+    private static Vector2 _dragOffset;
 
     public static bool RequestCloseThisFrame { get; private set; }
 
@@ -132,7 +137,7 @@ public static class UiTheme
         }
     }
 
-    public static void DrawWindowChrome(Config config, string? titleOverride = null, Action? onClose = null)
+    public static void DrawWindowChrome(Config config, string? titleOverride = null, Action? onClose = null, float reservedHeight = 0f)
     {
         RequestCloseThisFrame = false;
 
@@ -179,18 +184,17 @@ public static class UiTheme
                 ImGui.ColorConvertFloat4ToU32(_frameState.FocusGlowColor), rounding + 3f * scale, ImDrawFlags.RoundCornersAll, glowThickness);
         }
 
-        var previousCursor = ImGui.GetCursorScreenPos();
         var buttonRadius = 7f * scale;
         var buttonSize = new Vector2(buttonRadius * 2f, buttonRadius * 2f);
         var buttonOffsetY = MathF.Max(2f * scale, style.FramePadding.Y * 0.25f);
         var buttonPos = new Vector2(windowPos.X + style.WindowPadding.X, windowPos.Y + style.WindowPadding.Y + buttonOffsetY);
-        ImGui.SetCursorScreenPos(buttonPos);
+        var closeRectMin = buttonPos;
+        var closeRectMax = buttonPos + buttonSize;
 
         ImGui.PushID("dc_theme_close");
         var clicked = ImGui.InvisibleButton("##close", buttonSize);
         var buttonHovered = ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenBlockedByActiveItem);
         ImGui.PopID();
-        ImGui.SetCursorScreenPos(previousCursor);
 
         var buttonCenter = buttonPos + new Vector2(buttonRadius);
         var baseColor = buttonHovered ? _frameState.CloseButtonHoveredColor : _frameState.CloseButtonColor;
@@ -202,9 +206,27 @@ public static class UiTheme
         drawList.AddLine(buttonCenter + new Vector2(-crossExtent, -crossExtent), buttonCenter + new Vector2(crossExtent, crossExtent), crossColor, crossThickness);
         drawList.AddLine(buttonCenter + new Vector2(-crossExtent, crossExtent), buttonCenter + new Vector2(crossExtent, -crossExtent), crossColor, crossThickness);
 
-        if (!string.IsNullOrEmpty(titleOverride))
+        var hasTitle = !string.IsNullOrEmpty(titleOverride);
+        Vector2 textPos = default;
+        Vector2 pillMin = default;
+        Vector2 pillMax = default;
+
+        if (hasTitle)
         {
-            var textPos = windowPos + new Vector2(style.WindowPadding.X + buttonSize.X + 6f * scale, style.WindowPadding.Y + style.FramePadding.Y * 0.25f * scale);
+            var textSize = ImGui.CalcTextSize(titleOverride);
+            var pillPadding = new Vector2(style.FramePadding.X * 0.8f, MathF.Max(style.FramePadding.Y * 0.45f, 4f * scale));
+            textPos = windowPos + new Vector2(style.WindowPadding.X + buttonSize.X + 10f * scale, style.WindowPadding.Y + style.FramePadding.Y * 0.25f * scale);
+            pillMin = textPos - pillPadding;
+            pillMax = textPos + textSize + pillPadding;
+            pillMin.X = MathF.Max(pillMin.X, windowPos.X + style.WindowPadding.X + buttonSize.X + style.ItemSpacing.X);
+            pillMax.X = MathF.Min(pillMax.X, windowPos.X + windowSize.X - style.WindowPadding.X);
+            pillMin.Y = MathF.Max(pillMin.Y, windowPos.Y + style.WindowPadding.Y);
+            pillMax.Y = MathF.Min(pillMax.Y, windowPos.Y + style.WindowPadding.Y + MathF.Max(reservedHeight, textSize.Y + pillPadding.Y * 2f));
+
+            var roundingRadius = (pillMax.Y - pillMin.Y) * 0.5f;
+            drawList.AddRectFilled(pillMin, pillMax, ImGui.ColorConvertFloat4ToU32(_frameState.TitlePillColor), roundingRadius);
+            drawList.AddRect(pillMin, pillMax, ImGui.ColorConvertFloat4ToU32(_frameState.TitlePillBorderColor), roundingRadius, ImDrawFlags.RoundCornersAll, 1.5f);
+
             drawList.AddText(textPos, ImGui.ColorConvertFloat4ToU32(_frameState.TextColor.W > 0f ? _frameState.TextColor : ImGui.GetStyle().Colors[(int)ImGuiCol.Text]), titleOverride);
         }
 
@@ -218,6 +240,36 @@ public static class UiTheme
             {
                 RequestCloseThisFrame = true;
             }
+        }
+
+        var dragHeight = reservedHeight > 0f ? reservedHeight : Math.Max(buttonSize.Y, (hasTitle ? pillMax.Y - pillMin.Y : buttonSize.Y) + style.FramePadding.Y * 0.5f);
+        var dragMin = new Vector2(closeRectMax.X + style.ItemSpacing.X, windowPos.Y + style.WindowPadding.Y);
+        var dragMax = new Vector2(windowPos.X + windowSize.X - style.WindowPadding.X, dragMin.Y + dragHeight);
+        if (hasTitle)
+        {
+            dragMin.X = MathF.Min(dragMin.X, pillMin.X);
+        }
+
+        var window = ImGui.GetCurrentWindow();
+        var windowId = window.ID;
+        var hoveringDragZone = ImGui.IsMouseHoveringRect(dragMin, dragMax, false);
+        if (_draggingWindow && _dragWindowId == windowId)
+        {
+            if (ImGui.IsMouseDown(ImGuiMouseButton.Left))
+            {
+                var mousePos = ImGui.GetMousePos();
+                ImGui.SetWindowPos(mousePos - _dragOffset);
+            }
+            else
+            {
+                _draggingWindow = false;
+            }
+        }
+        else if (hoveringDragZone && ImGui.IsMouseClicked(ImGuiMouseButton.Left))
+        {
+            _draggingWindow = true;
+            _dragWindowId = windowId;
+            _dragOffset = ImGui.GetMousePos() - windowPos;
         }
     }
 
@@ -305,6 +357,11 @@ public static class UiTheme
 
         _frameState.CloseButtonColor = AdjustAlpha(secondary, 0.7f);
         _frameState.CloseButtonHoveredColor = AdjustAlpha(accent, 0.85f);
+
+        var pillBase = Blend(primary, accent, 0.28f, Math.Clamp(primary.W + 0.12f, 0f, 1f));
+        _frameState.TitlePillColor = AdjustAlpha(pillBase, Math.Clamp(pillBase.W, 0.55f, 0.85f));
+        var pillBorder = Blend(_frameState.BorderColor, accent, 0.2f, Math.Clamp(_frameState.BorderHoverColor.W + 0.1f, 0f, 1f));
+        _frameState.TitlePillBorderColor = AdjustAlpha(pillBorder, Math.Clamp(pillBorder.W, 0.6f, 0.95f));
     }
 
     private static Vector4 Blend(Vector4 baseColor, Vector4 accent, float t, float alpha)


### PR DESCRIPTION
## Summary
- clamp chat attachment sizing to the available content width while preserving aspect ratio
- render embed preview color stripes with a wider fill so the accent band is fully visible
- update the NotePad editor with a live markdown preview, officer-gated delete actions, and improved read-only rendering
- refresh presence data when the sidebar is empty and enhance custom window chrome with a persistent title pill overlay

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed75efa380832888fe759eb59146a6