### PR TITLE
Add coverage for chat bridge payload formats

### DIFF
--- a/tests/ChatBridgeNoTokenTests.cs
+++ b/tests/ChatBridgeNoTokenTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using DemiCatPlugin;
+using System.Text.Json;
 using Xunit;
 
 public class ChatBridgeNoTokenTests
@@ -105,6 +106,88 @@ public class ChatBridgeNoTokenTests
 
 #if TEST
         Assert.Contains("{\"op\":\"sub\",\"channels\":[]}", frames);
+#endif
+    }
+
+    [Fact]
+    public async Task Send_FormatsPayloadForServerCompatibility()
+    {
+        var handler = new SuccessHandler();
+        var client = new HttpClient(handler);
+        var config = new Config { ApiBaseUrl = "http://localhost" };
+        var tm = new TokenManager();
+        var bridge = new ChatBridge(config, client, tm, () => new Uri("ws://localhost"), new ChannelSelectionService(config));
+
+#if TEST
+        var frames = new List<string>();
+        bridge.ForceWebSocketOpen = true;
+        bridge.SendRawInterceptor = frames.Add;
+#endif
+
+        var payload = new
+        {
+            content = "hello",
+            embedColor = 42,
+            metadata = new { nested = true }
+        };
+
+        await bridge.Send("123", payload);
+
+#if TEST
+        var frame = Assert.Single(frames);
+        using var doc = JsonDocument.Parse(frame);
+        var root = doc.RootElement;
+        Assert.Equal("send", root.GetProperty("op").GetString());
+        Assert.Equal("123", root.GetProperty("channel").GetString());
+        var data = root.GetProperty("d");
+        Assert.Equal("hello", data.GetProperty("content").GetString());
+        Assert.Equal(42, data.GetProperty("embedColor").GetInt32());
+        Assert.True(data.GetProperty("metadata").GetProperty("nested").GetBoolean());
+#endif
+    }
+
+    [Fact]
+    public async Task AckAsync_UsesCurFieldForCursorUpdates()
+    {
+        var handler = new SuccessHandler();
+        var client = new HttpClient(handler);
+        var config = new Config { ApiBaseUrl = "http://localhost", GuildId = "guild" };
+        var tm = new TokenManager();
+        var bridge = new ChatBridge(config, client, tm, () => new Uri("ws://localhost"), new ChannelSelectionService(config));
+
+#if TEST
+        var frames = new List<string>();
+        bridge.ForceWebSocketOpen = true;
+        bridge.SendRawInterceptor = frames.Add;
+#endif
+
+        bridge.Subscribe("123", config.GuildId, ChannelKind.Chat);
+
+        await Task.Delay(10);
+
+#if TEST
+        frames.Clear();
+#endif
+
+        var cursorsField = typeof(ChatBridge).GetField("_cursors", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var ackedField = typeof(ChatBridge).GetField("_acked", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var cursors = (Dictionary<string, long>)cursorsField.GetValue(bridge)!;
+        var acked = (Dictionary<string, long>)ackedField.GetValue(bridge)!;
+        var key = ChannelKeyHelper.BuildCursorKey(config.GuildId, ChannelKind.Chat, "123");
+        cursors[key] = 9876;
+        acked.Remove(key);
+
+        var ackAsync = typeof(ChatBridge).GetMethod("AckAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var task = (Task)ackAsync.Invoke(bridge, new object[] { "123" })!;
+        await task;
+
+#if TEST
+        var frame = Assert.Single(frames);
+        using var doc = JsonDocument.Parse(frame);
+        var root = doc.RootElement;
+        Assert.Equal("ack", root.GetProperty("op").GetString());
+        Assert.Equal("123", root.GetProperty("channel").GetString());
+        Assert.Equal(9876, root.GetProperty("cur").GetInt64());
 #endif
     }
 

--- a/tests/test_chat_ws.py
+++ b/tests/test_chat_ws.py
@@ -1079,6 +1079,48 @@ def test_chat_ws_unsubscribe_cleans_channel_state(monkeypatch):
     _run(scenario())
 
 
+def test_chat_ws_sub_accepts_lowercase_kind(monkeypatch):
+    async def scenario():
+        manager = ws_chat.ChatConnectionManager()
+        ws = StubWebSocket()
+        ctx = RequestContext(
+            user=types.SimpleNamespace(character_name=None),
+            guild=types.SimpleNamespace(id=1, discord_guild_id=777),
+            key=types.SimpleNamespace(),
+            roles=[],
+        )
+        connection = ws_chat.ChatConnection(ctx=ctx)
+        manager.connections[ws] = connection
+
+        channel_id = "55"
+        meta = ws_chat.ChannelMeta(guild_id=1, discord_guild_id=777, kind="FC_CHAT")
+
+        async def fake_fetch(channels):
+            assert channels == {channel_id}
+            return {channel_id: meta}
+
+        monkeypatch.setattr(manager, "_fetch_channel_meta_bulk", fake_fetch)
+
+        request = {"channels": [{"id": channel_id, "kind": "fc_chat", "guildId": "777"}]}
+        await manager.sub(ws, request)
+
+        assert channel_id in connection.channels
+        assert connection.metadata[channel_id].kind == "FC_CHAT"
+        assert connection.metadata[channel_id].guild_id_value() == "777"
+
+        assert len(ws.sent) >= 2
+        ack = json.loads(ws.sent[0])
+        resync = json.loads(ws.sent[1])
+        assert ack["op"] == "ack"
+        assert ack["kind"] == "FC_CHAT"
+        assert ack["guildId"] == "777"
+        assert resync["op"] == "resync"
+        assert resync["kind"] == "FC_CHAT"
+        assert resync["guildId"] == "777"
+
+    _run(scenario())
+
+
 def test_chat_ws_history_global_cap(monkeypatch):
     async def scenario():
         manager = ws_chat.ChatConnectionManager()


### PR DESCRIPTION
## Summary
- add C# unit tests that capture the websocket frames produced by ChatBridge send and ack paths
- add a websocket manager test to confirm lowercase channel kinds from the plugin remain compatible with server metadata

## Testing
- pytest tests/test_chat_ws.py

------
https://chatgpt.com/codex/tasks/task_e_68f0dce07b748328960b7de797332f69