### PR TITLE
Make presence sidebar event-driven and defer readiness until data loads

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -41,6 +41,7 @@ public class ChatWindow : IDisposable
     protected string _statusMessage = string.Empty;
     private string _lastError = string.Empty;
     protected readonly DiscordPresenceService? _presence;
+    private bool _presenceAwaitingSnapshot;
     protected readonly List<string> _attachments = new();
     private readonly FileDialogManager _fileDialog = new();
     private string _attachmentError = string.Empty;
@@ -673,6 +674,10 @@ public class ChatWindow : IDisposable
         _config = config;
         _httpClient = httpClient;
         _presence = presence;
+        if (_presence != null)
+        {
+            _presence.PresencesChanged += HandlePresenceServicePresencesChanged;
+        }
         _tokenManager = tokenManager;
         _channelService = channelService;
         _channelSelection = channelSelection;
@@ -758,6 +763,17 @@ public class ChatWindow : IDisposable
         _subscribeCts?.Cancel();
         _subscribeCts?.Dispose();
         _subscribeCts = null;
+    }
+
+    private void BeginAwaitingPresenceSnapshot()
+    {
+        if (_presence == null)
+        {
+            return;
+        }
+
+        _presenceAwaitingSnapshot = true;
+        _presence.SetPresenceReady(false);
     }
 
     protected bool TrySubscribeCurrentChannel(bool force = false, bool refreshMessages = true)
@@ -919,7 +935,7 @@ public class ChatWindow : IDisposable
             return;
         }
 
-        _presence?.SetPresenceReady(true);
+        BeginAwaitingPresenceSnapshot();
         _bridge.Start();
         TrySubscribeCurrentChannel(force: true);
         _presence?.Reset();
@@ -932,6 +948,7 @@ public class ChatWindow : IDisposable
         OnSubscriptionStateChanged(false);
         _presence?.Stop();
         _presence?.SetPresenceReady(false);
+        _presenceAwaitingSnapshot = false;
         _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = string.Empty);
     }
 
@@ -4255,6 +4272,10 @@ public class ChatWindow : IDisposable
     public void Dispose()
     {
         StopNetworking();
+        if (_presence != null)
+        {
+            _presence.PresencesChanged -= HandlePresenceServicePresencesChanged;
+        }
         DetachBridgeEvents();
         _channelSelection.ChannelChanged -= HandleChannelSelectionChanged;
         _typingCoalescer.TypingUsersChanged -= HandleTypingUsersChanged;
@@ -4610,6 +4631,7 @@ public class ChatWindow : IDisposable
 
     private void HandleBridgeLinked()
     {
+        BeginAwaitingPresenceSnapshot();
         _presence?.Reload();
         _ = _presence?.Refresh(force: true);
         TrySubscribeCurrentChannel(force: true, refreshMessages: false);
@@ -4618,6 +4640,36 @@ public class ChatWindow : IDisposable
     private void HandleBridgeUnlinked()
     {
         // nothing additional
+    }
+
+    private void HandlePresenceServicePresencesChanged(object? sender, EventArgs e)
+    {
+        if (_presence == null)
+        {
+            return;
+        }
+
+        if (!_networkingActive && !_presenceAwaitingSnapshot)
+        {
+            return;
+        }
+
+        if (!_presence.Loaded)
+        {
+            if (_networkingActive)
+            {
+                _presenceAwaitingSnapshot = true;
+                _presence.SetPresenceReady(false);
+            }
+
+            return;
+        }
+
+        if (_presenceAwaitingSnapshot)
+        {
+            _presence.SetPresenceReady(true);
+            _presenceAwaitingSnapshot = false;
+        }
     }
 
     protected virtual Uri BuildWebSocketUri()

--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -46,6 +46,8 @@ public class DiscordPresenceService : IDisposable
     private const string ApiKeyMissingStatus = "API key not configured";
     private const string PluginDisabledStatus = "Plugin disabled";
 
+    public event EventHandler? PresencesChanged;
+
     public IReadOnlyList<PresenceDto> Presences => _presences;
     public string StatusMessage => _statusMessage;
     public bool Loaded => _loaded;
@@ -547,6 +549,8 @@ public class DiscordPresenceService : IDisposable
                 _indexById[dto.Id] = _presences.Count - 1;
             }
         }
+
+        OnPresencesChanged();
     }
 
     private static void MutatePresenceInPlace(PresenceDto existing, PresenceDto dto)
@@ -656,6 +660,7 @@ public class DiscordPresenceService : IDisposable
         }
 
         Reindex();
+        OnPresencesChanged();
     }
 
     private void Reindex()
@@ -725,12 +730,14 @@ public class DiscordPresenceService : IDisposable
                 DisposePresencesUnlocked(_presences);
                 _presences.Clear();
                 _indexById.Clear();
+                OnPresencesChanged();
             });
         }
 
         DisposePresencesUnlocked(_presences);
         _presences.Clear();
         _indexById.Clear();
+        OnPresencesChanged();
         return Task.CompletedTask;
     }
 
@@ -757,6 +764,9 @@ public class DiscordPresenceService : IDisposable
 
     private void UpdateStatusMessage(string message)
         => _ = PluginServices.Instance!.Framework.RunOnTick(() => _statusMessage = message);
+
+    private void OnPresencesChanged()
+        => PresencesChanged?.Invoke(this, EventArgs.Empty);
 
     private void SetConnectionState(PresenceConnectionState state)
     {

--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -42,7 +42,7 @@ public class FcChatWindow : ChatWindow
     {
         if (presence != null)
         {
-            _presenceSidebar = new PresenceSidebar(presence)
+            _presenceSidebar = new PresenceSidebar(presence, config, httpClient)
             {
                 TextureLoader = LoadTexture,
                 TextureTouch = TextureTouchAction
@@ -72,8 +72,6 @@ public class FcChatWindow : ChatWindow
             base.Draw();
             return;
         }
-
-        _ = RoleCache.EnsureLoaded(_httpClient, _config);
 
         if (_presenceSidebar != null)
         {

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -53,7 +53,7 @@ public class OfficerChatWindow : ChatWindow
     {
         if (presence != null)
         {
-            _presenceSidebar = new PresenceSidebar(presence)
+            _presenceSidebar = new PresenceSidebar(presence, config, httpClient)
             {
                 TextureLoader = LoadTexture,
                 TextureTouch = TextureTouchAction
@@ -171,7 +171,6 @@ public class OfficerChatWindow : ChatWindow
         var showPresence = _presenceSidebar != null && _tokenManager.IsReady();
         if (showPresence)
         {
-            _ = RoleCache.EnsureLoaded(_httpClient, _config);
             _presenceSidebar!.Draw(ref _presenceWidth);
             ImGui.SameLine();
             ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), false);

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Numerics;
 using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
@@ -17,6 +18,8 @@ namespace DemiCatPlugin;
 public class PresenceSidebar : IDisposable
 {
     private readonly DiscordPresenceService _service;
+    private readonly Config _config;
+    private readonly HttpClient _httpClient;
     private static readonly Vector4 OnlineColor = new(0.2f, 0.8f, 0.2f, 1f);
     private static readonly Vector4 IdleColor = new(0.95f, 0.75f, 0.2f, 1f);
     private static readonly Vector4 DndColor = new(0.9f, 0.3f, 0.3f, 1f);
@@ -41,23 +44,22 @@ public class PresenceSidebar : IDisposable
 
     private const string PresenceUnavailableMessage = "Presence unavailable";
     private static readonly TimeSpan RefreshCooldown = TimeSpan.FromSeconds(1);
-    private static readonly TimeSpan RebuildInterval = TimeSpan.FromMilliseconds(250);
-    private static readonly TimeSpan ForceRefreshInterval = TimeSpan.FromSeconds(10);
-
     private Task? _refreshTask;
     private bool _refreshInFlight;
     private DateTime _nextRefreshAllowed = DateTime.MinValue;
     private readonly List<PresenceDto> _items = new();
-    private DateTime _lastRebuild = DateTime.MinValue;
     private PresenceConnectionState _lastConn = PresenceConnectionState.Disconnected;
-    private DateTime _lastForceRefresh = DateTime.MinValue;
+    private bool _pendingRebuild = true;
 
     public Action<string?, Action<ISharedImmediateTexture?>>? TextureLoader { get; set; }
     public Action<string?>? TextureTouch { get; set; }
 
-    public PresenceSidebar(DiscordPresenceService service)
+    public PresenceSidebar(DiscordPresenceService service, Config config, HttpClient httpClient)
     {
         _service = service;
+        _config = config;
+        _httpClient = httpClient;
+        _service.PresencesChanged += HandlePresencesChanged;
     }
 
     public void Draw(ref float width)
@@ -72,21 +74,23 @@ public class PresenceSidebar : IDisposable
             shouldReturn = true;
         }
 
-        var snapshot = _service.GetSnapshot();
-        var hasSnapshot = snapshot != null && snapshot.Count > 0;
+        EnsureRolesLoaded();
+
         var connection = _service.ConnectionState;
         if (_lastConn != connection && connection == PresenceConnectionState.Connected)
         {
             _items.Clear();
-            _lastRebuild = DateTime.MinValue;
+            _pendingRebuild = true;
         }
         _lastConn = connection;
 
-        if (DateTime.UtcNow - _lastRebuild >= RebuildInterval)
+        if (_pendingRebuild)
         {
-            RebuildFrom(snapshot);
-            _lastRebuild = DateTime.UtcNow;
+            RebuildFrom(_service.Presences);
+            _pendingRebuild = false;
         }
+
+        var hasSnapshot = _items.Count > 0;
 
         ImGui.BeginChild("##presence", new Vector2(width, 0), true);
 
@@ -98,31 +102,7 @@ public class PresenceSidebar : IDisposable
             }
             else if (!_service.Loaded && !hasSnapshot)
             {
-                if (!_refreshInFlight && DateTime.UtcNow >= _nextRefreshAllowed)
-                {
-                    var refreshTask = _service.Refresh();
-                    _refreshTask = refreshTask;
-                    _refreshInFlight = true;
-
-                    void CompleteRefresh()
-                    {
-                        _nextRefreshAllowed = DateTime.UtcNow + RefreshCooldown;
-                        if (ReferenceEquals(_refreshTask, refreshTask))
-                        {
-                            _refreshTask = null;
-                        }
-                        _refreshInFlight = false;
-                    }
-
-                    if (!refreshTask.IsCompleted)
-                    {
-                        _ = refreshTask.ContinueWith(_ => CompleteRefresh(), TaskScheduler.Default);
-                    }
-                    else
-                    {
-                        CompleteRefresh();
-                    }
-                }
+                TryRequestRefresh(force: false);
                 ShowStatus(_service.StatusMessage);
             }
             else
@@ -140,7 +120,8 @@ public class PresenceSidebar : IDisposable
                 var presencesSource = _items;
                 if (presencesSource == null || presencesSource.Count == 0)
                 {
-                    ShowStatus(_service.StatusMessage);
+                    MaybeRequestRecoveryRefresh(connection);
+                    ShowStatus(string.IsNullOrWhiteSpace(_service.StatusMessage) ? null : _service.StatusMessage);
                 }
                 else if (!RoleCache.IsLoaded)
                 {
@@ -149,20 +130,15 @@ public class PresenceSidebar : IDisposable
                 else
                 {
                     var presences = presencesSource.ToList();
-                if (presences.Count == 0)
-                {
-                    if (DateTime.UtcNow - _lastForceRefresh >= ForceRefreshInterval)
+                    if (presences.Count == 0)
                     {
-                        _lastForceRefresh = DateTime.UtcNow;
-                        _ = _service.Refresh(force: true);
+                        MaybeRequestRecoveryRefresh(connection);
+                        ShowStatus(string.IsNullOrWhiteSpace(_service.StatusMessage) ? null : _service.StatusMessage);
                     }
-
-                    ShowStatus(string.IsNullOrWhiteSpace(_service.StatusMessage) ? null : _service.StatusMessage);
-                }
-                else
-                {
-                    if (!string.IsNullOrEmpty(_service.StatusMessage))
+                    else
                     {
+                        if (!string.IsNullOrEmpty(_service.StatusMessage))
+                        {
                             ImGui.TextUnformatted(_service.StatusMessage);
                             ImGui.Spacing();
                         }
@@ -575,7 +551,75 @@ public class PresenceSidebar : IDisposable
 
     public void Dispose()
     {
-        // No resources to dispose; the underlying service is disposed separately.
+        _service.PresencesChanged -= HandlePresencesChanged;
+    }
+
+    private void HandlePresencesChanged(object? sender, EventArgs e)
+    {
+        _pendingRebuild = true;
+    }
+
+    private void TryRequestRefresh(bool force)
+    {
+        if (_refreshInFlight)
+        {
+            return;
+        }
+
+        if (!force && DateTime.UtcNow < _nextRefreshAllowed)
+        {
+            return;
+        }
+
+        var refreshTask = _service.Refresh(force: force);
+        _refreshTask = refreshTask;
+        _refreshInFlight = true;
+
+        void CompleteRefresh()
+        {
+            _nextRefreshAllowed = DateTime.UtcNow + RefreshCooldown;
+            if (ReferenceEquals(_refreshTask, refreshTask))
+            {
+                _refreshTask = null;
+            }
+
+            _refreshInFlight = false;
+        }
+
+        if (!refreshTask.IsCompleted)
+        {
+            _ = refreshTask.ContinueWith(_ => CompleteRefresh(), TaskScheduler.Default);
+        }
+        else
+        {
+            CompleteRefresh();
+        }
+    }
+
+    private void MaybeRequestRecoveryRefresh(PresenceConnectionState connection)
+    {
+        if (connection == PresenceConnectionState.Connected && string.IsNullOrWhiteSpace(_service.StatusMessage))
+        {
+            return;
+        }
+
+        TryRequestRefresh(force: true);
+    }
+
+    private void EnsureRolesLoaded()
+    {
+        if (RoleCache.IsLoaded)
+        {
+            return;
+        }
+
+        var tokenManager = TokenManager.Instance;
+        if (tokenManager?.IsReady() != true)
+        {
+            return;
+        }
+
+        _ = RoleCache.EnsureLoaded(_httpClient, _config);
     }
 
     private static bool IsOffline(string? status)

--- a/tests/PresenceServiceLifecycleTests.cs
+++ b/tests/PresenceServiceLifecycleTests.cs
@@ -74,6 +74,9 @@ public class PresenceServiceLifecycleTests : IDisposable
         var window = new ChatWindow(config, httpClient, presence, tokenManager, channelService);
 
         window.StartNetworking();
+        Assert.False(presence.IsPresenceReady);
+
+        presence.Refresh(force: true).GetAwaiter().GetResult();
         Assert.True(presence.IsPresenceReady);
 
         window.StopNetworking();

--- a/tests/PresenceSidebarTests.cs
+++ b/tests/PresenceSidebarTests.cs
@@ -51,7 +51,7 @@ public class PresenceSidebarTests
         var config = new Config();
         var httpClient = new HttpClient(new StubHandler());
         var service = new DiscordPresenceService(config, httpClient);
-        return new PresenceSidebar(service);
+        return new PresenceSidebar(service, config, httpClient);
     }
 
     private static void InvokeDrawPresence(PresenceSidebar sidebar, PresenceDto presence)


### PR DESCRIPTION
## Summary
- subscribe the presence sidebar to DiscordPresenceService.PresencesChanged so the UI only rebuilds when data updates
- trigger role cache loading from the sidebar and replace the timer-based refresh loop with recovery checks tied to connection state and status messages
- defer marking presences ready until a snapshot arrives, reset the flag on reloads, and adjust tests for the new behavior

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ee3978e10c8328bd389803d07ef928