### PR TITLE
Improve presence cache resilience and add coverage

### DIFF
--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -536,6 +536,10 @@ public class DiscordPresenceService : IDisposable
             var presence = _presences[idx];
             var oldId = presence.Id;
             MutatePresenceInPlace(presence, dto);
+            if (!string.Equals(oldId, presence.Id, StringComparison.Ordinal))
+            {
+                PluginServices.Instance?.Log.Warning($"Presence Id changed {oldId} -> {presence.Id}");
+            }
             UpdateIndexForIdChange(idx, oldId, presence.Id);
         }
         else
@@ -546,6 +550,10 @@ public class DiscordPresenceService : IDisposable
                 var presence = _presences[idx];
                 var oldId = presence.Id;
                 MutatePresenceInPlace(presence, dto);
+                if (!string.Equals(oldId, presence.Id, StringComparison.Ordinal))
+                {
+                    PluginServices.Instance?.Log.Warning($"Presence Id changed {oldId} -> {presence.Id}");
+                }
                 UpdateIndexForIdChange(idx, oldId, presence.Id);
             }
             else
@@ -577,6 +585,7 @@ public class DiscordPresenceService : IDisposable
                 existing.AvatarTexture = null;
                 existing.AvatarLoadFailed = false;
                 existing.AvatarLoadRequested = false;
+                existing.AvatarFailedAt = null;
                 changed = true;
             }
         }
@@ -589,6 +598,7 @@ public class DiscordPresenceService : IDisposable
                 existing.BannerTexture = null;
                 existing.BannerLoadFailed = false;
                 existing.BannerLoadRequested = false;
+                existing.BannerFailedAt = null;
                 changed = true;
             }
         }
@@ -607,6 +617,7 @@ public class DiscordPresenceService : IDisposable
         {
             existing.AvatarTexture = dto.AvatarTexture;
             existing.AvatarLoadFailed = false;
+            existing.AvatarFailedAt = null;
             changed = true;
         }
 
@@ -614,6 +625,7 @@ public class DiscordPresenceService : IDisposable
         {
             existing.BannerTexture = dto.BannerTexture;
             existing.BannerLoadFailed = false;
+            existing.BannerFailedAt = null;
             changed = true;
         }
 

--- a/DemiCatPlugin/PresenceDto.cs
+++ b/DemiCatPlugin/PresenceDto.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Text.Json.Serialization;
@@ -76,6 +77,7 @@ public class PresenceDto
     [JsonIgnore] public ISharedImmediateTexture? AvatarTexture { get; set; }
     [JsonIgnore] public bool AvatarLoadRequested { get; set; }
     [JsonIgnore] public bool AvatarLoadFailed { get; set; }
+    [JsonIgnore] public DateTime? AvatarFailedAt { get; set; }
 
     private string? _bannerUrl;
 
@@ -107,6 +109,7 @@ public class PresenceDto
     [JsonIgnore] public ISharedImmediateTexture? BannerTexture { get; set; }
     [JsonIgnore] public bool BannerLoadRequested { get; set; }
     [JsonIgnore] public bool BannerLoadFailed { get; set; }
+    [JsonIgnore] public DateTime? BannerFailedAt { get; set; }
 
     private uint? _accentColorValue;
 
@@ -210,6 +213,8 @@ public class PresenceDto
         BannerLoadRequested = false;
         AvatarLoadFailed = false;
         BannerLoadFailed = false;
+        AvatarFailedAt = null;
+        BannerFailedAt = null;
     }
 }
 

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -41,6 +41,7 @@ public class PresenceSidebar : IDisposable
         "offline",
         "invisible",
     };
+    private static readonly TimeSpan TextureRetryWindow = TimeSpan.FromSeconds(45);
 
     private const string PresenceUnavailableMessage = "Presence unavailable";
     private static readonly TimeSpan RefreshCooldown = TimeSpan.FromSeconds(1);
@@ -332,6 +333,19 @@ public class PresenceSidebar : IDisposable
         ImGui.PushID(presence.Id);
         var drawList = ImGui.GetWindowDrawList();
 
+        var now = DateTime.UtcNow;
+        if (presence.AvatarLoadFailed && (!presence.AvatarFailedAt.HasValue || now - presence.AvatarFailedAt.Value >= TextureRetryWindow))
+        {
+            presence.AvatarLoadFailed = false;
+            presence.AvatarFailedAt = null;
+        }
+
+        if (presence.BannerLoadFailed && (!presence.BannerFailedAt.HasValue || now - presence.BannerFailedAt.Value >= TextureRetryWindow))
+        {
+            presence.BannerLoadFailed = false;
+            presence.BannerFailedAt = null;
+        }
+
         const float rowHeight = 44f;
         var backgroundMin = ImGui.GetCursorScreenPos();
         var availableWidth = MathF.Max(0f, ImGui.GetContentRegionAvail().X);
@@ -366,6 +380,7 @@ public class PresenceSidebar : IDisposable
                 presence.AvatarTexture = t;
                 presence.AvatarLoadRequested = false;
                 presence.AvatarLoadFailed = t == null;
+                presence.AvatarFailedAt = t == null ? DateTime.UtcNow : null;
             });
         }
 
@@ -388,6 +403,7 @@ public class PresenceSidebar : IDisposable
                 presence.AvatarTexture = null;
                 presence.AvatarLoadRequested = false;
                 presence.AvatarLoadFailed = false;
+                presence.AvatarFailedAt = null;
                 if (TextureLoader != null && !string.IsNullOrEmpty(presence.AvatarUrl))
                 {
                     presence.AvatarLoadRequested = true;
@@ -396,6 +412,7 @@ public class PresenceSidebar : IDisposable
                         presence.AvatarTexture = t;
                         presence.AvatarLoadRequested = false;
                         presence.AvatarLoadFailed = t == null;
+                        presence.AvatarFailedAt = t == null ? DateTime.UtcNow : null;
                     });
                 }
             }
@@ -635,6 +652,7 @@ public class PresenceSidebar : IDisposable
                     presence.BannerTexture = t;
                     presence.BannerLoadRequested = false;
                     presence.BannerLoadFailed = t == null;
+                    presence.BannerFailedAt = t == null ? DateTime.UtcNow : null;
                 });
             }
             return;
@@ -658,6 +676,7 @@ public class PresenceSidebar : IDisposable
                 presence.BannerTexture = null;
                 presence.BannerLoadRequested = false;
                 presence.BannerLoadFailed = false;
+                presence.BannerFailedAt = null;
             }
         }
 
@@ -670,6 +689,7 @@ public class PresenceSidebar : IDisposable
                 presence.BannerTexture = t;
                 presence.BannerLoadRequested = false;
                 presence.BannerLoadFailed = t == null;
+                presence.BannerFailedAt = t == null ? DateTime.UtcNow : null;
             });
         }
 

--- a/tests/DiscordPresenceServiceTests.cs
+++ b/tests/DiscordPresenceServiceTests.cs
@@ -531,6 +531,124 @@ public class DiscordPresenceServiceTests
     }
 
     [Fact]
+    public void ApplyPresenceUpdate_RoleReorderDoesNotTouch()
+    {
+        var config = new Config { ApiBaseUrl = "http://unit-test" };
+        using var httpClient = new HttpClient(new StubPresenceHandler());
+        var service = new DiscordPresenceService(config, httpClient);
+
+        var listField = typeof(DiscordPresenceService).GetField("_presences", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (List<PresenceDto>)listField.GetValue(service)!;
+
+        var existing = new PresenceDto
+        {
+            Id = "501",
+            Name = "RoleUser",
+            Status = "online",
+        };
+        existing.Roles = new List<string> { "a", "b" };
+        existing.Touch();
+        var initialRevision = existing.Revision;
+        list.Add(existing);
+
+        var update = new PresenceDto
+        {
+            Id = "501",
+            Name = "RoleUser",
+            Status = "online",
+            Roles = new List<string> { "b", "a" }
+        };
+
+        service.ApplyPresenceUpdate(update);
+
+        Assert.Equal(initialRevision, existing.Revision);
+        Assert.NotSame(update.Roles, existing.Roles);
+        Assert.Equal(new[] { "a", "b" }, existing.Roles);
+    }
+
+    [Fact]
+    public void ApplyPresenceUpdate_IdChangeUpdatesIndex()
+    {
+        var config = new Config { ApiBaseUrl = "http://unit-test" };
+        using var httpClient = new HttpClient(new StubPresenceHandler());
+        var service = new DiscordPresenceService(config, httpClient);
+
+        var listField = typeof(DiscordPresenceService).GetField("_presences", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (List<PresenceDto>)listField.GetValue(service)!;
+        var indexField = typeof(DiscordPresenceService).GetField("_indexById", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var index = (Dictionary<string, int>)indexField.GetValue(service)!;
+
+        var existing = new PresenceDto
+        {
+            Id = "99",
+            Name = "Indexed",
+            Status = "online",
+        };
+        list.Add(existing);
+        index["99"] = 0;
+
+        var update = new PresenceDto
+        {
+            Id = "100",
+            Name = "Indexed",
+            Status = "online"
+        };
+
+        service.ApplyPresenceUpdate(update);
+
+        Assert.Equal("100", existing.Id);
+        Assert.True(index.TryGetValue("100", out var mappedIndex));
+        Assert.Equal(0, mappedIndex);
+        Assert.DoesNotContain(index.Keys, key => key == "99");
+    }
+
+    [Fact]
+    public void ApplyPresenceUpdate_AvatarUrlChangeResetsTransientState()
+    {
+        var config = new Config { ApiBaseUrl = "http://unit-test" };
+        using var httpClient = new HttpClient(new StubPresenceHandler());
+        var service = new DiscordPresenceService(config, httpClient);
+
+        var listField = typeof(DiscordPresenceService).GetField("_presences", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = (List<PresenceDto>)listField.GetValue(service)!;
+        var indexField = typeof(DiscordPresenceService).GetField("_indexById", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var index = (Dictionary<string, int>)indexField.GetValue(service)!;
+
+        var texture = Mock.Of<ISharedImmediateTexture>();
+        var existing = new PresenceDto
+        {
+            Id = "75",
+            Name = "AvatarUser",
+            Status = "online",
+            AvatarUrl = "https://example.com/old.png",
+            AvatarTexture = texture,
+            AvatarLoadRequested = true,
+            AvatarLoadFailed = true,
+            AvatarFailedAt = DateTime.UtcNow.AddMinutes(-5),
+        };
+        list.Add(existing);
+        index["75"] = 0;
+        var previousRevision = existing.Revision;
+
+        var update = new PresenceDto
+        {
+            Id = "75",
+            Name = "AvatarUser",
+            Status = "online",
+            AvatarUrl = "https://example.com/new.png"
+        };
+
+        service.ApplyPresenceUpdate(update);
+
+        Assert.Equal("https://example.com/new.png", existing.AvatarUrl);
+        Assert.Null(existing.AvatarTexture);
+        Assert.False(existing.AvatarLoadRequested);
+        Assert.False(existing.AvatarLoadFailed);
+        Assert.Null(existing.AvatarFailedAt);
+        Assert.True(existing.Revision > previousRevision);
+    }
+
+    [Fact]
     public void ApplyPresenceSnapshot_MutatesExistingEntriesAndRemovesMissing()
     {
         var config = new Config { ApiBaseUrl = "http://unit-test" };


### PR DESCRIPTION
## Summary
- log presence identifier changes and reset transient fields whenever URLs or textures update
- track avatar and banner load failure timestamps to allow periodic retries in the sidebar renderer
- cover role reordering, identifier updates, and avatar URL transitions with new presence service tests

## Testing
- dotnet test tests/DemiCatPlugin.Tests.csproj *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3d123f7d883289beb5cade661a075