### PR TITLE
Fix missing HttpStatusCode import in SyncShellWatcher

### DIFF
--- a/DemiCatPlugin/SyncShell/SyncShellWatcher.cs
+++ b/DemiCatPlugin/SyncShell/SyncShellWatcher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Net;
 using System.Net.WebSockets;
 using System.Text.Json;
 using System.Threading;


### PR DESCRIPTION
## Summary
- add the System.Net namespace to SyncShellWatcher so HttpStatusCode resolves during builds

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f18005db6c832897dd719aab69f308