### PR TITLE
Remove emoji text placeholders

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -2141,7 +2141,11 @@ public class ChatWindow : IDisposable
                             emoji.LoadRequested = false;
                         });
                     }
-                    ImGui.TextUnformatted($":{name}:");
+                    EmojiPlaceholderRenderer.Draw(new Vector2(20f, 20f));
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.SetTooltip($":{name}:");
+                    }
                 }
                 else
                 {
@@ -2172,7 +2176,11 @@ public class ChatWindow : IDisposable
                                 emoji.LoadRequested = false;
                             });
                         }
-                        ImGui.TextUnformatted($":{name}:");
+                        EmojiPlaceholderRenderer.Draw(new Vector2(20f, 20f));
+                        if (ImGui.IsItemHovered())
+                        {
+                            ImGui.SetTooltip($":{name}:");
+                        }
                     }
                 }
             }

--- a/DemiCatPlugin/Emoji/EmojiPicker.cs
+++ b/DemiCatPlugin/Emoji/EmojiPicker.cs
@@ -18,7 +18,10 @@ public sealed class EmojiPicker
     private string _search = string.Empty;
     private readonly ConcurrentDictionary<string, bool> _customTextureRequests = new();
     private readonly ConcurrentDictionary<string, bool> _unicodeTextureRequests = new();
-    private const int GridVirtualizationOverscanRows = 2;
+    private readonly ConcurrentDictionary<string, DateTime> _customTextureFailures = new();
+    private readonly ConcurrentDictionary<string, DateTime> _unicodeTextureFailures = new();
+    private static readonly TimeSpan TextureFailureRetryDelay = TimeSpan.FromMinutes(2);
+    private const int GridVirtualizationOverscanRows = 5;
 
     private enum EmojiTab
     {
@@ -169,7 +172,7 @@ public sealed class EmojiPicker
                     }
 
                     var emoji = filtered[index];
-                    var texture = AcquireTexture(emoji.ImageUrl, _unicodeTextureRequests);
+                    var texture = AcquireTexture(emoji.ImageUrl, _unicodeTextureRequests, _unicodeTextureFailures);
                     var clicked = false;
 
                     ImGui.PushID(index);
@@ -183,11 +186,7 @@ public sealed class EmojiPicker
                     }
                     else
                     {
-                        using var _ = _manager.PushEmojiFont();
-                        if (ImGui.Button(emoji.Emoji, new Vector2(_tileSize, _tileSize)))
-                        {
-                            clicked = true;
-                        }
+                        clicked = EmojiPlaceholderRenderer.DrawButton(new Vector2(_tileSize, _tileSize));
                     }
 
                     if (!string.IsNullOrEmpty(emoji.Name) && ImGui.IsItemHovered())
@@ -295,7 +294,7 @@ public sealed class EmojiPicker
 
                     var emoji = items[index];
                     var tooltip = emoji.Animated ? $":{emoji.Name}: (gif)" : $":{emoji.Name}:";
-                    var texture = AcquireTexture(emoji.ImageUrl, _customTextureRequests);
+                    var texture = AcquireTexture(emoji.ImageUrl, _customTextureRequests, _customTextureFailures);
                     var clicked = false;
 
                     ImGui.PushID(emoji.Id);
@@ -309,10 +308,7 @@ public sealed class EmojiPicker
                     }
                     else
                     {
-                        if (ImGui.Button(tooltip, new Vector2(_tileSize * 3f, _tileSize)))
-                        {
-                            clicked = true;
-                        }
+                        clicked = EmojiPlaceholderRenderer.DrawButton(new Vector2(_tileSize, _tileSize));
                     }
 
                     if (ImGui.IsItemHovered())
@@ -430,7 +426,10 @@ public sealed class EmojiPicker
         }
     }
 
-    private static ISharedImmediateTexture? AcquireTexture(string? imageUrl, ConcurrentDictionary<string, bool> requests)
+    private static ISharedImmediateTexture? AcquireTexture(
+        string? imageUrl,
+        ConcurrentDictionary<string, bool> requests,
+        ConcurrentDictionary<string, DateTime> failures)
     {
         if (string.IsNullOrEmpty(imageUrl))
         {
@@ -440,6 +439,16 @@ public sealed class EmojiPicker
         if (WebTextureCache.TryGetTexture(imageUrl, out var texture) && texture != null)
         {
             return texture;
+        }
+
+        if (failures.TryGetValue(imageUrl, out var lastFailure))
+        {
+            if (DateTime.UtcNow - lastFailure < TextureFailureRetryDelay)
+            {
+                return null;
+            }
+
+            failures.TryRemove(imageUrl, out _);
         }
 
         if (requests.TryGetValue(imageUrl, out var completed) && completed)
@@ -454,9 +463,11 @@ public sealed class EmojiPicker
                 if (tex != null)
                 {
                     requests[imageUrl] = true;
+                    failures.TryRemove(imageUrl, out _);
                 }
                 else
                 {
+                    failures[imageUrl] = DateTime.UtcNow;
                     requests.TryRemove(imageUrl, out _);
                 }
             });

--- a/DemiCatPlugin/Emoji/EmojiPlaceholderRenderer.cs
+++ b/DemiCatPlugin/Emoji/EmojiPlaceholderRenderer.cs
@@ -1,0 +1,38 @@
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
+
+namespace DemiCatPlugin.Emoji;
+
+internal static class EmojiPlaceholderRenderer
+{
+    private static readonly uint FillColor = ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 0.06f));
+    private static readonly uint BorderColor = ImGui.ColorConvertFloat4ToU32(new Vector4(1f, 1f, 1f, 0.15f));
+    private const float CornerRadius = 4f;
+
+    public static void Draw(Vector2 size)
+    {
+        ImGui.Dummy(size);
+        DrawDecoration();
+    }
+
+    public static bool DrawButton(Vector2 size)
+    {
+        var clicked = ImGui.InvisibleButton("##placeholder", size);
+        DrawDecoration();
+        return clicked;
+    }
+
+    private static void DrawDecoration()
+    {
+        if (!ImGui.IsItemVisible())
+        {
+            return;
+        }
+
+        var drawList = ImGui.GetWindowDrawList();
+        var min = ImGui.GetItemRectMin();
+        var max = ImGui.GetItemRectMax();
+        drawList.AddRectFilled(min, max, FillColor, CornerRadius);
+        drawList.AddRect(min, max, BorderColor, CornerRadius);
+    }
+}

--- a/DemiCatPlugin/Emoji/EmojiRenderer.cs
+++ b/DemiCatPlugin/Emoji/EmojiRenderer.cs
@@ -45,11 +45,11 @@ public static class EmojiRenderer
             }
             else
             {
-                ImGui.TextUnformatted(label);
+                EmojiPlaceholderRenderer.Draw(new Vector2(size, size));
             }
         });
 
-        if (ImGui.IsItemHovered())
+        if (!string.IsNullOrEmpty(label) && ImGui.IsItemHovered())
         {
             ImGui.SetTooltip(label);
         }
@@ -85,8 +85,7 @@ public static class EmojiRenderer
                 RequestUnicodeTexture(imageUrl);
             }
 
-            using var font = manager.PushEmojiFont();
-            ImGui.TextUnformatted(value);
+            EmojiPlaceholderRenderer.Draw(new Vector2(size, size));
             if (!string.IsNullOrEmpty(tooltip) && ImGui.IsItemHovered())
             {
                 ImGui.SetTooltip(tooltip);
@@ -94,8 +93,7 @@ public static class EmojiRenderer
             return;
         }
 
-        using var fallbackFont = manager.PushEmojiFont();
-        ImGui.TextUnformatted(value);
+        EmojiPlaceholderRenderer.Draw(new Vector2(size, size));
     }
 
     private static void RequestUnicodeTexture(string imageUrl)


### PR DESCRIPTION
## Summary
- add a shared emoji placeholder renderer to draw transparent stand-ins while textures load
- update the emoji picker and renderer to use placeholders instead of text fallbacks
- update chat reactions to avoid colon-style text and keep tooltips while textures load

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ed968b213083288060a6d4061100ca