### PR TITLE
Fix tooltip handling and dictionary constraint

### DIFF
--- a/DemiCatPlugin/DiscordPresenceService.cs
+++ b/DemiCatPlugin/DiscordPresenceService.cs
@@ -807,6 +807,7 @@ public class DiscordPresenceService : IDisposable
     }
 
     private static bool SameSet<T>(IReadOnlyList<T> left, IReadOnlyList<T> right, IEqualityComparer<T>? comparer = null)
+        where T : notnull
     {
         comparer ??= EqualityComparer<T>.Default;
 

--- a/DemiCatPlugin/PresenceSidebar.cs
+++ b/DemiCatPlugin/PresenceSidebar.cs
@@ -483,10 +483,7 @@ public class PresenceSidebar : IDisposable
             return;
         }
 
-        if (!ImGui.BeginTooltip())
-        {
-            return;
-        }
+        ImGui.BeginTooltip();
 
         try
         {


### PR DESCRIPTION
## Summary
- remove the invalid boolean check around `ImGui.BeginTooltip` now that the API returns void
- enforce a `notnull` constraint on the `SameSet` helper to satisfy the dictionary key requirement

## Testing
- dotnet build (fails: `dotnet` CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f3df00b8708328afe47dff7ae0e2bc