### PR TITLE
Handle unauthorized websocket failures

### DIFF
--- a/DemiCatPlugin/ApiHelpers.cs
+++ b/DemiCatPlugin/ApiHelpers.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Net.WebSockets;
 using System.Net;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,6 +10,9 @@ namespace DemiCatPlugin;
 
 internal static class ApiHelpers
 {
+    private static readonly Regex StatusCodeRegex =
+        new("status code '?([0-9]{3})'?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     internal static bool ValidateApiBaseUrl(Config config)
     {
         if (!Uri.TryCreate(config.ApiBaseUrl, UriKind.Absolute, out var uri) ||
@@ -30,6 +34,51 @@ internal static class ApiHelpers
             request.Headers.Add("X-Api-Key", token);
         }
     }
+
+    internal static HttpStatusCode? ExtractStatusCode(Exception ex)
+    {
+        Exception? current = ex;
+        while (current != null)
+        {
+            if (current is HttpRequestException http && http.StatusCode.HasValue)
+            {
+                return http.StatusCode.Value;
+            }
+
+            if (current is WebSocketException ws)
+            {
+                if (ws.InnerException != null)
+                {
+                    var inner = ExtractStatusCode(ws.InnerException);
+                    if (inner.HasValue)
+                    {
+                        return inner.Value;
+                    }
+                }
+
+                var message = ws.Message;
+                if (!string.IsNullOrEmpty(message))
+                {
+                    var match = StatusCodeRegex.Match(message);
+                    if (match.Success && int.TryParse(match.Groups[1].Value, out var numeric) &&
+                        Enum.IsDefined(typeof(HttpStatusCode), numeric))
+                    {
+                        return (HttpStatusCode)numeric;
+                    }
+                }
+            }
+
+            current = current.InnerException;
+        }
+
+        return null;
+    }
+
+    internal static bool IsUnauthorized(Exception ex)
+        => ExtractStatusCode(ex) == HttpStatusCode.Unauthorized;
+
+    internal static bool IsForbidden(Exception ex)
+        => ExtractStatusCode(ex) == HttpStatusCode.Forbidden;
 
     internal static void AddAuthHeader(ClientWebSocket socket, TokenManager tokenManager)
         => AddAuthHeader(socket, tokenManager.Token);

--- a/DemiCatPlugin/ChannelWatcher.cs
+++ b/DemiCatPlugin/ChannelWatcher.cs
@@ -201,35 +201,89 @@ public class ChannelWatcher : IDisposable
             catch (HttpRequestException ex)
             {
                 hadTransportError = true;
-                retryStatusCode = ex.StatusCode.HasValue ? (int)ex.StatusCode.Value : null;
-                retryStatusDetail = ex.StatusCode?.ToString() ?? ex.Message;
-                if (ex.StatusCode == HttpStatusCode.Forbidden)
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status.HasValue)
+                {
+                    retryStatusCode = (int)status.Value;
+                    retryStatusDetail = status.Value.ToString();
+                }
+                else
+                {
+                    retryStatusCode = ex.StatusCode.HasValue ? (int)ex.StatusCode.Value : null;
+                    retryStatusDetail = ex.StatusCode?.ToString() ?? ex.Message;
+                }
+
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
+                {
+                    PluginServices.Instance!.Log.Warning("Clearing stored token after channel watcher auth failure.");
+                    _ = Task.Run(() => _tokenManager.Clear("Authentication failed"));
+                }
+                else if (status == HttpStatusCode.Forbidden)
                 {
                     ShowPermissionWarning();
                 }
+
                 LogConnectionException(ex, "connect");
             }
             catch (WebSocketException ex)
             {
                 hadTransportError = true;
-                if (ws?.CloseStatus == WebSocketCloseStatus.PolicyViolation || ex.Message?.Contains("403", StringComparison.Ordinal) == true)
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status.HasValue)
+                {
+                    retryStatusCode = (int)status.Value;
+                    retryStatusDetail = status.Value.ToString();
+                }
+                else
+                {
+                    retryStatusCode = (int)ex.WebSocketErrorCode;
+                    retryStatusDetail = ex.WebSocketErrorCode.ToString();
+                }
+
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
+                {
+                    PluginServices.Instance!.Log.Warning("Clearing stored token after channel watcher auth failure.");
+                    _ = Task.Run(() => _tokenManager.Clear("Authentication failed"));
+                }
+                else if (status == HttpStatusCode.Forbidden || ws?.CloseStatus == WebSocketCloseStatus.PolicyViolation)
                 {
                     ShowPermissionWarning();
                 }
-                retryStatusCode = (int)ex.WebSocketErrorCode;
-                retryStatusDetail = ex.WebSocketErrorCode.ToString();
+
                 LogConnectionException(ex, "connect");
             }
             catch (IOException ex)
             {
                 hadTransportError = true;
-                retryStatusDetail = ex.Message;
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
+                {
+                    PluginServices.Instance!.Log.Warning("Clearing stored token after channel watcher auth failure.");
+                    _ = Task.Run(() => _tokenManager.Clear("Authentication failed"));
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    ShowPermissionWarning();
+                }
+
+                retryStatusDetail = status?.ToString() ?? ex.Message;
                 LogConnectionException(ex, "connect");
             }
             catch (Exception ex)
             {
                 hadTransportError = true;
-                retryStatusDetail = ex.Message;
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
+                {
+                    PluginServices.Instance!.Log.Warning("Clearing stored token after channel watcher auth failure.");
+                    _ = Task.Run(() => _tokenManager.Clear("Authentication failed"));
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    ShowPermissionWarning();
+                }
+
+                retryStatusDetail = status?.ToString() ?? ex.Message;
                 LogConnectionException(ex, "loop");
             }
             finally

--- a/DemiCatPlugin/ChatBridge.cs
+++ b/DemiCatPlugin/ChatBridge.cs
@@ -58,6 +58,7 @@ public class ChatBridge : IChatBridge
     private static readonly JsonSerializerOptions JsonOpts = new() { PropertyNameCaseInsensitive = true };
     private static readonly TimeSpan DefaultConnectTimeout = TimeSpan.FromSeconds(10);
     private const string ForbiddenMessage = "Forbidden – check API key/roles";
+    private const string InvalidTokenMessage = "Invalid API key";
     private bool _permissionWarningShown;
     private static void OnFramework(Action action)
         => PluginServices.Instance?.Framework.RunOnTick(action);
@@ -751,6 +752,7 @@ public class ChatBridge : IChatBridge
             }
 
             var forbidden = false;
+            var unauthorized = false;
             Exception? transportError = null;
             var failureStage = "connect";
             var connected = false;
@@ -823,25 +825,45 @@ public class ChatBridge : IChatBridge
             }
             catch (HttpRequestException ex)
             {
-                forbidden = ex.StatusCode == HttpStatusCode.Forbidden;
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                forbidden = status == HttpStatusCode.Forbidden;
+                unauthorized = status == HttpStatusCode.Unauthorized;
                 transportError = ex;
                 failureStage = connected ? "receive" : "connect";
             }
             catch (WebSocketException ex)
             {
-                forbidden = ex.Message?.Contains("403", StringComparison.Ordinal) == true
-                    || (ex.InnerException as HttpRequestException)?.StatusCode == HttpStatusCode.Forbidden;
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                forbidden = status == HttpStatusCode.Forbidden;
+                unauthorized = status == HttpStatusCode.Unauthorized;
                 transportError = ex;
                 failureStage = connected ? "receive" : "connect";
             }
             catch (IOException ex)
             {
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Forbidden)
+                {
+                    forbidden = true;
+                }
+                if (status == HttpStatusCode.Unauthorized)
+                {
+                    unauthorized = true;
+                }
                 transportError = ex;
                 failureStage = connected ? "receive" : "connect";
             }
             catch (Exception ex)
             {
-                forbidden |= (ex.InnerException as HttpRequestException)?.StatusCode == HttpStatusCode.Forbidden;
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Forbidden)
+                {
+                    forbidden = true;
+                }
+                if (status == HttpStatusCode.Unauthorized)
+                {
+                    unauthorized = true;
+                }
                 transportError = ex;
                 failureStage = connected ? "receive" : "connect";
             }
@@ -878,7 +900,15 @@ public class ChatBridge : IChatBridge
                 LogConnectionException(transportError, failureStage);
             }
 
-            if (forbidden)
+            if (unauthorized)
+            {
+                ResetState();
+                OnFramework(() => Unlinked?.Invoke());
+                _tokenValid = false;
+                _tokenManager.Clear("Invalid API key");
+                OnFramework(() => StatusChanged?.Invoke(InvalidTokenMessage));
+            }
+            else if (forbidden)
             {
                 ShowPermissionWarning();
                 ResetState();
@@ -892,11 +922,13 @@ public class ChatBridge : IChatBridge
             }
             _reconnectAttempt++;
             var backoff = GetReconnectDelay(_reconnectAttempt);
-            var statusMessage = forbidden
-                ? ForbiddenMessage
-                : connectTimedOut
-                    ? "Connection timed out; retrying..."
-                    : $"Reconnecting in {backoff.TotalSeconds:0.#}s...";
+            var statusMessage = unauthorized
+                ? InvalidTokenMessage
+                : forbidden
+                    ? ForbiddenMessage
+                    : connectTimedOut
+                        ? "Connection timed out; retrying..."
+                        : $"Reconnecting in {backoff.TotalSeconds:0.#}s...";
             OnFramework(() => StatusChanged?.Invoke(statusMessage));
             await DelayWithBackoff(backoff, token);
         }

--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -758,6 +758,19 @@ public class DiscordPresenceService : IDisposable
 
     private void HandleConnectionException(Exception ex)
     {
+        var status = ApiHelpers.ExtractStatusCode(ex);
+        if (status == HttpStatusCode.Unauthorized)
+        {
+            TokenManager.Instance?.Clear("Invalid API key");
+            UpdateStatusMessage("Authentication failed");
+            return;
+        }
+
+        if (status == HttpStatusCode.Forbidden)
+        {
+            UpdateStatusMessage("Forbidden – check API key/roles");
+        }
+
         LogConnectionException(ex, "connect");
         UpdateStatusMessage($"Connection failed: {ex.Message}");
     }

--- a/DemiCatPlugin/NotePadService.cs
+++ b/DemiCatPlugin/NotePadService.cs
@@ -722,12 +722,38 @@ public sealed class NotePadService : IDisposable
             catch (HttpRequestException ex)
             {
                 PluginServices.Instance?.Log.Warning(ex, "NotePad websocket transport error");
-                ShowThrottledToast("NotePad connection failed", ex.Message);
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
+                {
+                    _tokenManager.Clear("Authentication failed");
+                    ShowThrottledToast("NotePad connection failed", "Authentication failed");
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    ShowThrottledToast("NotePad connection failed", "Forbidden – check API key/roles");
+                }
+                else
+                {
+                    ShowThrottledToast("NotePad connection failed", ex.Message);
+                }
             }
             catch (WebSocketException ex)
             {
                 PluginServices.Instance?.Log.Warning(ex, "NotePad websocket error");
-                ShowThrottledToast("NotePad connection failed", ex.Message);
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
+                {
+                    _tokenManager.Clear("Authentication failed");
+                    ShowThrottledToast("NotePad connection failed", "Authentication failed");
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    ShowThrottledToast("NotePad connection failed", "Forbidden – check API key/roles");
+                }
+                else
+                {
+                    ShowThrottledToast("NotePad connection failed", ex.Message);
+                }
             }
             catch (Exception ex)
             {

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -156,36 +156,61 @@ public class RequestWatcher : IDisposable
             catch (HttpRequestException ex)
             {
                 hadTransportError = true;
-                if (ex.StatusCode == HttpStatusCode.Unauthorized)
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
                 {
-                    if (_tokenManager.IsReady())
-                    {
-                        _tokenManager.Clear("Authentication failed");
-                    }
+                    _tokenManager.Clear("Authentication failed");
                 }
-                else if (ex.StatusCode == HttpStatusCode.Forbidden)
+                else if (status == HttpStatusCode.Forbidden)
                 {
                     ShowPermissionWarning();
                 }
+
                 LogConnectionException(ex, "connect");
             }
             catch (WebSocketException ex)
             {
                 hadTransportError = true;
-                if (ws?.CloseStatus == WebSocketCloseStatus.PolicyViolation || ex.Message?.Contains("403", StringComparison.Ordinal) == true)
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
+                {
+                    _tokenManager.Clear("Authentication failed");
+                }
+                else if (status == HttpStatusCode.Forbidden || ws?.CloseStatus == WebSocketCloseStatus.PolicyViolation)
                 {
                     ShowPermissionWarning();
                 }
+
                 LogConnectionException(ex, "connect");
             }
             catch (IOException ex)
             {
                 hadTransportError = true;
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
+                {
+                    _tokenManager.Clear("Authentication failed");
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    ShowPermissionWarning();
+                }
+
                 LogConnectionException(ex, "connect");
             }
             catch (Exception ex)
             {
                 hadTransportError = true;
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
+                {
+                    _tokenManager.Clear("Authentication failed");
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    ShowPermissionWarning();
+                }
+
                 PluginServices.Instance?.Log.Error(ex, "Request watcher loop failed");
             }
             finally

--- a/DemiCatPlugin/SyncShell/SyncShellWatcher.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellWatcher.cs
@@ -157,6 +157,16 @@ public sealed class SyncShellWatcher : ISyncShellWatcher
             }
             catch (Exception ex)
             {
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized && _tokenManager.IsReady())
+                {
+                    _tokenManager.Clear("Authentication failed");
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    _log.Warning("SyncShell watcher forbidden; check API key/roles");
+                }
+
                 _attempt++;
                 _log.Warning(ex, "SyncShell watcher connection failed (attempt {Attempt})", _attempt);
             }

--- a/DemiCatPlugin/UiRenderer.cs
+++ b/DemiCatPlugin/UiRenderer.cs
@@ -497,21 +497,57 @@ public class UiRenderer : IAsyncDisposable, IDisposable
             catch (HttpRequestException ex)
             {
                 LogWebSocketException(ex, "connect");
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized)
+                {
+                    TokenManager.Instance?.Clear("Invalid API key");
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    ShowPermissionToast();
+                }
                 ScheduleNextWebSocketAttempt();
             }
             catch (WebSocketException ex)
             {
                 LogWebSocketException(ex, "connect");
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized)
+                {
+                    TokenManager.Instance?.Clear("Invalid API key");
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    ShowPermissionToast();
+                }
                 ScheduleNextWebSocketAttempt();
             }
             catch (IOException ex)
             {
                 LogWebSocketException(ex, "connect");
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized)
+                {
+                    TokenManager.Instance?.Clear("Invalid API key");
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    ShowPermissionToast();
+                }
                 ScheduleNextWebSocketAttempt();
             }
             catch (Exception ex)
             {
                 LogWebSocketException(ex, "connect");
+                var status = ApiHelpers.ExtractStatusCode(ex);
+                if (status == HttpStatusCode.Unauthorized)
+                {
+                    TokenManager.Instance?.Clear("Invalid API key");
+                }
+                else if (status == HttpStatusCode.Forbidden)
+                {
+                    ShowPermissionToast();
+                }
                 ScheduleNextWebSocketAttempt();
             }
             finally

--- a/tests/ApiHelpersTests.cs
+++ b/tests/ApiHelpersTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.WebSockets;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -145,5 +146,24 @@ public class ApiHelpersTests
         {
             RestorePluginServices(previousServices);
         }
+    }
+
+    [Fact]
+    public void ExtractStatusCode_FromHttpRequestException()
+    {
+        var ex = new HttpRequestException("auth", null, HttpStatusCode.Unauthorized);
+        Assert.Equal(HttpStatusCode.Unauthorized, ApiHelpers.ExtractStatusCode(ex));
+        Assert.True(ApiHelpers.IsUnauthorized(ex));
+        Assert.False(ApiHelpers.IsForbidden(ex));
+    }
+
+    [Fact]
+    public void ExtractStatusCode_FromWebSocketExceptionMessage()
+    {
+        var message = "The server returned status code '403' when status code '101' was expected.";
+        var ex = new WebSocketException(WebSocketError.Success, message);
+        Assert.Equal(HttpStatusCode.Forbidden, ApiHelpers.ExtractStatusCode(ex));
+        Assert.True(ApiHelpers.IsForbidden(ex));
+        Assert.False(ApiHelpers.IsUnauthorized(ex));
     }
 }


### PR DESCRIPTION
## Summary
- add shared helpers to derive HTTP status codes from transport exceptions
- clear stored API tokens and surface user messaging when websocket connections fail with 401/403 responses
- extend API helper tests to cover status extraction

## Testing
- pytest tests/test_ws_api_key.py tests/test_chat_ws.py tests/test_ws_retry.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f0e202613c8328980a0bf9feada87b