### PR TITLE
Add missing syncshell transfer budgets migration

### DIFF
--- a/demibot/demibot/db/migrations/versions/0055_add_syncshell_transfer_budgets.py
+++ b/demibot/demibot/db/migrations/versions/0055_add_syncshell_transfer_budgets.py
@@ -1,0 +1,45 @@
+"""0055_add_syncshell_transfer_budgets
+
+Revision ID: 0055_add_syncshell_transfer_budgets
+Revises: 0054_expand_channelkind_and_status_text
+Create Date: 2025-10-14 23:50:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import BIGINT
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0055_add_syncshell_transfer_budgets"
+down_revision: Union[str, None] = "0054_expand_channelkind_and_status_text"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "syncshell_transfer_budgets",
+        sa.Column(
+            "user_id",
+            BIGINT(unsigned=True),
+            sa.ForeignKey("users.id"),
+            primary_key=True,
+        ),
+        sa.Column("window_start", sa.DateTime(), nullable=False),
+        sa.Column(
+            "used_bytes",
+            BIGINT(unsigned=True),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("syncshell_transfer_budgets")
+

--- a/demibot/demibot/db/migrations/versions/0056_add_requests_channel_kind.py
+++ b/demibot/demibot/db/migrations/versions/0056_add_requests_channel_kind.py
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0056_add_requests_channel_kind"
-down_revision: Union[str, None] = "0054_expand_channelkind_and_status_text"
+down_revision: Union[str, None] = "0055_add_syncshell_transfer_budgets"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -322,6 +322,16 @@ class SyncshellRateLimit(Base):
     window_start: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
+class SyncshellTransferBudget(Base):
+    __tablename__ = "syncshell_transfer_budgets"
+
+    user_id: Mapped[int] = mapped_column(
+        BIGINT(unsigned=True), ForeignKey("users.id"), primary_key=True
+    )
+    window_start: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    used_bytes: Mapped[int] = mapped_column(BigInteger, default=0)
+
+
 class SyncshellInvite(Base):
     __tablename__ = "syncshell_invites"
     __table_args__ = (


### PR DESCRIPTION
## Summary
- add the missing Alembic revision for syncshell transfer budgets so the migration chain has a single head again
- register the SyncshellTransferBudget ORM model alongside the existing Syncshell models
- update the requests channel migration to depend on the new revision

## Testing
- pytest tests/test_syncshell_limits.py *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_68eee8a1e02483288d3a8d9442cde79b