### PR TITLE
Normalize awaiting_confirm status usage and migrate legacy values

### DIFF
--- a/DemiCatPlugin/RequestBoardWindow.cs
+++ b/DemiCatPlugin/RequestBoardWindow.cs
@@ -327,6 +327,7 @@ public class RequestBoardWindow
         "claimed" => RequestStatus.Claimed,
         "in_progress" => RequestStatus.InProgress,
         "awaiting_confirm" => RequestStatus.AwaitingConfirm,
+        "awaiting_confirmation" => RequestStatus.AwaitingConfirm,
         "completed" => RequestStatus.Completed,
         "cancelled" => RequestStatus.Cancelled,
         "approved" => RequestStatus.Approved,

--- a/DemiCatPlugin/RequestStateService.cs
+++ b/DemiCatPlugin/RequestStateService.cs
@@ -243,6 +243,7 @@ internal static class RequestStateService
         "claimed" => RequestStatus.Claimed,
         "in_progress" => RequestStatus.InProgress,
         "awaiting_confirm" => RequestStatus.AwaitingConfirm,
+        "awaiting_confirmation" => RequestStatus.AwaitingConfirm,
         "completed" => RequestStatus.Completed,
         "cancelled" => RequestStatus.Cancelled,
         "approved" => RequestStatus.Approved,

--- a/DemiCatPlugin/RequestWatcher.cs
+++ b/DemiCatPlugin/RequestWatcher.cs
@@ -294,6 +294,7 @@ public class RequestWatcher : IDisposable
                 "claimed" => RequestStatus.Claimed,
                 "in_progress" => RequestStatus.InProgress,
                 "awaiting_confirm" => RequestStatus.AwaitingConfirm,
+                "awaiting_confirmation" => RequestStatus.AwaitingConfirm,
                 "completed" => RequestStatus.Completed,
                 "cancelled" => RequestStatus.Cancelled,
                 "approved" => RequestStatus.Approved,

--- a/demibot/demibot/db/migrations/versions/0060_fix_request_status_spelling.py
+++ b/demibot/demibot/db/migrations/versions/0060_fix_request_status_spelling.py
@@ -1,0 +1,41 @@
+"""normalize awaiting_confirm status spelling
+
+Revision ID: 0060_fix_request_status_spelling
+Revises: 0059_remove_syncshell_tables
+Create Date: 2025-01-05
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0060_fix_request_status_spelling"
+down_revision = "0059_remove_syncshell_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE requests
+            SET status = 'awaiting_confirm'
+            WHERE status = 'awaiting_confirmation'
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE requests
+            SET status = 'awaiting_confirmation'
+            WHERE status = 'awaiting_confirm'
+            """
+        )
+    )


### PR DESCRIPTION
## Summary
- normalize the Dalamud plugin's request status parsing so any legacy `awaiting_confirmation` payloads are treated as the canonical `awaiting_confirm`
- add an Alembic migration that rewrites legacy request status rows to the canonical spelling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3c6f349988328a6b5642686dac393