### PR TITLE
Fix ChatWindow closing brace placement

### DIFF
--- a/DemiCatPlugin/ChatWindow.cs
+++ b/DemiCatPlugin/ChatWindow.cs
@@ -4907,6 +4907,7 @@ public class ChatWindow : IDisposable
             }
         });
     }
-}
+
     protected bool IsDisposed => Volatile.Read(ref _disposed) == 1;
+}
 


### PR DESCRIPTION
## Summary
- move the `IsDisposed` property back inside `ChatWindow` to correct the class closing brace placement
- resolve the resulting C# compiler errors about stray closing braces

## Testing
- `dotnet build` *(fails: .NET SDK is not installed in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0dcfcb90c83289e30639ec22599c9