### PR TITLE
Remove duplicate SyncShell Compile entries

### DIFF
--- a/DemiCatPlugin/DemiCatPlugin.csproj
+++ b/DemiCatPlugin/DemiCatPlugin.csproj
@@ -50,19 +50,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="SyncShell\CustomizePlusIpc.cs" />
-    <Compile Include="SyncShell\SimpleHeelsIpc.cs" />
-    <Compile Include="SyncShell\PalettePlusIpc.cs" />
-    <Compile Include="SyncShell\HonorificIpc.cs" />
-    <Compile Include="SyncShell\PenumbraIpc.cs" />
-    <Compile Include="SyncShell\GlamourerIpc.cs" />
-    <Compile Include="SyncShell\Debouncer.cs" />
-    <Compile Include="SyncShell\SyncShellWatcher.cs" />
-    <Compile Include="SyncShell\ISyncShellWatcher.cs" />
-    <Compile Include="SyncShell\ISyncShellService.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="Dock\**\*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- remove the explicit SyncShell Compile item group so the SDK's implicit includes do not conflict

## Testing
- dotnet build -c Release *(fails: dotnet is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eed372e95c83288dac55fd617d40b6