### PR TITLE
Make SyncShell drop migration a no-op

### DIFF
--- a/demibot/demibot/db/migrations/versions/0058_drop_syncshell_tables.py
+++ b/demibot/demibot/db/migrations/versions/0058_drop_syncshell_tables.py
@@ -9,9 +9,6 @@ from __future__ import annotations
 
 from typing import Sequence, Union
 
-import sqlalchemy as sa
-from alembic import op
-
 # revision identifiers, used by Alembic.
 revision: str = "0058_drop_syncshell_tables"
 down_revision: Union[str, None] = "0057_expand_presence_status_text_to_text"
@@ -19,67 +16,18 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-def _table_exists(table_name: str) -> bool:
-    inspector = sa.inspect(op.get_bind())
-    return inspector.has_table(table_name)
-
-
-def _drop_index_if_exists(index_name: str, table_name: str) -> None:
-    inspector = sa.inspect(op.get_bind())
-    if not inspector.has_table(table_name):
-        return
-
-    indexes = {index["name"] for index in inspector.get_indexes(table_name)}
-    if index_name in indexes:
-        op.drop_index(index_name, table_name=table_name)
-
-
-def _drop_table_if_exists(table_name: str) -> None:
-    if _table_exists(table_name):
-        op.drop_table(table_name)
-
-
 def upgrade() -> None:
-    """Remove legacy SyncShell tables when present."""
+    """Intentionally left blank.
 
-    # Drop syncshell presence tracking tables
-    _drop_index_if_exists("ix_syncshell_presence_member_user_id", "syncshell_presence")
-    _drop_index_if_exists("ix_syncshell_presence_user_id", "syncshell_presence")
-    _drop_table_if_exists("syncshell_presence")
+    SyncShell tables are ignored going forward, so this migration performs no
+    schema changes to keep the history linear without touching existing data.
+    """
 
-    _drop_index_if_exists("ix_syncshell_members_member_user_id", "syncshell_members")
-    _drop_index_if_exists("ix_syncshell_members_user_id", "syncshell_members")
-    _drop_table_if_exists("syncshell_members")
-
-    # Drop invite tables and related indexes
-    _drop_index_if_exists("ix_syncshell_invites_target_status", "syncshell_invites")
-    _drop_index_if_exists(
-        "ix_syncshell_invites_inviter_target_display_name_status",
-        "syncshell_invites",
-    )
-    _drop_index_if_exists(
-        "ix_syncshell_invites_inviter_target_user_status",
-        "syncshell_invites",
-    )
-    _drop_index_if_exists("ix_syncshell_invites_status", "syncshell_invites")
-    _drop_index_if_exists("ix_syncshell_invites_target_user_id", "syncshell_invites")
-    _drop_index_if_exists("ix_syncshell_invites_inviter_id", "syncshell_invites")
-    _drop_table_if_exists("syncshell_invites")
-
-    # Drop transfer budget tracking
-    _drop_table_if_exists("syncshell_transfer_budgets")
-
-    # Drop pairing metadata and rate limits
-    _drop_table_if_exists("syncshell_rate_limits")
-    _drop_index_if_exists("ix_syncshell_pairings_expires_at", "syncshell_pairings")
-    _drop_index_if_exists("ix_syncshell_pairings_token", "syncshell_pairings")
-    _drop_table_if_exists("syncshell_pairings")
-    _drop_table_if_exists("syncshell_manifests")
+    return None
 
 
 def downgrade() -> None:
-    """Downgrade is a no-op because SyncShell support was removed entirely."""
+    """Downgrade is also a no-op."""
 
-    # SyncShell is deprecated; keep schema unchanged on downgrade.
-    pass
+    return None
 


### PR DESCRIPTION
## Summary
- make the 0058 SyncShell migration a no-op so the schema history stays linear without dropping tables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3b70c48948328ba2b142544a732be