### PR TITLE
Ensure events window discovers channels and Apollo embeds

### DIFF
--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -1094,10 +1094,23 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             var eventChannels = (dto.Event ?? new List<ChannelDto>())
                 .Where(c => c != null)
                 .ToList();
+
             foreach (var channel in eventChannels)
             {
                 channel.EnsureKind(ChannelKind.Event);
             }
+
+            eventChannels = ChannelDtoExtensions.SortForDisplay(eventChannels);
+
+            if (eventChannels.Count == 0)
+            {
+                var fallback = await FetchEventChannelsFallback();
+                if (fallback.Count > 0)
+                {
+                    eventChannels = fallback;
+                }
+            }
+
             if (await ChannelNameResolver.Resolve(eventChannels, _httpClient, _config, refreshed, () => FetchChannels(true))) return;
             _ = PluginServices.Instance!.Framework.RunOnTick(() =>
             {
@@ -1189,6 +1202,29 @@ public class UiRenderer : IAsyncDisposable, IDisposable
                 _channelsLoaded = true;
             });
         }
+    }
+
+    private async Task<List<ChannelDto>> FetchEventChannelsFallback()
+    {
+        var fallbackUrl = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels?kind={ChannelKind.Event}";
+        using var request = new HttpRequestMessage(HttpMethod.Get, fallbackUrl);
+        ApiHelpers.AddAuthHeader(request, TokenManager.Instance!);
+        using var response = await _httpClient.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            return new List<ChannelDto>();
+        }
+
+        using var stream = await response.Content.ReadAsStreamAsync();
+        var channels = await JsonSerializer.DeserializeAsync<List<ChannelDto>>(stream, JsonOpts) ?? new List<ChannelDto>();
+        var sanitized = channels.Where(c => c != null).ToList();
+
+        foreach (var channel in sanitized)
+        {
+            channel.EnsureKind(ChannelKind.Event);
+        }
+
+        return ChannelDtoExtensions.SortForDisplay(sanitized);
     }
 
     private class ChannelListDto

--- a/demibot/demibot/discordbot/cogs/mirror.py
+++ b/demibot/demibot/discordbot/cogs/mirror.py
@@ -32,7 +32,28 @@ from ..utils import api_call_with_retries, get_or_create_user
 class ApolloHelper:
     """Utility helpers for Apollo embed detection."""
 
-    APOLLO_APPLICATION_ID = int(os.getenv("APOLLO_APPLICATION_ID", "0"))
+    _DEFAULT_APPLICATION_ID = 475744554910351370
+
+    _env_app_id = os.getenv("APOLLO_APPLICATION_ID")
+    _parsed_app_id: int | None
+    if _env_app_id is None or not _env_app_id.strip():
+        _parsed_app_id = None
+    else:
+        try:
+            _parsed_app_id = int(_env_app_id)
+        except ValueError:
+            logging.getLogger(__name__).warning(
+                "Invalid APOLLO_APPLICATION_ID '%s'; using default %s",
+                _env_app_id,
+                _DEFAULT_APPLICATION_ID,
+            )
+            _parsed_app_id = None
+
+    APOLLO_APPLICATION_ID = (
+        _parsed_app_id
+        if _parsed_app_id and _parsed_app_id > 0
+        else _DEFAULT_APPLICATION_ID
+    )
 
     @staticmethod
     def IsApolloMessage(message: discord.Message) -> bool:  # noqa: N802
@@ -40,6 +61,9 @@ class ApolloHelper:
 
         app_id = getattr(message, "application_id", None)
         if ApolloHelper.APOLLO_APPLICATION_ID and app_id == ApolloHelper.APOLLO_APPLICATION_ID:
+            return True
+        author_id = getattr(getattr(message, "author", None), "id", None)
+        if ApolloHelper.APOLLO_APPLICATION_ID and author_id == ApolloHelper.APOLLO_APPLICATION_ID:
             return True
         for emb in getattr(message, "embeds", []) or []:
             data = emb.to_dict()

--- a/tests/test_apollo_embed.py
+++ b/tests/test_apollo_embed.py
@@ -23,7 +23,7 @@ http_pkg = types.ModuleType("demibot.http")
 http_pkg.__path__ = [str(root / "demibot/http")]
 sys.modules.setdefault("demibot.http", http_pkg)
 
-from demibot.discordbot.cogs.mirror import Mirror
+from demibot.discordbot.cogs.mirror import ApolloHelper, Mirror
 from demibot.db.models import Embed, Guild, GuildChannel, ChannelKind
 from demibot.db.session import get_session, init_db
 from demibot.http.routes.embeds import get_embeds
@@ -35,11 +35,11 @@ class DummyBot:
 
 
 class DummyAuthor:
-    def __init__(self) -> None:
+    def __init__(self, name: str = "Apollo") -> None:
         self.bot = True
         self.id = 999
-        self.display_name = "Apollo"
-        self.name = "Apollo"
+        self.display_name = name
+        self.name = name
 
 
 class DummyChannel:
@@ -48,13 +48,21 @@ class DummyChannel:
 
 
 class DummyMessage:
-    def __init__(self, channel_id: int, embed: discord.Embed) -> None:
-        self.author = DummyAuthor()
+    def __init__(
+        self,
+        channel_id: int,
+        embed: discord.Embed,
+        *,
+        application_id: int | None = None,
+        author_name: str = "Apollo",
+    ) -> None:
+        self.author = DummyAuthor(author_name)
         self.channel = DummyChannel(channel_id)
         self.id = 42
         self.content = ""
         self.mentions = []
         self.embeds = [embed]
+        self.application_id = application_id
         btn = SimpleNamespace(
             type=2,
             custom_id="rsvp:yes",
@@ -64,7 +72,12 @@ class DummyMessage:
         )
         row = SimpleNamespace(children=[btn])
         self.components = [row]
-async def _run_test() -> None:
+async def _run_test(
+    *,
+    include_footer: bool = True,
+    application_id: int | None = None,
+    author_name: str = "Apollo",
+) -> None:
     db_path = Path("test.db")
     if db_path.exists():
         db_path.unlink()
@@ -80,8 +93,14 @@ async def _run_test() -> None:
         await db.commit()
 
     emb = discord.Embed(title="Raid Night", description="Prepare")
-    emb.set_footer(text="Powered by Apollo")
-    msg = DummyMessage(123, emb)
+    if include_footer:
+        emb.set_footer(text="Powered by Apollo")
+    msg = DummyMessage(
+        123,
+        emb,
+        application_id=application_id,
+        author_name=author_name,
+    )
 
     mirror = Mirror(bot)
     await mirror.on_message(msg)
@@ -104,3 +123,13 @@ async def _run_test() -> None:
 
 def test_apollo_embed_stored_and_retrieved() -> None:
     asyncio.run(_run_test())
+
+
+def test_apollo_embed_detected_by_application_id() -> None:
+    asyncio.run(
+        _run_test(
+            include_footer=False,
+            application_id=ApolloHelper.APOLLO_APPLICATION_ID,
+            author_name="Scheduler",
+        )
+    )


### PR DESCRIPTION
## Summary
- add a fallback request so the events window still lists configured channels when the aggregate channel API returns empty
- default Apollo embed detection to the bot application's known ID and treat messages from that author as Apollo
- extend the Apollo embed test harness to exercise detection by application ID

## Testing
- pytest tests/test_apollo_embed.py *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68ed8358b97c8328b65de1cf424dca3a