### PR TITLE
Fix nullable texture loader delegate in presence window

### DIFF
--- a/DemiCatPlugin/PresenceWindow.cs
+++ b/DemiCatPlugin/PresenceWindow.cs
@@ -15,7 +15,16 @@ public sealed class PresenceWindow : IDisposable
     {
         _sidebar = new PresenceSidebar(service, config, httpClient)
         {
-            TextureLoader = WebTextureCache.Get,
+            TextureLoader = static (url, onReady) =>
+            {
+                if (string.IsNullOrEmpty(url))
+                {
+                    onReady(null);
+                    return;
+                }
+
+                WebTextureCache.Get(url, onReady);
+            },
             TextureTouch = TouchTexture
         };
     }


### PR DESCRIPTION
## Summary
- wrap the presence window texture loader to guard against null URLs before calling `WebTextureCache`

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f37a6235308328a47c50b060639202