### PR TITLE
Add event-driven SyncShell support for additional Mare systems

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -341,7 +341,7 @@ public class ChannelWatcher : IDisposable
         PluginServices.Instance!.Log.Error(ex, $"channel.ws {stage} failed");
     }
 
-    internal static async Task<(string message, WebSocketMessageType messageType)> ReceiveMessageAsync(WebSocket ws, byte[] buffer, CancellationToken token)
+    public static async Task<(string message, WebSocketMessageType messageType)> ReceiveMessageAsync(WebSocket ws, byte[] buffer, CancellationToken token)
     {
         using var ms = new MemoryStream();
         WebSocketReceiveResult result;

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -70,6 +70,10 @@ public class Plugin : IDalamudPlugin
     private readonly SyncShellClient _syncShellClient;
     private readonly PenumbraIpc _penumbraIpc;
     private readonly GlamourerIpc _glamourerIpc;
+    private readonly CustomizePlusIpc _customizePlusIpc;
+    private readonly SimpleHeelsIpc _simpleHeelsIpc;
+    private readonly PalettePlusIpc _palettePlusIpc;
+    private readonly HonorificIpc _honorificIpc;
     private readonly SyncShellWatcher _syncShellWatcher;
     private readonly SyncShellService _syncShellService;
 
@@ -112,6 +116,10 @@ public class Plugin : IDalamudPlugin
         _syncShellClient = new SyncShellClient(_httpClient, _config, _tokenManager);
         _penumbraIpc = new PenumbraIpc(_services.PluginInterface, _services.Log);
         _glamourerIpc = new GlamourerIpc(_services.PluginInterface, _services.ClientState, _services.Log);
+        _customizePlusIpc = new CustomizePlusIpc(_services.PluginInterface, _services.Log);
+        _simpleHeelsIpc = new SimpleHeelsIpc(_services.PluginInterface, _services.Log);
+        _palettePlusIpc = new PalettePlusIpc(_services.PluginInterface, _services.Log);
+        _honorificIpc = new HonorificIpc(_services.PluginInterface, _services.Log);
         _syncShellWatcher = new SyncShellWatcher(_config, _tokenManager, _services.Log);
         _syncShellService = new SyncShellService(
             _config,
@@ -120,12 +128,20 @@ public class Plugin : IDalamudPlugin
             _blobStore,
             _penumbraIpc,
             _glamourerIpc,
+            _customizePlusIpc,
+            _simpleHeelsIpc,
+            _palettePlusIpc,
+            _honorificIpc,
             _services.Log,
             _services.ClientState,
             _services.Framework,
             _services.ObjectTable,
             _syncShellWatcher);
         _services.GlamourerIpc = _glamourerIpc;
+        _services.CustomizePlusIpc = _customizePlusIpc;
+        _services.SimpleHeelsIpc = _simpleHeelsIpc;
+        _services.PalettePlusIpc = _palettePlusIpc;
+        _services.HonorificIpc = _honorificIpc;
         _services.SyncShellService = _syncShellService;
         var baseChatBridge = new ChatBridge(
             _config,

--- a/DemiCatPlugin/PluginServices.cs
+++ b/DemiCatPlugin/PluginServices.cs
@@ -52,6 +52,14 @@ internal class PluginServices
 
     internal GlamourerIpc? GlamourerIpc { get; set; }
 
+    internal CustomizePlusIpc? CustomizePlusIpc { get; set; }
+
+    internal SimpleHeelsIpc? SimpleHeelsIpc { get; set; }
+
+    internal PalettePlusIpc? PalettePlusIpc { get; set; }
+
+    internal HonorificIpc? HonorificIpc { get; set; }
+
     public PluginServices()
     {
         Instance = this;

--- a/DemiCatPlugin/SyncShell/CustomizePlusIpc.cs
+++ b/DemiCatPlugin/SyncShell/CustomizePlusIpc.cs
@@ -1,0 +1,142 @@
+using System;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Ipc.Exceptions;
+using Dalamud.Plugin.Services;
+
+namespace DemiCatPlugin.SyncShell;
+
+public sealed class CustomizePlusIpc
+{
+    private static readonly string[] ApplyGateNames =
+    {
+        "CustomizePlus.ApplyProfileJson",
+        "CustomizePlus.Api/ApplyProfileJson",
+    };
+
+    private static readonly string[] ExportGateNames =
+    {
+        "CustomizePlus.ExportCurrentProfileJson",
+    };
+
+    private readonly IPluginLog _log;
+    private readonly ICallGateSubscriber<string, object?>? _applyGate;
+    private readonly ICallGateSubscriber<string>? _exportGate;
+    private string? _lastAppliedJson;
+
+    public CustomizePlusIpc(IDalamudPluginInterface pluginInterface, IPluginLog log)
+    {
+        if (pluginInterface == null)
+        {
+            throw new ArgumentNullException(nameof(pluginInterface));
+        }
+
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+
+        _applyGate = TryGetApplyGate(pluginInterface);
+        _exportGate = TryGetExportGate(pluginInterface);
+        Available = _applyGate != null;
+    }
+
+    public bool Available { get; }
+
+    public string? LastAppliedJson => _lastAppliedJson;
+
+    public void ApplyProfileJson(string json)
+    {
+        if (!Available || _applyGate == null || string.IsNullOrWhiteSpace(json))
+        {
+            return;
+        }
+
+        try
+        {
+            _applyGate.InvokeAction(json);
+            _lastAppliedJson = json;
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Customize+ ApplyProfileJson failed");
+        }
+    }
+
+    public string? TryExportProfileJson()
+    {
+        if (_exportGate == null)
+        {
+            return _lastAppliedJson;
+        }
+
+        try
+        {
+            var json = _exportGate.InvokeFunc();
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                _lastAppliedJson = json;
+                return json;
+            }
+        }
+        catch (IpcError)
+        {
+            // Gate exists but failed; fall back to last applied JSON.
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Customize+ export failed");
+        }
+
+        return _lastAppliedJson;
+    }
+
+    private ICallGateSubscriber<string, object?>? TryGetApplyGate(IDalamudPluginInterface pluginInterface)
+    {
+        foreach (var name in ApplyGateNames)
+        {
+            try
+            {
+                var gate = pluginInterface.GetIpcSubscriber<string, object?>(name);
+                if (gate != null)
+                {
+                    return gate;
+                }
+            }
+            catch (IpcNotReadyError)
+            {
+                // Try next name; plugin not ready yet.
+            }
+            catch (IpcError)
+            {
+                // Try next name.
+            }
+            catch (Exception ex)
+            {
+                _log.Debug(ex, "Customize+ apply gate {Gate} unavailable", name);
+            }
+        }
+
+        return null;
+    }
+
+    private ICallGateSubscriber<string>? TryGetExportGate(IDalamudPluginInterface pluginInterface)
+    {
+        foreach (var name in ExportGateNames)
+        {
+            try
+            {
+                return pluginInterface.GetIpcSubscriber<string>(name);
+            }
+            catch (IpcNotReadyError)
+            {
+            }
+            catch (IpcError)
+            {
+            }
+            catch (Exception ex)
+            {
+                _log.Debug(ex, "Customize+ export gate {Gate} unavailable", name);
+            }
+        }
+
+        return null;
+    }
+}

--- a/DemiCatPlugin/SyncShell/GlamourerIpc.cs
+++ b/DemiCatPlugin/SyncShell/GlamourerIpc.cs
@@ -1,6 +1,7 @@
 using System;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Ipc.Exceptions;
 using Dalamud.Plugin.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -11,8 +12,16 @@ public sealed class GlamourerIpc
 {
     private readonly IDalamudPluginInterface _pluginInterface;
     private readonly IClientState _clientState;
+    private static readonly string[] ApplyGateNames =
+    {
+        "Glamourer.Api/ApplyPlayerDesign",
+        "Glamourer.Api/ApplyAll",
+        "Glamourer.Api/Design/Apply",
+    };
+
     private readonly IPluginLog _log;
     private readonly ICallGateSubscriber<int, uint, (int, JObject?)>? _getState;
+    private readonly ICallGateSubscriber<string, object?>? _applyDesign;
 
     public GlamourerIpc(IDalamudPluginInterface pluginInterface, IClientState clientState, IPluginLog log)
     {
@@ -23,16 +32,19 @@ public sealed class GlamourerIpc
         try
         {
             _getState = _pluginInterface.GetIpcSubscriber<int, uint, (int, JObject?)>("Glamourer.GetState");
-            Available = _getState != null;
         }
         catch (Exception ex)
         {
-            Available = false;
             _log.Information(ex, "Glamourer IPC unavailable");
         }
+
+        _applyDesign = TryGetApplyGate();
+        Available = _getState != null || _applyDesign != null;
     }
 
     public bool Available { get; }
+
+    public bool CanApply => _applyDesign != null;
 
     public string? TryGetPlayerDesignJson()
     {
@@ -62,5 +74,49 @@ public sealed class GlamourerIpc
             _log.Warning(ex, "Failed to capture Glamourer state");
             return null;
         }
+    }
+
+    public void ApplyPlayerDesignJson(string json)
+    {
+        if (!CanApply || _applyDesign == null || string.IsNullOrWhiteSpace(json))
+        {
+            return;
+        }
+
+        try
+        {
+            _applyDesign.InvokeAction(json);
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to apply Glamourer design");
+        }
+    }
+
+    private ICallGateSubscriber<string, object?>? TryGetApplyGate()
+    {
+        foreach (var gate in ApplyGateNames)
+        {
+            try
+            {
+                var subscriber = _pluginInterface.GetIpcSubscriber<string, object?>(gate);
+                if (subscriber != null)
+                {
+                    return subscriber;
+                }
+            }
+            catch (IpcNotReadyError)
+            {
+            }
+            catch (IpcError)
+            {
+            }
+            catch (Exception ex)
+            {
+                _log.Debug(ex, "Glamourer apply gate {Gate} unavailable", gate);
+            }
+        }
+
+        return null;
     }
 }

--- a/DemiCatPlugin/SyncShell/HonorificIpc.cs
+++ b/DemiCatPlugin/SyncShell/HonorificIpc.cs
@@ -1,0 +1,121 @@
+using System;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Ipc.Exceptions;
+using Dalamud.Plugin.Services;
+
+namespace DemiCatPlugin.SyncShell;
+
+public sealed class HonorificIpc
+{
+    private const string ApplyGateName = "Honorific.Api/SetTitleJson";
+    private const string ExportGateName = "Honorific.Api/GetTitleJson";
+
+    private readonly IPluginLog _log;
+    private readonly ICallGateSubscriber<string, object?>? _applyGate;
+    private readonly ICallGateSubscriber<string>? _exportGate;
+    private string? _lastAppliedJson;
+
+    public HonorificIpc(IDalamudPluginInterface pluginInterface, IPluginLog log)
+    {
+        if (pluginInterface == null)
+        {
+            throw new ArgumentNullException(nameof(pluginInterface));
+        }
+
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+
+        _applyGate = TryGetApplyGate(pluginInterface);
+        _exportGate = TryGetExportGate(pluginInterface);
+        Available = _applyGate != null;
+    }
+
+    public bool Available { get; }
+
+    public string? LastAppliedJson => _lastAppliedJson;
+
+    public void SetTitleJson(string json)
+    {
+        if (!Available || _applyGate == null || string.IsNullOrWhiteSpace(json))
+        {
+            return;
+        }
+
+        try
+        {
+            _applyGate.InvokeAction(json);
+            _lastAppliedJson = json;
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Honorific SetTitleJson failed");
+        }
+    }
+
+    public string? TryGetTitleJson()
+    {
+        if (_exportGate == null)
+        {
+            return _lastAppliedJson;
+        }
+
+        try
+        {
+            var json = _exportGate.InvokeFunc();
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                _lastAppliedJson = json;
+                return json;
+            }
+        }
+        catch (IpcError)
+        {
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Honorific export failed");
+        }
+
+        return _lastAppliedJson;
+    }
+
+    private ICallGateSubscriber<string, object?>? TryGetApplyGate(IDalamudPluginInterface pluginInterface)
+    {
+        try
+        {
+            return pluginInterface.GetIpcSubscriber<string, object?>(ApplyGateName);
+        }
+        catch (IpcNotReadyError)
+        {
+        }
+        catch (IpcError)
+        {
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Honorific apply gate unavailable");
+        }
+
+        return null;
+    }
+
+    private ICallGateSubscriber<string>? TryGetExportGate(IDalamudPluginInterface pluginInterface)
+    {
+        try
+        {
+            return pluginInterface.GetIpcSubscriber<string>(ExportGateName);
+        }
+        catch (IpcNotReadyError)
+        {
+        }
+        catch (IpcError)
+        {
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Honorific export gate unavailable");
+        }
+
+        return null;
+    }
+}

--- a/DemiCatPlugin/SyncShell/Models.cs
+++ b/DemiCatPlugin/SyncShell/Models.cs
@@ -25,6 +25,18 @@ public sealed class AppearanceMeta
     [JsonPropertyName("glamourer")]
     public string? GlamourerJson { get; set; }
 
+    [JsonPropertyName("cplus")]
+    public string? CustomizePlusJson { get; set; }
+
+    [JsonPropertyName("heels")]
+    public string? SimpleHeelsJson { get; set; }
+
+    [JsonPropertyName("palette")]
+    public string? PalettePlusJson { get; set; }
+
+    [JsonPropertyName("honorific")]
+    public string? HonorificJson { get; set; }
+
     [JsonPropertyName("blobs")]
     public List<BlobRef> Blobs { get; } = new();
 }

--- a/DemiCatPlugin/SyncShell/PalettePlusIpc.cs
+++ b/DemiCatPlugin/SyncShell/PalettePlusIpc.cs
@@ -1,0 +1,139 @@
+using System;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Ipc.Exceptions;
+using Dalamud.Plugin.Services;
+
+namespace DemiCatPlugin.SyncShell;
+
+public sealed class PalettePlusIpc
+{
+    private static readonly string[] ApplyGateNames =
+    {
+        "PalettePlus.ApplyProfileJson",
+        "PalettePlus.Api/ApplyProfileJson",
+    };
+
+    private static readonly string[] ExportGateNames =
+    {
+        "PalettePlus.ExportProfileJson",
+    };
+
+    private readonly IPluginLog _log;
+    private readonly ICallGateSubscriber<string, object?>? _applyGate;
+    private readonly ICallGateSubscriber<string>? _exportGate;
+    private string? _lastAppliedJson;
+
+    public PalettePlusIpc(IDalamudPluginInterface pluginInterface, IPluginLog log)
+    {
+        if (pluginInterface == null)
+        {
+            throw new ArgumentNullException(nameof(pluginInterface));
+        }
+
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+
+        _applyGate = TryGetApplyGate(pluginInterface);
+        _exportGate = TryGetExportGate(pluginInterface);
+        Available = _applyGate != null;
+    }
+
+    public bool Available { get; }
+
+    public string? LastAppliedJson => _lastAppliedJson;
+
+    public void ApplyProfileJson(string json)
+    {
+        if (!Available || _applyGate == null || string.IsNullOrWhiteSpace(json))
+        {
+            return;
+        }
+
+        try
+        {
+            _applyGate.InvokeAction(json);
+            _lastAppliedJson = json;
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Palette+ ApplyProfileJson failed");
+        }
+    }
+
+    public string? TryExportProfileJson()
+    {
+        if (_exportGate == null)
+        {
+            return _lastAppliedJson;
+        }
+
+        try
+        {
+            var json = _exportGate.InvokeFunc();
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                _lastAppliedJson = json;
+                return json;
+            }
+        }
+        catch (IpcError)
+        {
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Palette+ export failed");
+        }
+
+        return _lastAppliedJson;
+    }
+
+    private ICallGateSubscriber<string, object?>? TryGetApplyGate(IDalamudPluginInterface pluginInterface)
+    {
+        foreach (var name in ApplyGateNames)
+        {
+            try
+            {
+                var gate = pluginInterface.GetIpcSubscriber<string, object?>(name);
+                if (gate != null)
+                {
+                    return gate;
+                }
+            }
+            catch (IpcNotReadyError)
+            {
+            }
+            catch (IpcError)
+            {
+            }
+            catch (Exception ex)
+            {
+                _log.Debug(ex, "Palette+ apply gate {Gate} unavailable", name);
+            }
+        }
+
+        return null;
+    }
+
+    private ICallGateSubscriber<string>? TryGetExportGate(IDalamudPluginInterface pluginInterface)
+    {
+        foreach (var name in ExportGateNames)
+        {
+            try
+            {
+                return pluginInterface.GetIpcSubscriber<string>(name);
+            }
+            catch (IpcNotReadyError)
+            {
+            }
+            catch (IpcError)
+            {
+            }
+            catch (Exception ex)
+            {
+                _log.Debug(ex, "Palette+ export gate {Gate} unavailable", name);
+            }
+        }
+
+        return null;
+    }
+}

--- a/DemiCatPlugin/SyncShell/SimpleHeelsIpc.cs
+++ b/DemiCatPlugin/SyncShell/SimpleHeelsIpc.cs
@@ -1,0 +1,139 @@
+using System;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Ipc;
+using Dalamud.Plugin.Ipc.Exceptions;
+using Dalamud.Plugin.Services;
+
+namespace DemiCatPlugin.SyncShell;
+
+public sealed class SimpleHeelsIpc
+{
+    private static readonly string[] ApplyGateNames =
+    {
+        "SimpleHeels.ApplyOffsetsJson",
+        "SimpleHeels.Api/ApplyOffsetsJson",
+    };
+
+    private static readonly string[] ExportGateNames =
+    {
+        "SimpleHeels.ExportCurrentOffsetsJson",
+    };
+
+    private readonly IPluginLog _log;
+    private readonly ICallGateSubscriber<string, object?>? _applyGate;
+    private readonly ICallGateSubscriber<string>? _exportGate;
+    private string? _lastAppliedJson;
+
+    public SimpleHeelsIpc(IDalamudPluginInterface pluginInterface, IPluginLog log)
+    {
+        if (pluginInterface == null)
+        {
+            throw new ArgumentNullException(nameof(pluginInterface));
+        }
+
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+
+        _applyGate = TryGetApplyGate(pluginInterface);
+        _exportGate = TryGetExportGate(pluginInterface);
+        Available = _applyGate != null;
+    }
+
+    public bool Available { get; }
+
+    public string? LastAppliedJson => _lastAppliedJson;
+
+    public void ApplyOffsetsJson(string json)
+    {
+        if (!Available || _applyGate == null || string.IsNullOrWhiteSpace(json))
+        {
+            return;
+        }
+
+        try
+        {
+            _applyGate.InvokeAction(json);
+            _lastAppliedJson = json;
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "SimpleHeels ApplyOffsetsJson failed");
+        }
+    }
+
+    public string? TryExportOffsetsJson()
+    {
+        if (_exportGate == null)
+        {
+            return _lastAppliedJson;
+        }
+
+        try
+        {
+            var json = _exportGate.InvokeFunc();
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                _lastAppliedJson = json;
+                return json;
+            }
+        }
+        catch (IpcError)
+        {
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "SimpleHeels export failed");
+        }
+
+        return _lastAppliedJson;
+    }
+
+    private ICallGateSubscriber<string, object?>? TryGetApplyGate(IDalamudPluginInterface pluginInterface)
+    {
+        foreach (var name in ApplyGateNames)
+        {
+            try
+            {
+                var gate = pluginInterface.GetIpcSubscriber<string, object?>(name);
+                if (gate != null)
+                {
+                    return gate;
+                }
+            }
+            catch (IpcNotReadyError)
+            {
+            }
+            catch (IpcError)
+            {
+            }
+            catch (Exception ex)
+            {
+                _log.Debug(ex, "SimpleHeels apply gate {Gate} unavailable", name);
+            }
+        }
+
+        return null;
+    }
+
+    private ICallGateSubscriber<string>? TryGetExportGate(IDalamudPluginInterface pluginInterface)
+    {
+        foreach (var name in ExportGateNames)
+        {
+            try
+            {
+                return pluginInterface.GetIpcSubscriber<string>(name);
+            }
+            catch (IpcNotReadyError)
+            {
+            }
+            catch (IpcError)
+            {
+            }
+            catch (Exception ex)
+            {
+                _log.Debug(ex, "SimpleHeels export gate {Gate} unavailable", name);
+            }
+        }
+
+        return null;
+    }
+}

--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -49,6 +49,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     private readonly BlobStore _blobStore;
     private readonly PenumbraIpc _penumbra;
     private readonly GlamourerIpc _glamourer;
+    private readonly CustomizePlusIpc _customizePlus;
+    private readonly SimpleHeelsIpc _simpleHeels;
+    private readonly PalettePlusIpc _palettePlus;
+    private readonly HonorificIpc _honorific;
     private readonly IPluginLog _log;
     private readonly IClientState _clientState;
     private readonly IFramework _framework;
@@ -85,6 +89,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     private bool _validationFailed;
     private string _status = "SyncShell disabled";
     private string? _glamourerJson;
+    private string? _customizePlusJson;
+    private string? _simpleHeelsJson;
+    private string? _palettePlusJson;
+    private string? _honorificJson;
     private DateTimeOffset _lastRedrawAt = DateTimeOffset.MinValue;
     private bool _loggedSettingsJsonDetection;
     private string? _cachedPenRoot;
@@ -104,6 +112,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         BlobStore blobStore,
         PenumbraIpc penumbra,
         GlamourerIpc glamourer,
+        CustomizePlusIpc customizePlus,
+        SimpleHeelsIpc simpleHeels,
+        PalettePlusIpc palettePlus,
+        HonorificIpc honorific,
         IPluginLog log,
         IClientState clientState,
         IFramework framework,
@@ -116,6 +128,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         _blobStore = blobStore ?? throw new ArgumentNullException(nameof(blobStore));
         _penumbra = penumbra ?? throw new ArgumentNullException(nameof(penumbra));
         _glamourer = glamourer ?? throw new ArgumentNullException(nameof(glamourer));
+        _customizePlus = customizePlus ?? throw new ArgumentNullException(nameof(customizePlus));
+        _simpleHeels = simpleHeels ?? throw new ArgumentNullException(nameof(simpleHeels));
+        _palettePlus = palettePlus ?? throw new ArgumentNullException(nameof(palettePlus));
+        _honorific = honorific ?? throw new ArgumentNullException(nameof(honorific));
         _log = log ?? throw new ArgumentNullException(nameof(log));
         _clientState = clientState ?? throw new ArgumentNullException(nameof(clientState));
         _framework = framework ?? throw new ArgumentNullException(nameof(framework));
@@ -421,6 +437,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             }
 
             _runCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _lastAppearanceHash = null;
             Status = "Initializing…";
             RefreshAppearanceCaches();
 
@@ -469,6 +486,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
             _runCts.Dispose();
             _runCts = null;
+            _lastAppearanceHash = null;
             Status = _config.EnableSyncShell ? "Idle" : "SyncShell disabled";
         }
         finally
@@ -600,6 +618,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     private void HandleTokenUnlinked(string? _unused)
     {
         _ = Stop();
+        _lastAppearanceHash = null;
         lock (_statusLock)
         {
             _status = "Not linked";
@@ -735,6 +754,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             return;
         }
 
+        _lastAppearanceHash = null;
         _ = Task.Run(async () =>
         {
             try
@@ -807,19 +827,40 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             return;
         }
 
-        List<string> ids = handles?
+        var input = handles?
             .Where(h => !string.IsNullOrWhiteSpace(h))
             .Select(h => h.Trim())
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList() ?? new List<string>();
 
-        if (ids.Count == 0)
+        if (input.Count == 0)
         {
             return;
         }
 
-        var before = ids.Count;
-        var filtered = new List<string>();
+        var resolved = new List<SyncshellMemberStatus>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var handle in input)
+        {
+            var member = ResolveMemberFromHandle(handle);
+            if (member == null || string.IsNullOrWhiteSpace(member.Id))
+            {
+                continue;
+            }
+
+            if (seen.Add(member.Id))
+            {
+                resolved.Add(member);
+            }
+        }
+
+        if (resolved.Count == 0)
+        {
+            return;
+        }
+
+        var before = resolved.Count;
+        var filtered = new List<SyncshellMemberStatus>();
         HashSet<string>? visibleHandles = null;
 
         if (_config.OnlySyncVisible)
@@ -827,16 +868,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             visibleHandles = GetVisibleHandles();
         }
 
-        foreach (var id in ids)
+        foreach (var member in resolved)
         {
             if (_config.OnlySyncVisible)
             {
-                var member = FindMember(id);
-                if (member == null)
-                {
-                    continue;
-                }
-
                 if (visibleHandles == null || !visibleHandles.Contains(MemberHandle(member)))
                 {
                     continue;
@@ -845,13 +880,13 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
             if (!_config.SyncAutoMode)
             {
-                if (!ulong.TryParse(id, out var parsed) || !_config.ManualAutoList.Contains(parsed))
+                if (!ulong.TryParse(member.Id, out var parsed) || !_config.ManualAutoList.Contains(parsed))
                 {
                     continue;
                 }
             }
 
-            filtered.Add(id);
+            filtered.Add(member);
         }
 
         if (_config.OnlySyncVisible)
@@ -861,10 +896,11 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         var token = _runCts.Token;
 
-        foreach (var id in filtered)
+        foreach (var member in filtered)
         {
             try
             {
+                var id = member.Id;
                 var target = GetOrCreateTarget(id);
                 target.Stage = SyncshellTargetStage.Queued;
 
@@ -987,6 +1023,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         lock (_appearanceLock)
         {
             appearance.GlamourerJson = _glamourerJson;
+            appearance.CustomizePlusJson = _customizePlusJson;
+            appearance.SimpleHeelsJson = _simpleHeelsJson;
+            appearance.PalettePlusJson = _palettePlusJson;
+            appearance.HonorificJson = _honorificJson;
             localBlobs = new Dictionary<string, LocalBlobInfo?>(_localBlobs, StringComparer.OrdinalIgnoreCase);
         }
 
@@ -1244,6 +1284,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
                 target.Stage = SyncshellTargetStage.Applying;
                 ActivateTempMod(memberId);
                 ApplyGlamourer(memberId);
+                ApplyCustomizePlus(memberId);
+                ApplySimpleHeels(memberId);
+                ApplyPalettePlus(memberId);
+                ApplyHonorific(memberId);
                 await DebouncedRedrawAsync(token).ConfigureAwait(false);
 
                 target.LastAppliedAt = DateTimeOffset.UtcNow;
@@ -1292,6 +1336,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         EnsureNotDisposed();
 
         string? glamourerJson = null;
+        string? customizePlusJson = null;
+        string? simpleHeelsJson = null;
+        string? palettePlusJson = null;
+        string? honorificJson = null;
         try
         {
             if (_glamourer.Available)
@@ -1302,6 +1350,54 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         catch (Exception ex)
         {
             _log.Warning(ex, "Glamourer IPC failed");
+        }
+
+        try
+        {
+            if (_customizePlus.Available)
+            {
+                customizePlusJson = OnFramework(() => _customizePlus.TryExportProfileJson());
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Customize+ IPC failed");
+        }
+
+        try
+        {
+            if (_simpleHeels.Available)
+            {
+                simpleHeelsJson = OnFramework(() => _simpleHeels.TryExportOffsetsJson());
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "SimpleHeels IPC failed");
+        }
+
+        try
+        {
+            if (_palettePlus.Available)
+            {
+                palettePlusJson = OnFramework(() => _palettePlus.TryExportProfileJson());
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Palette+ IPC failed");
+        }
+
+        try
+        {
+            if (_honorific.Available)
+            {
+                honorificJson = OnFramework(() => _honorific.TryGetTitleJson());
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Debug(ex, "Honorific IPC failed");
         }
 
         var modRoot = ResolvePenumbraRoot();
@@ -1333,7 +1429,11 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         lock (_appearanceLock)
         {
-            _glamourerJson = string.IsNullOrWhiteSpace(glamourerJson) ? null : glamourerJson;
+            _glamourerJson = NormalizeJsonValue(glamourerJson);
+            _customizePlusJson = NormalizeJsonValue(customizePlusJson);
+            _simpleHeelsJson = NormalizeJsonValue(simpleHeelsJson);
+            _palettePlusJson = NormalizeJsonValue(palettePlusJson);
+            _honorificJson = NormalizeJsonValue(honorificJson);
             _localBlobs.Clear();
             foreach (var entry in discovered)
             {
@@ -1391,10 +1491,26 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         return relative.Replace('\\', '/').ToLowerInvariant();
     }
 
+    private static string? NormalizeJsonValue(string? json)
+        => string.IsNullOrWhiteSpace(json) ? null : json;
+
     private static string NormalizeHandle(string name, string? world = null)
         => string.IsNullOrWhiteSpace(world)
             ? name.Trim().ToLowerInvariant()
             : $"{name.Trim().ToLowerInvariant()}@{world.Trim().ToLowerInvariant()}";
+
+    private static string NormalizeIncomingHandle(string handle)
+    {
+        if (string.IsNullOrWhiteSpace(handle))
+        {
+            return string.Empty;
+        }
+
+        var parts = handle.Split('@', 2, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length == 2
+            ? NormalizeHandle(parts[0], parts[1])
+            : NormalizeHandle(handle);
+    }
 
     private static string MemberHandle(SyncshellMemberStatus member)
         => NormalizeHandle(member.DisplayName);
@@ -1462,10 +1578,48 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             }
         }
 
-        if (!string.IsNullOrWhiteSpace(appearance.GlamourerJson))
+        WriteSystemJsonFile(modPath, "glamourer.json", appearance.GlamourerJson);
+        WriteSystemJsonFile(modPath, "cplus.json", appearance.CustomizePlusJson);
+        WriteSystemJsonFile(modPath, "heels.json", appearance.SimpleHeelsJson);
+        WriteSystemJsonFile(modPath, "palette.json", appearance.PalettePlusJson);
+        WriteSystemJsonFile(modPath, "honorific.json", appearance.HonorificJson);
+    }
+
+    private void WriteSystemJsonFile(string modPath, string fileName, string? json)
+    {
+        var path = Path.Combine(modPath, fileName);
+
+        try
         {
-            File.WriteAllText(Path.Combine(modPath, "glamourer.json"), appearance.GlamourerJson);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+
+                return;
+            }
+
+            File.WriteAllText(path, json);
         }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "Failed to stage {File} for SyncShell", fileName);
+        }
+    }
+
+    private string? ReadSystemJson(string memberId, string fileName)
+    {
+        var root = EnsureWorkspaceRoot();
+        var path = Path.Combine(root, "mods", memberId, "current", fileName);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        var json = File.ReadAllText(path);
+        return string.IsNullOrWhiteSpace(json) ? null : json;
     }
 
     private string EnsureWorkspaceRoot()
@@ -1492,26 +1646,116 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
     private void ApplyGlamourer(string memberId)
     {
+        if (!_glamourer.CanApply)
+        {
+            return;
+        }
+
         try
         {
-            var root = EnsureWorkspaceRoot();
-            var path = Path.Combine(root, "mods", memberId, "current", "glamourer.json");
-            if (!File.Exists(path))
+            var json = ReadSystemJson(memberId, "glamourer.json");
+            if (string.IsNullOrWhiteSpace(json))
             {
                 return;
             }
 
-            var json = File.ReadAllText(path);
-            if (string.IsNullOrWhiteSpace(json) || !_glamourer.Available)
-            {
-                return;
-            }
-
-            OnFramework(() => _glamourer.TryGetPlayerDesignJson());
+            OnFramework(() => _glamourer.ApplyPlayerDesignJson(json));
         }
         catch (Exception ex)
         {
             _log.Warning(ex, "ApplyGlamourer failed for {Member}", memberId);
+        }
+    }
+
+    private void ApplyCustomizePlus(string memberId)
+    {
+        if (!_customizePlus.Available)
+        {
+            return;
+        }
+
+        try
+        {
+            var json = ReadSystemJson(memberId, "cplus.json");
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return;
+            }
+
+            OnFramework(() => _customizePlus.ApplyProfileJson(json));
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "ApplyCustomizePlus failed for {Member}", memberId);
+        }
+    }
+
+    private void ApplySimpleHeels(string memberId)
+    {
+        if (!_simpleHeels.Available)
+        {
+            return;
+        }
+
+        try
+        {
+            var json = ReadSystemJson(memberId, "heels.json");
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return;
+            }
+
+            OnFramework(() => _simpleHeels.ApplyOffsetsJson(json));
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "ApplySimpleHeels failed for {Member}", memberId);
+        }
+    }
+
+    private void ApplyPalettePlus(string memberId)
+    {
+        if (!_palettePlus.Available)
+        {
+            return;
+        }
+
+        try
+        {
+            var json = ReadSystemJson(memberId, "palette.json");
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return;
+            }
+
+            OnFramework(() => _palettePlus.ApplyProfileJson(json));
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "ApplyPalettePlus failed for {Member}", memberId);
+        }
+    }
+
+    private void ApplyHonorific(string memberId)
+    {
+        if (!_honorific.Available)
+        {
+            return;
+        }
+
+        try
+        {
+            var json = ReadSystemJson(memberId, "honorific.json");
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return;
+            }
+
+            OnFramework(() => _honorific.SetTitleJson(json));
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "ApplyHonorific failed for {Member}", memberId);
         }
     }
 
@@ -1526,6 +1770,10 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
 
         Add(appearance.GlamourerJson);
+        Add(appearance.CustomizePlusJson);
+        Add(appearance.SimpleHeelsJson);
+        Add(appearance.PalettePlusJson);
+        Add(appearance.HonorificJson);
 
         foreach (var blob in (appearance.Blobs ?? new List<BlobRef>()).OrderBy(b => b.Sha256, StringComparer.OrdinalIgnoreCase))
         {
@@ -1653,6 +1901,28 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         lock (_memberLock)
         {
             return _members.FirstOrDefault(m => string.Equals(m.Id, memberId, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    private SyncshellMemberStatus? ResolveMemberFromHandle(string handleOrId)
+    {
+        if (string.IsNullOrWhiteSpace(handleOrId))
+        {
+            return null;
+        }
+
+        var trimmed = handleOrId.Trim();
+        var normalizedHandle = NormalizeIncomingHandle(trimmed);
+
+        lock (_memberLock)
+        {
+            var byId = _members.FirstOrDefault(m => string.Equals(m.Id, trimmed, StringComparison.OrdinalIgnoreCase));
+            if (byId != null)
+            {
+                return byId;
+            }
+
+            return _members.FirstOrDefault(m => string.Equals(MemberHandle(m), normalizedHandle, StringComparison.OrdinalIgnoreCase));
         }
     }
 


### PR DESCRIPTION
## Summary
- extend the SyncShell appearance payload to carry Customize+, SimpleHeels, Palette+, and Honorific JSON alongside Glamourer data and blob metadata
- add IPC wrappers for Customize+, SimpleHeels, Palette+, and Honorific, update Glamourer IPC to support applying designs, and wire all into SyncShellService
- stage and apply the new system JSON files during sync, expand the appearance hash, and resolve watcher handles to member IDs before queuing work

## Testing
- `dotnet build DemiCatPlugin/DemiCatPlugin.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eebfcd5b3883289f655a517730e6f3