### PR TITLE
Fix alembic head conflict with placeholder migration

### DIFF
--- a/demibot/demibot/db/migrations/versions/0054_add_syncshell_member_scope.py
+++ b/demibot/demibot/db/migrations/versions/0054_add_syncshell_member_scope.py
@@ -1,0 +1,29 @@
+"""0054_add_syncshell_member_scope (legacy placeholder)
+
+Revision ID: 0054_add_syncshell_member_scope
+Revises: 0053_add_notepad_tables
+Create Date: 2024-10-15 00:00:00.000000
+"""
+
+from __future__ import annotations
+from typing import Sequence, Union
+
+# Alembic imports
+from alembic import op  # noqa: F401 (kept to look like a normal migration)
+
+# revision identifiers, used by Alembic.
+revision: str = "0054_add_syncshell_member_scope"
+down_revision: Union[str, None] = "0053_add_notepad_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Intentionally no-op. This placeholder exists to reconcile history
+    # when previous deployments used a different 0054 id.
+    pass
+
+
+def downgrade() -> None:
+    # No-op; reversing a placeholder would do nothing as well.
+    pass

--- a/demibot/demibot/db/migrations/versions/0055_add_syncshell_transfer_budgets.py
+++ b/demibot/demibot/db/migrations/versions/0055_add_syncshell_transfer_budgets.py
@@ -16,7 +16,10 @@ from sqlalchemy.dialects.mysql import BIGINT
 
 # revision identifiers, used by Alembic.
 revision: str = "0055_add_syncshell_transfer_budgets"
-down_revision: Union[str, None] = "0054_expand_channelkind_and_status_text"
+down_revision: Union[str, Sequence[str], None] = (
+    "0054_expand_channelkind_and_status_text",
+    "0054_add_syncshell_member_scope",
+)
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- add a legacy 0054 placeholder migration to reconcile historic heads
- update 0055 migration to depend on both 0054 variants so alembic sees a single head

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eeee234eb88328ae1c11d6aef62b73