### PR TITLE
Expand presence status text capacity

### DIFF
--- a/SQL Schema.sql
+++ b/SQL Schema.sql
@@ -810,7 +810,7 @@ CREATE TABLE `presences` (
   `user_id` bigint unsigned NOT NULL,
   `status` varchar(16) NOT NULL,
   `updated_at` datetime NOT NULL,
-  `status_text` varchar(255) DEFAULT NULL,
+  `status_text` text DEFAULT NULL,
   PRIMARY KEY (`guild_id`,`user_id`),
   KEY `ix_presences_guild_id_status` (`guild_id`,`status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/demibot/demibot/db/migrations/versions/0057_expand_presence_status_text_to_text.py
+++ b/demibot/demibot/db/migrations/versions/0057_expand_presence_status_text_to_text.py
@@ -1,0 +1,40 @@
+"""0057_expand_presence_status_text_to_text
+
+Revision ID: 0057_expand_presence_status_text_to_text
+Revises: 0056_add_requests_channel_kind
+Create Date: 2025-10-15 00:10:01.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0057_expand_presence_status_text_to_text"
+down_revision: Union[str, None] = "0056_add_requests_channel_kind"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "presences",
+        "status_text",
+        existing_type=sa.String(length=255),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "presences",
+        "status_text",
+        existing_type=sa.Text(),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+    )

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
+import sqlalchemy as sa
 from sqlalchemy import (
     BigInteger,
     Boolean,
@@ -520,7 +521,7 @@ class Presence(Base):
     guild_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
     user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True), primary_key=True)
     status: Mapped[str] = mapped_column(String(16))
-    status_text: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    status_text: Mapped[Optional[str]] = mapped_column(sa.Text(), nullable=True)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )


### PR DESCRIPTION
## Summary
- increase the presences.status_text column to use a TEXT field so long Discord statuses are stored without errors
- update the ORM model and reference SQL schema to match the new column type
- add an alembic migration to alter existing databases to the TEXT column
- restore the SQLAlchemy Text import so existing mapped_column(Text) declarations continue to work

## Testing
- pytest *(fails: missing optional dependencies in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eef1435f9c8328b619e8f13918b484