### PR TITLE
Normalize request and channel string payloads

### DIFF
--- a/DemiCatPlugin/ChannelService.cs
+++ b/DemiCatPlugin/ChannelService.cs
@@ -19,6 +19,14 @@ public class ChannelService
         PropertyNameCaseInsensitive = true
     };
 
+    private static string S(string? v) => string.IsNullOrWhiteSpace(v) ? string.Empty : v;
+    private static string? SN(object? v) => v switch
+    {
+        null => null,
+        string s => s,
+        _ => v.ToString()
+    };
+
     public ChannelService(Config config, HttpClient httpClient, TokenManager tokenManager)
     {
         _config = config;
@@ -28,7 +36,8 @@ public class ChannelService
 
     public async Task<IReadOnlyList<ChannelDto>> FetchAsync(string kind, CancellationToken ct)
     {
-        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels?kind={kind}";
+        var normalizedKind = ChannelKeyHelper.NormalizeKind(kind);
+        var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels?kind={Uri.EscapeDataString(normalizedKind)}";
         var delay = TimeSpan.FromMilliseconds(500);
 
         for (var attempt = 0; ; attempt++)
@@ -45,8 +54,11 @@ public class ChannelService
                 var channels = await JsonSerializer.DeserializeAsync<List<ChannelDto>>(stream, JsonOpts, linkedCts.Token) ?? new List<ChannelDto>();
                 foreach (var channel in channels)
                 {
-                    channel.EnsureKind(kind);
-                    channel.Name = DecodeJsonUnicodeEscapes(channel.Name);
+                    channel.EnsureKind(normalizedKind);
+                    channel.Id = S(channel.Id);
+                    channel.Name = DecodeJsonUnicodeEscapes(S(channel.Name));
+                    channel.ParentId = SN(channel.ParentId);
+                    channel.GuildId = SN(channel.GuildId);
                 }
                 return ChannelDtoExtensions.SortForDisplay(channels);
             }
@@ -69,7 +81,8 @@ public class ChannelService
         CancellationToken ct
     )
     {
-        if (string.IsNullOrWhiteSpace(channelId))
+        channelId = S(channelId);
+        if (string.IsNullOrEmpty(channelId))
         {
             return null;
         }
@@ -80,8 +93,9 @@ public class ChannelService
         }
 
         var normalizedKind = ChannelKeyHelper.NormalizeKind(kind);
+        var encodedId = Uri.EscapeDataString(channelId);
         var url =
-            $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{channelId}/validate?kind={normalizedKind}";
+            $"{_config.ApiBaseUrl.TrimEnd('/')}/api/channels/{encodedId}/validate?kind={Uri.EscapeDataString(normalizedKind)}";
 
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         ApiHelpers.AddAuthHeader(request, _tokenManager);

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -35,6 +35,14 @@ public class RequestBoardWindow
     private SortMode _sortMode = SortMode.MostRecent;
     private static readonly string[] SortLabels = { "Type", "Name", "Most Recent" };
 
+    private static string S(string? v) => string.IsNullOrWhiteSpace(v) ? string.Empty : v;
+    private static string? SN(object? v) => v switch
+    {
+        null => null,
+        string s => s,
+        _ => v.ToString()
+    };
+
     public RequestBoardWindow(Config config, HttpClient httpClient)
     {
         _config = config;
@@ -79,8 +87,9 @@ public class RequestBoardWindow
         foreach (var req in requests)
         {
             ImGui.PushID(req.Id);
-            ImGui.TextWrapped(string.IsNullOrEmpty(req.Description) ? req.Title : req.Description);
-            ImGui.TextUnformatted($"Created By: {req.CreatedBy}");
+            var displayText = string.IsNullOrWhiteSpace(req.Description) ? req.Title : req.Description;
+            ImGui.TextWrapped(S(displayText));
+            ImGui.TextUnformatted($"Created By: {S(req.CreatedBy)}");
             if (req.Status == RequestStatus.Approved)
             {
                 ImGui.TextUnformatted("[Legacy Status: Approved]");
@@ -107,7 +116,7 @@ public class RequestBoardWindow
             if (ImGui.Combo("Urgency", ref urgIdx, urgLabels, urgLabels.Length))
                 _newUrgency = (RequestUrgency)urgIdx;
             if (!string.IsNullOrEmpty(_createStatus))
-                ImGui.TextUnformatted(_createStatus);
+                ImGui.TextUnformatted(S(_createStatus));
             if (ImGui.Button("Create"))
             {
                 if (ValidateNewRequest())
@@ -192,8 +201,14 @@ public class RequestBoardWindow
                         _conflicts[req.Id] = true;
                         return;
                     }
-                    var id = payload.GetProperty("id").GetString() ?? req.Id;
-                    var title = payload.TryGetProperty("title", out var tEl) ? tEl.GetString() ?? req.Title : req.Title;
+                    var id = S(payload.GetProperty("id").GetString() ?? req.Id);
+                    if (string.IsNullOrEmpty(id))
+                    {
+                        _conflicts[req.Id] = true;
+                        return;
+                    }
+                    var titleRaw = payload.TryGetProperty("title", out var tEl) ? tEl.GetString() : null;
+                    var title = string.IsNullOrWhiteSpace(titleRaw) ? req.Title : titleRaw!;
                     var statusStr = payload.GetProperty("status").GetString() ?? StatusToString(newStatus);
                     var typeStr = payload.TryGetProperty("type", out var typeEl) ? typeEl.GetString() ?? TypeToString(req.Type) : TypeToString(req.Type);
                     var urgencyStr = payload.TryGetProperty("urgency", out var uEl) ? uEl.GetString() ?? UrgencyToString(req.Urgency) : UrgencyToString(req.Urgency);
@@ -202,8 +217,8 @@ public class RequestBoardWindow
                     var hq = payload.TryGetProperty("hq", out var hEl) ? hEl.GetBoolean() : req.Hq;
                     var quantity = payload.TryGetProperty("quantity", out var qEl) ? qEl.GetInt32() : req.Quantity;
                     var assigneeId = payload.TryGetProperty("assignee_id", out var aEl) ? aEl.GetUInt32() : (uint?)req.AssigneeId;
-                    var description = payload.TryGetProperty("description", out var descEl) ? descEl.GetString() ?? req.Description : req.Description;
-                    var createdBy = payload.TryGetProperty("created_by", out var cbEl) ? cbEl.GetString() ?? req.CreatedBy : req.CreatedBy;
+                    var description = S(payload.TryGetProperty("description", out var descEl) ? descEl.GetString() : req.Description);
+                    var createdBy = S(payload.TryGetProperty("created_by", out var cbEl) ? cbEl.GetString() : req.CreatedBy);
                     DateTime createdAt = req.CreatedAt;
                     if (payload.TryGetProperty("created", out var cEl))
                         cEl.TryGetDateTime(out createdAt);
@@ -258,7 +273,8 @@ public class RequestBoardWindow
                 var json = await resp.Content.ReadAsStringAsync();
                 using var doc = JsonDocument.Parse(json);
                 var payload = doc.RootElement;
-                var title = payload.TryGetProperty("title", out var tEl) ? tEl.GetString() ?? "Request" : "Request";
+                var titleRaw = payload.TryGetProperty("title", out var tEl) ? tEl.GetString() : null;
+                var title = string.IsNullOrWhiteSpace(titleRaw) ? "Request" : titleRaw!;
                 var statusStr = payload.TryGetProperty("status", out var sEl) ? sEl.GetString() ?? "open" : "open";
                 var typeStr = payload.TryGetProperty("type", out var tType) ? tType.GetString() ?? "item" : "item";
                 var urgencyStr = payload.TryGetProperty("urgency", out var uEl) ? uEl.GetString() ?? "low" : "low";
@@ -268,8 +284,8 @@ public class RequestBoardWindow
                 var hq = payload.TryGetProperty("hq", out var hEl) && hEl.GetBoolean();
                 var quantity = payload.TryGetProperty("quantity", out var qEl) ? qEl.GetInt32() : 0;
                 var assigneeId = payload.TryGetProperty("assignee_id", out var aEl) ? aEl.GetUInt32() : (uint?)null;
-                var description = payload.TryGetProperty("description", out var descEl) ? descEl.GetString() ?? string.Empty : string.Empty;
-                var createdBy = payload.TryGetProperty("created_by", out var cbEl) ? cbEl.GetString() ?? string.Empty : string.Empty;
+                var description = S(payload.TryGetProperty("description", out var descEl) ? descEl.GetString() : null);
+                var createdBy = S(payload.TryGetProperty("created_by", out var cbEl) ? cbEl.GetString() : null);
                 DateTime createdAt = DateTime.MinValue;
                 if (payload.TryGetProperty("created", out var cEl))
                     cEl.TryGetDateTime(out createdAt);
@@ -384,8 +400,8 @@ public class RequestBoardWindow
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/requests";
             var body = new
             {
-                title = _newTitle,
-                description = string.IsNullOrWhiteSpace(_newDescription) ? null : _newDescription,
+                title = S(_newTitle),
+                description = SN(string.IsNullOrWhiteSpace(_newDescription) ? null : _newDescription),
                 type = TypeToString(_newType),
                 urgency = UrgencyToString(_newUrgency)
             };

--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -14,6 +14,14 @@ internal static class RequestStateService
     private static readonly object LockObj = new();
     private static Config? _config;
 
+    private static string S(string? v) => string.IsNullOrWhiteSpace(v) ? string.Empty : v;
+    private static string? SN(object? v) => v switch
+    {
+        null => null,
+        string s => s,
+        _ => v.ToString()
+    };
+
     public static IEnumerable<RequestState> All
     {
         get
@@ -68,6 +76,21 @@ internal static class RequestStateService
 
     public static void Upsert(RequestState state)
     {
+        if (state == null)
+        {
+            return;
+        }
+
+        state.Id = S(state.Id);
+        state.Title = string.IsNullOrWhiteSpace(state.Title) ? "Request" : state.Title;
+        state.Description = S(state.Description);
+        state.CreatedBy = S(state.CreatedBy);
+
+        if (string.IsNullOrEmpty(state.Id))
+        {
+            return;
+        }
+
         lock (LockObj)
         {
             if (RequestsMap.TryGetValue(state.Id, out var existing))
@@ -166,14 +189,15 @@ internal static class RequestStateService
                 list = Array.Empty<JsonElement>();
             foreach (var payload in list)
             {
-                var id = payload.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
+                var id = S(payload.TryGetProperty("id", out var idEl) ? idEl.GetString() : null);
                 var deleted = payload.TryGetProperty("deleted", out var delEl) && delEl.GetBoolean();
                 if (deleted)
                 {
-                    if (id != null) Remove(id);
+                    if (!string.IsNullOrEmpty(id)) Remove(id);
                     continue;
                 }
-                var title = payload.TryGetProperty("title", out var titleEl) ? titleEl.GetString() ?? "Request" : "Request";
+                var titleRaw = payload.TryGetProperty("title", out var titleEl) ? titleEl.GetString() : null;
+                var title = string.IsNullOrWhiteSpace(titleRaw) ? "Request" : titleRaw!;
                 var statusString = payload.TryGetProperty("status", out var statusEl) ? statusEl.GetString() : null;
                 var typeString = payload.TryGetProperty("type", out var typeEl) ? typeEl.GetString() : null;
                 var urgencyString = payload.TryGetProperty("urgency", out var urgEl) ? urgEl.GetString() : null;
@@ -183,12 +207,12 @@ internal static class RequestStateService
                 var hq = payload.TryGetProperty("hq", out var hqEl) && hqEl.GetBoolean();
                 var quantity = payload.TryGetProperty("quantity", out var qtyEl) ? qtyEl.GetInt32() : 0;
                 var assigneeId = payload.TryGetProperty("assigneeId", out var aEl) ? aEl.GetUInt32() : (uint?)null;
-                var description = payload.TryGetProperty("description", out var descEl) ? descEl.GetString() ?? string.Empty : string.Empty;
-                var createdBy = payload.TryGetProperty("createdBy", out var cbEl) ? cbEl.GetString() ?? string.Empty : string.Empty;
+                var description = S(payload.TryGetProperty("description", out var descEl) ? descEl.GetString() : null);
+                var createdBy = S(payload.TryGetProperty("createdBy", out var cbEl) ? cbEl.GetString() : null);
                 DateTime createdAt = DateTime.MinValue;
                 if (payload.TryGetProperty("created", out var cEl))
                     cEl.TryGetDateTime(out createdAt);
-                if (id == null || statusString == null) continue;
+                if (string.IsNullOrEmpty(id) || string.IsNullOrWhiteSpace(statusString)) continue;
                 Upsert(new RequestState
                 {
                     Id = id,
@@ -209,7 +233,7 @@ internal static class RequestStateService
             }
             if (newToken != null)
             {
-                config.RequestsDeltaToken = newToken;
+                config.RequestsDeltaToken = SN(newToken) ?? string.Empty;
             }
             Prune();
         }


### PR DESCRIPTION
## Summary
- sanitize persisted request state data to ensure string fields fall back to safe defaults
- guard request board UI serialization to avoid passing non-string payloads to the API
- normalize channel fetch/validation inputs and encode query parameters before calling the backend

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ef9805e76883289eb8ec8261712320