### PR TITLE
Reduce logging verbosity defaults

### DIFF
--- a/demibot/demibot/log_config.py
+++ b/demibot/demibot/log_config.py
@@ -1,12 +1,49 @@
+from __future__ import annotations
+
 import logging
+import os
 import sys
+from typing import Dict
 
 import structlog
 
 
+DEFAULT_LOG_LEVEL = logging.INFO
+
+_NOISY_LOGGERS: Dict[str, int] = {
+    "discord": logging.WARNING,
+    "discord.gateway": logging.ERROR,
+    "urllib3": logging.WARNING,
+}
+
+
+def _get_log_level_from_env() -> int:
+    """Return the log level specified by ``DEMIBOT_LOG_LEVEL`` (default INFO)."""
+
+    level_name = os.getenv("DEMIBOT_LOG_LEVEL")
+    if not level_name:
+        return DEFAULT_LOG_LEVEL
+
+    level = logging.getLevelName(level_name.upper())
+    if isinstance(level, int):
+        return level
+
+    logging.getLogger(__name__).warning(
+        "Invalid DEMIBOT_LOG_LEVEL=%s, defaulting to INFO", level_name
+    )
+    return DEFAULT_LOG_LEVEL
+
+
 def setup_logging() -> None:
-    """Configure structlog with JSON output."""
-    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    """Configure structlog with JSON output and sensible defaults."""
+
+    level = _get_log_level_from_env()
+
+    logging.basicConfig(level=level, stream=sys.stdout)
+
+    for logger_name, minimum_level in _NOISY_LOGGERS.items():
+        logging.getLogger(logger_name).setLevel(max(level, minimum_level))
+
     structlog.configure(
         processors=[
             structlog.processors.TimeStamper(fmt="iso"),
@@ -14,7 +51,7 @@ def setup_logging() -> None:
             structlog.processors.EventRenamer("message"),
             structlog.processors.JSONRenderer(),
         ],
-        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        wrapper_class=structlog.make_filtering_bound_logger(level),
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
     )

--- a/demibot/demibot/main.py
+++ b/demibot/demibot/main.py
@@ -33,7 +33,6 @@ async def main_async() -> None:
     )
     args = parser.parse_args()
 
-    logging.basicConfig(level=logging.DEBUG)
     log_config.setup_logging()
     cfg = await ensure_config(force_reconfigure=args.reconfigure)
 


### PR DESCRIPTION
## Summary
- respect a DEMIBOT_LOG_LEVEL override while defaulting to INFO
- clamp noisy third-party loggers to warning or error levels
- remove redundant DEBUG basicConfig call from the main entry point

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68eee085ccdc8328aa4ed230670ce930