### PR TITLE
Handle optional route imports

### DIFF
--- a/demibot/demibot/http/api.py
+++ b/demibot/demibot/http/api.py
@@ -82,7 +82,16 @@ def create_app() -> FastAPI:
     from . import routes as routes_pkg
 
     for _, module_name, _ in pkgutil.iter_modules(routes_pkg.__path__):
-        module = import_module(f"{routes_pkg.__name__}.{module_name}")
+        try:
+            module = import_module(f"{routes_pkg.__name__}.{module_name}")
+        except ImportError as exc:
+            logger.warning(
+                "routes.import_failed",
+                module=module_name,
+                error=str(exc),
+            )
+            continue
+
         router = getattr(module, "router", None)
         if router is not None:
             app.include_router(router)


### PR DESCRIPTION
## Summary
- skip FastAPI route modules that fail to import so the server continues starting
- log a warning when a route import fails for easier diagnosis

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3bdb2478883288bfea8f5a6820eae