### PR TITLE
Handle uppercase channel kind queries and fix roster response models

### DIFF
--- a/demibot/demibot/http/routes/channels.py
+++ b/demibot/demibot/http/routes/channels.py
@@ -180,14 +180,15 @@ async def get_channels(
         return {"id": str(channel_id), "name": new_name}, changed
 
     # Allow fetching a single channel kind for plugin convenience
-    single_kinds = {
-        ChannelKind.EVENT.value: ChannelKind.EVENT,
-        ChannelKind.FC_CHAT.value: ChannelKind.FC_CHAT,
-        ChannelKind.OFFICER_CHAT.value: ChannelKind.OFFICER_CHAT,
-        ChannelKind.REQUESTS.value: ChannelKind.REQUESTS,
+    single_kind_targets = {
+        ChannelKind.EVENT,
+        ChannelKind.FC_CHAT,
+        ChannelKind.OFFICER_CHAT,
+        ChannelKind.REQUESTS,
     }
-    if kind in single_kinds:
-        channel_kind = single_kinds[kind]
+    requested_kind = _parse_channel_kind(kind)
+    if requested_kind in single_kind_targets:
+        channel_kind = requested_kind
         result = await db.execute(
             select(GuildChannel.channel_id, GuildChannel.name).where(
                 GuildChannel.guild_id == ctx.guild.id,

--- a/demibot/demibot/http/routes/presences.py
+++ b/demibot/demibot/http/routes/presences.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
+from typing import Any
 from sqlalchemy import and_, select
 
 from ..deps import RequestContext, api_key_auth
@@ -35,7 +36,7 @@ router = APIRouter(prefix="/api")
 @router.get("/presences")
 async def list_presences(
     ctx: RequestContext = Depends(api_key_auth),
-) -> list[dict[str, str | list[str] | None]]:
+) -> list[dict[str, Any]]:
     db_presences: list[dict[str, object | None]] | None = None
     try:
         async with get_session() as db:

--- a/demibot/demibot/http/routes/users.py
+++ b/demibot/demibot/http/routes/users.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import and_, select
@@ -52,7 +53,7 @@ async def get_me(
 async def get_users(
     ctx: RequestContext = Depends(api_key_auth),
     db: AsyncSession = Depends(get_db),
-):
+) -> list[dict[str, Any]]:
     discord_guild_id = getattr(ctx.guild, "discord_guild_id", None)
     if discord_guild_id is None:
         discord_guild_id = ctx.guild.id


### PR DESCRIPTION
## Summary
- treat the `kind` query parameter on `/api/channels` case-insensitively so uppercase values from the plugin still return a list response
- relax the `/api/presences` and `/api/users` response annotations so FastAPI no longer rejects role detail dictionaries

## Testing
- python -m compileall demibot/demibot/http/routes

------
https://chatgpt.com/codex/tasks/task_e_68f3875afea48328b35ae711045ed7ce