### PR TITLE
Fix build issues in ChatWindow and NotePadWindow

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -409,7 +409,7 @@ public class ChatWindow : IDisposable
             return "Send a message";
         }
 
-        var prefix = channelName.StartsWith('#', StringComparison.Ordinal) ? string.Empty : "#";
+        var prefix = channelName.StartsWith("#", StringComparison.Ordinal) ? string.Empty : "#";
         return $"Send message to {prefix}{channelName}";
     }
 

--- a/DemiCatPlugin/NotePadWindow.cs
+++ b/DemiCatPlugin/NotePadWindow.cs
@@ -338,7 +338,7 @@ public sealed class NotePadWindow : IDisposable
             headerPos.Y + (headerHeight - buttonSize.Y) * 0.5f);
         ImGui.SetCursorScreenPos(buttonPos);
         ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, style.FrameRounding);
-        if (IsReadOnly || isBuiltIn)
+        if (IsReadOnly || section.IsBuiltIn)
         {
             ImGui.BeginDisabled();
             ImGui.Button(buttonText, buttonSize);


### PR DESCRIPTION
## Summary
- use the string-based overload of `StartsWith` when inspecting channel names
- block note creation for built-in sections by referencing `section.IsBuiltIn`

## Testing
- `dotnet build` *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eed97bf6688328acc75a7d52113e3b