### PR TITLE
Fix close button hit test after chrome redesign

### DIFF
--- a/DemiCatPlugin/UiTheme.cs
+++ b/DemiCatPlugin/UiTheme.cs
@@ -191,10 +191,13 @@ public static class UiTheme
         var closeRectMin = buttonPos;
         var closeRectMax = buttonPos + buttonSize;
 
+        var previousCursorPos = ImGui.GetCursorScreenPos();
+        ImGui.SetCursorScreenPos(buttonPos);
         ImGui.PushID("dc_theme_close");
         var clicked = ImGui.InvisibleButton("##close", buttonSize);
         var buttonHovered = ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenBlockedByActiveItem);
         ImGui.PopID();
+        ImGui.SetCursorScreenPos(previousCursorPos);
 
         var buttonCenter = buttonPos + new Vector2(buttonRadius);
         var baseColor = buttonHovered ? _frameState.CloseButtonHoveredColor : _frameState.CloseButtonColor;


### PR DESCRIPTION
## Summary
- restore the close button hit target by positioning the invisible button at the drawn location
- reset the cursor after hit testing so layout of subsequent elements is unchanged

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ed897924a883289f87a8be1b7fccc3