### PR TITLE
Remove syncshell schema artifacts

### DIFF
--- a/SQL Schema.sql
+++ b/SQL Schema.sql
@@ -407,7 +407,6 @@ INSERT INTO `guild_channels` VALUES
 (1,1406428761171300516,'chat','📦crafting-list📦',NULL),
 (1,1406428798559453284,'chat','🎭shenanigans🎭',NULL),
 (1,1406645986985644143,'chat','demibot-test',NULL),
-(1,1411094717969600626,'chat','syncshell',NULL),
 (1,1411127020146000004,'chat','test2',NULL),
 (3,1218700195169304688,'chat','Development Channels',NULL),
 (3,1218700195169304689,'chat','Voice Channels',NULL),
@@ -431,7 +430,6 @@ INSERT INTO `guild_channels` VALUES
 (3,1330891011731488778,'chat','bozja-eureka-events',NULL),
 (3,1330891039791255603,'chat','pvp-events',NULL),
 (3,1330891793146974218,'chat','miscellaneous-events',NULL),
-(3,1411094720884641814,'chat','syncshell',NULL),
 (4,1337786583696408616,'chat','General',NULL),
 (4,1337786583696408617,'chat','Voice Channels',NULL),
 (4,1337786583696408618,'fc_chat','💬general-discussion',NULL),
@@ -508,7 +506,6 @@ INSERT INTO `guild_channels` VALUES
 (4,1408924101187211316,'chat','🧩mare-service-debug🧩',NULL),
 (4,1409911507348619264,'chat','DemiCat',NULL),
 (4,1409911863386575002,'chat','📜demicat-v1-2-2-1-release-notes📜',NULL),
-(4,1411094725305303194,'chat','syncshell',NULL),
 (4,1411324235472830598,'chat','concepts',NULL),
 (4,1412094196332101844,'chat','📺screenshots',NULL),
 (4,1414766174969008199,'chat','🧠brain-storms⛈️',NULL),
@@ -1115,85 +1112,6 @@ CREATE TABLE `signup_presets` (
 LOCK TABLES `signup_presets` WRITE;
 /*!40000 ALTER TABLE `signup_presets` DISABLE KEYS */;
 /*!40000 ALTER TABLE `signup_presets` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `syncshell_manifests`
---
-
-DROP TABLE IF EXISTS `syncshell_manifests`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8mb4 */;
-CREATE TABLE `syncshell_manifests` (
-  `user_id` bigint unsigned NOT NULL,
-  `manifest_json` text NOT NULL,
-  `created_at` datetime NOT NULL,
-  `updated_at` datetime NOT NULL,
-  PRIMARY KEY (`user_id`),
-  CONSTRAINT `syncshell_manifests_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `syncshell_manifests`
---
-
-LOCK TABLES `syncshell_manifests` WRITE;
-/*!40000 ALTER TABLE `syncshell_manifests` DISABLE KEYS */;
-/*!40000 ALTER TABLE `syncshell_manifests` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `syncshell_pairings`
---
-
-DROP TABLE IF EXISTS `syncshell_pairings`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8mb4 */;
-CREATE TABLE `syncshell_pairings` (
-  `user_id` bigint unsigned NOT NULL,
-  `token` varchar(64) NOT NULL,
-  `created_at` datetime NOT NULL,
-  `expires_at` datetime NOT NULL,
-  PRIMARY KEY (`user_id`),
-  UNIQUE KEY `ix_syncshell_pairings_token` (`token`),
-  KEY `ix_syncshell_pairings_expires_at` (`expires_at`),
-  CONSTRAINT `syncshell_pairings_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `syncshell_pairings`
---
-
-LOCK TABLES `syncshell_pairings` WRITE;
-/*!40000 ALTER TABLE `syncshell_pairings` DISABLE KEYS */;
-/*!40000 ALTER TABLE `syncshell_pairings` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
--- Table structure for table `syncshell_rate_limits`
---
-
-DROP TABLE IF EXISTS `syncshell_rate_limits`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8mb4 */;
-CREATE TABLE `syncshell_rate_limits` (
-  `user_id` bigint unsigned NOT NULL,
-  `requests` int NOT NULL DEFAULT '0',
-  `window_start` datetime NOT NULL,
-  PRIMARY KEY (`user_id`),
-  CONSTRAINT `syncshell_rate_limits_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `syncshell_rate_limits`
---
-
-LOCK TABLES `syncshell_rate_limits` WRITE;
-/*!40000 ALTER TABLE `syncshell_rate_limits` DISABLE KEYS */;
-/*!40000 ALTER TABLE `syncshell_rate_limits` ENABLE KEYS */;
 UNLOCK TABLES;
 
 --

--- a/demibot/demibot/db/migrations/versions/0058_drop_syncshell_tables.py
+++ b/demibot/demibot/db/migrations/versions/0058_drop_syncshell_tables.py
@@ -1,0 +1,172 @@
+"""0058_drop_syncshell_tables
+
+Revision ID: 0058_drop_syncshell_tables
+Revises: 0057_expand_presence_status_text_to_text
+Create Date: 2025-10-20 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import BIGINT
+
+# revision identifiers, used by Alembic.
+revision: str = "0058_drop_syncshell_tables"
+down_revision: Union[str, None] = "0057_expand_presence_status_text_to_text"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Drop syncshell presence tracking tables
+    op.drop_index("ix_syncshell_presence_member_user_id", table_name="syncshell_presence")
+    op.drop_index("ix_syncshell_presence_user_id", table_name="syncshell_presence")
+    op.drop_table("syncshell_presence")
+
+    op.drop_index("ix_syncshell_members_member_user_id", table_name="syncshell_members")
+    op.drop_index("ix_syncshell_members_user_id", table_name="syncshell_members")
+    op.drop_table("syncshell_members")
+
+    # Drop invite tables and related indexes
+    op.drop_index("ix_syncshell_invites_target_status", table_name="syncshell_invites")
+    op.drop_index(
+        "ix_syncshell_invites_inviter_target_display_name_status",
+        table_name="syncshell_invites",
+    )
+    op.drop_index(
+        "ix_syncshell_invites_inviter_target_user_status",
+        table_name="syncshell_invites",
+    )
+    op.drop_index("ix_syncshell_invites_status", table_name="syncshell_invites")
+    op.drop_index("ix_syncshell_invites_target_user_id", table_name="syncshell_invites")
+    op.drop_index("ix_syncshell_invites_inviter_id", table_name="syncshell_invites")
+    op.drop_table("syncshell_invites")
+
+    # Drop transfer budget tracking
+    op.drop_table("syncshell_transfer_budgets")
+
+    # Drop pairing metadata and rate limits
+    op.drop_table("syncshell_rate_limits")
+    op.drop_index("ix_syncshell_pairings_expires_at", table_name="syncshell_pairings")
+    op.drop_index("ix_syncshell_pairings_token", table_name="syncshell_pairings")
+    op.drop_table("syncshell_pairings")
+    op.drop_table("syncshell_manifests")
+
+
+def downgrade() -> None:
+    # Recreate pairing manifests and rate limit structures
+    op.create_table(
+        "syncshell_manifests",
+        sa.Column("user_id", BIGINT(unsigned=True), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column("manifest_json", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+
+    op.create_table(
+        "syncshell_pairings",
+        sa.Column("user_id", BIGINT(unsigned=True), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column("token", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index(
+        "ix_syncshell_pairings_token",
+        "syncshell_pairings",
+        ["token"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_syncshell_pairings_expires_at",
+        "syncshell_pairings",
+        ["expires_at"],
+    )
+    op.create_table(
+        "syncshell_rate_limits",
+        sa.Column("user_id", BIGINT(unsigned=True), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column("requests", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("window_start", sa.DateTime(), nullable=False),
+    )
+
+    # Recreate transfer budget tracking
+    op.create_table(
+        "syncshell_transfer_budgets",
+        sa.Column("user_id", BIGINT(unsigned=True), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column("window_start", sa.DateTime(), nullable=False),
+        sa.Column("used_bytes", BIGINT(unsigned=True), nullable=False, server_default="0"),
+    )
+
+    # Recreate invite tables and indexes
+    op.create_table(
+        "syncshell_invites",
+        sa.Column("id", sa.String(length=64), primary_key=True),
+        sa.Column("inviter_id", BIGINT(unsigned=True), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("target_user_id", BIGINT(unsigned=True), sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("target_display_name", sa.String(length=255), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_syncshell_invites_inviter_id", "syncshell_invites", ["inviter_id"])
+    op.create_index("ix_syncshell_invites_target_user_id", "syncshell_invites", ["target_user_id"])
+    op.create_index("ix_syncshell_invites_status", "syncshell_invites", ["status"])
+    op.create_index(
+        "ix_syncshell_invites_inviter_target_user_status",
+        "syncshell_invites",
+        ["inviter_id", "target_user_id", "status"],
+    )
+    op.create_index(
+        "ix_syncshell_invites_inviter_target_display_name_status",
+        "syncshell_invites",
+        ["inviter_id", "target_display_name", "status"],
+    )
+    op.create_index(
+        "ix_syncshell_invites_target_status",
+        "syncshell_invites",
+        ["target_user_id", "status"],
+    )
+
+    # Recreate membership and presence tracking
+    op.create_table(
+        "syncshell_members",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", BIGINT(unsigned=True), nullable=False),
+        sa.Column("member_user_id", BIGINT(unsigned=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["member_user_id"], ["users.id"]),
+        sa.UniqueConstraint("user_id", "member_user_id", name="uq_syncshell_member_pair"),
+    )
+    op.create_index("ix_syncshell_members_user_id", "syncshell_members", ["user_id"])
+    op.create_index(
+        "ix_syncshell_members_member_user_id",
+        "syncshell_members",
+        ["member_user_id"],
+    )
+
+    op.create_table(
+        "syncshell_presence",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", BIGINT(unsigned=True), nullable=False),
+        sa.Column("member_user_id", BIGINT(unsigned=True), nullable=False),
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("last_seen", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["member_user_id"], ["users.id"]),
+        sa.UniqueConstraint("user_id", "member_user_id", name="uq_syncshell_presence_pair"),
+    )
+    op.create_index("ix_syncshell_presence_user_id", "syncshell_presence", ["user_id"])
+    op.create_index(
+        "ix_syncshell_presence_member_user_id",
+        "syncshell_presence",
+        ["member_user_id"],
+    )
+


### PR DESCRIPTION
## Summary
- remove syncshell seed channels and table definitions from the SQL snapshot
- add Alembic revision 0058 to drop the remaining syncshell tables and indexes

## Testing
- pytest *(fails: missing optional dependencies such as fastapi, sqlalchemy, aiohttp)*

------
https://chatgpt.com/codex/tasks/task_e_68f2e4295d5c83289afa45ab7bb2763c