### PR TITLE
Add dedicated roster window for presence list

### DIFF
--- a/DemiCatPlugin/FcChatWindow.cs
+++ b/DemiCatPlugin/FcChatWindow.cs
@@ -11,9 +11,6 @@ namespace DemiCatPlugin;
 
 public class FcChatWindow : ChatWindow
 {
-    private readonly PresenceSidebar? _presenceSidebar;
-    private float _presenceWidth = 200f;
-
     protected override bool MentionsEnabled => true;
 
     public FcChatWindow(
@@ -40,14 +37,6 @@ public class FcChatWindow : ChatWindow
             emojiManager,
             chatBridge)
     {
-        if (presence != null)
-        {
-            _presenceSidebar = new PresenceSidebar(presence, config, httpClient)
-            {
-                TextureLoader = LoadTexture,
-                TextureTouch = TextureTouchAction
-            };
-        }
     }
 
     public override void StartNetworking()
@@ -71,12 +60,6 @@ public class FcChatWindow : ChatWindow
         {
             base.Draw();
             return;
-        }
-
-        if (_presenceSidebar != null)
-        {
-            _presenceSidebar.Draw(ref _presenceWidth);
-            ImGui.SameLine();
         }
 
         ImGui.BeginChild("##fcChat", ImGui.GetContentRegionAvail(), false);

--- a/DemiCatPlugin/MainWindow.cs
+++ b/DemiCatPlugin/MainWindow.cs
@@ -24,6 +24,7 @@ public class MainWindow : IDisposable
     private readonly TemplatesWindow _templates;
     private readonly RequestBoardWindow _requestBoard;
     private readonly NotePadWindow _notePad;
+    private readonly PresenceWindow _presence;
     private readonly EmojiManager _emojiManager;
     private readonly HttpClient _httpClient;
     private const float FadeAlphaTolerance = 0.001f;
@@ -53,6 +54,7 @@ public class MainWindow : IDisposable
         DockIds.Templates,
         DockIds.NotePad,
         DockIds.Requests,
+        DockIds.Presence,
         DockIds.Chat,
         DockIds.Officer
     };
@@ -91,7 +93,8 @@ public class MainWindow : IDisposable
         ChannelService channelService,
         ChannelSelectionService channelSelection,
         EmojiManager emojiManager,
-        NotePadWindow notePad)
+        NotePadWindow notePad,
+        PresenceWindow presence)
     {
         _config = config;
         _ui = ui;
@@ -104,6 +107,7 @@ public class MainWindow : IDisposable
         _templates = new TemplatesWindow(config, httpClient, channelService, channelSelection, emojiManager);
         _requestBoard = new RequestBoardWindow(config, httpClient);
         _notePad = notePad;
+        _presence = presence;
         _dockIconDirectory = PluginServices.Instance?.PluginInterface.AssemblyLocation.DirectoryName is { } dir
             ? Path.Combine(dir, "Dock")
             : null;
@@ -232,6 +236,15 @@ public class MainWindow : IDisposable
             () => ToggleWindow(DockIds.Requests)));
 
         AddDockItem(new DockItem(
+            DockIds.Presence,
+            "Roster",
+            "SyncShell.png",
+            () => _config.SyncedChat && IsLinked(),
+            () => _config.SyncedChat && IsLinked(),
+            () => GetWindowOpen(DockIds.Presence),
+            () => ToggleWindow(DockIds.Presence)));
+
+        AddDockItem(new DockItem(
             DockIds.Chat,
             _chat is FcChatWindow ? "FC Chat" : "Chat",
             "FCChat.png",
@@ -321,6 +334,11 @@ public class MainWindow : IDisposable
         if (!linked || !_config.Requests)
         {
             ForceWindowClosed(DockIds.Requests);
+        }
+
+        if (!linked || !_config.SyncedChat)
+        {
+            ForceWindowClosed(DockIds.Presence);
         }
 
         if (!linked || _chat == null || !_config.EnableFcChat || !_config.SyncedChat)
@@ -782,6 +800,7 @@ public class MainWindow : IDisposable
         public const string Templates = "templates";
         public const string NotePad = "notepad";
         public const string Requests = "requests";
+        public const string Presence = "presence";
         public const string Chat = "chat";
         public const string Officer = "officer";
         public const string Settings = "settings";
@@ -865,6 +884,20 @@ public class MainWindow : IDisposable
                 DockIds.Requests,
                 "Request Board",
                 () => _requestBoard.Draw(),
+                styleAlpha,
+                primaryColor,
+                childBaseColor,
+                tabBaseColor,
+                tabActiveBaseColor,
+                tabHoveredBaseColor);
+        }
+
+        if (GetWindowOpen(DockIds.Presence))
+        {
+            interacted |= DrawContentWindow(
+                DockIds.Presence,
+                "Roster",
+                () => _presence.Draw(),
                 styleAlpha,
                 primaryColor,
                 childBaseColor,

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -22,8 +22,6 @@ public class OfficerChatWindow : ChatWindow
     private const string NoOfficerAccessMessage = "No officer access for this key.";
     private DateTime _lastRolesRefresh = DateTime.MinValue;
     private bool _subscribed;
-    private readonly PresenceSidebar? _presenceSidebar;
-    private float _presenceWidth = 200f;
     private CancellationTokenSource? _refreshRolesCts;
 
     protected override bool MentionsEnabled => true;
@@ -52,15 +50,6 @@ public class OfficerChatWindow : ChatWindow
             emojiManager,
             chatBridge)
     {
-        if (presence != null)
-        {
-            _presenceSidebar = new PresenceSidebar(presence, config, httpClient)
-            {
-                TextureLoader = LoadTexture,
-                TextureTouch = TextureTouchAction
-            };
-        }
-
         _bridge.StatusChanged += OnBridgeStatusChangedForOfficer;
     }
 
@@ -174,23 +163,12 @@ public class OfficerChatWindow : ChatWindow
             Subscribe();
         }
 
-        var showPresence = _presenceSidebar != null && _tokenManager.IsReady();
-        if (showPresence)
-        {
-            _presenceSidebar!.Draw(ref _presenceWidth);
-            ImGui.SameLine();
-            ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), false);
-        }
-
+        ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), false);
         base.Draw();
 
         // Reserved padded area beneath the standard chat input for upcoming officer tools.
         ImGui.Dummy(new Vector2(0, ImGui.GetFrameHeightWithSpacing()));
-
-        if (showPresence)
-        {
-            ImGui.EndChild();
-        }
+        ImGui.EndChild();
     }
 
     protected override string MessagesPath => "/api/officer-messages";

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -41,6 +41,7 @@ public class Plugin : IDalamudPlugin
     private readonly ChatWindow _chatWindow;
     private readonly OfficerChatWindow _officerChatWindow;
     private readonly DiscordPresenceService _presenceService;
+    private readonly PresenceWindow _presenceWindow;
     private readonly MainWindow _mainWindow;
     private readonly ChannelWatcher _channelWatcher;
     private readonly RequestWatcher _requestWatcher;
@@ -128,6 +129,8 @@ public class Plugin : IDalamudPlugin
         _presenceService = new DiscordPresenceService(_config, _httpClient);
         _presenceService.SetPresenceReady(false);
 
+        _presenceWindow = new PresenceWindow(_presenceService, _config, _httpClient);
+
         _channelService = new ChannelService(_config, _httpClient, _tokenManager);
         _avatarCache = new AvatarCache(TextureProvider, _httpClient);
         _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _messageCache, _avatarCache, _emojiManager, _sharedChatBridge);
@@ -146,7 +149,8 @@ public class Plugin : IDalamudPlugin
             _channelService,
             _channelSelection,
             _emojiManager,
-            _notePadWindow
+            _notePadWindow,
+            _presenceWindow
         );
 
         _channelWatcher = new ChannelWatcher(_config, _ui, _mainWindow.EventCreateWindow, _mainWindow.TemplatesWindow, _chatWindow, _officerChatWindow, _tokenManager, _httpClient);
@@ -160,6 +164,7 @@ public class Plugin : IDalamudPlugin
         _settings.ChannelWatcher = _channelWatcher;
         _settings.RequestWatcher = _requestWatcher;
         _settings.NotePadService = _notePadService;
+        _settings.PresenceService = _presenceService;
 
         _mainWindow.HasOfficerAccess = OfficerPermissions.HasAccess(_config);
         _mainWindow.SetNotePadReadOnly(!_tokenManager.IsReady());
@@ -264,6 +269,7 @@ public class Plugin : IDalamudPlugin
         _requestWatcher.Dispose();
         _notePadWindow.Dispose();
         _notePadService.Dispose();
+        _presenceWindow.Dispose();
         _presenceService?.Dispose();
         _chatWindow.Dispose();
         _officerChatWindow.Dispose();

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -64,6 +64,41 @@ public class PresenceSidebar : IDisposable
 
     public void Draw(ref float width)
     {
+        DrawContent(new Vector2(width, 0));
+
+        ImGui.SameLine();
+        ImGui.InvisibleButton("##presence_resize", new Vector2(6, -1));
+        if (ImGui.IsItemActive())
+        {
+            width += ImGui.GetIO().MouseDelta.X;
+        }
+
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.SetMouseCursor(ResizeEwCursor);
+        }
+
+        width = Math.Clamp(width, 140f, 600f);
+    }
+
+    public void DrawStandalone()
+    {
+        var size = ImGui.GetContentRegionAvail();
+        if (size.X < 0f)
+        {
+            size.X = 0f;
+        }
+
+        if (size.Y < 0f)
+        {
+            size.Y = 0f;
+        }
+
+        DrawContent(size);
+    }
+
+    private void DrawContent(Vector2 size)
+    {
         var shouldReturn = false;
 
         void ShowStatus(string? message)
@@ -92,7 +127,8 @@ public class PresenceSidebar : IDisposable
 
         var hasSnapshot = _items.Count > 0;
 
-        ImGui.BeginChild("##presence", new Vector2(width, 0), true);
+        var clampedSize = new Vector2(MathF.Max(0f, size.X), MathF.Max(0f, size.Y));
+        ImGui.BeginChild("##presence", clampedSize, true);
 
         try
         {
@@ -264,20 +300,6 @@ public class PresenceSidebar : IDisposable
         finally
         {
             ImGui.EndChild();
-
-            ImGui.SameLine();
-            ImGui.InvisibleButton("##presence_resize", new Vector2(6, -1));
-            if (ImGui.IsItemActive())
-            {
-                width += ImGui.GetIO().MouseDelta.X;
-            }
-
-            if (ImGui.IsItemHovered())
-            {
-                ImGui.SetMouseCursor(ResizeEwCursor);
-            }
-
-            width = Math.Clamp(width, 140f, 600f);
         }
 
         if (shouldReturn)

--- a/DemiCatPlugin/PresenceWindow.cs
+++ b/DemiCatPlugin/PresenceWindow.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Net.Http;
+
+namespace DemiCatPlugin;
+
+/// <summary>
+/// Standalone window wrapper around <see cref="PresenceSidebar"/> so the
+/// roster can be surfaced independently from the chat views.
+/// </summary>
+public sealed class PresenceWindow : IDisposable
+{
+    private readonly PresenceSidebar _sidebar;
+
+    public PresenceWindow(DiscordPresenceService service, Config config, HttpClient httpClient)
+    {
+        _sidebar = new PresenceSidebar(service, config, httpClient)
+        {
+            TextureLoader = WebTextureCache.Get,
+            TextureTouch = TouchTexture
+        };
+    }
+
+    public void Draw()
+    {
+        _sidebar.DrawStandalone();
+    }
+
+    public void Dispose()
+    {
+        _sidebar.Dispose();
+    }
+
+    private static void TouchTexture(string? url)
+    {
+        if (string.IsNullOrEmpty(url))
+        {
+            return;
+        }
+
+        WebTextureCache.TryGetTexture(url, out _);
+    }
+}

--- a/DemiCatPlugin/SettingsWindow.cs
+++ b/DemiCatPlugin/SettingsWindow.cs
@@ -50,6 +50,7 @@ public class SettingsWindow : IDisposable
     public ChannelWatcher? ChannelWatcher { get; set; }
     public RequestWatcher? RequestWatcher { get; set; }
     public NotePadService? NotePadService { get; set; }
+    public DiscordPresenceService? PresenceService { get; set; }
 
     public SettingsWindow(Config config, TokenManager tokenManager, HttpClient httpClient, Func<Task<bool>> refreshRoles, Func<Task> startNetworking, IPluginLog log, IDalamudPluginInterface pluginInterface)
     {
@@ -554,6 +555,7 @@ public class SettingsWindow : IDisposable
             (MainWindow.DockIds.Templates, "Templates"),
             (MainWindow.DockIds.NotePad, "NotePad"),
             (MainWindow.DockIds.Requests, "Requests"),
+            (MainWindow.DockIds.Presence, "Roster"),
             (MainWindow.DockIds.Chat, "FC Chat"),
             (MainWindow.DockIds.Officer, "Officer Chat"),
         };
@@ -842,12 +844,8 @@ public class SettingsWindow : IDisposable
         }, "Failed to stop NotePad service.");
         SafeInvoke(() =>
         {
-            var presence = ChatWindow?.Presence ?? OfficerChatWindow?.Presence;
-            if (presence != null)
-            {
-                presence.SetPresenceReady(false);
-                presence.Stop();
-            }
+            PresenceService?.SetPresenceReady(false);
+            PresenceService?.Stop(clearPresences: true);
         }, "Failed to stop presence service.");
     }
 
@@ -951,7 +949,7 @@ public class SettingsWindow : IDisposable
     private async Task HardReloadIdentityAndStartInternalAsync()
     {
         var framework = PluginServices.Instance?.Framework;
-        var presence = ChatWindow?.Presence ?? OfficerChatWindow?.Presence;
+        var presence = _config.SyncedChat ? PresenceService : null;
         var presenceRestarted = false;
 
         void UpdateStatus(string status)
@@ -1164,9 +1162,12 @@ public class SettingsWindow : IDisposable
 
             try
             {
-                presence?.Reset();
-                presence?.Reload();
-                presenceRestarted = presence != null;
+                if (presence != null)
+                {
+                    presence.Reset();
+                    presence.Reload();
+                    presenceRestarted = true;
+                }
             }
             catch (Exception ex)
             {

--- a/tests/PluginChannelValidationTests.cs
+++ b/tests/PluginChannelValidationTests.cs
@@ -67,6 +67,8 @@ public class PluginChannelValidationTests
         var requestWatcher = new RequestWatcher(config, httpClient, tokenManager);
         var chatWindow = new ChatWindow(config, httpClient, null, tokenManager, channelService);
         var officerChatWindow = new OfficerChatWindow(config, httpClient, null, tokenManager, channelService);
+        var presenceService = new DiscordPresenceService(config, httpClient);
+        var presenceWindow = new PresenceWindow(presenceService, config, httpClient);
         var notePadService = new NotePadService(config, httpClient, tokenManager);
         var notePadWindow = new NotePadWindow(config, notePadService);
         var settingsWindow = new SettingsWindow(
@@ -89,7 +91,8 @@ public class PluginChannelValidationTests
             channelService,
             channelSelection,
             emojiManager,
-            notePadWindow
+            notePadWindow,
+            presenceWindow
         );
         var channelWatcher = new ChannelWatcher(
             config,
@@ -107,6 +110,7 @@ public class PluginChannelValidationTests
         settingsWindow.OfficerChatWindow = officerChatWindow;
         settingsWindow.ChannelWatcher = channelWatcher;
         settingsWindow.RequestWatcher = requestWatcher;
+        settingsWindow.PresenceService = presenceService;
 
         SetPrivateField(plugin, "_services", services);
         SetPrivateField(plugin, "_config", config);
@@ -118,6 +122,7 @@ public class PluginChannelValidationTests
         SetPrivateField(plugin, "_ui", ui);
         SetPrivateField(plugin, "_settings", settingsWindow);
         SetPrivateField(plugin, "_chatWindow", chatWindow);
+        SetPrivateField(plugin, "_presenceWindow", presenceWindow);
         SetPrivateField(plugin, "_officerChatWindow", officerChatWindow);
         SetPrivateField(plugin, "_mainWindow", mainWindow);
         SetPrivateField(plugin, "_channelWatcher", channelWatcher);


### PR DESCRIPTION
## Summary
- add a `PresenceWindow` wrapper so the roster can render independently using the existing sidebar logic
- remove the embedded presence UI from the FC and officer chat windows and expose the roster through a new dock item in the main window
- wire the plugin and settings flow to manage the shared presence service directly for the new window

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f3749426188328a2bb534596fd8344