### PR TITLE
Fix Alembic revision identifiers in latest migration

### DIFF
--- a/demibot/demibot/db/migrations/versions/0054_expand_channelkind_and_status_text.py
+++ b/demibot/demibot/db/migrations/versions/0054_expand_channelkind_and_status_text.py
@@ -14,10 +14,10 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = "0054_expand_channelkind_and_status_text"
-down_revision: Union[str, None] = "0053_add_notepad_tables"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+revision = "0054_expand_channelkind_and_status_text"
+down_revision = "0053_add_notepad_tables"
+branch_labels = None
+depends_on = None
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- ensure the newest Alembic migration defines revision identifiers with standard assignments for compatibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eee5c2089c8328be4c37c8404c77b4