### PR TITLE
Fix ImGui window ID usage and MathF clamp for compatibility

### DIFF
--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -716,7 +716,8 @@ public sealed class NotePadWindow : IDisposable
         if (available.Y > 220f)
         {
             var maxPreview = MathF.Max(120f, available.Y - 160f);
-            previewHeight = MathF.Clamp(available.Y * 0.35f, 120f, maxPreview);
+            var previewTarget = available.Y * 0.35f;
+            previewHeight = MathF.Min(MathF.Max(previewTarget, 120f), maxPreview);
         }
 
         if (previewHeight > 0f)

--- a/DemiCatPlugin/UiTheme.cs
+++ b/DemiCatPlugin/UiTheme.cs
@@ -250,8 +250,7 @@ public static class UiTheme
             dragMin.X = MathF.Min(dragMin.X, pillMin.X);
         }
 
-        var window = ImGui.GetCurrentWindow();
-        var windowId = window.ID;
+        var windowId = ImGui.GetID("dc_theme_drag_zone");
         var hoveringDragZone = ImGui.IsMouseHoveringRect(dragMin, dragMax, false);
         if (_draggingWindow && _dragWindowId == windowId)
         {


### PR DESCRIPTION
## Summary
- use ImGui.GetID to derive a stable drag zone identifier without relying on removed APIs
- replace MathF.Clamp usage with equivalent min/max logic to support older frameworks

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ed818867fc8328a9ce50dce3c1af5c