### PR TITLE
Guard presence index collision on ID updates

### DIFF
--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -795,7 +795,14 @@ public class DiscordPresenceService : IDisposable
 
         if (!string.IsNullOrWhiteSpace(newId))
         {
-            _indexById[newId] = idx;
+            if (_indexById.TryGetValue(newId, out var otherIdx) && otherIdx != idx)
+            {
+                Reindex();
+            }
+            else
+            {
+                _indexById[newId] = idx;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent overwriting existing presence indices when IDs collide by rebuilding the index if needed

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f3d4a5e30483288bc904256dbad983