### PR TITLE
Unify embed border emoji picker with shared emoji UI

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -490,8 +490,7 @@ public class ChatWindow : IDisposable
             EmbedColorOverride = GetEmbedColorOverride(),
             Border = _config.GetEmbedBorderSettingsCopy(_channelKind),
             EmojiManager = _emojiManager,
-            EmojiTileSize = Config.SanitizeEmojiTileSize(_config.EmojiTileSize),
-            EmojiGridHeight = Config.SanitizeEmojiGridHeight(_config.EmojiGridHeight)
+            EmojiPicker = _emojiPicker
         };
 
         var result = EmbedStyleControls.Draw(context);

--- a/DemiCatPlugin/EmbedStyleControls.cs
+++ b/DemiCatPlugin/EmbedStyleControls.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
@@ -9,8 +8,6 @@ namespace DemiCatPlugin;
 
 public static class EmbedStyleControls
 {
-    private static readonly Dictionary<string, string> GlyphSearchTerms = new();
-
     public sealed class Context
     {
         public string ChannelKindKey { get; init; } = string.Empty;
@@ -18,8 +15,7 @@ public static class EmbedStyleControls
         public uint? EmbedColorOverride { get; init; }
         public Config.EmbedBorderSettings Border { get; init; } = Config.EmbedBorderSettings.CreateDefault(global::DemiCatPlugin.ChannelKind.Chat);
         public EmojiManager? EmojiManager { get; init; }
-        public float EmojiTileSize { get; init; } = Config.MinEmojiTileSize;
-        public float EmojiGridHeight { get; init; } = Config.MinEmojiGridHeight;
+        public EmojiPicker? EmojiPicker { get; init; }
     }
 
     public sealed class Result
@@ -96,11 +92,16 @@ public static class EmbedStyleControls
         }
 
         var glyphSymbol = EmbedBorderBuilder.GetGlyphSymbol(border.Glyph);
+        var displayGlyph = glyphSymbol;
+        if (context.EmojiManager != null)
+        {
+            displayGlyph = EmojiFormatter.Normalize(context.EmojiManager, glyphSymbol) ?? glyphSymbol;
+        }
         var glyphPopupId = $"embedBorderGlyphPopup##{context.ChannelKindKey}";
         var glyphButtonSize = new Vector2(ImGui.GetFrameHeight() * 1.8f, ImGui.GetFrameHeight());
         using (context.EmojiManager?.PushEmojiFont())
         {
-            if (ImGui.Button($"{glyphSymbol}##embedBorderGlyph_{context.ChannelKindKey}", glyphButtonSize))
+            if (ImGui.Button($"{displayGlyph}##embedBorderGlyph_{context.ChannelKindKey}", glyphButtonSize))
             {
                 ImGui.OpenPopup(glyphPopupId);
             }
@@ -112,6 +113,14 @@ public static class EmbedStyleControls
             border.Glyph = selectedGlyph;
             borderChanged = true;
             glyphSymbol = selectedGlyph;
+            if (context.EmojiManager != null)
+            {
+                displayGlyph = EmojiFormatter.Normalize(context.EmojiManager, selectedGlyph) ?? selectedGlyph;
+            }
+            else
+            {
+                displayGlyph = selectedGlyph;
+            }
         }
 
         var tooltip = TryGetEmojiName(context, glyphSymbol);
@@ -171,119 +180,29 @@ public static class EmbedStyleControls
             return null;
         }
 
+        var picker = context.EmojiPicker;
         var manager = context.EmojiManager;
-        var searchKey = GetSearchKey(context);
-        if (manager == null || !manager.CanLoadStandard)
+        if (picker == null || manager == null)
         {
-            ImGui.TextDisabled("Emoji list unavailable. Link DemiCat to load emoji.");
+            ImGui.TextDisabled("Emoji picker unavailable.");
         }
         else
         {
-            if (!GlyphSearchTerms.TryGetValue(searchKey, out var search))
-            {
-                search = string.Empty;
-            }
-
-            if (ImGui.InputTextWithHint($"##borderEmojiSearch_{searchKey}", "Search…", ref search, 64))
-            {
-                GlyphSearchTerms[searchKey] = search;
-            }
-
-            UiTheme.DrawSectionSeparator();
-
-            _ = manager.EnsureUnicodeAsync();
-            var status = manager.UnicodeStatus;
-            var items = manager.Unicode;
-            IReadOnlyList<UnicodeEmoji> filtered = items;
-
-            if (!string.IsNullOrWhiteSpace(search) && items.Count > 0)
-            {
-                var matches = new List<UnicodeEmoji>();
-                foreach (var emoji in items)
-                {
-                    if (emoji.Name.Contains(search, StringComparison.OrdinalIgnoreCase) ||
-                        emoji.Emoji.Contains(search, StringComparison.OrdinalIgnoreCase))
-                    {
-                        matches.Add(emoji);
-                    }
-                }
-                filtered = matches;
-            }
-
-            if (filtered.Count == 0)
-            {
-                if (status.Loading)
-                {
-                    ImGui.TextDisabled("Loading emoji…");
-                }
-                else if (status.HasError && !string.IsNullOrEmpty(status.Error))
-                {
-                    ImGui.TextWrapped(status.Error);
-                }
-                else
-                {
-                    ImGui.TextDisabled(string.IsNullOrWhiteSpace(search) ? "No emoji available." : "No matches.");
-                }
-            }
-            else
-            {
-                var tileSize = Math.Clamp(context.EmojiTileSize, Config.MinEmojiTileSize, Config.MaxEmojiTileSize);
-                var childSize = context.EmojiGridHeight > 0f ? new Vector2(0f, context.EmojiGridHeight) : Vector2.Zero;
-                ImGui.BeginChild($"##borderEmojiGrid_{searchKey}", childSize, false);
-
-                var avail = Math.Max(1f, ImGui.GetContentRegionAvail().X);
-                var columns = Math.Max(1, (int)Math.Floor((avail + 4f) / (tileSize + 4f)));
-                var column = 0;
-
-                using var font = manager.PushEmojiFont();
-                for (var i = 0; i < filtered.Count; i++)
-                {
-                    if (column >= columns)
-                    {
-                        ImGui.NewLine();
-                        column = 0;
-                    }
-
-                    var emoji = filtered[i];
-                    ImGui.PushID(i);
-                    if (ImGui.Button(emoji.Emoji, new Vector2(tileSize, tileSize)))
-                    {
-                        selected = emoji.Emoji;
-                    }
-                    if (!string.IsNullOrEmpty(emoji.Name) && ImGui.IsItemHovered())
-                    {
-                        ImGui.SetTooltip(emoji.Name);
-                    }
-                    ImGui.PopID();
-
-                    column++;
-                    if (column < columns)
-                    {
-                        ImGui.SameLine();
-                    }
-
-                    if (!string.IsNullOrEmpty(selected))
-                    {
-                        break;
-                    }
-                }
-
-                ImGui.EndChild();
-            }
+            ImGui.PushID(popupId);
+            selected = picker.Draw();
+            ImGui.PopID();
         }
 
-        if (!string.IsNullOrEmpty(selected))
+        if (!string.IsNullOrEmpty(selected) && manager != null)
         {
-            GlyphSearchTerms[searchKey] = string.Empty;
+            var normalized = EmojiFormatter.Normalize(manager, selected) ?? selected;
+            selected = Config.SanitizeEmbedBorderGlyph(normalized);
             ImGui.CloseCurrentPopup();
         }
 
         ImGui.EndPopup();
-        return string.IsNullOrEmpty(selected) ? null : Config.SanitizeEmbedBorderGlyph(selected);
+        return string.IsNullOrEmpty(selected) ? null : selected;
     }
-
-    private static string GetSearchKey(Context context)
-        => string.IsNullOrWhiteSpace(context.ChannelKindKey) ? "default" : context.ChannelKindKey;
 
     private static string? TryGetEmojiName(Context context, string glyph)
     {
@@ -296,6 +215,21 @@ public static class EmbedStyleControls
         if (manager == null)
         {
             return null;
+        }
+
+        if (EmojiFormatter.TryParseCustomToken(glyph, out var id, out var name, out _))
+        {
+            if (manager.TryGetCustomEmoji(id, out var custom) && custom != null)
+            {
+                return $":{custom.Name}:";
+            }
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                return $":{name}:";
+            }
+
+            return id;
         }
 
         foreach (var emoji in manager.Unicode)


### PR DESCRIPTION
## Summary
- reuse the shared emoji picker for embed border glyph selection so the UI matches message emoji picking
- normalize selected emoji for display/tooltips and surface custom emoji metadata in the border controls
- expose the shared picker through the embed style context instead of duplicating search/grid logic

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed8cf095f083288bcbf2d9c3b27292