### PR TITLE
Add requests channel kind and extend presence status length

### DIFF
--- a/SQL Schema.sql
+++ b/SQL Schema.sql
@@ -376,7 +376,7 @@ DROP TABLE IF EXISTS `guild_channels`;
 CREATE TABLE `guild_channels` (
   `guild_id` int NOT NULL,
   `channel_id` bigint unsigned NOT NULL,
-  `kind` enum('chat','event','fc_chat','officer_chat','officer_visible') NOT NULL,
+  `kind` enum('chat','event','fc_chat','officer_chat','officer_visible','requests') NOT NULL,
   `name` varchar(255) DEFAULT NULL,
   `webhook_url` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`guild_id`,`channel_id`,`kind`),
@@ -810,7 +810,7 @@ CREATE TABLE `presences` (
   `user_id` bigint unsigned NOT NULL,
   `status` varchar(16) NOT NULL,
   `updated_at` datetime NOT NULL,
-  `status_text` varchar(128) DEFAULT NULL,
+  `status_text` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`guild_id`,`user_id`),
   KEY `ix_presences_guild_id_status` (`guild_id`,`status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/demibot/demibot/db/migrations/versions/0054_expand_channelkind_and_status_text.py
+++ b/demibot/demibot/db/migrations/versions/0054_expand_channelkind_and_status_text.py
@@ -1,0 +1,50 @@
+"""0054_expand_channelkind_and_status_text
+
+Revision ID: 0054_expand_channelkind_and_status_text
+Revises: 0053_add_notepad_tables
+Create Date: 2024-10-15 00:00:01.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0054_expand_channelkind_and_status_text"
+down_revision: Union[str, None] = "0053_add_notepad_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE guild_channels MODIFY kind "
+        "ENUM('chat','event','fc_chat','officer_chat','officer_visible','requests') NOT NULL"
+    )
+
+    op.alter_column(
+        "presences",
+        "status_text",
+        existing_type=sa.String(length=128),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE guild_channels MODIFY kind "
+        "ENUM('chat','event','fc_chat','officer_chat','officer_visible') NOT NULL"
+    )
+
+    op.alter_column(
+        "presences",
+        "status_text",
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=128),
+        existing_nullable=True,
+    )

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -66,6 +66,7 @@ class ChannelKind(str, Enum):
     FC_CHAT = "fc_chat"
     OFFICER_CHAT = "officer_chat"
     OFFICER_VISIBLE = "officer_visible"
+    REQUESTS = "requests"
 
 
 class Guild(Base):
@@ -509,7 +510,7 @@ class Presence(Base):
     guild_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
     user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
     status: Mapped[str] = mapped_column(String(16))
-    status_text: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    status_text: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )

--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -184,6 +184,7 @@ async def get_channels(
         ChannelKind.EVENT.value: ChannelKind.EVENT,
         ChannelKind.FC_CHAT.value: ChannelKind.FC_CHAT,
         ChannelKind.OFFICER_CHAT.value: ChannelKind.OFFICER_CHAT,
+        ChannelKind.REQUESTS.value: ChannelKind.REQUESTS,
     }
     if kind in single_kinds:
         channel_kind = single_kinds[kind]


### PR DESCRIPTION
## Summary
- add the new `requests` value to the channel kind enum and expose it through the channels API
- allow presence status text to store longer messages and keep the schema dump in sync
- add an Alembic migration to update the enum and column definition in MySQL

## Testing
- pytest tests/test_presences.py *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68eee2ff862c8328a1e11dcf657f73f0