### PR TITLE
Improve async cleanup and guard disposed resources

### DIFF
--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -63,12 +63,25 @@ public class ChannelWatcher : IDisposable
         _task = Run(_cts.Token);
     }
 
-    public void Stop()
+    public async Task Stop()
     {
-        _cts?.Cancel();
-        try { _task?.GetAwaiter().GetResult(); } catch { }
+        var cts = _cts;
         _cts = null;
+
+        cts?.Cancel();
+        if (_task != null)
+        {
+            try
+            {
+                await _task.ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+        }
+
         _task = null;
+        cts?.Dispose();
     }
 
     private async Task Run(CancellationToken token)
@@ -407,11 +420,7 @@ public class ChannelWatcher : IDisposable
 
     public void Dispose()
     {
-        _cts?.Cancel();
-        try { _task?.GetAwaiter().GetResult(); } catch { }
-        _cts?.Dispose();
-        _cts = null;
-        _task = null;
+        _ = Stop();
         if (Instance == this) Instance = null;
     }
 }

--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -293,28 +293,50 @@ public class ChatBridge : IChatBridge
 
     public void Stop()
     {
-        _cts?.Cancel();
-        try { _task?.GetAwaiter().GetResult(); }
-        catch (OperationCanceledException) { }
-        catch { }
-        if (_ws != null)
-        {
-            using var closeCts = new CancellationTokenSource(WebSocketCloseTimeout);
-            var closeTask = CloseWebSocketGracefully(closeCts.Token);
-            try
-            {
-                closeTask.GetAwaiter().GetResult();
-            }
-            catch (OperationCanceledException)
-            {
-            }
-        }
-        _ws?.Dispose();
-        _ws = null;
-        _cts?.Dispose();
+        var cts = _cts;
         _cts = null;
-        _tokenValid = false;
+        cts?.Cancel();
+
+        var runTask = _task;
         _task = null;
+        if (runTask != null)
+        {
+            _ = runTask.ContinueWith(t =>
+            {
+                if (t.Exception != null)
+                {
+                    PluginServices.Instance?.Log.Debug(t.Exception, "ChatBridge run loop faulted during stop");
+                }
+            }, TaskScheduler.Default);
+        }
+
+        var socket = _ws;
+        _ws = null;
+        if (socket != null)
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    using var closeCts = new CancellationTokenSource(WebSocketCloseTimeout);
+                    await CloseWebSocketGracefully(closeCts.Token, socket).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception ex)
+                {
+                    PluginServices.Instance?.Log.Debug(ex, "ChatBridge websocket close failed");
+                }
+                finally
+                {
+                    socket.Dispose();
+                }
+            });
+        }
+
+        cts?.Dispose();
+        _tokenValid = false;
         ResetState();
     }
 
@@ -1382,9 +1404,9 @@ public class ChatBridge : IChatBridge
         }
     }
 
-    private async Task CloseWebSocketGracefully(CancellationToken token)
+    private async Task CloseWebSocketGracefully(CancellationToken token, ClientWebSocket? socketOverride = null)
     {
-        var socket = _ws;
+        var socket = socketOverride ?? _ws;
         if (socket == null)
         {
             return;

--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -123,6 +123,7 @@ public class ChatWindow : IDisposable
         TimeSpan.FromMilliseconds(800)
     };
     private CancellationTokenSource? _subscribeCts;
+    private int _disposed;
 
     protected string CurrentChannelId => _channelSelection.GetChannel(_channelKind, _config.GuildId);
     protected string ChannelKindKey => _channelKind;
@@ -812,6 +813,11 @@ public class ChatWindow : IDisposable
 
     protected bool TrySubscribeCurrentChannel(bool force = false, bool refreshMessages = true)
     {
+        if (IsDisposed)
+        {
+            return false;
+        }
+
         if (refreshMessages)
         {
             _pendingRefreshAfterSubscribe = true;
@@ -825,12 +831,23 @@ public class ChatWindow : IDisposable
 
         _ = Task.Run(async () =>
         {
+            if (IsDisposed)
+            {
+                cts.Dispose();
+                return;
+            }
+
             try
             {
                 await Task.Delay(150, cts.Token).ConfigureAwait(false);
 
                 void Execute()
                 {
+                    if (IsDisposed)
+                    {
+                        return;
+                    }
+
                     if (!ReferenceEquals(_subscribeCts, cts))
                     {
                         return;
@@ -888,6 +905,11 @@ public class ChatWindow : IDisposable
 
     private void DoSubscribeCurrentChannel(bool force, bool refreshMessages)
     {
+        if (IsDisposed)
+        {
+            return;
+        }
+
         if (refreshMessages)
         {
             _pendingRefreshAfterSubscribe = true;
@@ -963,6 +985,11 @@ public class ChatWindow : IDisposable
 
     public virtual void StartNetworking()
     {
+        if (IsDisposed)
+        {
+            return;
+        }
+
         if (!MarkNetworkingStarted())
         {
             TrySubscribeCurrentChannel(force: true);
@@ -976,6 +1003,16 @@ public class ChatWindow : IDisposable
     }
 
     public void StopNetworking()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        StopNetworkingCore();
+    }
+
+    private void StopNetworkingCore()
     {
         _bridge.Stop();
         MarkNetworkingStopped();
@@ -3864,6 +3901,11 @@ public class ChatWindow : IDisposable
 
     public virtual async Task RefreshMessages(CancellationToken cancellationToken = default)
     {
+        if (IsDisposed)
+        {
+            return;
+        }
+
         var channelId = CurrentChannelId;
         if (!ApiHelpers.ValidateApiBaseUrl(_config) || string.IsNullOrEmpty(channelId))
         {
@@ -3939,6 +3981,11 @@ public class ChatWindow : IDisposable
 
     private async Task DoRefreshMessagesAsync(string channelId, CancellationToken token)
     {
+        if (IsDisposed)
+        {
+            return;
+        }
+
         var requestedChannelId = channelId;
         const int PageSize = 50;
         var all = new List<DiscordMessageDto>();
@@ -4081,6 +4128,11 @@ public class ChatWindow : IDisposable
 
         _ = PluginServices.Instance!.Framework.RunOnTick(() =>
         {
+            if (IsDisposed)
+            {
+                return;
+            }
+
             if (!string.Equals(requestedChannelId, CurrentChannelId, StringComparison.Ordinal))
             {
                 return;
@@ -4318,7 +4370,12 @@ public class ChatWindow : IDisposable
 
     public void Dispose()
     {
-        StopNetworking();
+        if (Interlocked.Exchange(ref _disposed, 1) == 1)
+        {
+            return;
+        }
+
+        StopNetworkingCore();
         if (_presence != null)
         {
             _presence.PresencesChanged -= HandlePresenceServicePresencesChanged;
@@ -4851,3 +4908,5 @@ public class ChatWindow : IDisposable
         });
     }
 }
+    protected bool IsDisposed => Volatile.Read(ref _disposed) == 1;
+

--- a/DemiCatPlugin/NotePadService.cs
+++ b/DemiCatPlugin/NotePadService.cs
@@ -72,10 +72,20 @@ public sealed class NotePadService : IDisposable
         _task = Task.Run(() => RunAsync(_cts.Token));
     }
 
-    public void Stop()
+    public async Task Stop()
     {
         _cts?.Cancel();
-        try { _task?.GetAwaiter().GetResult(); } catch { }
+        if (_task != null)
+        {
+            try
+            {
+                await _task.ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+        }
+
         _cts = null;
         _task = null;
     }
@@ -934,7 +944,7 @@ public sealed class NotePadService : IDisposable
 
     public void Dispose()
     {
-        Stop();
+        _ = Stop();
         _stateLock.Dispose();
         _refreshLock.Dispose();
     }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -265,7 +265,15 @@ public class Plugin : IDalamudPlugin
         var log = services?.Log;
         try
         {
-            RunOnFrameworkAsync(WebTextureCache.Clear).GetAwaiter().GetResult();
+            var clearTask = RunOnFrameworkAsync(WebTextureCache.Clear);
+            _ = clearTask.ContinueWith(t =>
+            {
+                if (t.Exception != null)
+                {
+                    log?.Warning(t.Exception, "Failed to clear web texture cache on framework thread.");
+                    WebTextureCache.Clear();
+                }
+            }, TaskScheduler.Default);
         }
         catch (Exception ex)
         {
@@ -311,7 +319,7 @@ public class Plugin : IDalamudPlugin
         _officerChatWindow.Dispose();
         _sharedChatBridge.Dispose();
         _mainWindow.Dispose();
-        _ui.DisposeAsync().GetAwaiter().GetResult();
+        _ = _ui.DisposeAsync();
         _settings.Dispose();
         _avatarCache.Dispose();
         _emojiManager.Dispose();
@@ -730,7 +738,7 @@ public class Plugin : IDalamudPlugin
         await _watcherRestartLock.WaitAsync().ConfigureAwait(false);
         try
         {
-            StopWatchers();
+            await StopWatchersAsync().ConfigureAwait(false);
             await StartWatchersAsync().ConfigureAwait(false);
         }
         finally
@@ -756,25 +764,39 @@ public class Plugin : IDalamudPlugin
 
     private void HandleTokenUnlinked(string? reason)
     {
-        void Execute()
+        async Task ExecuteAsync()
         {
-            StopWatchers();
-            _mainWindow.IsOpen = false;
-            _mainWindow.SetNotePadReadOnly(true);
-            _mainWindow.NotifyLinkRequired();
-            _settings.IsOpen = true;
+            await StopWatchersAsync().ConfigureAwait(false);
 
-            var hadOfficerAccess = _config.IsOfficerToken;
-            _config.IsOfficerToken = false;
-            _mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
-            if (hadOfficerAccess)
+            void UpdateUi()
             {
-                _services.PluginInterface?.SavePluginConfig(_config);
+                _mainWindow.IsOpen = false;
+                _mainWindow.SetNotePadReadOnly(true);
+                _mainWindow.NotifyLinkRequired();
+                _settings.IsOpen = true;
+
+                var hadOfficerAccess = _config.IsOfficerToken;
+                _config.IsOfficerToken = false;
+                _mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
+                if (hadOfficerAccess)
+                {
+                    _services.PluginInterface?.SavePluginConfig(_config);
+                }
+
+                if (IsAuthenticationFailure(reason))
+                {
+                    ShowInvalidTokenToast();
+                }
             }
 
-            if (IsAuthenticationFailure(reason))
+            var frameworkInner = PluginServices.Instance?.Framework ?? _services.Framework;
+            if (frameworkInner != null)
             {
-                ShowInvalidTokenToast();
+                frameworkInner.RunOnTick(UpdateUi);
+            }
+            else
+            {
+                UpdateUi();
             }
         }
 
@@ -784,7 +806,7 @@ public class Plugin : IDalamudPlugin
         {
             try
             {
-                framework.RunOnTick(Execute);
+                framework.RunOnTick(() => _ = ExecuteAsync());
                 return;
             }
             catch (Exception ex)
@@ -794,7 +816,7 @@ public class Plugin : IDalamudPlugin
             }
         }
 
-        Execute();
+        _ = ExecuteAsync();
     }
 
     private async Task StartWatchersAsync()
@@ -961,12 +983,12 @@ public class Plugin : IDalamudPlugin
         PluginServices.Instance?.ToastGui.ShowError(message);
     }
 
-    private void StopWatchers()
+    private async Task StopWatchersAsync()
     {
         _services.Log.Info("Stopping watchers");
-        _requestWatcher.Stop();
-        _channelWatcher.Stop();
-        _notePadService.Stop();
+        await _requestWatcher.Stop().ConfigureAwait(false);
+        await _channelWatcher.Stop().ConfigureAwait(false);
+        await _notePadService.Stop().ConfigureAwait(false);
         _chatWindow.StopNetworking();
         _officerChatWindow.StopNetworking();
         _officerWatcherRunning = false;
@@ -1123,13 +1145,13 @@ public class Plugin : IDalamudPlugin
                         if (stopRequestWatcher)
                         {
                             _services.Log.Info("Stopping request watcher");
-                            _requestWatcher.Stop();
+                            await _requestWatcher.Stop().ConfigureAwait(false);
                         }
 
                         if (stopChannelWatcher)
                         {
                             _services.Log.Info("Stopping channel watcher");
-                            _channelWatcher.Stop();
+                            await _channelWatcher.Stop().ConfigureAwait(false);
                         }
 
                         if (stopOfficer)

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -43,12 +43,25 @@ public class RequestWatcher : IDisposable
         _task = Run(_cts.Token);
     }
 
-    public void Stop()
+    public async Task Stop()
     {
-        _cts?.Cancel();
-        try { _task?.GetAwaiter().GetResult(); } catch { }
+        var cts = _cts;
         _cts = null;
+
+        cts?.Cancel();
+        if (_task != null)
+        {
+            try
+            {
+                await _task.ConfigureAwait(false);
+            }
+            catch
+            {
+            }
+        }
+
         _task = null;
+        cts?.Dispose();
     }
 
     private async Task Run(CancellationToken token)
@@ -368,8 +381,7 @@ public class RequestWatcher : IDisposable
 
     public void Dispose()
     {
-        _cts?.Cancel();
-        try { _task?.GetAwaiter().GetResult(); } catch { }
+        _ = Stop();
         _cts?.Dispose();
         _cts = null;
         _task = null;

--- a/DemiCatPlugin/SyncShell/Debouncer.cs
+++ b/DemiCatPlugin/SyncShell/Debouncer.cs
@@ -57,6 +57,44 @@ internal sealed class Debouncer : IDisposable
         }
     }
 
+    public void Run(Func<Task> action)
+    {
+        if (action == null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            _cts?.Cancel();
+            _cts?.Dispose();
+            _cts = new CancellationTokenSource();
+            var token = _cts.Token;
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(_delay, token).ConfigureAwait(false);
+                    if (token.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    await action().ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception ex)
+                {
+                    PluginServices.Instance?.Log.Warning(ex, "Debouncer action failed");
+                }
+            }, CancellationToken.None);
+        }
+    }
+
     private void ThrowIfDisposed()
     {
         if (_disposed)

--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -291,7 +291,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private string? ResolvePenumbraRoot()
+    private async Task<string?> ResolvePenumbraRootAsync()
     {
         lock (_penRootLock)
         {
@@ -333,7 +333,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             {
                 try
                 {
-                    var viaIpc = OnFramework(() => _penumbra.GetModDirectory());
+                    var viaIpc = await OnFrameworkAsync(() => _penumbra.GetModDirectory()).ConfigureAwait(false);
                     if (!string.IsNullOrWhiteSpace(viaIpc) && Directory.Exists(viaIpc))
                     {
                         resolved = viaIpc;
@@ -439,7 +439,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             _runCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             _lastAppearanceHash = null;
             Status = "Initializing…";
-            RefreshAppearanceCaches();
+            await RefreshAppearanceCachesAsync().ConfigureAwait(false);
 
             _prefetchQueue = Channel.CreateUnbounded<string>();
             _applyQueue = Channel.CreateUnbounded<string>();
@@ -510,8 +510,8 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
                 return;
             }
 
-            RefreshAppearanceCaches();
-            _appearanceDebounce.Run(PublishIfChanged);
+            await RefreshAppearanceCachesAsync().ConfigureAwait(false);
+            _appearanceDebounce.Run(() => PublishIfChangedAsync());
         }
         finally
         {
@@ -639,7 +639,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             try
             {
                 await Task.Delay(TerritoryDebounce, _runCts?.Token ?? CancellationToken.None).ConfigureAwait(false);
-                RefreshAppearanceCaches();
+                await RefreshAppearanceCachesAsync().ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -671,7 +671,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private void PublishIfChanged()
+    private async Task PublishIfChangedAsync()
     {
         if (_paused || _runCts == null || _tokenManager.State != LinkState.Linked)
         {
@@ -682,7 +682,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         Dictionary<string, LocalBlobInfo?> localBlobs;
         try
         {
-            (payload, localBlobs) = BuildPublishPayload();
+            (payload, localBlobs) = await BuildPublishPayloadAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -865,7 +865,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         if (_config.OnlySyncVisible)
         {
-            visibleHandles = GetVisibleHandles();
+            visibleHandles = await GetVisibleHandlesAsync().ConfigureAwait(false);
         }
 
         foreach (var member in resolved)
@@ -920,14 +920,14 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private string[] BuildActiveMemberList()
+    private async Task<string[]> BuildActiveMemberListAsync()
     {
         var roster = Members;
         var eligible = roster.Where(m => m.TokenLinked && string.Equals(m.Presence, "online", StringComparison.OrdinalIgnoreCase));
 
         if (_config.OnlySyncVisible)
         {
-            var visible = GetVisibleHandles();
+            var visible = await GetVisibleHandlesAsync().ConfigureAwait(false);
             eligible = eligible.Where(m => visible.Contains(MemberHandle(m)));
         }
 
@@ -943,7 +943,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             .ToArray();
     }
 
-    private T OnFramework<T>(Func<T> fn)
+    private Task<T> OnFrameworkAsync<T>(Func<T> fn)
     {
         if (fn == null)
         {
@@ -954,7 +954,14 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         if (Environment.CurrentManagedThreadId == _frameworkThreadId)
         {
-            return fn();
+            try
+            {
+                return Task.FromResult(fn());
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<T>(ex);
+            }
         }
 
         var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -962,18 +969,18 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         {
             try
             {
-                tcs.SetResult(fn());
+                tcs.TrySetResult(fn());
             }
             catch (Exception ex)
             {
-                tcs.SetException(ex);
+                tcs.TrySetException(ex);
             }
         });
 
-        return tcs.Task.GetAwaiter().GetResult();
+        return tcs.Task;
     }
 
-    private void OnFramework(Action fn)
+    private Task OnFrameworkAsync(Action fn)
     {
         if (fn == null)
         {
@@ -984,8 +991,15 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         if (Environment.CurrentManagedThreadId == _frameworkThreadId)
         {
-            fn();
-            return;
+            try
+            {
+                fn();
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException(ex);
+            }
         }
 
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -994,25 +1008,25 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             try
             {
                 fn();
-                tcs.SetResult(true);
+                tcs.TrySetResult(true);
             }
             catch (Exception ex)
             {
-                tcs.SetException(ex);
+                tcs.TrySetException(ex);
             }
         });
 
-        tcs.Task.GetAwaiter().GetResult();
+        return tcs.Task;
     }
 
-    private (PublishPayload Payload, Dictionary<string, LocalBlobInfo?> LocalBlobs) BuildPublishPayload()
+    private async Task<(PublishPayload Payload, Dictionary<string, LocalBlobInfo?> LocalBlobs)> BuildPublishPayloadAsync()
     {
-        var actorHash = OnFramework(() =>
+        var actorHash = await OnFrameworkAsync(() =>
         {
             var player = _clientState.LocalPlayer;
             return player?.Name.TextValue ?? string.Empty;
             // Omit world label to avoid GeneratedSheets dependency; actorHash is just the name.
-        });
+        }).ConfigureAwait(false);
 
         var appearance = new AppearanceMeta
         {
@@ -1185,7 +1199,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
                         token).ConfigureAwait(false);
                 }
 
-                StageTempModForMember(memberId, meta.Appearance);
+                await StageTempModForMemberAsync(memberId, meta.Appearance).ConfigureAwait(false);
                 target.LastHash = ComputeAppearanceHash(meta.Appearance);
                 target.Stage = SyncshellTargetStage.Prefetched;
 
@@ -1247,7 +1261,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
                             token).ConfigureAwait(false);
                     }
 
-                    StageTempModForMember(memberId, meta.Appearance);
+                    await StageTempModForMemberAsync(memberId, meta.Appearance).ConfigureAwait(false);
                     target.LastHash = ComputeAppearanceHash(meta.Appearance);
                     target.Stage = SyncshellTargetStage.Prefetched;
                 }
@@ -1266,7 +1280,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             if (_config.OnlySyncVisible)
             {
                 var member = Members.FirstOrDefault(m => string.Equals(m.Id, memberId, StringComparison.OrdinalIgnoreCase));
-                var visible = GetVisibleHandles();
+                var visible = await GetVisibleHandlesAsync().ConfigureAwait(false);
                 if (member == null || !visible.Contains(MemberHandle(member)))
                 {
                     continue;
@@ -1282,12 +1296,12 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             try
             {
                 target.Stage = SyncshellTargetStage.Applying;
-                ActivateTempMod(memberId);
-                ApplyGlamourer(memberId);
-                ApplyCustomizePlus(memberId);
-                ApplySimpleHeels(memberId);
-                ApplyPalettePlus(memberId);
-                ApplyHonorific(memberId);
+                await ActivateTempModAsync(memberId).ConfigureAwait(false);
+                await ApplyGlamourerAsync(memberId).ConfigureAwait(false);
+                await ApplyCustomizePlusAsync(memberId).ConfigureAwait(false);
+                await ApplySimpleHeelsAsync(memberId).ConfigureAwait(false);
+                await ApplyPalettePlusAsync(memberId).ConfigureAwait(false);
+                await ApplyHonorificAsync(memberId).ConfigureAwait(false);
                 await DebouncedRedrawAsync(token).ConfigureAwait(false);
 
                 target.LastAppliedAt = DateTimeOffset.UtcNow;
@@ -1318,11 +1332,11 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
                 await Task.Delay(wait, token).ConfigureAwait(false);
             }
 
-            OnFramework(() =>
+            await OnFrameworkAsync(() =>
             {
                 var index = _clientState.LocalPlayer?.ObjectIndex ?? 0;
                 _penumbra.RedrawObject(index);
-            });
+            }).ConfigureAwait(false);
             _lastRedrawAt = DateTimeOffset.UtcNow;
         }
         finally
@@ -1331,7 +1345,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    public void RefreshAppearanceCaches()
+    public async Task RefreshAppearanceCachesAsync()
     {
         EnsureNotDisposed();
 
@@ -1344,7 +1358,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         {
             if (_glamourer.Available)
             {
-                glamourerJson = OnFramework(() => _glamourer.TryGetPlayerDesignJson());
+                glamourerJson = await OnFrameworkAsync(() => _glamourer.TryGetPlayerDesignJson()).ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -1356,7 +1370,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         {
             if (_customizePlus.Available)
             {
-                customizePlusJson = OnFramework(() => _customizePlus.TryExportProfileJson());
+                customizePlusJson = await OnFrameworkAsync(() => _customizePlus.TryExportProfileJson()).ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -1368,7 +1382,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         {
             if (_simpleHeels.Available)
             {
-                simpleHeelsJson = OnFramework(() => _simpleHeels.TryExportOffsetsJson());
+                simpleHeelsJson = await OnFrameworkAsync(() => _simpleHeels.TryExportOffsetsJson()).ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -1380,7 +1394,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         {
             if (_palettePlus.Available)
             {
-                palettePlusJson = OnFramework(() => _palettePlus.TryExportProfileJson());
+                palettePlusJson = await OnFrameworkAsync(() => _palettePlus.TryExportProfileJson()).ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -1392,7 +1406,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         {
             if (_honorific.Available)
             {
-                honorificJson = OnFramework(() => _honorific.TryGetTitleJson());
+                honorificJson = await OnFrameworkAsync(() => _honorific.TryGetTitleJson()).ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -1400,7 +1414,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             _log.Debug(ex, "Honorific IPC failed");
         }
 
-        var modRoot = ResolvePenumbraRoot();
+        var modRoot = await ResolvePenumbraRootAsync().ConfigureAwait(false);
 
         var discovered = new Dictionary<string, LocalBlobInfo?>(StringComparer.OrdinalIgnoreCase);
         if (!string.IsNullOrWhiteSpace(modRoot) && Directory.Exists(modRoot))
@@ -1443,7 +1457,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         if (IsRunning)
         {
-            _appearanceDebounce.Run(PublishIfChanged);
+            _appearanceDebounce.Run(() => PublishIfChangedAsync());
         }
     }
 
@@ -1515,8 +1529,8 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
     private static string MemberHandle(SyncshellMemberStatus member)
         => NormalizeHandle(member.DisplayName);
 
-    private HashSet<string> GetVisibleHandles()
-        => OnFramework(() =>
+    private Task<HashSet<string>> GetVisibleHandlesAsync()
+        => OnFrameworkAsync(() =>
         {
             var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             try
@@ -1545,9 +1559,9 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             return set;
         });
 
-    private void StageTempModForMember(string memberId, AppearanceMeta appearance)
+    private async Task StageTempModForMemberAsync(string memberId, AppearanceMeta appearance)
     {
-        var root = EnsureWorkspaceRoot();
+        var root = await EnsureWorkspaceRootAsync().ConfigureAwait(false);
         var modPath = Path.Combine(root, "mods", memberId, "current");
         var filesRoot = Path.Combine(modPath, "files");
         Directory.CreateDirectory(filesRoot);
@@ -1609,9 +1623,9 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private string? ReadSystemJson(string memberId, string fileName)
+    private async Task<string?> ReadSystemJsonAsync(string memberId, string fileName)
     {
-        var root = EnsureWorkspaceRoot();
+        var root = await EnsureWorkspaceRootAsync().ConfigureAwait(false);
         var path = Path.Combine(root, "mods", memberId, "current", fileName);
         if (!File.Exists(path))
         {
@@ -1622,9 +1636,9 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         return string.IsNullOrWhiteSpace(json) ? null : json;
     }
 
-    private string EnsureWorkspaceRoot()
+    private async Task<string> EnsureWorkspaceRootAsync()
     {
-        var root = ResolvePenumbraRoot();
+        var root = await ResolvePenumbraRootAsync().ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(root))
         {
@@ -1637,14 +1651,14 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         return dcRoot;
     }
 
-    private void ActivateTempMod(string memberId)
+    private async Task ActivateTempModAsync(string memberId)
     {
-        var root = EnsureWorkspaceRoot();
+        var root = await EnsureWorkspaceRootAsync().ConfigureAwait(false);
         var modPath = Path.Combine(root, "mods", memberId, "current");
-        OnFramework(() => _penumbra.SetTemporaryMod(modPath));
+        await OnFrameworkAsync(() => _penumbra.SetTemporaryMod(modPath)).ConfigureAwait(false);
     }
 
-    private void ApplyGlamourer(string memberId)
+    private async Task ApplyGlamourerAsync(string memberId)
     {
         if (!_glamourer.CanApply)
         {
@@ -1653,13 +1667,13 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         try
         {
-            var json = ReadSystemJson(memberId, "glamourer.json");
+            var json = await ReadSystemJsonAsync(memberId, "glamourer.json").ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(json))
             {
                 return;
             }
 
-            OnFramework(() => _glamourer.ApplyPlayerDesignJson(json));
+            await OnFrameworkAsync(() => _glamourer.ApplyPlayerDesignJson(json!)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -1667,7 +1681,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private void ApplyCustomizePlus(string memberId)
+    private async Task ApplyCustomizePlusAsync(string memberId)
     {
         if (!_customizePlus.Available)
         {
@@ -1676,13 +1690,13 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         try
         {
-            var json = ReadSystemJson(memberId, "cplus.json");
+            var json = await ReadSystemJsonAsync(memberId, "cplus.json").ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(json))
             {
                 return;
             }
 
-            OnFramework(() => _customizePlus.ApplyProfileJson(json));
+            await OnFrameworkAsync(() => _customizePlus.ApplyProfileJson(json!)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -1690,7 +1704,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private void ApplySimpleHeels(string memberId)
+    private async Task ApplySimpleHeelsAsync(string memberId)
     {
         if (!_simpleHeels.Available)
         {
@@ -1699,13 +1713,13 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         try
         {
-            var json = ReadSystemJson(memberId, "heels.json");
+            var json = await ReadSystemJsonAsync(memberId, "heels.json").ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(json))
             {
                 return;
             }
 
-            OnFramework(() => _simpleHeels.ApplyOffsetsJson(json));
+            await OnFrameworkAsync(() => _simpleHeels.ApplyOffsetsJson(json!)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -1713,7 +1727,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private void ApplyPalettePlus(string memberId)
+    private async Task ApplyPalettePlusAsync(string memberId)
     {
         if (!_palettePlus.Available)
         {
@@ -1722,13 +1736,13 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         try
         {
-            var json = ReadSystemJson(memberId, "palette.json");
+            var json = await ReadSystemJsonAsync(memberId, "palette.json").ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(json))
             {
                 return;
             }
 
-            OnFramework(() => _palettePlus.ApplyProfileJson(json));
+            await OnFrameworkAsync(() => _palettePlus.ApplyProfileJson(json!)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -1736,7 +1750,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         }
     }
 
-    private void ApplyHonorific(string memberId)
+    private async Task ApplyHonorificAsync(string memberId)
     {
         if (!_honorific.Available)
         {
@@ -1745,13 +1759,13 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
 
         try
         {
-            var json = ReadSystemJson(memberId, "honorific.json");
+            var json = await ReadSystemJsonAsync(memberId, "honorific.json").ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(json))
             {
                 return;
             }
 
-            OnFramework(() => _honorific.SetTitleJson(json));
+            await OnFrameworkAsync(() => _honorific.SetTitleJson(json!)).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/DemiCatPlugin/SyncShell/SyncShellWatcher.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellWatcher.cs
@@ -78,14 +78,18 @@ public sealed class SyncShellWatcher : ISyncShellWatcher
         }
 
         cts.Cancel();
-        try
+        if (task != null)
         {
-            task?.GetAwaiter().GetResult();
+            _ = task.ContinueWith(t =>
+            {
+                if (t.Exception != null)
+                {
+                    PluginServices.Instance?.Log.Debug(t.Exception, "SyncShell watcher stop fault");
+                }
+                cts.Dispose();
+            }, TaskScheduler.Default);
         }
-        catch
-        {
-        }
-        finally
+        else
         {
             cts.Dispose();
         }

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -143,41 +143,44 @@ public class UiRenderer : IAsyncDisposable, IDisposable
         _webSocket = null;
         if (socket != null)
         {
-            try
+            _ = Task.Run(async () =>
             {
-                var closeTask = CloseClientWebSocketWithTimeoutAsync(socket, CancellationToken.None);
-                var completedTask = Task.WhenAny(closeTask, Task.Delay(WebSocketCloseWaitTimeout)).GetAwaiter().GetResult();
-                if (completedTask != closeTask)
+                try
+                {
+                    var closeTask = CloseClientWebSocketWithTimeoutAsync(socket, CancellationToken.None);
+                    var completedTask = await Task.WhenAny(closeTask, Task.Delay(WebSocketCloseWaitTimeout)).ConfigureAwait(false);
+                    if (completedTask != closeTask)
+                    {
+                        socket.Abort();
+                    }
+                    else
+                    {
+                        await closeTask.ConfigureAwait(false);
+                    }
+                }
+                catch (OperationCanceledException)
                 {
                     socket.Abort();
                 }
-                else
+                catch (WebSocketException)
                 {
-                    closeTask.GetAwaiter().GetResult();
+                    socket.Abort();
                 }
-            }
-            catch (OperationCanceledException)
-            {
-                socket.Abort();
-            }
-            catch (WebSocketException)
-            {
-                socket.Abort();
-            }
-            catch (ObjectDisposedException)
-            {
-            }
-            catch (InvalidOperationException)
-            {
-            }
-            catch (Exception)
-            {
-                socket.Abort();
-            }
-            finally
-            {
-                socket.Dispose();
-            }
+                catch (ObjectDisposedException)
+                {
+                }
+                catch (InvalidOperationException)
+                {
+                }
+                catch (Exception)
+                {
+                    socket.Abort();
+                }
+                finally
+                {
+                    socket.Dispose();
+                }
+            });
         }
         _webSocketReconnectAttempt = 0;
         _nextWebSocketAttempt = DateTime.MaxValue;
@@ -1267,7 +1270,7 @@ public class UiRenderer : IAsyncDisposable, IDisposable
     public void Dispose()
     {
         _channelSelection.ChannelChanged -= HandleChannelChanged;
-        DisposeAsync().GetAwaiter().GetResult();
+        _ = DisposeAsync();
     }
 }
 


### PR DESCRIPTION
## Summary
- harden ChatWindow against use-after-dispose and ensure refresh tasks bail out when the window is torn down
- convert SyncShellService helpers and debouncer to true async flows and avoid synchronous blocking during publish/apply pipelines
- update watcher, bridge, UI renderer, and plugin shutdown paths to cancel work asynchronously instead of blocking on Task.GetResult

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ef8a0a73b08328bb4ad68a6713f096