### PR TITLE
Handle request type strings defensively

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -332,13 +332,21 @@ public class RequestBoardWindow
         _ => "item"
     };
 
-    private static RequestType ParseType(string type) => type switch
+    private static RequestType ParseType(string type)
     {
-        "item" => RequestType.Item,
-        "run" => RequestType.Run,
-        "event" => RequestType.Event,
-        _ => RequestType.Item
-    };
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            return RequestType.Item;
+        }
+
+        return type.ToLowerInvariant() switch
+        {
+            "item" => RequestType.Item,
+            "run" => RequestType.Run,
+            "event" => RequestType.Event,
+            _ => RequestType.Item
+        };
+    }
 
     private static string UrgencyToString(RequestUrgency urgency) => urgency switch
     {

--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -232,13 +232,21 @@ internal static class RequestStateService
         _ => RequestStatus.Open
     };
 
-    private static RequestType ParseType(string type) => type switch
+    private static RequestType ParseType(string type)
     {
-        "item" => RequestType.Item,
-        "run" => RequestType.Run,
-        "event" => RequestType.Event,
-        _ => RequestType.Item
-    };
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            return RequestType.Item;
+        }
+
+        return type.ToLowerInvariant() switch
+        {
+            "item" => RequestType.Item,
+            "run" => RequestType.Run,
+            "event" => RequestType.Event,
+            _ => RequestType.Item
+        };
+    }
 
     private static RequestUrgency ParseUrgency(string urgency) => urgency switch
     {


### PR DESCRIPTION
## Summary
- normalize incoming request type strings before mapping them to the enum
- fall back early when the type payload is null or whitespace to avoid errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eefeb9d5d4832896bbe68f68b394b3