### PR TITLE
Implement SyncShell appearance cache refresh

### DIFF
--- a/DemiCatPlugin/SyncShell/SyncShellService.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellService.cs
@@ -567,6 +567,26 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
         return true;
     }
 
+    public void RefreshAppearanceCaches()
+    {
+        EnsureNotDisposed();
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await RefreshAppearanceCachesAsync().ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Failed to refresh appearance caches");
+            }
+        }, CancellationToken.None);
+    }
+
     public void Dispose()
     {
         if (_disposed)
@@ -766,7 +786,7 @@ public sealed class SyncShellService : ISyncShellService, IDisposable
             }
         }, CancellationToken.None);
 
-        _ = Task.Run(RefreshAppearanceCaches, CancellationToken.None);
+        RefreshAppearanceCaches();
     }
 
     private void HandleWatcherNearbySet(string[] handles)


### PR DESCRIPTION
## Summary
- implement the `ISyncShellService.RefreshAppearanceCaches` interface method by scheduling the asynchronous refresh and logging failures
- call the new helper directly when the SyncShell watcher connects to avoid redundant task scheduling

## Testing
- `dotnet build -c Release` *(fails: `dotnet` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0de81d10883288175178f2e7f539b