### PR TITLE
Handle empty presence updates and align role metadata caching

### DIFF
--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -636,9 +636,9 @@ public class DiscordPresenceService : IDisposable
             changed = true;
         }
 
-        if (!string.IsNullOrWhiteSpace(dto.StatusText))
+        if (dto.StatusTextProvided)
         {
-            var sanitized = string.IsNullOrWhiteSpace(dto.StatusText) ? null : dto.StatusText;
+            var sanitized = dto.StatusText;
             if (!string.Equals(existing.StatusText, sanitized, StringComparison.Ordinal))
             {
                 existing.StatusText = sanitized;
@@ -646,21 +646,63 @@ public class DiscordPresenceService : IDisposable
             }
         }
 
-        if (dto.Roles.Count > 0 && !ReferenceEquals(existing.Roles, dto.Roles))
+        if (dto.RolesProvided)
         {
-            existing.Roles = dto.Roles;
-            changed = true;
+            if (!existing.Roles.SequenceEqual(dto.Roles))
+            {
+                existing.Roles = dto.Roles;
+                changed = true;
+            }
         }
 
-        if (dto.RoleDetails.Count > 0 && !ReferenceEquals(existing.RoleDetails, dto.RoleDetails))
+        if (dto.RoleDetailsProvided)
         {
-            existing.RoleDetails = dto.RoleDetails;
-            changed = true;
+            if (!RoleDetailsEqual(existing.RoleDetails, dto.RoleDetails))
+            {
+                existing.RoleDetails = dto.RoleDetails;
+                changed = true;
+            }
         }
 
         if (changed)
         {
             existing.Touch();
+        }
+
+        static bool RoleDetailsEqual(List<PresenceRoleDto> left, List<PresenceRoleDto> right)
+        {
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+
+            if (left.Count != right.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < left.Count; i++)
+            {
+                var a = left[i];
+                var b = right[i];
+                if (a == null && b == null)
+                {
+                    continue;
+                }
+
+                if (a == null || b == null)
+                {
+                    return false;
+                }
+
+                if (!string.Equals(a.Id, b.Id, StringComparison.Ordinal) ||
+                    !string.Equals(a.Name, b.Name, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 

--- a/DemiCatPlugin/PresenceDto.cs
+++ b/DemiCatPlugin/PresenceDto.cs
@@ -12,12 +12,20 @@ public class PresenceDto
     [JsonPropertyName("status")] public string Status { get; set; } = string.Empty;
 
     private string? _statusText;
+    private bool _statusTextProvided;
+
+    [JsonIgnore]
+    public bool StatusTextProvided => _statusTextProvided;
 
     [JsonIgnore]
     public string? StatusText
     {
         get => _statusText;
-        set => _statusText = string.IsNullOrWhiteSpace(value) ? null : value;
+        set
+        {
+            _statusTextProvided = true;
+            _statusText = string.IsNullOrWhiteSpace(value) ? null : value;
+        }
     }
 
     [JsonPropertyName("status_text")]
@@ -128,15 +136,38 @@ public class PresenceDto
     [JsonIgnore]
     public long Revision { get; private set; }
 
-    [JsonPropertyName("roles")] public List<string> Roles { get; set; } = new();
+    private List<string> _roles = new();
+    private bool _rolesProvided;
+
+    [JsonIgnore]
+    public bool RolesProvided => _rolesProvided;
+
+    [JsonPropertyName("roles")]
+    public List<string> Roles
+    {
+        get => _roles;
+        set
+        {
+            _rolesProvided = true;
+            _roles = value ?? new List<string>();
+        }
+    }
 
     private List<PresenceRoleDto> _roleDetails = new();
+    private bool _roleDetailsProvided;
+
+    [JsonIgnore]
+    public bool RoleDetailsProvided => _roleDetailsProvided;
 
     [JsonIgnore]
     public List<PresenceRoleDto> RoleDetails
     {
         get => _roleDetails;
-        set => _roleDetails = value ?? new List<PresenceRoleDto>();
+        set
+        {
+            _roleDetailsProvided = true;
+            _roleDetails = value ?? new List<PresenceRoleDto>();
+        }
     }
 
     [JsonPropertyName("role_details")]

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -212,7 +212,7 @@ public class PresenceSidebar : IDisposable
 
                             foreach (var card in cards)
                             {
-                                card.EnsureMetadata(roleById);
+                                card.EnsureMetadata(roleById, roleVersion);
                             }
 
                             var online = cards
@@ -510,7 +510,7 @@ public class PresenceSidebar : IDisposable
     private sealed class PresenceCard
     {
         private long _cachedRevision = long.MinValue;
-        private int _cachedRoleVersion = -1;
+        private long _cachedRoleVersion = long.MinValue;
         private readonly List<string> _roleNames = new();
 
         public PresenceCard(PresenceDto presence)
@@ -535,13 +535,12 @@ public class PresenceSidebar : IDisposable
         public void InvalidateMetadata()
         {
             _cachedRevision = long.MinValue;
-            _cachedRoleVersion = -1;
+            _cachedRoleVersion = long.MinValue;
         }
 
-        public void EnsureMetadata(IReadOnlyDictionary<string, RoleDto> roleById)
+        public void EnsureMetadata(IReadOnlyDictionary<string, RoleDto>? roleById, long roleVersion)
         {
             var revision = Presence.Revision;
-            var roleVersion = roleById?.Count ?? 0;
             if (_cachedRevision == revision && _cachedRoleVersion == roleVersion)
             {
                 return;

--- a/tests/DiscordPresenceServiceTests.cs
+++ b/tests/DiscordPresenceServiceTests.cs
@@ -428,6 +428,73 @@ public class DiscordPresenceServiceTests
     }
 
     [Fact]
+    public void ApplyPresenceUpdate_ClearsRolesWhenEmptyListProvided()
+    {
+        var config = new Config { ApiBaseUrl = "http://unit-test" };
+        using var httpClient = new HttpClient(new StubPresenceHandler());
+        var service = new DiscordPresenceService(config, httpClient);
+
+        var field = typeof(DiscordPresenceService).GetField("_presences", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (List<PresenceDto>)field.GetValue(service)!;
+
+        var existing = new PresenceDto
+        {
+            Id = "200",
+            Name = "WithRoles",
+            Status = "online"
+        };
+        existing.Roles.Add("a");
+        existing.RoleDetails.Add(new PresenceRoleDto { Id = "a", Name = "Role" });
+        list.Add(existing);
+
+        var update = new PresenceDto
+        {
+            Id = "200",
+            Name = "WithRoles",
+            Status = "online",
+            Roles = new List<string>(),
+            RoleDetails = new List<PresenceRoleDto>()
+        };
+
+        service.ApplyPresenceUpdate(update);
+
+        Assert.Empty(existing.Roles);
+        Assert.Empty(existing.RoleDetails);
+    }
+
+    [Fact]
+    public void ApplyPresenceUpdate_ClearsStatusTextWhenEmptyStringProvided()
+    {
+        var config = new Config { ApiBaseUrl = "http://unit-test" };
+        using var httpClient = new HttpClient(new StubPresenceHandler());
+        var service = new DiscordPresenceService(config, httpClient);
+
+        var field = typeof(DiscordPresenceService).GetField("_presences", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (List<PresenceDto>)field.GetValue(service)!;
+
+        var existing = new PresenceDto
+        {
+            Id = "201",
+            Name = "Status",
+            Status = "online",
+            StatusText = "Hello"
+        };
+        list.Add(existing);
+
+        var update = new PresenceDto
+        {
+            Id = "201",
+            Name = "Status",
+            Status = "online",
+            StatusText = string.Empty
+        };
+
+        service.ApplyPresenceUpdate(update);
+
+        Assert.Null(existing.StatusText);
+    }
+
+    [Fact]
     public void ApplyPresenceUpdate_NewBannerClearsOldTexture()
     {
         var config = new Config { ApiBaseUrl = "http://unit-test" };


### PR DESCRIPTION
## Summary
- treat empty status text and role payloads as explicit clears while avoiding unnecessary churn
- track presence DTO field availability to decide when to mutate cached presences
- rely on the shared role cache version when caching card metadata and cover the new behavior with tests

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f3cb96b6f88328b1519ab51ba3237c