### PR TITLE
Add Alembic migration for requests channel kind head

### DIFF
--- a/demibot/demibot/db/migrations/versions/0056_add_requests_channel_kind.py
+++ b/demibot/demibot/db/migrations/versions/0056_add_requests_channel_kind.py
@@ -1,0 +1,33 @@
+"""0056_add_requests_channel_kind
+
+Revision ID: 0056_add_requests_channel_kind
+Revises: 0054_expand_channelkind_and_status_text
+Create Date: 2024-10-15 00:05:01.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0056_add_requests_channel_kind"
+down_revision: Union[str, None] = "0054_expand_channelkind_and_status_text"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE guild_channels MODIFY kind "
+        "ENUM('chat','event','fc_chat','officer_chat','officer_visible','requests') NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE guild_channels MODIFY kind "
+        "ENUM('chat','event','fc_chat','officer_chat','officer_visible') NOT NULL"
+    )


### PR DESCRIPTION
## Summary
- add the missing Alembic revision 0056_add_requests_channel_kind so Alembic sees a single head after 0054
- ensure the migration upgrades and downgrades the guild_channels.kind enum to include the requests value

## Testing
- pytest tests/test_requests_delta.py *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68eee6cba4ec8328b37ccce1990da637