### PR TITLE
Add officer member management UI and API

### DIFF
--- a/DemiCatPlugin/ManageMembersWindow.cs
+++ b/DemiCatPlugin/ManageMembersWindow.cs
@@ -1,0 +1,676 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility;
+using System.Numerics;
+
+namespace DemiCatPlugin;
+
+public sealed class ManageMembersWindow
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private const string ConfirmPopupId = "Confirm Member Action##dc_manage_members";
+
+    private readonly Config _config;
+    private readonly HttpClient _httpClient;
+    private readonly TokenManager _tokenManager;
+    private readonly object _sync = new();
+    private readonly List<MemberEntry> _members = new();
+
+    private bool _loading;
+    private bool _actionInProgress;
+    private string _statusMessage = string.Empty;
+    private bool _statusIsError;
+    private PendingActionKind _pendingAction = PendingActionKind.None;
+    private MemberEntry? _pendingMember;
+    private bool _needsInitialRefresh = true;
+
+    private enum PendingActionKind
+    {
+        None,
+        Remove,
+        Ban
+    }
+
+    private sealed record MemberEntry
+    {
+        public string DiscordUserId { get; init; } = string.Empty;
+        public string DisplayName { get; init; } = string.Empty;
+        public string? Nickname { get; init; }
+        public string? GlobalName { get; init; }
+        public string? CharacterName { get; init; }
+        public DateTimeOffset? LastUsedAt { get; init; }
+        public bool IsBanned { get; init; }
+    }
+
+    private sealed record MemberDto
+    {
+        [JsonPropertyName("discordUserId")]
+        public string? DiscordUserId { get; init; }
+
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; init; }
+
+        [JsonPropertyName("nickname")]
+        public string? Nickname { get; init; }
+
+        [JsonPropertyName("globalName")]
+        public string? GlobalName { get; init; }
+
+        [JsonPropertyName("characterName")]
+        public string? CharacterName { get; init; }
+
+        [JsonPropertyName("lastUsedAt")]
+        public string? LastUsedAt { get; init; }
+
+        [JsonPropertyName("isBanned")]
+        public bool IsBanned { get; init; }
+    }
+
+    private readonly struct FetchResult
+    {
+        public FetchResult(List<MemberEntry> members, string message, bool isError)
+        {
+            Members = members;
+            Message = message;
+            IsError = isError;
+        }
+
+        public List<MemberEntry> Members { get; }
+        public string Message { get; }
+        public bool IsError { get; }
+    }
+
+    public bool IsOpen { get; set; }
+
+    public ManageMembersWindow(Config config, HttpClient httpClient, TokenManager tokenManager)
+    {
+        _config = config;
+        _httpClient = httpClient;
+        _tokenManager = tokenManager;
+    }
+
+    public void Open()
+    {
+        IsOpen = true;
+        _needsInitialRefresh = true;
+    }
+
+    public void Reset()
+    {
+        lock (_sync)
+        {
+            _members.Clear();
+            _loading = false;
+            _actionInProgress = false;
+            _statusMessage = string.Empty;
+            _statusIsError = false;
+            _pendingAction = PendingActionKind.None;
+            _pendingMember = null;
+            _needsInitialRefresh = true;
+        }
+
+        IsOpen = false;
+    }
+
+    public void Draw()
+    {
+        if (!IsOpen)
+        {
+            return;
+        }
+
+        using var scope = new UiStyleScope(_config);
+        ImGui.SetNextWindowSize(new Vector2(560f, 480f), ImGuiCond.FirstUseEver);
+
+        var open = IsOpen;
+        ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0f);
+        var flags = ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoTitleBar;
+        var began = ImGui.Begin("Manage Members##dc_manage_members", ref open, flags);
+        if (began)
+        {
+            var style = ImGui.GetStyle();
+            var chromeHeight = Math.Max(22f * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight() + style.FramePadding.Y * 1.5f);
+            ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y));
+            ImGui.Dummy(new Vector2(1f, chromeHeight));
+            ImGui.SetCursorPos(new Vector2(style.WindowPadding.X, style.WindowPadding.Y + chromeHeight));
+
+            DrawContent();
+            UiTheme.DrawWindowChrome(_config, "Manage Members", () => open = false, chromeHeight);
+        }
+        ImGui.End();
+        ImGui.PopStyleVar();
+
+        IsOpen = (!open || UiTheme.RequestCloseThisFrame) ? false : open;
+    }
+
+    private void DrawContent()
+    {
+        if (!OfficerPermissions.HasAccess(_config))
+        {
+            ImGui.TextUnformatted("Officer permissions are required to manage DemiCat members.");
+            return;
+        }
+
+        if (!_tokenManager.IsReady())
+        {
+            ImGui.TextUnformatted("Link DemiCat before managing members.");
+            return;
+        }
+
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            ImGui.TextUnformatted("Set a valid API base URL in settings to manage members.");
+            return;
+        }
+
+        if (_needsInitialRefresh)
+        {
+            _needsInitialRefresh = false;
+            StartRefresh();
+        }
+
+        bool loading;
+        bool actionInProgress;
+        string statusMessage;
+        bool statusIsError;
+        MemberEntry[] members;
+
+        lock (_sync)
+        {
+            loading = _loading;
+            actionInProgress = _actionInProgress;
+            statusMessage = _statusMessage;
+            statusIsError = _statusIsError;
+            members = _members.ToArray();
+        }
+
+        if (ImGui.Button("Refresh"))
+        {
+            StartRefresh(force: true);
+        }
+
+        if (loading)
+        {
+            ImGui.SameLine();
+            ImGui.TextUnformatted("Refreshing…");
+        }
+        else if (actionInProgress)
+        {
+            ImGui.SameLine();
+            ImGui.TextUnformatted("Applying changes…");
+        }
+
+        if (!string.IsNullOrEmpty(statusMessage))
+        {
+            var color = statusIsError
+                ? new Vector4(1f, 0.45f, 0.45f, 1f)
+                : new Vector4(0.6f, 0.85f, 1f, 1f);
+            ImGui.PushStyleColor(ImGuiCol.Text, color);
+            ImGui.TextWrapped(statusMessage);
+            ImGui.PopStyleColor();
+        }
+
+        UiTheme.DrawSectionSeparator();
+
+        if (ImGui.BeginChild("##manageMembersList", ImGui.GetContentRegionAvail(), false))
+        {
+            if (members.Length == 0)
+            {
+                ImGui.TextUnformatted(loading
+                    ? "Loading members…"
+                    : "No linked DemiCat users currently have access.");
+            }
+            else
+            {
+                DrawMemberTable(members, actionInProgress);
+            }
+        }
+        ImGui.EndChild();
+
+        DrawConfirmationPopup();
+    }
+
+    private void DrawMemberTable(MemberEntry[] members, bool disableActions)
+    {
+        var tableFlags = ImGuiTableFlags.RowBg
+            | ImGuiTableFlags.BordersOuterH
+            | ImGuiTableFlags.BordersOuterV
+            | ImGuiTableFlags.BordersInnerH
+            | ImGuiTableFlags.SizingStretchProp;
+
+        if (!ImGui.BeginTable("##manageMembersTable", 3, tableFlags))
+        {
+            return;
+        }
+
+        ImGui.TableSetupColumn("Member", ImGuiTableColumnFlags.WidthStretch, 0.55f);
+        ImGui.TableSetupColumn("Last Activity", ImGuiTableColumnFlags.WidthFixed, 160f * ImGuiHelpers.GlobalScale);
+        ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthFixed, 230f * ImGuiHelpers.GlobalScale);
+        ImGui.TableHeadersRow();
+
+        foreach (var member in members)
+        {
+            ImGui.PushID(member.DiscordUserId);
+            ImGui.TableNextRow();
+
+            ImGui.TableNextColumn();
+            DrawMemberName(member);
+
+            ImGui.TableNextColumn();
+            DrawLastSeen(member);
+
+            ImGui.TableNextColumn();
+            DrawMemberActions(member, disableActions);
+
+            ImGui.PopID();
+        }
+
+        ImGui.EndTable();
+    }
+
+    private static void DrawMemberName(MemberEntry member)
+    {
+        ImGui.TextUnformatted(member.DisplayName);
+
+        if (!string.IsNullOrWhiteSpace(member.Nickname)
+            && !string.Equals(member.Nickname, member.DisplayName, StringComparison.Ordinal))
+        {
+            ImGui.TextDisabled($"Nickname: {member.Nickname}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(member.GlobalName)
+            && !string.Equals(member.GlobalName, member.DisplayName, StringComparison.Ordinal))
+        {
+            ImGui.TextDisabled($"Global: {member.GlobalName}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(member.CharacterName))
+        {
+            ImGui.TextDisabled($"Character: {member.CharacterName}");
+        }
+
+        ImGui.TextDisabled($"Discord ID: {member.DiscordUserId}");
+
+        if (member.IsBanned)
+        {
+            ImGui.TextColored(new Vector4(1f, 0.6f, 0.4f, 1f), "Banned");
+        }
+    }
+
+    private static void DrawLastSeen(MemberEntry member)
+    {
+        if (member.LastUsedAt is not { } lastUsed)
+        {
+            ImGui.TextDisabled("No activity");
+            return;
+        }
+
+        var localized = lastUsed.ToLocalTime();
+        ImGui.TextUnformatted(localized.ToString("g", CultureInfo.CurrentCulture));
+    }
+
+    private void DrawMemberActions(MemberEntry member, bool disableActions)
+    {
+        var style = ImGui.GetStyle();
+        var buttonWidth = Math.Max(
+            120f * ImGuiHelpers.GlobalScale,
+            ImGui.CalcTextSize("Remove Access").X + style.FramePadding.X * 2f);
+
+        var disabled = disableActions || member.IsBanned;
+        if (disabled)
+        {
+            ImGui.BeginDisabled();
+        }
+
+        if (ImGui.Button("Remove Access", new Vector2(buttonWidth, 0f)))
+        {
+            _pendingAction = PendingActionKind.Remove;
+            _pendingMember = member;
+            ImGui.OpenPopup(ConfirmPopupId);
+        }
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.SetTooltip("Disable every DemiCat API key this member has linked so they lose access immediately.");
+        }
+
+        if (disabled)
+        {
+            ImGui.EndDisabled();
+        }
+
+        ImGui.SameLine();
+
+        var banDisabled = disableActions || member.IsBanned;
+        if (banDisabled)
+        {
+            ImGui.BeginDisabled();
+        }
+
+        if (ImGui.Button("Ban User", new Vector2(buttonWidth, 0f)))
+        {
+            _pendingAction = PendingActionKind.Ban;
+            _pendingMember = member;
+            ImGui.OpenPopup(ConfirmPopupId);
+        }
+        if (ImGui.IsItemHovered())
+        {
+            ImGui.SetTooltip("Revoke access and prevent this Discord user from linking DemiCat again.");
+        }
+
+        if (banDisabled)
+        {
+            ImGui.EndDisabled();
+        }
+    }
+
+    private void DrawConfirmationPopup()
+    {
+        if (_pendingAction == PendingActionKind.None || _pendingMember == null)
+        {
+            return;
+        }
+
+        var open = true;
+        if (!ImGui.BeginPopupModal(ConfirmPopupId, ref open, ImGuiWindowFlags.AlwaysAutoResize))
+        {
+            if (!open)
+            {
+                ClearPendingAction();
+            }
+            return;
+        }
+
+        var member = _pendingMember;
+        var action = _pendingAction;
+        var highlight = new Vector4(1f, 0.6f, 0.4f, 1f);
+
+        ImGui.TextWrapped(action == PendingActionKind.Ban
+            ? $"Ban {member.DisplayName}? This revokes their access and blocks future links until they are manually unbanned."
+            : $"Remove access for {member.DisplayName}? They will need to relink DemiCat to regain access.");
+
+        ImGui.Spacing();
+
+        if (_actionInProgress)
+        {
+            ImGui.BeginDisabled();
+        }
+
+        var confirmLabel = action == PendingActionKind.Ban ? "Ban" : "Remove";
+        ImGui.PushStyleColor(ImGuiCol.Button, highlight);
+        ImGui.PushStyleColor(ImGuiCol.ButtonHovered, highlight);
+        ImGui.PushStyleColor(ImGuiCol.ButtonActive, highlight);
+        if (ImGui.Button(confirmLabel))
+        {
+            ImGui.CloseCurrentPopup();
+            ClearPendingAction();
+            StartAction(action, member);
+        }
+        ImGui.PopStyleColor(3);
+
+        if (_actionInProgress)
+        {
+            ImGui.EndDisabled();
+        }
+
+        ImGui.SameLine();
+        if (ImGui.Button("Cancel"))
+        {
+            ImGui.CloseCurrentPopup();
+            ClearPendingAction();
+        }
+
+        ImGui.EndPopup();
+    }
+
+    private void ClearPendingAction()
+    {
+        _pendingAction = PendingActionKind.None;
+        _pendingMember = null;
+    }
+
+    private void StartRefresh(bool force = false)
+    {
+        lock (_sync)
+        {
+            if (_loading)
+            {
+                return;
+            }
+
+            _loading = true;
+            if (force)
+            {
+                _statusMessage = string.Empty;
+            }
+        }
+
+        _ = Task.Run(async () =>
+        {
+            var result = await FetchMembersAsync().ConfigureAwait(false);
+
+            lock (_sync)
+            {
+                _members.Clear();
+                _members.AddRange(result.Members);
+                _loading = false;
+                if (!string.IsNullOrEmpty(result.Message))
+                {
+                    _statusMessage = result.Message;
+                    _statusIsError = result.IsError;
+                }
+                else if (!_statusIsError)
+                {
+                    _statusMessage = string.Empty;
+                }
+            }
+        });
+    }
+
+    private async Task<FetchResult> FetchMembersAsync()
+    {
+        if (!EnsureReady(out var error))
+        {
+            return new FetchResult(new List<MemberEntry>(), error, true);
+        }
+
+        try
+        {
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/officer/members";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
+            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorText = await ReadErrorAsync(response).ConfigureAwait(false);
+                var message = $"Failed to load members ({(int)response.StatusCode} {response.StatusCode}{errorText}).";
+                return new FetchResult(new List<MemberEntry>(), message, true);
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            var dto = await JsonSerializer.DeserializeAsync<List<MemberDto>>(stream, JsonOptions).ConfigureAwait(false)
+                ?? new List<MemberDto>();
+
+            var members = dto
+                .Select(Convert)
+                .Where(m => m != null)
+                .Select(m => m!)
+                .OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            return new FetchResult(members, string.Empty, false);
+        }
+        catch (Exception ex)
+        {
+            return new FetchResult(new List<MemberEntry>(), $"Failed to load members: {ex.Message}", true);
+        }
+    }
+
+    private void StartAction(PendingActionKind action, MemberEntry member)
+    {
+        lock (_sync)
+        {
+            if (_actionInProgress)
+            {
+                return;
+            }
+
+            _actionInProgress = true;
+        }
+
+        _ = Task.Run(async () =>
+        {
+            var result = await ExecuteActionAsync(action, member).ConfigureAwait(false);
+
+            lock (_sync)
+            {
+                _actionInProgress = false;
+                _statusMessage = result.Message;
+                _statusIsError = result.IsError;
+                if (result.Success)
+                {
+                    _members.RemoveAll(m => m.DiscordUserId == member.DiscordUserId);
+                }
+            }
+        });
+    }
+
+    private async Task<(bool Success, string Message, bool IsError)> ExecuteActionAsync(PendingActionKind action, MemberEntry member)
+    {
+        if (!EnsureReady(out var error))
+        {
+            return (false, error, true);
+        }
+
+        var suffix = action == PendingActionKind.Ban ? "ban" : "remove";
+        try
+        {
+            var url = $"{_config.ApiBaseUrl.TrimEnd('/')}/api/officer/members/{member.DiscordUserId}/{suffix}";
+            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+            ApiHelpers.AddAuthHeader(request, _tokenManager);
+            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+            if (response.IsSuccessStatusCode)
+            {
+                var successMessage = action == PendingActionKind.Ban
+                    ? $"{member.DisplayName} has been banned from DemiCat."
+                    : $"Removed DemiCat access for {member.DisplayName}.";
+                return (true, successMessage, false);
+            }
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                var fallbackMessage = action == PendingActionKind.Ban
+                    ? $"{member.DisplayName} is already banned."
+                    : $"{member.DisplayName} no longer has DemiCat access.";
+                return (true, fallbackMessage, false);
+            }
+
+            var detail = await ReadErrorAsync(response).ConfigureAwait(false);
+            var failureMessage = action == PendingActionKind.Ban
+                ? $"Failed to ban {member.DisplayName} ({(int)response.StatusCode} {response.StatusCode}{detail})."
+                : $"Failed to remove access for {member.DisplayName} ({(int)response.StatusCode} {response.StatusCode}{detail}).";
+            return (false, failureMessage, true);
+        }
+        catch (Exception ex)
+        {
+            var message = action == PendingActionKind.Ban
+                ? $"Failed to ban {member.DisplayName}: {ex.Message}"
+                : $"Failed to remove access for {member.DisplayName}: {ex.Message}";
+            return (false, message, true);
+        }
+    }
+
+    private static async Task<string> ReadErrorAsync(HttpResponseMessage response)
+    {
+        try
+        {
+            var text = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return string.Empty;
+            }
+
+            return $": {text.Trim()}";
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
+    private bool EnsureReady(out string message)
+    {
+        if (!OfficerPermissions.HasAccess(_config))
+        {
+            message = "Officer permissions are required.";
+            return false;
+        }
+
+        if (!_tokenManager.IsReady())
+        {
+            message = "Link DemiCat before managing members.";
+            return false;
+        }
+
+        if (!ApiHelpers.ValidateApiBaseUrl(_config))
+        {
+            message = "Set a valid API base URL in settings.";
+            return false;
+        }
+
+        message = string.Empty;
+        return true;
+    }
+
+    private static MemberEntry? Convert(MemberDto dto)
+    {
+        if (dto.DiscordUserId is not { Length: > 0 } id)
+        {
+            return null;
+        }
+
+        DateTimeOffset? lastUsed = null;
+        if (!string.IsNullOrWhiteSpace(dto.LastUsedAt)
+            && DateTimeOffset.TryParse(dto.LastUsedAt, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed))
+        {
+            lastUsed = parsed;
+        }
+
+        var displayName = dto.DisplayName;
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = dto.Nickname;
+        }
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = dto.GlobalName;
+        }
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            displayName = dto.CharacterName;
+        }
+        displayName ??= id;
+
+        return new MemberEntry
+        {
+            DiscordUserId = id,
+            DisplayName = displayName,
+            Nickname = dto.Nickname,
+            GlobalName = dto.GlobalName,
+            CharacterName = dto.CharacterName,
+            LastUsedAt = lastUsed,
+            IsBanned = dto.IsBanned
+        };
+    }
+}

--- a/DemiCatPlugin/OfficerChatWindow.cs
+++ b/DemiCatPlugin/OfficerChatWindow.cs
@@ -26,6 +26,8 @@ public class OfficerChatWindow : ChatWindow
 
     protected override bool MentionsEnabled => true;
 
+    public ManageMembersWindow? ManageMembersWindow { get; set; }
+
     public OfficerChatWindow(
         Config config,
         HttpClient httpClient,
@@ -162,6 +164,8 @@ public class OfficerChatWindow : ChatWindow
         {
             Subscribe();
         }
+
+        DrawAdminSection();
 
         ImGui.BeginChild("##officerChat", ImGui.GetContentRegionAvail(), false);
         base.Draw();
@@ -487,14 +491,58 @@ public class OfficerChatWindow : ChatWindow
         }
     }
 
-    private void TryRefreshRoles()
+    private void DrawAdminSection()
+    {
+        ImGui.PushID("OfficerAdminSection");
+
+        ImGui.TextUnformatted("Admin Tools");
+        UiTheme.DrawSectionSeparator();
+
+        if (ImGui.Button("Resync Roles"))
+        {
+            TryRefreshRoles(force: true);
+        }
+
+        if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+        {
+            ImGui.SetTooltip("Immediately refresh officer permissions for every linked DemiCat user. Use this after promotions or demotions in Discord to sync access without waiting for the automatic update.");
+        }
+
+        ImGui.SameLine();
+
+        var manageDisabled = ManageMembersWindow == null;
+        if (manageDisabled)
+        {
+            ImGui.BeginDisabled();
+        }
+
+        if (ImGui.Button("Manage Members"))
+        {
+            ManageMembersWindow?.Open();
+        }
+
+        if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+        {
+            ImGui.SetTooltip("Open the membership manager to review linked DemiCat users, revoke their access, or ban accounts that violate the rules.");
+        }
+
+        if (manageDisabled)
+        {
+            ImGui.EndDisabled();
+        }
+
+        UiTheme.DrawSectionSeparator();
+        ImGui.PopID();
+    }
+
+    private void TryRefreshRoles(bool force = false)
     {
         if (IsDisposed)
         {
             return;
         }
 
-        if (DateTime.UtcNow - _lastRolesRefresh < TimeSpan.FromSeconds(30))
+        if (!force && DateTime.UtcNow - _lastRolesRefresh < TimeSpan.FromSeconds(30))
         {
             return;
         }

--- a/DemiCatPlugin/Plugin.cs
+++ b/DemiCatPlugin/Plugin.cs
@@ -42,6 +42,7 @@ public class Plugin : IDalamudPlugin
     private readonly OfficerChatWindow _officerChatWindow;
     private readonly DiscordPresenceService _presenceService;
     private readonly PresenceWindow _presenceWindow;
+    private readonly ManageMembersWindow _manageMembersWindow;
     private readonly MainWindow _mainWindow;
     private readonly ChannelWatcher _channelWatcher;
     private readonly RequestWatcher _requestWatcher;
@@ -135,6 +136,8 @@ public class Plugin : IDalamudPlugin
         _avatarCache = new AvatarCache(TextureProvider, _httpClient);
         _chatWindow = new FcChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _messageCache, _avatarCache, _emojiManager, _sharedChatBridge);
         _officerChatWindow = new OfficerChatWindow(_config, _httpClient, _presenceService, _tokenManager, _channelService, _channelSelection, _messageCache, _avatarCache, _emojiManager, _sharedChatBridge);
+        _manageMembersWindow = new ManageMembersWindow(_config, _httpClient, _tokenManager);
+        _officerChatWindow.ManageMembersWindow = _manageMembersWindow;
 
         _notePadService = new NotePadService(_config, _httpClient, _tokenManager);
         _notePadWindow = new NotePadWindow(_config, _notePadService);
@@ -173,6 +176,7 @@ public class Plugin : IDalamudPlugin
 
         _services.PluginInterface.UiBuilder.Draw += _mainWindow.Draw;
         _services.PluginInterface.UiBuilder.Draw += _settings.Draw;
+        _services.PluginInterface.UiBuilder.Draw += _manageMembersWindow.Draw;
 
         _openMainUi = () => _mainWindow.IsOpen = true;
         _services.PluginInterface.UiBuilder.OpenMainUi += _openMainUi;
@@ -246,6 +250,7 @@ public class Plugin : IDalamudPlugin
         {
             pluginInterface.UiBuilder.Draw -= _mainWindow.Draw;
             pluginInterface.UiBuilder.Draw -= _settings.Draw;
+            pluginInterface.UiBuilder.Draw -= _manageMembersWindow.Draw;
 
             // Unsubscribe UI open handlers
             pluginInterface.UiBuilder.OpenMainUi -= _openMainUi;
@@ -739,6 +744,7 @@ public class Plugin : IDalamudPlugin
                 _mainWindow.SetNotePadReadOnly(true);
                 _mainWindow.NotifyLinkRequired();
                 _settings.IsOpen = true;
+                _manageMembersWindow.Reset();
 
                 var hadOfficerAccess = _config.IsOfficerToken;
                 _config.IsOfficerToken = false;

--- a/SQL Schema.sql
+++ b/SQL Schema.sql
@@ -714,6 +714,33 @@ INSERT INTO `memberships` VALUES
 UNLOCK TABLES;
 
 --
+-- Table structure for table `guild_member_ban`
+--
+
+DROP TABLE IF EXISTS `guild_member_ban`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `guild_member_ban` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `guild_id` int NOT NULL,
+  `discord_user_id` bigint unsigned NOT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_guild_member_ban_guild_user` (`guild_id`,`discord_user_id`),
+  CONSTRAINT `guild_member_ban_ibfk_1` FOREIGN KEY (`guild_id`) REFERENCES `guilds` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `guild_member_ban`
+--
+
+LOCK TABLES `guild_member_ban` WRITE;
+/*!40000 ALTER TABLE `guild_member_ban` DISABLE KEYS */;
+/*!40000 ALTER TABLE `guild_member_ban` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Table structure for table `messages`
 --
 

--- a/demibot/demibot/db/migrations/versions/0061_add_guild_member_ban.py
+++ b/demibot/demibot/db/migrations/versions/0061_add_guild_member_ban.py
@@ -1,0 +1,38 @@
+"""0061_add_guild_member_ban
+
+Revision ID: 0061_add_guild_member_ban
+Revises: 0060_fix_request_status_spelling
+Create Date: 2024-07-20 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.mysql import BIGINT
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0061_add_guild_member_ban"
+down_revision: Union[str, None] = "0060_fix_request_status_spelling"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "guild_member_ban",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("guild_id", sa.Integer(), nullable=False),
+        sa.Column("discord_user_id", BIGINT(unsigned=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["guild_id"], ["guilds.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("guild_id", "discord_user_id", name="uq_guild_member_ban_guild_user"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("guild_member_ban")

--- a/demibot/demibot/db/models.py
+++ b/demibot/demibot/db/models.py
@@ -189,6 +189,18 @@ class Membership(Base):
     accent_color: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
 
+class GuildMemberBan(Base):
+    __tablename__ = "guild_member_ban"
+    __table_args__ = (
+        UniqueConstraint("guild_id", "discord_user_id", name="uq_guild_member_ban_guild_user"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"))
+    discord_user_id: Mapped[int] = mapped_column(BIGINT(unsigned=True))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
 class Role(Base):
     __tablename__ = "roles"
 

--- a/demibot/demibot/http/routes/officer_members.py
+++ b/demibot/demibot/http/routes/officer_members.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import and_, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import RequestContext, api_key_auth, get_db
+from ...db.models import GuildMemberBan, Membership, User, UserKey
+
+
+router = APIRouter(prefix="/api")
+
+
+def _require_officer(ctx: RequestContext) -> None:
+    if "officer" not in ctx.roles:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+
+
+@router.get("/officer/members")
+async def get_officer_members(
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> list[dict[str, Any]]:
+    _require_officer(ctx)
+
+    stmt = (
+        select(
+            User.discord_user_id,
+            User.global_name,
+            User.character_name,
+            Membership.nickname,
+            UserKey.last_used_at,
+        )
+        .join(UserKey, User.id == UserKey.user_id)
+        .join(
+            Membership,
+            and_(
+                Membership.guild_id == ctx.guild.id,
+                Membership.user_id == User.id,
+            ),
+            isouter=True,
+        )
+        .where(UserKey.guild_id == ctx.guild.id, UserKey.enabled)
+    )
+
+    result = await db.execute(stmt)
+    rows = result.all()
+    if not rows:
+        return []
+
+    grouped: dict[int, dict[str, Any]] = defaultdict(lambda: {
+        "discord_user_id": 0,
+        "global_name": None,
+        "character_name": None,
+        "nickname": None,
+        "last_used_at": None,
+    })
+
+    for discord_id, global_name, character_name, nickname, last_used_at in rows:
+        entry = grouped[discord_id]
+        entry["discord_user_id"] = discord_id
+        if entry["global_name"] is None and global_name is not None:
+            entry["global_name"] = global_name
+        if entry["character_name"] is None and character_name is not None:
+            entry["character_name"] = character_name
+        if entry["nickname"] is None and nickname is not None:
+            entry["nickname"] = nickname
+        if last_used_at is not None:
+            current = entry.get("last_used_at")
+            if current is None or last_used_at > current:
+                entry["last_used_at"] = last_used_at
+
+    banned_stmt = select(GuildMemberBan.discord_user_id).where(
+        GuildMemberBan.guild_id == ctx.guild.id
+    )
+    banned_result = await db.execute(banned_stmt)
+    banned_ids = {row[0] for row in banned_result.all()}
+
+    payload: list[dict[str, Any]] = []
+    for entry in grouped.values():
+        discord_id = entry["discord_user_id"]
+        nickname = entry["nickname"]
+        global_name = entry["global_name"]
+        character_name = entry["character_name"]
+
+        display_name = nickname or global_name or character_name or str(discord_id)
+        last_used_at = entry.get("last_used_at")
+        payload.append(
+            {
+                "discordUserId": str(discord_id),
+                "displayName": display_name,
+                "nickname": nickname,
+                "globalName": global_name,
+                "characterName": character_name,
+                "lastUsedAt": last_used_at.isoformat() if last_used_at else None,
+                "isBanned": discord_id in banned_ids,
+            }
+        )
+
+    payload.sort(key=lambda item: item["displayName"].casefold())
+    return payload
+
+
+@router.post("/officer/members/{discord_user_id}/remove")
+async def remove_member_access(
+    discord_user_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    _require_officer(ctx)
+
+    user = await db.scalar(select(User).where(User.discord_user_id == discord_user_id))
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="member_not_found")
+
+    result = await db.execute(
+        update(UserKey)
+        .where(
+            UserKey.user_id == user.id,
+            UserKey.guild_id == ctx.guild.id,
+            UserKey.enabled,
+        )
+        .values(enabled=False, updated_at=func.now())
+    )
+
+    if result.rowcount == 0:
+        has_keys = await db.scalar(
+            select(UserKey.id).where(
+                UserKey.user_id == user.id,
+                UserKey.guild_id == ctx.guild.id,
+            )
+        )
+        if has_keys is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="member_not_found")
+
+    await db.commit()
+    return {"status": "ok"}
+
+
+@router.post("/officer/members/{discord_user_id}/ban")
+async def ban_member(
+    discord_user_id: int,
+    ctx: RequestContext = Depends(api_key_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    _require_officer(ctx)
+
+    user = await db.scalar(select(User).where(User.discord_user_id == discord_user_id))
+    if user is not None:
+        await db.execute(
+            update(UserKey)
+            .where(
+                UserKey.user_id == user.id,
+                UserKey.guild_id == ctx.guild.id,
+                UserKey.enabled,
+            )
+            .values(enabled=False, updated_at=func.now())
+        )
+
+    existing = await db.scalar(
+        select(GuildMemberBan.id).where(
+            GuildMemberBan.guild_id == ctx.guild.id,
+            GuildMemberBan.discord_user_id == discord_user_id,
+        )
+    )
+
+    if existing is None:
+        ban = GuildMemberBan(guild_id=ctx.guild.id, discord_user_id=discord_user_id)
+        db.add(ban)
+
+    await db.commit()
+    return {"status": "ok"}

--- a/tests/test_officer_members_endpoint.py
+++ b/tests/test_officer_members_endpoint.py
@@ -1,0 +1,222 @@
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select, text
+
+root = Path(__file__).resolve().parents[1] / "demibot"
+if str(root) not in sys.path:
+    sys.path.append(str(root))
+
+from demibot.db.models import Guild, GuildMemberBan, Membership, User, UserKey
+from demibot.db.session import get_session, init_db
+from demibot.http.deps import RequestContext, api_key_auth, get_db
+from demibot.http.routes.officer_members import router as officer_router
+
+
+async def prepare_db() -> None:
+    await init_db("sqlite+aiosqlite://")
+    async with get_session() as db:
+        for table in ("guild_member_ban", "user_keys", "memberships", "users", "guilds"):
+            await db.execute(text(f"DELETE FROM {table}"))
+        await db.commit()
+
+
+def create_test_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(officer_router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_officer_members_requires_officer_role():
+    await prepare_db()
+    app = create_test_app()
+
+    user_ctx = SimpleNamespace(id=1)
+    guild_ctx = SimpleNamespace(id=1, discord_guild_id=123)
+
+    async def override_auth():
+        return RequestContext(user=user_ctx, guild=guild_ctx, key=None, roles=[])
+
+    async def override_db():
+        yield None
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/officer/members")
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_officer_members_lists_active_users():
+    await prepare_db()
+
+    async with get_session() as db:
+        guild = Guild(id=1, discord_guild_id=999, name="Guild")
+        user = User(id=1, discord_user_id=1001, global_name="Officer One", character_name="Alice")
+        membership = Membership(guild_id=guild.id, user_id=user.id, nickname="Alicia")
+        active_key = UserKey(
+            id=1,
+            user_id=user.id,
+            guild_id=guild.id,
+            token="abc",
+            enabled=True,
+            last_used_at=datetime(2024, 1, 5, 12, 0, 0),
+        )
+        stale_key = UserKey(
+            id=2,
+            user_id=user.id,
+            guild_id=guild.id,
+            token="def",
+            enabled=True,
+            last_used_at=datetime(2024, 1, 1, 12, 0, 0),
+        )
+        disabled_user = User(id=2, discord_user_id=2002, global_name="Member Two")
+        disabled_membership = Membership(guild_id=guild.id, user_id=disabled_user.id)
+        disabled_key = UserKey(
+            id=3,
+            user_id=disabled_user.id,
+            guild_id=guild.id,
+            token="ghi",
+            enabled=False,
+        )
+
+        db.add_all(
+            [
+                guild,
+                user,
+                membership,
+                active_key,
+                stale_key,
+                disabled_user,
+                disabled_membership,
+                disabled_key,
+            ]
+        )
+        await db.commit()
+
+    app = create_test_app()
+
+    user_ctx = SimpleNamespace(id=1, discord_user_id=1001)
+    guild_ctx = SimpleNamespace(id=1, discord_guild_id=999)
+
+    async def override_auth():
+        return RequestContext(user=user_ctx, guild=guild_ctx, key=None, roles=["officer"])
+
+    async def override_db():
+        async with get_session() as session:
+            yield session
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/officer/members")
+
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    entry = data[0]
+    assert entry["discordUserId"] == "1001"
+    assert entry["displayName"] == "Alicia"
+    assert entry["globalName"] == "Officer One"
+    assert entry["characterName"] == "Alice"
+    assert entry["nickname"] == "Alicia"
+    assert entry["isBanned"] is False
+    assert entry["lastUsedAt"].startswith("2024-01-05T12:00:00")
+
+
+@pytest.mark.asyncio
+async def test_remove_member_disables_keys():
+    await prepare_db()
+
+    async with get_session() as db:
+        guild = Guild(id=1, discord_guild_id=777, name="Guild")
+        user = User(id=1, discord_user_id=1111, global_name="Member")
+        membership = Membership(guild_id=guild.id, user_id=user.id)
+        key = UserKey(id=1, user_id=user.id, guild_id=guild.id, token="tok", enabled=True)
+        db.add_all([guild, user, membership, key])
+        await db.commit()
+
+    app = create_test_app()
+
+    user_ctx = SimpleNamespace(id=1, discord_user_id=1111)
+    guild_ctx = SimpleNamespace(id=1, discord_guild_id=777)
+
+    async def override_auth():
+        return RequestContext(user=user_ctx, guild=guild_ctx, key=None, roles=["officer"])
+
+    async def override_db():
+        async with get_session() as session:
+            yield session
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/officer/members/1111/remove")
+
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+
+    async with get_session() as db:
+        stored_key = await db.scalar(select(UserKey).where(UserKey.id == 1))
+        assert stored_key is not None and stored_key.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_ban_member_creates_record_and_disables_access():
+    await prepare_db()
+
+    async with get_session() as db:
+        guild = Guild(id=1, discord_guild_id=555, name="Guild")
+        user = User(id=1, discord_user_id=3333, global_name="Member")
+        membership = Membership(guild_id=guild.id, user_id=user.id)
+        key = UserKey(id=1, user_id=user.id, guild_id=guild.id, token="tok", enabled=True)
+        db.add_all([guild, user, membership, key])
+        await db.commit()
+
+    app = create_test_app()
+
+    user_ctx = SimpleNamespace(id=1, discord_user_id=3333)
+    guild_ctx = SimpleNamespace(id=1, discord_guild_id=555)
+
+    async def override_auth():
+        return RequestContext(user=user_ctx, guild=guild_ctx, key=None, roles=["officer"])
+
+    async def override_db():
+        async with get_session() as session:
+            yield session
+
+    app.dependency_overrides[api_key_auth] = override_auth
+    app.dependency_overrides[get_db] = override_db
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/officer/members/3333/ban")
+
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+
+    async with get_session() as db:
+        stored_key = await db.scalar(select(UserKey).where(UserKey.id == 1))
+        assert stored_key is not None and stored_key.enabled is False
+
+        ban = await db.scalar(select(GuildMemberBan).where(GuildMemberBan.guild_id == 1))
+        assert ban is not None


### PR DESCRIPTION
## Summary
- add an in-window admin section to the officer chat with role resync and member management controls
- implement a Manage Members window that lists linked users and lets officers revoke or ban access
- expose backend endpoints and schema to track bans, and cover them with API tests

## Testing
- pytest tests/test_officer_members_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68f3d422a1d8832899c852ca38f24ac4