### PR TITLE
Centralize string helpers and validate request titles

### DIFF
--- a/DemiCatPlugin/ChannelService.cs
+++ b/DemiCatPlugin/ChannelService.cs
@@ -7,6 +7,8 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
+using static DemiCatPlugin.StringUtil;
+
 namespace DemiCatPlugin;
 
 public class ChannelService
@@ -17,14 +19,6 @@ public class ChannelService
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
         PropertyNameCaseInsensitive = true
-    };
-
-    private static string S(string? v) => string.IsNullOrWhiteSpace(v) ? string.Empty : v;
-    private static string? SN(object? v) => v switch
-    {
-        null => null,
-        string s => s,
-        _ => v.ToString()
     };
 
     public ChannelService(Config config, HttpClient httpClient, TokenManager tokenManager)

--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Dalamud.Bindings.ImGui;
 using System.Numerics;
 
+using static DemiCatPlugin.StringUtil;
+
 namespace DemiCatPlugin;
 
 public class RequestBoardWindow
@@ -34,14 +36,6 @@ public class RequestBoardWindow
 
     private SortMode _sortMode = SortMode.MostRecent;
     private static readonly string[] SortLabels = { "Type", "Name", "Most Recent" };
-
-    private static string S(string? v) => string.IsNullOrWhiteSpace(v) ? string.Empty : v;
-    private static string? SN(object? v) => v switch
-    {
-        null => null,
-        string s => s,
-        _ => v.ToString()
-    };
 
     public RequestBoardWindow(Config config, HttpClient httpClient)
     {
@@ -382,11 +376,21 @@ public class RequestBoardWindow
 
     private bool ValidateNewRequest()
     {
+        var title = TrimLimit(_newTitle);
+        var desc = TrimLimit(_newDescription);
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            _createStatus = "Title is required.";
+            return false;
+        }
         if (_newTitle.Length > 2000 || _newDescription.Length > 2000)
         {
             _createStatus = "Title or description exceeds 2000 characters";
             return false;
         }
+        // Normalize fields in place so CreateRequest uses the sanitized values
+        _newTitle = title;
+        _newDescription = desc;
         _createStatus = string.Empty;
         return true;
     }
@@ -400,8 +404,8 @@ public class RequestBoardWindow
             var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/requests";
             var body = new
             {
-                title = S(_newTitle),
-                description = SN(string.IsNullOrWhiteSpace(_newDescription) ? null : _newDescription),
+                title = TrimLimit(_newTitle),
+                description = NullIfWhite(TrimLimit(_newDescription)),
                 type = TypeToString(_newType),
                 urgency = UrgencyToString(_newUrgency)
             };

--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -6,6 +6,8 @@ using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 
+using static DemiCatPlugin.StringUtil;
+
 namespace DemiCatPlugin;
 
 internal static class RequestStateService
@@ -13,14 +15,6 @@ internal static class RequestStateService
     private static readonly Dictionary<string, RequestState> RequestsMap = new();
     private static readonly object LockObj = new();
     private static Config? _config;
-
-    private static string S(string? v) => string.IsNullOrWhiteSpace(v) ? string.Empty : v;
-    private static string? SN(object? v) => v switch
-    {
-        null => null,
-        string s => s,
-        _ => v.ToString()
-    };
 
     public static IEnumerable<RequestState> All
     {
@@ -82,7 +76,7 @@ internal static class RequestStateService
         }
 
         state.Id = S(state.Id);
-        state.Title = string.IsNullOrWhiteSpace(state.Title) ? "Request" : state.Title;
+        state.Title = string.IsNullOrWhiteSpace(state.Title) ? "Request" : TrimLimit(state.Title);
         state.Description = S(state.Description);
         state.CreatedBy = S(state.CreatedBy);
 
@@ -197,7 +191,7 @@ internal static class RequestStateService
                     continue;
                 }
                 var titleRaw = payload.TryGetProperty("title", out var titleEl) ? titleEl.GetString() : null;
-                var title = string.IsNullOrWhiteSpace(titleRaw) ? "Request" : titleRaw!;
+                var title = string.IsNullOrWhiteSpace(titleRaw) ? "Request" : TrimLimit(titleRaw);
                 var statusString = payload.TryGetProperty("status", out var statusEl) ? statusEl.GetString() : null;
                 var typeString = payload.TryGetProperty("type", out var typeEl) ? typeEl.GetString() : null;
                 var urgencyString = payload.TryGetProperty("urgency", out var urgEl) ? urgEl.GetString() : null;

--- a/DemiCatPlugin/StringUtil.cs
+++ b/DemiCatPlugin/StringUtil.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace DemiCatPlugin;
+
+internal static class StringUtil
+{
+    // Safe string (never null; trims; returns "")
+    public static string S(string? v) => string.IsNullOrWhiteSpace(v) ? string.Empty : v.Trim();
+
+    // Safe nullable (passes null through; ToString() otherwise)
+    public static string? SN(object? v) => v switch
+    {
+        null => null,
+        string s => s,
+        _ => v.ToString()
+    };
+
+    // Null if empty/whitespace (after trim)
+    public static string? NullIfWhite(string? v) => string.IsNullOrWhiteSpace(v) ? null : v!.Trim();
+
+    // Trim and hard-limit length (default 2000 to match existing UI rule)
+    public static string TrimLimit(string? v, int max = 2000)
+    {
+        var t = S(v);
+        return t.Length <= max ? t : t.Substring(0, max);
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `StringUtil` helper to centralize string normalization logic
- update channel/request services and UI to use the new helpers
- enforce non-empty, length-limited request titles before sending create calls

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68efe8a0516483288d65cf7cbbce7df8