### PR TITLE
Fix async warnings when stopping services

### DIFF
--- a/DemiCatPlugin/NotePadService.cs
+++ b/DemiCatPlugin/NotePadService.cs
@@ -67,7 +67,7 @@ public sealed class NotePadService : IDisposable
 
     public void Start()
     {
-        Stop();
+        Stop().GetAwaiter().GetResult();
         _cts = new CancellationTokenSource();
         _task = Task.Run(() => RunAsync(_cts.Token));
     }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -822,7 +822,7 @@ public class Plugin : IDalamudPlugin
             var frameworkInner = PluginServices.Instance?.Framework ?? _services.Framework;
             if (frameworkInner != null)
             {
-                frameworkInner.RunOnTick(UpdateUi);
+            _ = frameworkInner.RunOnTick(UpdateUi);
             }
             else
             {

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -1102,11 +1102,23 @@ public class SettingsWindow : IDisposable
         {
             if (ChannelWatcher != null)
             {
-                ChannelWatcher.Stop();
+                ChannelWatcher.Stop().GetAwaiter().GetResult();
             }
         }, "Failed to stop ChannelWatcher.");
-        SafeInvoke(() => RequestWatcher?.Stop(), "Failed to stop RequestWatcher.");
-        SafeInvoke(() => NotePadService?.Stop(), "Failed to stop NotePad service.");
+        SafeInvoke(() =>
+        {
+            if (RequestWatcher != null)
+            {
+                RequestWatcher.Stop().GetAwaiter().GetResult();
+            }
+        }, "Failed to stop RequestWatcher.");
+        SafeInvoke(() =>
+        {
+            if (NotePadService != null)
+            {
+                NotePadService.Stop().GetAwaiter().GetResult();
+            }
+        }, "Failed to stop NotePad service.");
         SafeInvoke(() =>
         {
             var presence = ChatWindow?.Presence ?? OfficerChatWindow?.Presence;


### PR DESCRIPTION
## Summary
- ensure NotePadService waits for any previous run to complete before starting a new task
- stop ChannelWatcher, RequestWatcher, and NotePadService synchronously in SettingsWindow to avoid unawaited task warnings
- explicitly discard the framework RunOnTick invocation to acknowledge the returned task

## Testing
- dotnet build -c Release *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f0df836eb083289e28d4b983856360