### PR TITLE
Fix missing SQLAlchemy Text import for guild config

### DIFF
--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
+    Text,
     Index,
     UniqueConstraint,
 )


### PR DESCRIPTION
## Summary
- import the SQLAlchemy `Text` type in the models module so guild configuration columns use a defined type

## Testing
- pytest *(fails: required optional dependencies such as httpx, sqlalchemy, fastapi, and aiohttp are not installed in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eef6396fa883289ffcdc8440b4b175