### PR TITLE
Delay presence networking until watchers start

### DIFF
--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -138,7 +138,7 @@ public class DiscordPresenceService : IDisposable
         }
     }
 
-    public void Stop()
+    public void Stop(bool clearPresences = false)
     {
         var cts = Interlocked.Exchange(ref _wsCts, null);
         cts?.Cancel();
@@ -147,21 +147,17 @@ public class DiscordPresenceService : IDisposable
         var socket = Interlocked.Exchange(ref _ws, null);
         socket?.Dispose();
 
-        _ = DisposeAllPresencesAsync();
+        if (clearPresences)
+        {
+            _ = DisposeAllPresencesAsync();
+        }
+
         SetConnectionState(PresenceConnectionState.Disconnected);
     }
 
     public void Dispose()
     {
-        var cts = Interlocked.Exchange(ref _wsCts, null);
-        cts?.Cancel();
-        cts?.Dispose();
-
-        var socket = Interlocked.Exchange(ref _ws, null);
-        socket?.Dispose();
-
-        _ = DisposeAllPresencesAsync();
-        SetConnectionState(PresenceConnectionState.Disconnected);
+        Stop(clearPresences: true);
     }
 
     public Task Refresh(bool force = false)

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -41,7 +41,7 @@ public class Plugin : IDalamudPlugin
     private readonly AvatarCache _avatarCache;
     private readonly ChatWindow _chatWindow;
     private readonly OfficerChatWindow _officerChatWindow;
-    private readonly DiscordPresenceService? _presenceService;
+    private readonly DiscordPresenceService _presenceService;
     private readonly MainWindow _mainWindow;
     private readonly ChannelWatcher _channelWatcher;
     private readonly RequestWatcher _requestWatcher;
@@ -149,16 +149,13 @@ public class Plugin : IDalamudPlugin
         _ui = new UiRenderer(_config, _httpClient, _channelSelection, _emojiManager);
         _settings = new SettingsWindow(_config, _tokenManager, _httpClient, () => RefreshRoles(_services.Log), _ui.StartNetworking, _services.Log, _services.PluginInterface);
 
-        _presenceService = _config.SyncedChat && _config.EnableFcChat
-            ? new DiscordPresenceService(_config, _httpClient)
-            : null;
+        _presenceService = new DiscordPresenceService(_config, _httpClient);
+        _presenceService.SetPresenceReady(false);
 
         _channelService = new ChannelService(_config, _httpClient, _tokenManager);
         _avatarCache = new AvatarCache(TextureProvider, _httpClient);
         _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _messageCache, _avatarCache, _emojiManager, _sharedChatBridge);
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _messageCache, _avatarCache, _emojiManager, _sharedChatBridge);
-
-        _presenceService?.Reset();
 
         _notePadService = new NotePadService(_config, _httpClient, _tokenManager);
         _notePadWindow = new NotePadWindow(_config, _notePadService);

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -73,6 +73,7 @@ public class PresenceSidebar : IDisposable
         }
 
         var snapshot = _service.GetSnapshot();
+        var hasSnapshot = snapshot != null && snapshot.Count > 0;
         var connection = _service.ConnectionState;
         if (_lastConn != connection && connection == PresenceConnectionState.Connected)
         {
@@ -91,11 +92,11 @@ public class PresenceSidebar : IDisposable
 
         try
         {
-            if (!_service.IsPresenceReady)
+            if (!_service.IsPresenceReady && !hasSnapshot)
             {
                 ShowStatus(null);
             }
-            else if (!_service.Loaded)
+            else if (!_service.Loaded && !hasSnapshot)
             {
                 if (!_refreshInFlight && DateTime.UtcNow >= _nextRefreshAllowed)
                 {
@@ -126,6 +127,16 @@ public class PresenceSidebar : IDisposable
             }
             else
             {
+                if (!_service.IsPresenceReady && hasSnapshot)
+                {
+                    var status = _service.StatusMessage;
+                    if (!string.IsNullOrEmpty(status))
+                    {
+                        ImGui.TextUnformatted(status);
+                        ImGui.Spacing();
+                    }
+                }
+
                 var presencesSource = _items;
                 if (presencesSource == null || presencesSource.Count == 0)
                 {


### PR DESCRIPTION
## Summary
- instantiate the Discord presence service without forcing it to connect until the chat watchers have verified connectivity
- keep cached presences visible in the sidebar even when networking is paused so the user list is not gated once populated
- allow the presence service to pause without clearing data unless an explicit shutdown occurs

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ed883fed74832894930dd59f94de3c