### PR TITLE
Ensure new SyncShell IPC dependencies are wired

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -50,6 +50,19 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="SyncShell\CustomizePlusIpc.cs" />
+    <Compile Include="SyncShell\SimpleHeelsIpc.cs" />
+    <Compile Include="SyncShell\PalettePlusIpc.cs" />
+    <Compile Include="SyncShell\HonorificIpc.cs" />
+    <Compile Include="SyncShell\PenumbraIpc.cs" />
+    <Compile Include="SyncShell\GlamourerIpc.cs" />
+    <Compile Include="SyncShell\Debouncer.cs" />
+    <Compile Include="SyncShell\SyncShellWatcher.cs" />
+    <Compile Include="SyncShell\ISyncShellWatcher.cs" />
+    <Compile Include="SyncShell\ISyncShellService.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="Dock\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/demibot/demibot/http/routes/syncshell.py
+++ b/demibot/demibot/http/routes/syncshell.py
@@ -1223,6 +1223,10 @@ class BlobRefModel(BaseModel):
 class AppearanceMetaModel(BaseModel):
     actorHash: str
     glamourer: Optional[str] = None
+    cplus: Optional[str] = None
+    heels: Optional[str] = None
+    palette: Optional[str] = None
+    honorific: Optional[str] = None
     blobs: list[BlobRefModel] = Field(default_factory=list)
 
     @field_validator("actorHash")

--- a/tests/SyncshellPublishFlowTests.cs
+++ b/tests/SyncshellPublishFlowTests.cs
@@ -65,6 +65,10 @@ public class SyncshellPublishFlowTests : IDisposable
         var frameworkMock = new Mock<IFramework>();
         var objectTableMock = new Mock<IObjectTable>();
         var glamourer = new GlamourerIpc(pluginInterfaceMock.Object, clientStateMock.Object, logMock.Object);
+        var customizePlus = new CustomizePlusIpc(pluginInterfaceMock.Object, logMock.Object);
+        var simpleHeels = new SimpleHeelsIpc(pluginInterfaceMock.Object, logMock.Object);
+        var palettePlus = new PalettePlusIpc(pluginInterfaceMock.Object, logMock.Object);
+        var honorific = new HonorificIpc(pluginInterfaceMock.Object, logMock.Object);
         var service = new SyncShellService(
             config,
             TokenManager.Instance!,
@@ -72,6 +76,10 @@ public class SyncshellPublishFlowTests : IDisposable
             blobStore,
             penumbra,
             glamourer,
+            customizePlus,
+            simpleHeels,
+            palettePlus,
+            honorific,
             logMock.Object,
             clientStateMock.Object,
             frameworkMock.Object,
@@ -145,6 +153,10 @@ public class SyncshellPublishFlowTests : IDisposable
         var frameworkMock = new Mock<IFramework>();
         var objectTableMock = new Mock<IObjectTable>();
         var glamourer = new GlamourerIpc(pluginInterfaceMock.Object, clientStateMock.Object, logMock.Object);
+        var customizePlus = new CustomizePlusIpc(pluginInterfaceMock.Object, logMock.Object);
+        var simpleHeels = new SimpleHeelsIpc(pluginInterfaceMock.Object, logMock.Object);
+        var palettePlus = new PalettePlusIpc(pluginInterfaceMock.Object, logMock.Object);
+        var honorific = new HonorificIpc(pluginInterfaceMock.Object, logMock.Object);
         var service = new SyncShellService(
             config,
             TokenManager.Instance!,
@@ -152,6 +164,10 @@ public class SyncshellPublishFlowTests : IDisposable
             blobStore,
             penumbra,
             glamourer,
+            customizePlus,
+            simpleHeels,
+            palettePlus,
+            honorific,
             logMock.Object,
             clientStateMock.Object,
             frameworkMock.Object,

--- a/tests/SyncshellServiceHelperTests.cs
+++ b/tests/SyncshellServiceHelperTests.cs
@@ -81,6 +81,10 @@ public class SyncshellServiceHelperTests
             using var blobStore = new BlobStore(pluginInterfaceMock.Object);
             var penumbra = new PenumbraIpc(pluginInterfaceMock.Object, logMock.Object);
             var glamourer = new GlamourerIpc(pluginInterfaceMock.Object, clientStateMock.Object, logMock.Object);
+            var customizePlus = new CustomizePlusIpc(pluginInterfaceMock.Object, logMock.Object);
+            var simpleHeels = new SimpleHeelsIpc(pluginInterfaceMock.Object, logMock.Object);
+            var palettePlus = new PalettePlusIpc(pluginInterfaceMock.Object, logMock.Object);
+            var honorific = new HonorificIpc(pluginInterfaceMock.Object, logMock.Object);
 
             var config = new Config
             {
@@ -103,6 +107,10 @@ public class SyncshellServiceHelperTests
                 blobStore,
                 penumbra,
                 glamourer,
+                customizePlus,
+                simpleHeels,
+                palettePlus,
+                honorific,
                 logMock.Object,
                 clientStateMock.Object,
                 frameworkMock.Object,

--- a/tests/syncshell_test_utils.py
+++ b/tests/syncshell_test_utils.py
@@ -108,6 +108,10 @@ def build_publish_payload(base: Path, *, discord_id: str = "1234") -> tuple[dict
         "appearance": {
             "actorHash": "actor-1",
             "glamourer": "{\"foo\":1}",
+            "cplus": "{\"scale\":1}",
+            "heels": "{\"offset\":0.5}",
+            "palette": "{\"preset\":\"default\"}",
+            "honorific": "{\"title\":\"Champion\"}",
             "blobs": [
                 {
                     "name": file_path.name,

--- a/tests/test_syncshell_blob_api.py
+++ b/tests/test_syncshell_blob_api.py
@@ -121,6 +121,10 @@ def test_meta_returns_latest_manifest(tmp_path, monkeypatch):
         "appearance": {
             "actorHash": "actor-1",
             "glamourer": "{\"foo\":1}",
+            "cplus": "{\"scale\":1}",
+            "heels": "{\"offset\":0.5}",
+            "palette": "{\"preset\":\"default\"}",
+            "honorific": "{\"title\":\"Champion\"}",
             "blobs": [
                 {
                     "name": "mod/file",


### PR DESCRIPTION
## Summary
- explicitly include the new SyncShell IPC helpers and interfaces in the plugin project file
- extend the server AppearanceMeta model to accept Customize+, SimpleHeels, Palette+, and Honorific payloads
- update SyncShell service tests and helpers to construct the service with the new IPC dependencies and cover the expanded payload shape

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68eec9089cc88328a913ea16d6a11a92