### PR TITLE
Remove unused Penumbra validation fields

### DIFF
--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -39,8 +39,6 @@ public class SettingsWindow : IDisposable
     private bool _isLinked;
     private static readonly int[] FadeDurations = { 5, 10, 15, 20, 30 };
     private string _penumbraOverride = string.Empty;
-    private string? _penumbraValidationMessage;
-    private bool _penumbraValidationSuccess;
 
     public bool IsOpen;
 


### PR DESCRIPTION
## Summary
- remove the unused Penumbra validation fields from `SettingsWindow` to clear build warnings

## Testing
- dotnet build DemiCatPlugin/DemiCatPlugin.csproj -c Release *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3741e0cb48328b23254fd824eb131